### PR TITLE
Generic/LowerCaseType: improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Runtime performance improvement for PHPCS CLI users. The improvement should be most noticeable for users on Windows.
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
+- The following sniffs have received performance related improvements:
+    - Generic.PHP.LowerCaseType
 - The -e (explain) command will now list sniffs in natural order
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Tests using the PHPCS native test framework with multiple test case files will now run the test case files in numeric order.

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -51,10 +51,10 @@ class LowerCaseTypeSniff implements Sniff
     public function register()
     {
         $tokens   = Tokens::$castTokens;
+        $tokens  += Tokens::$ooScopeTokens;
         $tokens[] = T_FUNCTION;
         $tokens[] = T_CLOSURE;
         $tokens[] = T_FN;
-        $tokens[] = T_VARIABLE;
         return $tokens;
 
     }//end register()
@@ -90,40 +90,66 @@ class LowerCaseTypeSniff implements Sniff
          * Check property types.
          */
 
-        if ($tokens[$stackPtr]['code'] === T_VARIABLE) {
-            try {
-                $props = $phpcsFile->getMemberProperties($stackPtr);
-            } catch (RuntimeException $e) {
-                // Not an OO property.
+        if (isset(Tokens::$ooScopeTokens[$tokens[$stackPtr]['code']]) === true) {
+            if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
                 return;
             }
 
-            if (empty($props) === true) {
-                // Parse error - property in interface or enum. Ignore.
-                return;
-            }
-
-            // Strip off potential nullable indication.
-            $type = ltrim($props['type'], '?');
-
-            if ($type !== '') {
-                $error     = 'PHP property type declarations must be lowercase; expected "%s" but found "%s"';
-                $errorCode = 'PropertyTypeFound';
-
-                if ($props['type_token'] === T_TYPE_INTERSECTION) {
-                    // Intersection types don't support simple types.
-                } else if (strpos($type, '|') !== false) {
-                    $this->processUnionType(
-                        $phpcsFile,
-                        $props['type_token'],
-                        $props['type_end_token'],
-                        $error,
-                        $errorCode
-                    );
-                } else if (isset($this->phpTypes[strtolower($type)]) === true) {
-                    $this->processType($phpcsFile, $props['type_token'], $type, $error, $errorCode);
+            for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $tokens[$stackPtr]['scope_closer']; $i++) {
+                // Skip over potentially large docblocks.
+                if ($tokens[$i]['code'] === \T_DOC_COMMENT_OPEN_TAG
+                    && isset($tokens[$i]['comment_closer']) === true
+                ) {
+                    $i = $tokens[$i]['comment_closer'];
+                    continue;
                 }
-            }
+
+                // Skip over function declarations and everything nested within.
+                if ($tokens[$i]['code'] === \T_FUNCTION
+                    && isset($tokens[$i]['scope_closer']) === true
+                ) {
+                    $i = $tokens[$i]['scope_closer'];
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] !== \T_VARIABLE) {
+                    continue;
+                }
+
+                try {
+                    $props = $phpcsFile->getMemberProperties($i);
+                } catch (RuntimeException $e) {
+                    // Not an OO property.
+                    continue;
+                }
+
+                if (empty($props) === true) {
+                    // Parse error - property in interface or enum. Ignore.
+                    return;
+                }
+
+                // Strip off potential nullable indication.
+                $type = ltrim($props['type'], '?');
+
+                if ($type !== '') {
+                    $error     = 'PHP property type declarations must be lowercase; expected "%s" but found "%s"';
+                    $errorCode = 'PropertyTypeFound';
+
+                    if ($props['type_token'] === T_TYPE_INTERSECTION) {
+                        // Intersection types don't support simple types.
+                    } else if (strpos($type, '|') !== false) {
+                        $this->processUnionType(
+                            $phpcsFile,
+                            $props['type_token'],
+                            $props['type_end_token'],
+                            $error,
+                            $errorCode
+                        );
+                    } else if (isset($this->phpTypes[strtolower($type)]) === true) {
+                        $this->processType($phpcsFile, $props['type_token'], $type, $error, $errorCode);
+                    }
+                }
+            }//end for
 
             return;
         }//end if


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3839:

> Someone reported a performance issue with the `Generic.PHP.LowerCaseType` sniff to me.
> 
> Running the Performance report (PR squizlabs/PHP_CodeSniffer#3810/PR #60) over a number of codebases, confirmed that the sniff ranked in the top 10 of "slow" sniffs.
> 
> As it was, the sniff would examine all variables it comes across and disregard them if they are not properties or not typed. The "disregard when not a property" was done by catching an exception thrown by the `File::getMemberProperties()` method.
> 
> As the majority of `T_VARIABLE` tokens in the average file are not property declarations, the `File::getMemberProperties()` method would be triggered lots and lots of times, with the majority of those times resulting in the need for creating and then catching and throwing away the above mentioned exception.
> 
> By changing the logic for the sniff to only look within OO constructs and skip over anything non-property, thus avoiding the unnecessary exception creation, I can see a significant difference in the sniff run time.
> 
> Using the test file which was originally shared with me and running the below command on PHP 7.4:
> ```bash
> phpcs -ps db.php --standard=Generic --report=source -vvv --sniffs=Generic.PHP.LowercaseType
> ```
> 
> ... yielded the following difference in runtime:
> 
> Base time:
> ```
>         *** START SNIFF PROCESSING REPORT ***
>         PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseTypeSniff: 0.3802 secs
>         *** END SNIFF PROCESSING REPORT ***
> ```
> 
> Time with the performance tweak included in this PR:
> ```
>         *** START SNIFF PROCESSING REPORT ***
>         PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseTypeSniff: 0.0113 secs
>         *** END SNIFF PROCESSING REPORT ***
> ```
> 
> Using the performance report to benchmark the improvement with a larger number of files, I see improvement across the board as well:
> 
> Command used: `phpcs -ps . --extensions=php --ignore=/vendor/ --report=performance --standard=psr12`
> 
> Output for the `Generic.PHP.LowercaseType` sniff:
> 
> Result | PHPCS itself       | Set of Projects A  | Set of Projects B  | Set of Projects C |
> ------ | ------------------ | ------------------ | ------------------ | ----------------- |
> Nr of Files Scanned | 614   | 4115               | 25546              | 2250              |
> Before | 0.131587 (  3.9 %) | 1.514729 (  3.0 %) | 5.390167 (  3.4 %) | 0.359674 (  4.2 %)
> After  | 0.029166 (  0.9 %) | 0.449517 (  0.9 %) | 1.917077 (  1.2 %) | 0.181097 (  2.2 %)
> 
> ---
> 
> I've also had a quick look at all other PHPCS native sniffs using the `File::getMemberProperties()` method. As those are all based on the `AbstractVariableSniff`, they don't seem to suffer from the same issue, or at least, nowhere near as badly.
> 
> I also considered changing the setup of the sniff to start using the `AbstractVariableSniff`, but considering this particular sniff is also examining functions and type casts, I believe that would make the sniff more complex than necessary.

---

Other useful info from the original PR:

> This PR will likely conflict with PR squizlabs/PHP_CodeSniffer#3662 and/or squizlabs/PHP_CodeSniffer#3833 and either one of those PRs may need rebasing if one of others gets merged first.

👆🏻 This translated to PRs #49 and #62 in this repo.


## Suggested changelog entry
Generic.PHP.LowercaseType: improved time-to-result for the sniff
