### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Actions:"
+    labels:
+      - "Type: chores/QA"


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3887:

> This commit adds an initial Dependabot configuration to:
> * Submit pull requests for security updates and version updates for GH Action runner dependencies.
> 
> At a later point in time, we could consider enabling it for Composer dependencies as well.
> 
> The configuration has been set up to:
> * Run weekly (for now).
> * Submit a maximum of 5 pull requests at a time. If additional pull requests are needed, these will subsequently be submitted the next time Dependabot runs after one or more of the open pull requests have been merged.
> * The commit messages for PRs submitted by Dependabot will be prefixed according the unofficial conventions used in this repo up to now.
> * The PRs will automatically be labelled with an appropriate label as already in use in this repo.
> 
> Refs:
> * https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
> * https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

## Suggested changelog entry
_N/A_