### PR TITLE
Tokenizer/PHP: fix mis-identification of 'readonly' keyword icw PHP 8.2 DNF types

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1313,23 +1313,89 @@ class PHP extends Tokenizer
                 "readonly" keyword for PHP < 8.1
             */
 
-            if (PHP_VERSION_ID < 80100
-                && $tokenIsArray === true
+            if ($tokenIsArray === true
                 && strtolower($token[1]) === 'readonly'
                 && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
             ) {
                 // Get the next non-whitespace token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || $tokens[$i][0] !== T_WHITESPACE
+                        || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
                 }
 
+                $isReadonlyKeyword = false;
+
                 if (isset($tokens[$i]) === false
                     || $tokens[$i] !== '('
                 ) {
+                    $isReadonlyKeyword = true;
+                } else if ($tokens[$i] === '(') {
+                    /*
+                     * Skip over tokens which can be used in type declarations.
+                     * At this point, the only token types which need to be taken into consideration
+                     * as potential type declarations are identifier names, T_ARRAY, T_CALLABLE and T_NS_SEPARATOR
+                     * and the union/intersection/dnf parentheses.
+                     */
+
+                    $foundDNFParens = 1;
+                    $foundDNFPipe   = 0;
+
+                    for (++$i; $i < $numTokens; $i++) {
+                        if (is_array($tokens[$i]) === true) {
+                            $tokenType = $tokens[$i][0];
+                        } else {
+                            $tokenType = $tokens[$i];
+                        }
+
+                        if (isset(Util\Tokens::$emptyTokens[$tokenType]) === true) {
+                            continue;
+                        }
+
+                        if ($tokenType === '|') {
+                            ++$foundDNFPipe;
+                            continue;
+                        }
+
+                        if ($tokenType === ')') {
+                            ++$foundDNFParens;
+                            continue;
+                        }
+
+                        if ($tokenType === '(') {
+                            ++$foundDNFParens;
+                            continue;
+                        }
+
+                        if ($tokenType === T_STRING
+                            || $tokenType === T_NAME_FULLY_QUALIFIED
+                            || $tokenType === T_NAME_RELATIVE
+                            || $tokenType === T_NAME_QUALIFIED
+                            || $tokenType === T_ARRAY
+                            || $tokenType === T_NAMESPACE
+                            || $tokenType === T_NS_SEPARATOR
+                            || $tokenType === T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG // PHP 8.0+.
+                            || $tokenType === '&' // PHP < 8.0.
+                        ) {
+                            continue;
+                        }
+
+                        // Reached the next token after.
+                        if (($foundDNFParens % 2) === 0
+                            && $foundDNFPipe >= 1
+                            && ($tokenType === T_VARIABLE
+                            || $tokenType === T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG)
+                        ) {
+                            $isReadonlyKeyword = true;
+                        }
+
+                        break;
+                    }//end for
+                }//end if
+
+                if ($isReadonlyKeyword === true) {
                     $finalTokens[$newStackPtr] = [
                         'code'    => T_READONLY,
                         'type'    => 'T_READONLY',
@@ -1337,8 +1403,23 @@ class PHP extends Tokenizer
                     ];
                     $newStackPtr++;
 
-                    continue;
-                }
+                    if (PHP_CODESNIFFER_VERBOSITY > 1 && $type !== T_READONLY) {
+                        echo "\t\t* token $stackPtr changed from $type to T_READONLY".PHP_EOL;
+                    }
+                } else {
+                    $finalTokens[$newStackPtr] = [
+                        'code'    => T_STRING,
+                        'type'    => 'T_STRING',
+                        'content' => $token[1],
+                    ];
+                    $newStackPtr++;
+
+                    if (PHP_CODESNIFFER_VERBOSITY > 1 && $type !== T_STRING) {
+                        echo "\t\t* token $stackPtr changed from $type to T_STRING".PHP_EOL;
+                    }
+                }//end if
+
+                continue;
             }//end if
 
             /*

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.inc
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.inc
@@ -49,9 +49,7 @@ class Foo
     public ReAdOnLy string $caseInsensitiveProperty;
 
     /* testReadonlyConstructorPropertyPromotion */
-    public function __construct(private readonly bool $constructorPropertyPromotion)
-    {
-    }
+    public function __construct(private readonly bool $constructorPropertyPromotion) {}
 
     /* testReadonlyConstructorPropertyPromotionWithReference */
     public function __construct(private ReadOnly bool &$constructorPropertyPromotion) {}
