### PR TITLE
PSR2/PSR12/ControlStructureSpacing: don't listen for `T_ELSE`

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -38,7 +38,6 @@ class ControlStructureSpacingSniff implements Sniff
             T_FOREACH,
             T_FOR,
             T_SWITCH,
-            T_ELSE,
             T_ELSEIF,
             T_CATCH,
             T_MATCH,

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -44,7 +44,6 @@ class ControlStructureSpacingSniff implements Sniff
             T_FOREACH,
             T_FOR,
             T_SWITCH,
-            T_ELSE,
             T_ELSEIF,
             T_CATCH,
             T_MATCH,


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3872:

> No functional changes.
> 
> These sniffs only concerns themselves with control structures which take parentheses, so listening for `T_ELSE` is unnecessary as the sniffs will never do anything for that token (they each bow out on no 'parenthesis_opener'/'parenthesis_closer' found).


## Suggested changelog entry
_N/A_


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
