### PR TITLE
Generic/Todo-Fixme sniffs: improve handling of docblock tags and efficiency fix

### DIFF
--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -35,7 +35,12 @@ class FixmeSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -12,7 +12,6 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 class FixmeSniff implements Sniff
 {
@@ -56,26 +55,43 @@ class FixmeSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
+        $tokens  = $phpcsFile->getTokens();
         $content = $tokens[$stackPtr]['content'];
         $matches = [];
-        preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches);
-        if (empty($matches) === false) {
-            // Clear whitespace and some common characters not required at
-            // the end of a fixme message to make the error more informative.
-            $type         = 'CommentFound';
-            $fixmeMessage = trim($matches[1]);
-            $fixmeMessage = trim($fixmeMessage, '-:[](). ');
-            $error        = 'Comment refers to a FIXME task';
-            $data         = [$fixmeMessage];
-            if ($fixmeMessage !== '') {
-                $type   = 'TaskFound';
-                $error .= ' "%s"';
-            }
 
-            $phpcsFile->addError($error, $stackPtr, $type, $data);
+        if (preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 1) {
+            return;
         }
+
+        // Clear whitespace and some common characters not required at
+        // the end of a to-do message to make the warning more informative.
+        $fixmeMessage = trim($matches[1]);
+        $fixmeMessage = trim($fixmeMessage, '-:[](). ');
+
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG
+            && $fixmeMessage === ''
+        ) {
+            $nextNonEmpty = $phpcsFile->findNext(T_DOC_COMMENT_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty !== false
+                && $tokens[$nextNonEmpty]['code'] === T_DOC_COMMENT_STRING
+            ) {
+                $fixmeMessage = trim($tokens[$nextNonEmpty]['content'], '-:[](). ');
+            }
+        }
+
+        $error = 'Comment refers to a FIXME task';
+        $type  = 'CommentFound';
+        $data  = [$fixmeMessage];
+        if ($fixmeMessage !== '') {
+            $error .= ' "%s"';
+            $type   = 'TaskFound';
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
+            $type .= 'InDocblock';
+        }
+
+        $phpcsFile->addError($error, $stackPtr, $type, $data);
 
     }//end process()
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -34,7 +34,12 @@ class TodoSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -11,7 +11,6 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 class TodoSniff implements Sniff
 {
@@ -55,26 +54,43 @@ class TodoSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
+        $tokens  = $phpcsFile->getTokens();
         $content = $tokens[$stackPtr]['content'];
         $matches = [];
-        preg_match('/(?:\A|[^\p{L}]+)todo([^\p{L}]+(.*)|\Z)/ui', $content, $matches);
-        if (empty($matches) === false) {
-            // Clear whitespace and some common characters not required at
-            // the end of a to-do message to make the warning more informative.
-            $type        = 'CommentFound';
-            $todoMessage = trim($matches[1]);
-            $todoMessage = trim($todoMessage, '-:[](). ');
-            $error       = 'Comment refers to a TODO task';
-            $data        = [$todoMessage];
-            if ($todoMessage !== '') {
-                $type   = 'TaskFound';
-                $error .= ' "%s"';
-            }
 
-            $phpcsFile->addWarning($error, $stackPtr, $type, $data);
+        if (preg_match('/(?:\A|[^\p{L}]+)todo([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 1) {
+            return;
         }
+
+        // Clear whitespace and some common characters not required at
+        // the end of a to-do message to make the warning more informative.
+        $todoMessage = trim($matches[1]);
+        $todoMessage = trim($todoMessage, '-:[](). ');
+
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG
+            && $todoMessage === ''
+        ) {
+            $nextNonEmpty = $phpcsFile->findNext(T_DOC_COMMENT_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty !== false
+                && $tokens[$nextNonEmpty]['code'] === T_DOC_COMMENT_STRING
+            ) {
+                $todoMessage = trim($tokens[$nextNonEmpty]['content'], '-:[](). ');
+            }
+        }
+
+        $error = 'Comment refers to a TODO task';
+        $type  = 'CommentFound';
+        $data  = [$todoMessage];
+        if ($todoMessage !== '') {
+            $error .= ' "%s"';
+            $type   = 'TaskFound';
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
+            $type .= 'InDocblock';
+        }
+
+        $phpcsFile->addWarning($error, $stackPtr, $type, $data);
 
     }//end process()
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.inc
@@ -21,3 +21,17 @@ Debug::bam('test');
 //FIXME.
 //éfixme
 //fixmeé
+
+/**
+ * While there is no official "fix me" tag, only `@todo`, let's support a tag for the purpose of this sniff anyway.
+ *
+ * @fixme This message should be picked up.
+ * @fixme: This message should be picked up too.
+ * @fixme - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @fixme
+ * @anothertag
+ *
+ * @param string $something FIXME: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.js
@@ -21,3 +21,17 @@ alert('test');
 //FIXME.
 //éfixme
 //fixmeé
+
+/**
+ * While there is no official "fix me" tag, only `@todo`, let's support a tag for the purpose of this sniff anyway.
+ *
+ * @fixme This message should be picked up.
+ * @fixme: This message should be picked up too.
+ * @fixme - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @fixme
+ * @anothertag
+ *
+ * @param string $something FIXME: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -40,6 +40,11 @@ class FixmeUnitTest extends AbstractSniffUnitTest
             16 => 1,
             18 => 1,
             21 => 1,
+            28 => 1,
+            29 => 1,
+            30 => 1,
+            33 => 1,
+            36 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
@@ -21,3 +21,15 @@ Debug::bam('test');
 //TODO.
 //étodo
 //todoé
+
+/**
+ * @todo This message should be picked up.
+ * @todo: This message should be picked up too.
+ * @todo - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @todo
+ * @anothertag
+ *
+ * @param string $something TODO: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.js
@@ -21,3 +21,15 @@ alert('test');
 //TODO.
 //étodo
 //todoé
+
+/**
+ * @todo This message should be picked up.
+ * @todo: This message should be picked up too.
+ * @todo - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @todo
+ * @anothertag
+ *
+ * @param string $something TODO: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -54,6 +54,11 @@ class TodoUnitTest extends AbstractSniffUnitTest
             16 => 1,
             18 => 1,
             21 => 1,
+            26 => 1,
+            27 => 1,
+            28 => 1,
+            31 => 1,
+            34 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3771:


> ### Generic/Todo-Fixme: make the sniffs more selective
> 
> The sniffs as-they-were, would sniff all comment related tokens, including `T_DOC_COMMENT_STAR`, `T_DOC_COMMENT_WHITESPACE` etc.
> 
> Sniffing those tokens is redundant and makes the sniffs slower than is needed.
> 
> Fixed now by making the tokens being registered by the sniffs more selective/targeted.
> 
> ### Generic/Todo: improve handling of "todo" tags in docblocks
> 
> Until now, the sniff would only examine an individual comment token, while when a `@todo` tag is used in a docblock, the "task description" is normally in the next `T_DOC_COMMENT_STRING` token.
> 
> This commit fixes this and the sniff will now take docblock `@todo` tags into account.
> 
> Includes additional unit tests.
> 
> ### Generic/Fixme: improve handling of "fixme" tags in docblocks
> 
> Essentially the same fix as applied in the sister-commit for the `Generic.Commenting.Todo` sniff.
> 
> Until now, the sniff would only examine an individual comment token, while when a `@fixme` tag is used in a docblock, the "task description" is normally in the next `T_DOC_COMMENT_STRING` token.
> 
> This commit fixes this and the sniff will now take docblock `@fixme` tags into account.
> 
> Includes additional unit tests.
> 
> Fixes squizlabs/PHP_CodeSniffer#3769 (well, aside from tags without a description, but that can't be helped)

## Suggested changelog entry
* Generic/Todo-Fixme: performance improvement
* Generic/Todo: improved handling of "todo" and "fixme" tags in docblocks