@@ -68,8 +66,6 @@ class ClassName {
 
     /* testReadonlyUsedAsMethodName */
     public function readonly() {
-        // Do something.
-
         /* testReadonlyUsedAsPropertyName */
         $this->readonly = 'foo';
 
@@ -79,9 +75,10 @@ class ClassName {
 }
 
 /* testReadonlyUsedAsFunctionName */
-function readonly()
-{
-}
+function readonly() {}
+
+/* testReadonlyUsedAsFunctionNameWithReturnByRef */
+function &readonly() {}
 
 /* testReadonlyUsedAsNamespaceName */
 namespace Readonly;
@@ -89,6 +86,16 @@ namespace Readonly;
 namespace My\Readonly\Collection;
 /* testReadonlyAsFunctionCall */
 $var = readonly($a, $b);
+/* testReadonlyAsNamespacedFunctionCall */
+$var = My\NS\readonly($a, $b);
+/* testReadonlyAsNamespaceRelativeFunctionCall */
+$var = namespace\ReadOnly($a, $b);
+/* testReadonlyAsMethodCall */
+$var = $obj->readonly($a, $b);
+/* testReadonlyAsNullsafeMethodCall */
+$var = $obj?->readOnly($a, $b);
+/* testReadonlyAsStaticMethodCallWithSpace */
+$var = ClassName::readonly ($a, $b);
 /* testClassConstantFetchWithReadonlyAsConstantName */
 echo ClassName::READONLY;
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.inc
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.inc
@@ -102,6 +102,42 @@ echo ClassName::READONLY;
 /* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */
 $var = readonly /* comment */ ();
 
+// These test cases are inspired by
+// https://github.com/php/php-src/commit/08b75395838b4b42a41e3c70684fa6c6b113eee0
+class ReadonlyWithDisjunctiveNormalForm
+{
+    /* testReadonlyPropertyDNFTypeUnqualified */
+    readonly (B&C)|A $h;
+
+    /* testReadonlyPropertyDNFTypeFullyQualified */
+    public readonly (\Fully\Qualified\B&\Full\C)|\Foo\Bar $j;
+
+    /* testReadonlyPropertyDNFTypePartiallyQualified */
+    protected readonly (Partially\Qualified&C)|A $l;
+
+    /* testReadonlyPropertyDNFTypeRelativeName */
+    private readonly (namespace\Relative&C)|A $n;
+
+    /* testReadonlyPropertyDNFTypeMultipleSets */
+    private readonly (A&C)|(B&C)|(C&D) $m;
+
+    /* testReadonlyPropertyDNFTypeWithArray */
+    private readonly (B & C)|array $o;
+
+    /* testReadonlyPropertyDNFTypeWithSpacesAndComments */
+    private readonly ( B & C /*something*/) | A $q;
+
+    public function __construct(
+        /* testReadonlyConstructorPropertyPromotionWithDNF */
+        private readonly (B&C)|A $b1,
+        /* testReadonlyConstructorPropertyPromotionWithDNFAndRefence */
+        readonly (B&C)|A &$b2,
+    ) {}
+
+    /* testReadonlyUsedAsMethodNameWithDNFParam */
+    public function readonly (A&B $param): void {}
+}
+
 /* testParseErrorLiveCoding */
 // This must be the last test in the file.
 readonly

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -213,6 +213,10 @@ class BackfillReadonlyTest extends AbstractMethodUnitTest
                 'readonly',
             ],
             [
+                '/* testReadonlyUsedAsFunctionNameWithReturnByRef */',
+                'readonly',
+            ],
+            [
                 '/* testReadonlyUsedAsNamespaceName */',
                 'Readonly',
             ],
@@ -222,6 +226,26 @@ class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyAsFunctionCall */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyAsNamespacedFunctionCall */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyAsNamespaceRelativeFunctionCall */',
+                'ReadOnly',
+            ],
+            [
+                '/* testReadonlyAsMethodCall */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyAsNullsafeMethodCall */',
+                'readOnly',
+            ],
+            [
+                '/* testReadonlyAsStaticMethodCallWithSpace */',
                 'readonly',
             ],
             [

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -148,7 +148,39 @@ class BackfillReadonlyTest extends AbstractMethodUnitTest
                 'readonly',
             ],
             [
-                '/* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */',
+                '/* testReadonlyPropertyDNFTypeUnqualified */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypeFullyQualified */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypePartiallyQualified */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypeRelativeName */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypeMultipleSets */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypeWithArray */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyPropertyDNFTypeWithSpacesAndComments */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyConstructorPropertyPromotionWithDNF */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyConstructorPropertyPromotionWithDNFAndRefence */',
                 'readonly',
             ],
             [
@@ -251,6 +283,14 @@ class BackfillReadonlyTest extends AbstractMethodUnitTest
             [
                 '/* testClassConstantFetchWithReadonlyAsConstantName */',
                 'READONLY',
+            ],
+            [
+                '/* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */',
+                'readonly',
+            ],
+            [
+                '/* testReadonlyUsedAsMethodNameWithDNFParam */',
+                'readonly',
             ],
         ];
 


