### PR TITLE
GH Actions: safeguard the PR label workflow some more

### DIFF
--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -2,16 +2,48 @@ name: Label new PRs
 
 on:
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  # The `pull_request_target` event is used for "normal" PRs to label them when they are opened.
+  # This will use the `labeler.yml` file in the default (master) branch of the repo.
   pull_request_target:
     types:
       - opened
       - ready_for_review
 
+  # The `pull_request` event is used for PRs which change the files which handle the labeling to prevent a silently failing action.
+  # This will use the `labeler.yml` file in the PR branch.
+  pull_request:
+    paths:
+      - '.github/workflows/label-new-prs.yml'
+      - '.github/labeler.yml'
+
 jobs:
   label-new-prs:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request_target'
+
+    name: Add labels to new PRs
 
     steps:
-      - uses: srvaroa/labeler@master
+      - name: Label new PRs
+        uses: srvaroa/labeler@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  validate-labeler-worflow:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request' && github.event.pull_request.merged == false
+
+    name: Validate changes to Labeler logic
+
+    steps:
+      # Checkout is needed to use the `use_local_config` option.
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Verify changes to the labeling logic
+        uses: srvaroa/labeler@master
+        with:
+          use_local_config: true
+          fail_on_error: true
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
The `srvaroa/labeler` action runner will use the `labeler.yml` from the repo's default branch by default, which is good from a security perspective, but that means that PRs changing the `labeler.yml` file will not be tested until they have been merged and a _next_ PR is opened.

As the `srvaroa/labeler` action runner will silently fail, this also means that the labeling will stop working without any indication (other than labels no longer being added).

I'd like to prevent getting into that situation (again). The `yamllint` workflow I introduced earlier is already a big step in the right direction.

This commit introduces a second safeguard:
* It adds a second job to the workflow which will only run when the files relevant for the workflow are being changed in a PR.
* In that case, this second job will: - run with the PR-local version of the `labeler.yml` file; - run on **_all_** pull request events (except merge), not only when the PR is opened. - fail the workflow run if any errors are encountered.

This should make sure that this workflow is safeguarded properly and will continuing functioning as intended, even when changes are made to the logic.


## Suggested changelog entry
_N/A_


## Related issues/external references

* srvaroa/labeler#105

