### PR TITLE
4.0 | File::isReference(): simplify code

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2061,6 +2061,7 @@ class File
                 if ($owner['code'] === T_FUNCTION
                     || $owner['code'] === T_CLOSURE
                     || $owner['code'] === T_FN
+                    || $owner['code'] === T_USE
                 ) {
                     $params = $this->getMethodParameters($this->tokens[$lastBracket]['parenthesis_owner']);
                     foreach ($params as $param) {
@@ -2070,19 +2071,6 @@ class File
                         }
                     }
                 }//end if
-            } else {
-                $prev = false;
-                for ($t = ($this->tokens[$lastBracket]['parenthesis_opener'] - 1); $t >= 0; $t--) {
-                    if ($this->tokens[$t]['code'] !== T_WHITESPACE) {
-                        $prev = $t;
-                        break;
-                    }
-                }
-
-                if ($prev !== false && $this->tokens[$prev]['code'] === T_USE) {
-                    // Closure use by reference.
-                    return true;
-                }
             }//end if
         }//end if
 


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3338:


> Commit 08824f327ce5e20d7528c5e838dd7fade3dcd11c added support for `T_USE` tokens for closures being parentheses owners and PR squizlabs/PHP_CodeSniffer#3104 fixed this up for non-closure use.
> 
> As the `File::getMethodParameters()` method also supports closure `use` parameters already, the code in the `File::isReference()` method can now be simplified.
> 
> The existing unit tests already cover this.

## Suggested changelog entry
_N/A_

