### PR TITLE
QA: remove unreachable code

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -142,6 +142,11 @@
         <type>error</type>
     </rule>
 
+    <!-- Do not allow unreachable code. -->
+    <rule ref="Squiz.PHP.NonExecutableCode">
+        <type>error</type>
+    </rule>
+
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
         <exclude-pattern>tests/bootstrap\.php</exclude-pattern>

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -148,8 +148,6 @@ abstract class AbstractScopeSniff implements Sniff
             return min($skipTokens);
         }
 
-        return;
-
     }//end process()
 
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -50,7 +50,7 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
                 12 => 1,
                 13 => 1,
             ];
-            break;
+
         case 'DuplicateClassNameUnitTest.2.inc':
             return [
                 2 => 1,
@@ -58,19 +58,18 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
                 4 => 1,
                 5 => 1,
             ];
-            break;
+
         case 'DuplicateClassNameUnitTest.5.inc':
             return [
                 3 => 1,
                 7 => 1,
             ];
-            break;
+
         case 'DuplicateClassNameUnitTest.6.inc':
             return [10 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -30,16 +30,15 @@ class InlineHTMLUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'InlineHTMLUnitTest.3.inc':
             return [4 => 1];
-            break;
+
         case 'InlineHTMLUnitTest.4.inc':
             return [1 => 1];
-            break;
+
         case 'InlineHTMLUnitTest.7.inc':
             return [1 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -50,14 +50,13 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
                 45 => 1,
                 82 => 1,
             ];
-            break;
+
         case 'LineLengthUnitTest.2.inc':
         case 'LineLengthUnitTest.3.inc':
             return [7 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()
@@ -89,20 +88,19 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
                 75 => 1,
                 84 => 1,
             ];
-            break;
+
         case 'LineLengthUnitTest.2.inc':
         case 'LineLengthUnitTest.3.inc':
             return [6 => 1];
-            break;
+
         case 'LineLengthUnitTest.4.inc':
             return [
                 10 => 1,
                 14 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -122,7 +122,7 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 499 => 1,
                 500 => 1,
             ];
-        break;
+
         case 'MultipleStatementAlignmentUnitTest.js':
             return [
                 11  => 1,
@@ -154,10 +154,9 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 114 => 1,
                 117 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -30,10 +30,9 @@ class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'CharacterBeforePHPOpeningTagUnitTest.1.inc':
             return [2 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -30,12 +30,12 @@ class ClosingPHPTagUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'ClosingPHPTagUnitTest.1.inc':
             return [9 => 1];
+
         case 'ClosingPHPTagUnitTest.2.inc':
             return [5 => 1];
-            break;
+
         default:
             return [];
-            break;
         }
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -52,7 +52,7 @@ class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
                 95  => 1,
                 100 => 2,
             ];
-        break;
+
         case 'LowerCaseConstantUnitTest.js':
             return [
                 2  => 1,
@@ -64,10 +64,9 @@ class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
                 13 => 1,
                 14 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -30,7 +30,6 @@ class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'RequireStrictTypesUnitTest.1.inc':
             return [];
-            break;
         }
 
         return [1 => 1];

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -32,10 +32,9 @@ class SyntaxUnitTest extends AbstractSniffUnitTest
         case 'SyntaxUnitTest.1.inc':
         case 'SyntaxUnitTest.2.inc':
             return [3 => 1];
-            break;
+
         default:
             return [];
-            break;
         }
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -37,7 +37,7 @@ class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
                 19 => 1,
                 20 => 1,
             ];
-            break;
+
         case 'UnnecessaryStringConcatUnitTest.js':
             return [
                 1  => 1,
@@ -46,10 +46,9 @@ class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
                 14 => 1,
                 15 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -85,7 +85,7 @@ class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
                 117 => 1,
                 118 => 1,
             ];
-            break;
+
         case 'DisallowSpaceIndentUnitTest.3.inc':
             return [
                 2  => 1,
@@ -96,16 +96,15 @@ class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
                 14 => 1,
                 15 => 1,
             ];
-            break;
+
         case 'DisallowSpaceIndentUnitTest.js':
             return [3 => 1];
-            break;
+
         case 'DisallowSpaceIndentUnitTest.css':
             return [2 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -212,8 +212,6 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             return $endOfStatement;
         }
 
-        return;
-
     }//end processMemberVar()
 
 

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -60,7 +60,7 @@ class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
                 1008 => 1,
                 1032 => 1,
             ];
-            break;
+
         case 'LongConditionClosingCommentUnitTest.js':
             return [
                 47  => 1,
@@ -76,10 +76,9 @@ class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
                 439 => 1,
                 444 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -73,7 +73,7 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 193 => 1,
                 194 => 2,
             ];
