### PR TITLE
GH Actions: add Yamllint to `validate` workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ scripts/          export-ignore
 .cspell.json      export-ignore
 .gitattributes    export-ignore
 .gitignore        export-ignore
+.yamllint.yml     export-ignore
 phpcs.xml.dist    export-ignore
 phpstan.neon.dist export-ignore
 phpunit.xml.dist  export-ignore

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,3 +63,18 @@ jobs:
           diff -B ./src/Standards/PSR12/ruleset.xml <(xmllint --format "./src/Standards/PSR12/ruleset.xml")
           diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml")
           diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml")
+
+  yamllint:
+    name: 'Lint Yaml'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Yamllint on all yaml files in repo
+        run: yamllint . --format colored --strict
+
+      - name: Pipe Yamllint results on to GH for inline display
+        if: ${{ failure() }}
+        run: yamllint . --format github --strict

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,23 @@
+# Details on the default config:
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+  - 'phpstan.neon'
+
+# Rule documentation: https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  colons:
+    max-spaces-after: -1  # Disabled to allow aligning of values.
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: {}
+  document-start:
+    present: false
+  line-length:
+    max: 150
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]


### PR DESCRIPTION
## Description
Add Yamllint to Validate workflow to loosely safeguard valid and consistent yaml files and prevent issues like seen in PR #68.

Includes adding a configuration file which loosens up the `default` ruleset to a degree I'm comfortable with.

Ref: https://yamllint.readthedocs.io/

## Suggested changelog entry
_N/A_
