### PR TITLE
PSR1/SideEffects: improve recognition of disable/enable annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Use composer or the phar files
 
 ### Fixed
+- Fixed bug #3386 : PSR1/SideEffects : improved recognition of disable/enable annotations
+    - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Fixed bug #3557 : Squiz.Arrays.ArrayDeclaration will now ignore PHP 7.4 array unpacking when determining whether an array is associative
     - Thanks to Volker Dusch (@edorian) for the patch
 - Fixed bug #3717 : Squiz.Commenting.FunctionComment: fixed false positive for InvalidNoReturn when type is never

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -103,7 +103,8 @@ class SideEffectsSniff implements Sniff
                 && (empty($tokens[$i]['sniffCodes']) === true
                 || isset($tokens[$i]['sniffCodes']['PSR1']) === true
                 || isset($tokens[$i]['sniffCodes']['PSR1.Files']) === true
-                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === true)
+                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === true
+                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects.FoundWithSymbols']) === true)
             ) {
                 do {
                     $i = $phpcsFile->findNext(T_PHPCS_ENABLE, ($i + 1));
@@ -111,7 +112,8 @@ class SideEffectsSniff implements Sniff
                     && empty($tokens[$i]['sniffCodes']) === false
                     && isset($tokens[$i]['sniffCodes']['PSR1']) === false
                     && isset($tokens[$i]['sniffCodes']['PSR1.Files']) === false
-                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === false);
+                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === false
+                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects.FoundWithSymbols']) === false);
 
                 if ($i === false) {
                     // The entire rest of the file is disabled,

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.17.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.17.inc
@@ -1,0 +1,8 @@
+<?php
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+define("MAXSIZE", 100);
+// phpcs:enable
+$defined = true;
+if (defined('MINSIZE') === false) {
+    $defined = false;
+}


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3772:

> As it was, the sniff would respect PHPCS disable annotations, but only when either unqualified or qualified up to a sniff name. It would not respect a disable annotation using a sniffname with errorcode, i.e. `PSR1.Files.SideEffects.FoundWithSymbols`.
> 
> While the `FoundWithSymbols` errorcode is the only error code for this sniff and using `// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols` is effectively the same as using `// phpcs:disable PSR1.Files.SideEffects`, I do believe end-users should not need to be aware of whether or not a sniff has multiple error codes when using disable annotations.
> 
> This updates the sniff to also respect disable annotations which include the error code.
> 
> Includes unit test.
> 
> Fixes squizlabs/PHP_CodeSniffer#3386



## Suggested changelog entry
PSR1/SideEffects: improved recognition of disable/enable annotations

