### PR TITLE
Generic/LowerCaseType: fix potential PHP notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Thanks to Dan Wallis (@fredden) for the patch
 - Fixed bug #3816 : PSR12/FileHeader: bug fix - false positives on PHP 8.2+ readonly classes
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
+- Fixed bug #3833 : Generic.PHP.LowerCaseType: fixed potential undefined array index notice
+    - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Fixed bug #3854 : Fatal error when using Gitblame report in combination with `--basepath` and running from project subdirectory
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Fixed bug #3867 : Tokenizer/PHP: union type and intersection type operators were not correctly tokenized for static properties without explicit visibility

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -98,6 +98,11 @@ class LowerCaseTypeSniff implements Sniff
                 return;
             }
 
+            if (empty($props) === true) {
+                // Parse error - property in interface or enum. Ignore.
+                return;
+            }
+
             // Strip off potential nullable indication.
             $type = ltrim($props['type'], '?');
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -93,4 +93,9 @@ function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
 $arrow = fn (Int $a, String $b, BOOL $c, Array $d, Foo\Bar $e) : Float => $a * $b;
 
-$cl = function (False $a, TRUE $b, Null $c): ?True {}
+$cl = function (False $a, TRUE $b, Null $c): ?True {};
+
+// Intentional error, should be ignored by the sniff.
+interface PropertiesNotAllowed {
+    public $notAllowed;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -93,4 +93,9 @@ function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : float => $a * $b;
 
-$cl = function (false $a, true $b, null $c): ?true {}
+$cl = function (false $a, true $b, null $c): ?true {};
+
+// Intentional error, should be ignored by the sniff.
+interface PropertiesNotAllowed {
+    public $notAllowed;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -83,7 +83,8 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [];
+        // Warning from getMemberProperties() about parse error.
+        return [100 => 1];
 
     }//end getWarningList()
 


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3833:

> The `Generic.PHP.LowerCaseType` sniff calls the `File::getMemberProperties()` method to get information about potential properties.
> 
> That method throws an exception when the `T_VARIABLE` token passed is not a property, but will create an `Internal.ParseError.InterfaceHasMemberVar` warning and return an empty array when the `T_VARIABLE` passed is an _illegal_ property, i.e. a property in a context in which it is not allowed (interface/enum).
> 
> As things were, the sniff did not take a potential return value of an empty array into account, which could result in an `Undefined array key "type"` PHP notice.
> 
> Fixed now.
> 
> Includes unit test.


---

Other relevant notes from the original PR:

> This PR will conflict with PR squizlabs/PHP_CodeSniffer#3662 and either one of them will need rebasing if the other gets merged first.

👆🏻 That is PR #49 in this repo


## Suggested changelog entry
Generic.PHP.LowerCaseType: fixed potential undefined array index notice