-            break;
+
         case 'OperatorBracketUnitTest.js':
             return [
                 5   => 1,
@@ -90,10 +90,9 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 63  => 1,
                 108 => 1,
             ];
-             break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -59,7 +59,7 @@ class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
                 131 => 1,
                 135 => 1,
             ];
-            break;
+
         case 'ComparisonOperatorUsageUnitTest.js':
             return [
                 5  => 1,
@@ -74,10 +74,9 @@ class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
                 67 => 1,
                 71 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -58,16 +58,15 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 147 => 1,
                 158 => 1,
             ];
-            break;
+
         case 'CommentedOutCodeUnitTest.css':
             return [
                 7  => 1,
                 16 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getWarningList()

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -33,13 +33,12 @@ class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
                 8  => 1,
                 18 => 1,
             ];
-            break;
+
         case 'DisallowInlineIfUnitTest.js':
             return [1 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -43,13 +43,12 @@ class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
                 44 => 1,
                 46 => 1,
             ];
-            break;
+
         case 'DisallowSizeFunctionsInLoopsUnitTest.js':
             return [1 => 1];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -83,7 +83,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 391 => 1,
                 396 => 1,
             ];
-            break;
+
         case 'NonExecutableCodeUnitTest.2.inc':
             return [
                 7  => 1,
@@ -97,7 +97,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 70 => 2,
                 71 => 2,
             ];
-            break;
+
         case 'NonExecutableCodeUnitTest.3.inc':
             return [
                 27 => 1,
@@ -108,7 +108,6 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
             ];
         default:
             return [];
-            break;
         }//end switch
 
     }//end getWarningList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -61,7 +61,7 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
                 261 => 1,
                 262 => 1,
             ];
-            break;
+
         case 'ControlStructureSpacingUnitTest.js':
             return [
                 3  => 1,
@@ -76,10 +76,9 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
                 74 => 2,
                 75 => 2,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -37,7 +37,7 @@ class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
                 31 => 1,
                 39 => 1,
             ];
-            break;
+
         case 'FunctionClosingBraceSpaceUnitTest.js':
             return [
                 13  => 1,
@@ -49,10 +49,9 @@ class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
                 84  => 1,
                 128 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -100,7 +100,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 266 => 2,
                 271 => 2,
             ];
-            break;
+
         case 'OperatorSpacingUnitTest.js':
             return [
                 4   => 1,
@@ -143,10 +143,9 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 100 => 1,
                 103 => 2,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -43,7 +43,7 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
                 30 => 2,
                 36 => 1,
             ];
-            break;
+
         case 'SemicolonSpacingUnitTest.js':
             return [
                 3  => 1,
@@ -56,10 +56,9 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
                 22 => 1,
                 25 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -44,26 +44,26 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 65 => 1,
                 73 => 1,
             ];
-            break;
+
         case 'SuperfluousWhitespaceUnitTest.2.inc':
             return [
                 2 => 1,
                 8 => 1,
             ];
-            break;
+
         case 'SuperfluousWhitespaceUnitTest.3.inc':
             return [
                 6  => 1,
                 10 => 1,
             ];
-            break;
+
         case 'SuperfluousWhitespaceUnitTest.4.inc':
         case 'SuperfluousWhitespaceUnitTest.5.inc':
             return [
                 1 => 1,
                 4 => 1,
             ];
-            break;
+
         case 'SuperfluousWhitespaceUnitTest.1.js':
             return [
                 1  => 1,
@@ -77,7 +77,7 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 38 => 1,
                 56 => 1,
             ];
-            break;
+
         case 'SuperfluousWhitespaceUnitTest.1.css':
             return [
                 1  => 1,
@@ -86,10 +86,9 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 11 => 1,
                 32 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -433,7 +433,6 @@ abstract class AbstractSniffUnitTest extends TestCase
      */
     public function setCliValues($filename, $config)
     {
-        return;
 
     }//end setCliValues()
 


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3912:

> 
> ### Tests: remove unreachable code
> `break` after a `return` statement is redundant.
> 
> As a side-note: I did have to chuckle when I saw that the `NonExecutableCode` test file also included this :joy:
> 
> ### Various: remove some redundant return statements
> 
> ... when the `return` is at the end of the function without a value, and therefore not needed.
> 
> ### PHPCS: add the `Squiz.PHP.NonExecutableCode` sniff to the ruleset
> 
> ... which is used for PHPCS itself.

### Suggested changelog entry
_N/A_

