### PR TITLE
Docs: variety of fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Improved README syntax highlighting
     - Thanks to Benjamin Loison (@Benjamin-Loison) for the patch
+- Various documentation improvements
+    - Thanks to Andrew Dawes (@AndrewDawes) and Juliette Reinders Folmer (@jrfnl) for the patches
 
 ### Removed
 - Removed support for installing via PEAR

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ use PHP_CodeSniffer\Util\Common;
  *                                     2: ruleset and file parsing output
  *                                     3: sniff execution output
  * @property bool     $interactive     Enable interactive checking mode.
- * @property bool     $parallel        Check files in parallel.
+ * @property int      $parallel        Check files in parallel.
  * @property bool     $cache           Enable the use of the file cache.
  * @property bool     $cacheFile       A file where the cache data should be written
  * @property bool     $colors          Display colours in output.

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -755,7 +755,7 @@ class File
 
 
     /**
-     * Records a warning against a specific token in the file.
+     * Records a warning against a specific line in the file.
      *
      * @param string $warning  The error message.
      * @param int    $line     The line on which the warning occurred.

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -199,7 +199,7 @@ class FileList implements \Iterator, \Countable
     /**
      * Return the file path of the current file being processed.
      *
-     * @return void
+     * @return string|null Path name or `null` when the end of the iterator has been reached.
      */
     #[ReturnTypeWillChange]
     public function key()

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -70,7 +70,7 @@ class Fixer
      * If a token is being "fixed" back to its last value, the fix is
      * probably conflicting with another.
      *
-     * @var array<int, string>
+     * @var array<int, array<string, mixed>>
      */
     private $oldTokenValues = [];
 
