### PR TITLE
GH Actions/label new PRs: tweak the conditions a little

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,9 +75,18 @@ labels:
   files:
   - "src/Standards/Zend/.*"
 
+- label: "Type: breaking change"
+  draft: False
+  body: "x\] Breaking change"
 - label: "Type: bug"
   draft: False
-  body: ".* bug .*"
+  body: "x\] Bug fix"
+- label: "Type: enhancement"
+  draft: False
+  body: "x\] New feature"
+- label: "Type: documentation"
+  draft: False
+  body: "x\] Documentation improvement"
 - label: "Type: documentation"
   draft: False
   files:


### PR DESCRIPTION
## Description

Tweak the labelling conditions a little to prevent running into a bug which I've reported to the action runner: srvaroa/labeler#104

The default pull request template contain a categorization section anyway (which is not typically used for maintainer PRs), so let's use that section to auto-label the "Type" for new PRs.

