### PR TITLE
PSR12/OpenTag: improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - The following sniffs have received performance related improvements:
     - Generic.PHP.LowerCaseType
+    - PSR12.Files.OpenTag
+    - Thanks to Juliette Reinders Folmer (@jrfnl) for the patches
 - The -e (explain) command will now list sniffs in natural order
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Tests using the PHPCS native test framework with multiple test case files will now run the test case files in numeric order.

--- a/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
@@ -44,12 +44,6 @@ class OpenTagSniff implements Sniff
             return $phpcsFile->numTokens;
         }
 
-        $next = $phpcsFile->findNext(T_INLINE_HTML, 0);
-        if ($next !== false) {
-            // This rule only applies to PHP-only files.
-            return $phpcsFile->numTokens;
-        }
-
         $tokens = $phpcsFile->getTokens();
         $next   = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($next === false) {
@@ -57,12 +51,21 @@ class OpenTagSniff implements Sniff
             return $phpcsFile->numTokens;
         }
 
-        if ($tokens[$next]['line'] === $tokens[$stackPtr]['line']) {
-            $error = 'Opening PHP tag must be on a line by itself';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotAlone');
-            if ($fix === true) {
-                $phpcsFile->fixer->addNewline($stackPtr);
-            }
+        if ($tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
+            // Tag is on a line by itself.
+            return $phpcsFile->numTokens;
+        }
+
+        $next = $phpcsFile->findNext(T_INLINE_HTML, 0);
+        if ($next !== false) {
+            // This rule only applies to PHP-only files.
+            return $phpcsFile->numTokens;
+        }
+
+        $error = 'Opening PHP tag must be on a line by itself';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotAlone');
+        if ($fix === true) {
+            $phpcsFile->fixer->addNewline($stackPtr);
         }
 
         return $phpcsFile->numTokens;


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3840:

> No functional changes at all, just improving performance of the sniff by changing the order of certain checks.
> 
> Some benchmarks for this change run using the Performance report (PR squizlabs/PHP_CodeSniffer#3810/PR #60):
> 
> Command: `phpcs -ps . --extensions=php --ignore=/vendor/ --report=performance --standard=psr12`
> 
> Output for the `PSR12.Files.OpenTag` sniff:
> 
> Result | PHPCS itself       | Set of Projects A  | Set of Projects B  | Set of Projects C |
> ------ | ------------------ | ------------------ | ------------------ | ----------------- |
> Nr of Files Scanned | 614   | 4115               | 25546              | 2250              |
> Before | 0.077045 (  2.3 %) | 0.982014 (  1.9 %) | 3.267655 (  2.1 %) | 0.179564 (  2.1 %)
> After  | 0.000928 (  0.0 %) | 0.013066 (  0.0 %) | 0.091816 (  0.1 %) | 0.109021 (  1.3 %)
> 
> With what the sniff does, the impact is biggest for files/codebases which already comply with the expectations of this sniff.



## Suggested changelog entry
PSR12.Files.OpenTag: improved time-to-result for the sniff