@@ -349,7 +349,7 @@ class Fixer
     /**
      * Start recording actions for a changeset.
      *
-     * @return void
+     * @return void|false
      */
     public function beginChangeset()
     {

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -28,7 +28,7 @@ class Hgblame extends VersionControl
      *
      * @param string $line Line to parse.
      *
-     * @return mixed string or false if impossible to recover.
+     * @return string|false String or FALSE if impossible to recover.
      */
     protected function getAuthor($line)
     {

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -45,7 +45,7 @@ class Info implements Report
 
 
     /**
-     * Prints the source of all errors and warnings.
+     * Prints the recorded metrics.
      *
      * @param string $cachedData    Any partial report data that was returned from
      *                              generateFileReport during the run.

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -154,7 +154,7 @@ class Notifysend implements Report
      * @param int      $totalErrors   Total number of errors found during the run.
      * @param int      $totalWarnings Total number of warnings found during the run.
      *
-     * @return string Error message or NULL if no error/warning found.
+     * @return string|null Error message or NULL if no error/warning found.
      */
     protected function generateMessage($checkedFiles, $totalErrors, $totalWarnings)
     {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -47,7 +47,7 @@ class Ruleset
      * The key is the regular expression and the value is the type
      * of ignore pattern (absolute or relative).
      *
-     * @var array<string, string>
+     * @var array<string, array>
      */
     public $ignorePatterns = [];
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -49,7 +49,7 @@ class Runner
     /**
      * Run the PHPCS script.
      *
-     * @return array
+     * @return int
      */
     public function runPHPCS()
     {
@@ -151,7 +151,7 @@ class Runner
     /**
      * Run the PHPCBF script.
      *
-     * @return array
+     * @return int
      */
     public function runPHPCBF()
     {
@@ -595,7 +595,7 @@ class Runner
      * @param string $file    The path of the file that raised the error.
      * @param int    $line    The line number the error was raised at.
      *
-     * @return void
+     * @return bool
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
     public function handleErrors($code, $message, $file, $line)

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -250,7 +250,7 @@ abstract class AbstractPatternSniff implements Sniff
      * @param int                         $stackPtr    The position in the tokens stack where
      *                                                 the listening token type was found.
      *
-     * @return array
+     * @return array|false
      */
     protected function processPattern($patternInfo, File $phpcsFile, $stackPtr)
     {
@@ -850,7 +850,7 @@ abstract class AbstractPatternSniff implements Sniff
      * Creates a skip pattern.
      *
      * @param string $pattern The pattern being parsed.
-     * @param string $from    The token content that the skip pattern starts from.
+     * @param int    $from    The token position that the skip pattern starts from.
      *
      * @return array The pattern step.
      * @see    createTokenPattern()

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -42,7 +42,7 @@ abstract class AbstractScopeSniff implements Sniff
     /**
      * The type of scope opener tokens that this test wishes to listen to.
      *
-     * @var string
+     * @var array<int|string>
      */
     private $scopeTokens = [];
 

--- a/src/Standards/Generic/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -19,7 +19,7 @@ class DisallowShortArraySyntaxSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -100,8 +100,8 @@ class JumbledIncrementerSniff implements Sniff
     /**
      * Get all used variables in the incrementer part of a for statement.
      *
-     * @param array(integer=>array) $tokens Array with all code sniffer tokens.
-     * @param array(string=>mixed)  $token  Current for loop token
+     * @param array<int, array>    $tokens Array with all code sniffer tokens.
+     * @param array<string, mixed> $token  Current for loop token
      *
      * @return string[] List of all found incrementer variables.
      */

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -62,7 +62,7 @@ class InlineControlStructureSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -22,14 +22,14 @@ class ClosureLinterSniff implements Sniff
      *
      * All other error codes will show warnings.
      *
-     * @var integer
+     * @var array
      */
     public $errorCodes = [];
 
     /**
      * A list of error codes to ignore.
      *
-     * @var integer
+     * @var array
      */
     public $ignoreCodes = [];
 

--- a/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
@@ -48,7 +48,7 @@ class InlineHTMLSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return int|null
+     * @return int|void
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -34,7 +34,7 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return void
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -28,7 +28,7 @@ class DisallowAlternativePHPTagsSniff implements Sniff
     /**
      * The current PHP version.
      *
-     * @var integer
+     * @var integer|string|null
      */
     private $phpVersion = null;
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -46,7 +46,7 @@ class DisallowShortOpenTagSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -64,7 +64,7 @@ class LowerCaseConstantSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -48,7 +48,7 @@ class SyntaxSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -49,7 +49,7 @@ class GitMergeConflictSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -50,7 +50,7 @@ class SubversionPropertiesSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -113,7 +113,7 @@ class SubversionPropertiesSniff implements Sniff
      *
      * @param string $path The path to return Subversion properties on.
      *
-     * @return array
+     * @return array|null
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If Subversion properties file could
      *                                                      not be opened.
      */

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -78,7 +78,7 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -56,7 +56,7 @@ class DisallowSpaceIndentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -56,7 +56,7 @@ class DisallowTabIndentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -80,7 +80,7 @@ class ScopeIndentSniff implements Sniff
      * This is a cached copy of the public version of this var, which
      * can be set in a ruleset file, and some core ignored tokens.
      *
-     * @var int[]
+     * @var array<int|string, bool>
      */
     private $ignoreIndentation = [];
 

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -19,7 +19,7 @@ class CSSLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
@@ -19,7 +19,7 @@ class ClosureLinterUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -68,7 +68,7 @@ class ESLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -19,7 +19,7 @@ class JSHintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -18,7 +18,7 @@ class ExecutableFileUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -18,7 +18,7 @@ class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
+++ b/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
@@ -43,7 +43,7 @@ class BrowserSpecificStylesSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
@@ -82,7 +82,7 @@ class IncludeOwnSystemSniff implements Sniff
      * @param int                         $stackPtr  The position in the tokens array of the
      *                                               potentially included class.
      *
-     * @return string
+     * @return bool
      */
     protected function getIncludedClassFromToken(
         $phpcsFile,

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -19,7 +19,7 @@ class IncludeSystemSniff extends AbstractScopeSniff
     /**
      * A list of classes that don't need to be included.
      *
-     * @var string[]
+     * @var array<string, bool>
      */
     private $ignore = [
         'self'                      => true,
@@ -286,7 +286,7 @@ class IncludeSystemSniff extends AbstractScopeSniff
      * @param int                         $stackPtr  The position in the tokens array of the
      *                                               potentially included class.
      *
-     * @return string
+     * @return string|false
      */
     protected function getIncludedClassFromToken(File $phpcsFile, array $tokens, $stackPtr)
     {

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -88,7 +88,7 @@ class FileCommentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return int
+     * @return int|void
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -36,7 +36,7 @@ class SideEffectsSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the token stack.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -36,7 +36,7 @@ class FileHeaderSniff implements Sniff
      * @param int                         $stackPtr  The position of the current
      *                                               token in the stack.
      *
-     * @return int|null
+     * @return int|void
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -284,7 +284,7 @@ class FileHeaderSniff implements Sniff
      * @param array                       $headerLines Header information, as sourced
      *                                                 from getHeaderLines().
      *
-     * @return int|null
+     * @return void
      */
     public function processHeaderLines(File $phpcsFile, $headerLines)
     {

--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -36,7 +36,7 @@ class UseDeclarationSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -241,7 +241,7 @@ class SwitchDeclarationSniff implements Sniff
      * @param int                         $stackPtr  The position to start looking at.
      * @param int                         $end       The position to stop looking at.
      *
-     * @return int|false
+     * @return int|bool
      */
     private function findNestedTerminator($phpcsFile, $stackPtr, $end)
     {

--- a/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -38,7 +38,7 @@ class EndFileNewlineSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -35,7 +35,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
      * @param array                       $tokens      The stack of tokens that make up
      *                                                 the file.
      *
-     * @return void
+     * @return bool
      */
     public function isMultiLineCall(File $phpcsFile, $stackPtr, $openBracket, $tokens)
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
@@ -27,7 +27,7 @@ class ClassDefinitionClosingBraceSpaceSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -27,7 +27,7 @@ class ClassDefinitionNameSpacingSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
@@ -27,7 +27,7 @@ class ClassDefinitionOpeningBraceSpaceSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
@@ -27,7 +27,7 @@ class ColonSpacingSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
@@ -26,7 +26,7 @@ class ColourDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
@@ -18,7 +18,7 @@ class DisallowMultipleStyleDefinitionsSniff implements Sniff
     /**
      * A list of tokenizers this sniff supports.
      *
-     * @var array
+     * @var string[]
      */
     public $supportedTokenizers = ['CSS'];
 
@@ -26,7 +26,7 @@ class DisallowMultipleStyleDefinitionsSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
@@ -26,7 +26,7 @@ class DuplicateStyleDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
@@ -27,7 +27,7 @@ class EmptyClassDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
@@ -27,7 +27,7 @@ class EmptyStyleDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
@@ -26,7 +26,7 @@ class LowercaseStyleDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
@@ -26,7 +26,7 @@ class MissingColonSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
@@ -27,7 +27,7 @@ class OpacitySniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -27,7 +27,7 @@ class SemicolonSpacingSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
@@ -41,7 +41,7 @@ class ShorthandSizeSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -27,7 +27,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
     /**
      * The current PHP version.
      *
-     * @var integer
+     * @var integer|string|null
      */
     private $phpVersion = null;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -49,7 +49,7 @@ class InlineCommentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return void|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -37,7 +37,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
      * @param array                       $tokens      The stack of tokens that make up
      *                                                 the file.
      *
-     * @return void
+     * @return bool
      */
     public function isMultiLineDeclaration($phpcsFile, $stackPtr, $openBracket, $tokens)
     {

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -44,7 +44,7 @@ class ComparisonOperatorUsageSniff implements Sniff
     /**
      * A list of invalid operators with their alternatives.
      *
-     * @var array<int, string>
+     * @var array<string, array<int, string>>
      */
     private static $invalidOps = [
         'PHP' => [

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -38,7 +38,7 @@ class DoubleQuoteUsageSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -19,7 +19,7 @@ class JSLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
@@ -19,7 +19,7 @@ class JavaScriptLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -36,7 +36,7 @@ class ClosingTagSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
+++ b/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
@@ -19,7 +19,7 @@ class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -905,10 +905,10 @@ class JS extends Tokenizer
      *
      * If a regular expression is not found, NULL is returned.
      *
-     * @param string $char   The index of the possible regex start character.
+     * @param int    $char   The index of the possible regex start character.
      * @param string $string The complete content of the string being tokenized.
-     * @param string $chars  An array of characters being tokenized.
-     * @param string $tokens The current array of tokens found in the string.
+     * @param array  $chars  An array of characters being tokenized.
+     * @param array  $tokens The current array of tokens found in the string.
      *
      * @return array<string, string>|null
      */

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -306,7 +306,7 @@ class PHP extends Tokenizer
     /**
      * Known lengths of tokens.
      *
-     * @var array<int, int>
+     * @var array<string|int, int>
      */
     public $knownLengths = [
         T_ABSTRACT                 => 8,

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -60,7 +60,7 @@ abstract class Tokenizer
     /**
      * Known lengths of tokens.
      *
-     * @var array<int, int>
+     * @var array<string|int, int>
      */
     public $knownLengths = [];
 

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -19,7 +19,7 @@ class Cache
     /**
      * The filesystem location of the cache file.
      *
-     * @var void
+     * @var string
      */
     private static $path = '';
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -35,7 +35,7 @@ class Common
      *
      * @param string $path The path to use.
      *
-     * @return mixed
+     * @return bool
      */
     public static function isPharFile($path)
     {
@@ -83,7 +83,7 @@ class Common
      *
      * @param string $path The path to use.
      *
-     * @return mixed
+     * @return string|false
      */
     public static function realpath($path)
     {

--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -56,7 +56,7 @@ class ReportWidthTest extends TestCase
 
     /**
      * Reset the static properties in the Config class to their true defaults to prevent this class
-     * from unfluencing other tests.
+     * from influencing other tests.
      *
      * @afterClass
      *
@@ -287,7 +287,7 @@ class ReportWidthTest extends TestCase
      * Helper function to set a static property on the Config class.
      *
      * @param string $name  The name of the property to set.
-     * @param mixed  $value The value to set the propert to.
+     * @param mixed  $value The value to set the property to.
      *
      * @return void
      */


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3910:

> ### Docs: various textual tweaks
> 
> ... picked up along the way.
> 
> ### ~~Docs: update a few URLs to https~~
> 
> ~~Follow up to squizlabs/PHP_CodeSniffer#3762~~
> 
> ### Docs: fix various incorrect type annotations
> 
> Includes a number of fixes previously pulled in (closed) PR squizlabs/PHP_CodeSniffer#3703.


👆🏻 Note: the second commit has been dropped as no longer necessary as those URLs were removed (references to the PEAR website + analysis website)

### Suggested changelog entry
_N/A_

## Types of changes
- [x] Documentation improvement

