### PR TITLE
Generic/IncrementDecrementSpacing: handle more situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The file documents changes to the PHP_CodeSniffer project.
 - Generic.PHP.RequireStrictTypes has a new warning for when there is a declare statement, but the strict_types directive is set to 0
     - The warning can be turned off by excluding the Generic.PHP.RequireStrictTypes.Disabled error code
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
+- Generic.WhiteSpace.IncrementDecrementSpacing now detects more spacing issues
+    - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - PSR2.Classes.PropertyDeclaration now enforces that the readonly modifier comes after the visibility modifier
     - PSR2 and PSR12 do not have documented rules for this as they pre-date the readonly modifier
     - PSR-PER has been used to confirm the order of this keyword so it can be applied to PSR2 and PSR12 correctly

--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -63,7 +63,8 @@ class IncrementDecrementSpacingSniff implements Sniff
         // Is this a pre-increment/decrement ?
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty !== false
-            && (($phpcsFile->tokenizerType === 'PHP' && $tokens[$nextNonEmpty]['code'] === T_VARIABLE)
+            && (($phpcsFile->tokenizerType === 'PHP'
+            && ($tokens[$nextNonEmpty]['code'] === T_VARIABLE || $tokens[$nextNonEmpty]['code'] === T_STRING))
             || ($phpcsFile->tokenizerType === 'JS' && $tokens[$nextNonEmpty]['code'] === T_STRING))
         ) {
             if ($nextNonEmpty === ($stackPtr + 1)) {
@@ -116,7 +117,10 @@ class IncrementDecrementSpacingSniff implements Sniff
         // Is this a post-increment/decrement ?
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty !== false
-            && (($phpcsFile->tokenizerType === 'PHP' && $tokens[$prevNonEmpty]['code'] === T_VARIABLE)
+            && (($phpcsFile->tokenizerType === 'PHP'
+            && ($tokens[$prevNonEmpty]['code'] === T_VARIABLE
+            || $tokens[$prevNonEmpty]['code'] === T_STRING
+            || $tokens[$prevNonEmpty]['code'] === T_CLOSE_SQUARE_BRACKET))
             || ($phpcsFile->tokenizerType === 'JS' && $tokens[$prevNonEmpty]['code'] === T_STRING))
         ) {
             if ($prevNonEmpty === ($stackPtr - 1)) {

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
@@ -15,3 +15,23 @@ $i /*comment*/ --;
 $i++;
 $i ++;
 $i /*comment*/ ++;
+
+// Handle properties and array access too.
+$i['key']++;
+$i['key'] ++;
+$i['key']['id']++;
+$i['key']['id'] ++;
+
+$obj->prop++;
+$obj->prop ++;
+$obj?->prop ++;
+
+$obj->obj->prop++;
+$obj->obj->prop ++;
+$obj?->obj->prop ++;
+
+$obj->prop['key']++;
+$obj->prop['key'] ++;
+
+--ClassName::$prop;
+-- ClassName::$prop;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
@@ -14,3 +14,23 @@ $i /*comment*/ --;
 $i++;
 $i++;
 $i /*comment*/ ++;
+
+// Handle properties and array access too.
+$i['key']++;
+$i['key']++;
+$i['key']['id']++;
+$i['key']['id']++;
+
+$obj->prop++;
+$obj->prop++;
+$obj?->prop++;
+
+$obj->obj->prop++;
+$obj->obj->prop++;
+$obj?->obj->prop++;
+
+$obj->prop['key']++;
+$obj->prop['key']++;
+
+--ClassName::$prop;
+--ClassName::$prop;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -27,19 +27,32 @@ class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
      */
     public function getErrorList($testFile='IncrementDecrementSpacingUnitTest.inc')
     {
+        $errors = [
+            5  => 1,
+            6  => 1,
+            8  => 1,
+            10 => 1,
+            13 => 1,
+            14 => 1,
+            16 => 1,
+            17 => 1,
+        ];
+
         switch ($testFile) {
         case 'IncrementDecrementSpacingUnitTest.inc':
+            $errors[21] = 1;
+            $errors[23] = 1;
+            $errors[26] = 1;
+            $errors[27] = 1;
+            $errors[30] = 1;
+            $errors[31] = 1;
+            $errors[34] = 1;
+            $errors[37] = 1;
+
+            return $errors;
+
         case 'IncrementDecrementSpacingUnitTest.js':
-            return [
-                5  => 1,
-                6  => 1,
-                8  => 1,
-                10 => 1,
-                13 => 1,
-                14 => 1,
-                16 => 1,
-                17 => 1,
-            ];
+            return $errors;
 
         default:
             return [];


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3626:

> The `Generic.WhiteSpace.IncrementDecrementSpacing` sniff, so far, only handled incrementors/decrementors when they were directly before/after the variable they apply to.
> 
> This commit enhances the sniff to also allow for finding superfluous whitespace when incrementing/decrementing a property or an array item.
> 
> Includes unit tests.
> 
> Note: I've only made this change for PHP files as JS support will be dropped anyway, so it didn't feel like a good use of my time to work on that.


## Suggested changelog entry
Generic/IncrementDecrementSpacing: detect spacing issues for more complex variables


---

From the conversation in the original issue:

> For pre-increment, I can think of a further/future iteration for the sniff - checking whether a pre-increment is used on a static property with a fully qualified classname or namespace relative classname, but that is something I choose not to handle (yet) when I made this change last year. When that change would be added, then, yes, extra tests would be needed for pre-in/decrement.
> ```php
> ++\ClassName::$prop;
> ++Relative\ClassName::$prop;
> --namespace\Relative\ClassName::$prop;
> ```
> 
> The reason I did not make that change (yet) is that this would need a different patch for PHPCS 3.x vs PHPCS 4.x, which would make the merge more complex. Also see squizlabs/PHP_CodeSniffer#3041.