### PR TITLE
README: update URL for downloading the PHAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ If you're using PHP_CodeSniffer as part of a team, or you're running it on a [CI
 The easiest way to get started with PHP_CodeSniffer is to download the Phar files for each of the commands:
 ```
 # Download using curl
-curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+curl -OL https://phars.phpcodesniffer.com/phpcs.phar
+curl -OL https://phars.phpcodesniffer.com/phpcbf.phar
 
 # Or download using wget
-wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-wget https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+wget https://phars.phpcodesniffer.com/phpcs.phar
+wget https://phars.phpcodesniffer.com/phpcbf.phar
 
 # Then test the downloaded PHARs
 php phpcs.phar -h


### PR DESCRIPTION
## Description
The GH Pages website has been re-activated under a new domain - phars.phpcodesniffer.com -.

The PHARs can now be downloaded from that domain and PHIVE should work as well, though a PR to phar.io will be needed to update the PHIVE alias redirect.


### Suggested changelog entry
The permanent address for PHAR downloads and downloading the PHARs via PHIVE has changed to phars.phpcodesniffer.com


## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

