### PR TITLE
Config::processLongArgument(): fix storing of unknown arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,8 @@ The file documents changes to the PHP_CodeSniffer project.
     - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 - Fixed bug #3906 : Tokenizer/CSS: fixed a bug related to the unsupported slash comment syntax
     - Thanks to Dan Wallis (@fredden) for the patch
+- Fixed bug #3913 : Config stored unknown "long" arguments in a (dynamic) `$values` property
+    - Thanks to Juliette Reinders Folmer (@jrfnl) for the patch
 
 Props also to Dan Wallis (@fredden) and Danny van der Sluijs (@DannyvdSluijs) for reviewing quite a few of the PRs for this release.
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1232,13 +1232,17 @@ class Config
                 if ($this->dieOnUnknownArg === false) {
                     $eqPos = strpos($arg, '=');
                     try {
+                        $unknown = $this->unknown;
+
                         if ($eqPos === false) {
-                            $this->values[$arg] = $arg;
+                            $unknown[$arg] = $arg;
                         } else {
-                            $value = substr($arg, ($eqPos + 1));
-                            $arg   = substr($arg, 0, $eqPos);
-                            $this->values[$arg] = $value;
+                            $value         = substr($arg, ($eqPos + 1));
+                            $arg           = substr($arg, 0, $eqPos);
+                            $unknown[$arg] = $value;
                         }
+
+                        $this->unknown = $unknown;
                     } catch (RuntimeException $e) {
                         // Value is not valid, so just ignore it.
                     }


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3913:

> These arguments should be stored in the `unknown` property. There is no `values` property.
> 
> Note: the read/write logic is to prevent a `Indirect modification of overloaded property PHP_CodeSniffer\Config::$unknown has no effect` PHP notice.


## Suggested changelog entry
_N/A_ (I don't think this bug had any impact on end-users)


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