### PR DESCRIPTION
## Description

Recreation and further iteration on upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3773 from @fredden:


### Tokenizer/PHP: add some extra tests for the readonly keyword backfill

Includes some minor tweaks to pre-existing tests.

### Fix mis-identification of 'readonly' keyword

PHP 8.2 introduces disjunctive normal form types, which use parentheses, which invalidates the previous "special casing" for function/method declarations and calls using the `readonly` keyword.

This commit fixes this.

Note: this does not (yet) add support for DNF types to the tokenizer or anywhere else in PHPCS, it only fixes the tokenization of `readonly`.

Includes additional tests.

Ref: https://github.com/php/php-src/commit/08b75395838b4b42a41e3c70684fa6c6b113eee0

Co-authored-by: Dan Wallis <dan@wallis.nz>

## Suggested changelog entry
Tokenizer/PHP: fixed the tokenization of the `readonly` keyword when used in combination with PHP 8.2 disjunctive normal types

---

## Original PR description and further discussion:

@fredden wrote:
> The test suite for this package is failing on PHP 8.2. This seems to be due to a mis-identification of the `readonly` keyword when used as a function name. For example, https://github.com/squizlabs/PHP_CodeSniffer/actions/runs/4318800044/jobs/7537540753.
> 
> This pull request fixes that test failure.
> 
> I have tested this with PHP version 8.2.3. I also noticed that the test case "testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens" seems to have been in the wrong category within the test suite.
> 
> ![Screenshot_2023-03-03_12-24-12](https://user-images.githubusercontent.com/334786/222719614-79b9ead5-1a2d-41e9-b51a-23f4243d0880.png)
> 

@fredden wrote:
> Using the following test code on https://onlinephp.io/
> 
> ```php
> <?php
> 
> function readonly() {
> 	print "yes\n";
> }
> 
> readonly();
> readonly ();
> readonly /* comment */ ();
> ```
> 
> I get expected results on PHP versions `8.2.3`, `8.0.28`, `7.4.33`, `7.3.33`, `7.2.34`, `7.1.33`, `7.0.33`, `5.6.40`, `5.5.38`, `5.4.45`, `5.3.29`, `5.2.17`, `5.1.6`, `5.0.5`, `4.4.9`, `4.3.11`, `4.2.3`, `4.1.2`, `4.0.6`
> 
> However, all versions of PHP 8.1.x produce a parse error on the last line with this code sample.
> 
> Do we need to add any special handling for PHP 8.1.x to this `readonly` detection?

@fredden wrote:
> @jrfnl as far as I know, this change should make all the automated tests pass. I expect that may help with the triage process for other pull requests. I don't know where this pull request fits in the list of what to review. I'm highlighting this to hopefully help, but please feel free to ignore this comment.

@jrfnl wrote:
> @fredden and me looked at this PR in detail together and this needs more work.
> 
> Findings:
> * The current fix will break on PHP 8.2 DNF.
> * More tests needs to be added.
> 
> Basically, we need to make sure that all tests which are included in this PHP Core commit are also included in the PHPCS Tokenizer `BackfillReadonlyTest` file and that those tests pass correctly: https://github.com/php/php-src/commit/08b75395838b4b42a41e3c70684fa6c6b113eee0
> 
> Also, in the original implementation of the backfill, the situation where a comment would be between the `readonly` and the `(` for function declarations/calls was not taken into account.
> This is not handled in PHP Core, however, the PHPCS token stream should still be consistent for this as it will otherwise break sniffs which specifically look for the `T_READONLY` token.
> 
> As for DNF: that doesn't need to be handled in this PR, but at the very least, the `readonly` keyword tokenization should not _break_ on it, while it currently would.
> 
> Related: in https://github.com/squizlabs/PHP_CodeSniffer/pull/3667 there are some comments/analysis about the change in the `readonly` tokenization in PHP Core and how it relates to DNF.
> 
> I look forward to a next iteration on this PR.

@jrfnl wrote:
> For reference - these are some older PRs related to the tokenization backfill for `readonly`:
> * https://github.com/squizlabs/PHP_CodeSniffer/pull/3480
> * https://github.com/squizlabs/PHP_CodeSniffer/pull/3507
> * https://github.com/squizlabs/PHP_CodeSniffer/pull/3584
> * And loosely related: https://github.com/squizlabs/PHP_CodeSniffer/pull/3484