### PR TITLE
4.0 | File::addMessage(): do not ignore Internal errors when scanning selectively

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -865,9 +865,11 @@ class File
         }
 
         // Filter out any messages for sniffs that shouldn't have run
-        // due to the use of the --sniffs command line argument.
+        // due to the use of the --sniffs or --exclude command line argument,
+        // but don't filter out "Internal" messages.
         if ($includeAll === false
-            && ((empty($this->configCache['sniffs']) === false
+            && (($parts[0] !== 'Internal'
+            && empty($this->configCache['sniffs']) === false
             && in_array(strtolower($listenerCode), $this->configCache['sniffs'], true) === false)
             || (empty($this->configCache['exclude']) === false
             && in_array(strtolower($listenerCode), $this->configCache['exclude'], true) === true))

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -51,11 +51,25 @@ final class ByteOrderMarkUnitTest extends AbstractSniffTestCase
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='')
     {
-        return [];
+        switch ($testFile) {
+        case 'ByteOrderMarkUnitTest.3.inc':
+        case 'ByteOrderMarkUnitTest.4.inc':
+        case 'ByteOrderMarkUnitTest.5.inc':
+            if ((bool) ini_get('short_open_tag') === false) {
+                // Warning about "no code found in file".
+                return [1 => 1];
+            }
+            return [];
+
+        default:
+            return [];
+        }
 
     }//end getWarningList()
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -61,7 +61,15 @@ final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffTestCase
     public function getWarningList($testFile='')
     {
         if ($testFile === 'DisallowAlternativePHPTagsUnitTest.2.inc') {
+            // Check if the Internal.NoCodeFound error can be expected on line 1.
+            $option = (bool) ini_get('short_open_tag');
+            $line1  = 1;
+            if ($option === true) {
+                $line1 = 0;
+            }
+
             return [
+                1 => $line1,
                 2 => 1,
                 3 => 1,
                 4 => 1,

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -91,10 +91,15 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
     public function getWarningList($testFile='')
     {
         switch ($testFile) {
-        case 'DisallowShortOpenTagUnitTest.1.inc':
-            return [];
         case 'DisallowShortOpenTagUnitTest.3.inc':
+            // Check if the Internal.NoCodeFound error can be expected on line 1.
+            $option = (bool) ini_get('short_open_tag');
+            $line1  = 1;
+            if ($option === true) {
+                $line1 = 0;
+            }
             return [
+                1  => $line1,
                 3  => 1,
                 6  => 1,
                 11 => 1,

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -229,10 +229,19 @@ final class EmbeddedPhpUnitTest extends AbstractSniffTestCase
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='')
     {
+        if ($testFile === 'EmbeddedPhpUnitTest.24.inc'
+            && (bool) ini_get('short_open_tag') === false
+        ) {
+            // Warning about "no code found in file".
+            return [1 => 1];
+        }
+
         return [];
 
     }//end getWarningList()

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -510,15 +510,15 @@ EOD;
 
             // Process with line suppression nested within disable/enable suppression.
             'disable/enable: slash comment, next line nested single line suppression'         => [
-                'before' => '// phpcs:disable'.PHP_EOL.'// phpcs:ignore',
+                'before' => "// phpcs:disable\n// phpcs:ignore",
                 'after'  => '// phpcs:enable',
             ],
             'disable/enable: slash comment, with @, next line nested single line suppression' => [
-                'before' => '// @phpcs:disable'.PHP_EOL.'// @phpcs:ignore',
+                'before' => "// @phpcs:disable\n// @phpcs:ignore",
                 'after'  => '// @phpcs:enable',
             ],
             'disable/enable: hash comment, next line nested single line suppression'          => [
-                'before' => '# @phpcs:disable'.PHP_EOL.'# @phpcs:ignore',
+                'before' => "# @phpcs:disable\n# @phpcs:ignore",
                 'after'  => '# @phpcs:enable',
             ],
         ];
@@ -689,7 +689,7 @@ EOD;
                 'before' => '/* phpcs:ignoreFile */',
             ],
             'ignoreFile: start of file, multi-line star comment'      => [
-                'before' => '/*'.PHP_EOL.' phpcs:ignoreFile'.PHP_EOL.' */',
+                'before' => "/*\n phpcs:ignoreFile\n */",
             ],
             'ignoreFile: start of file, single-line docblock comment' => [
                 'before' => '/** phpcs:ignoreFile */',
@@ -771,11 +771,11 @@ EOD;
                 'expectedErrors' => 1,
             ],
             'disable: single sniff, docblock'              => [
-                'before'         => '/**'.PHP_EOL.' * phpcs:disable Generic.Commenting.Todo'.PHP_EOL.' */ ',
+                'before'         => "/**\n * phpcs:disable Generic.Commenting.Todo\n */ ",
                 'expectedErrors' => 1,
             ],
             'disable: single sniff, docblock, with @'      => [
-                'before'         => '/**'.PHP_EOL.' * @phpcs:disable Generic.Commenting.Todo'.PHP_EOL.' */ ',
+                'before'         => "/**\n * @phpcs:disable Generic.Commenting.Todo\n */ ",
                 'expectedErrors' => 1,
             ],
 
@@ -784,7 +784,7 @@ EOD;
                 'before' => '// phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant',
             ],
             'disable: multiple sniff in multiple comments' => [
-                'before' => '// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'// phpcs:disable Generic.PHP.LowerCaseConstant',
+                'before' => "// phpcs:disable Generic.Commenting.Todo\n// phpcs:disable Generic.PHP.LowerCaseConstant",
             ],
 
             // Selectiveness variations.
@@ -805,17 +805,17 @@ EOD;
 
             // Wrong category/sniff/code.
             'disable: wrong error code and category'       => [
-                'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.PHP.LowerCaseConstant.Upper,Generic.Comments'.PHP_EOL.' */ ',
+                'before'           => "/**\n * phpcs:disable Generic.PHP.LowerCaseConstant.Upper,Generic.Comments\n */ ",
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
             'disable: wrong category, docblock'            => [
-                'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.Files'.PHP_EOL.' */ ',
+                'before'           => "/**\n * phpcs:disable Generic.Files\n */ ",
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
             'disable: wrong category, docblock, with @'    => [
-                'before'           => '/**'.PHP_EOL.' * @phpcs:disable Generic.Files'.PHP_EOL.' */ ',
+                'before'           => "/**\n * @phpcs:disable Generic.Files\n */ ",
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
@@ -1070,7 +1070,7 @@ EOD;
                 'expectedWarnings' => 1,
             ],
             'disable: single sniff; ignore: single sniff' => [
-                'before'           => '// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'// phpcs:ignore Generic.PHP.LowerCaseConstant',
+                'before'           => "// phpcs:disable Generic.Commenting.Todo\n// phpcs:ignore Generic.PHP.LowerCaseConstant",
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 0,
             ],

--- a/tests/Core/File/AddMessageSelectiveInternalHandlingTest.php
+++ b/tests/Core/File/AddMessageSelectiveInternalHandlingTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Tests that handling of Internal errors in combination with sniff selection.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that handling of Internal errors in combination with sniff selection.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::addMessage
+ */
+final class AddMessageSelectiveInternalHandlingTest extends TestCase
+{
+
+
+    /**
+     * Verify that if an Internal code is silenced from the ruleset, it will stay silenced, independently of sniff selection.
+     *
+     * @param string $sniffs  Sniff selection.
+     * @param string $exclude Sniff exclusions.
+     *
+     * @dataProvider dataSniffSelection
+     *
+     * @return void
+     */
+    public function testRulesetIgnoredInternalErrorIsIgnored($sniffs, $exclude)
+    {
+        $phpcsFile = $this->getPhpcsFile($sniffs, $exclude);
+
+        $added = $phpcsFile->addError('No code found', 0, 'Internal.NoCodeFound');
+        $this->assertFalse($added);
+
+    }//end testRulesetIgnoredInternalErrorIsIgnored()
+
+
+    /**
+     * Verify that if an Internal code is NOT silenced from the ruleset, sniff selection doesn't silence it.
+     *
+     * @param string $sniffs  Sniff selection.
+     * @param string $exclude Sniff exclusions.
+     *
+     * @dataProvider dataSniffSelection
+     *
+     * @return void
+     */
+    public function testOtherInternalErrorIsNotIgnored($sniffs, $exclude)
+    {
+        $phpcsFile = $this->getPhpcsFile($sniffs, $exclude);
+
+        $added = $phpcsFile->addError('Some other error', 0, 'Internal.SomeError');
+        $this->assertTrue($added);
+
+    }//end testOtherInternalErrorIsNotIgnored()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testA()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataSniffSelection()
+    {
+        return [
+            'Ruleset only, no CLI selection'  => [
+                'sniffs'  => '',
+                'exclude' => '',
+            ],
+            'Ruleset + CLI sniffs selection'  => [
+                'sniffs'  => 'Generic.Files.ByteOrderMark,Generic.PHP.DisallowShortOpenTag',
+                'exclude' => '',
+            ],
+            'Ruleset + CLI exclude selection' => [
+                'sniffs'  => '',
+                'exclude' => 'Generic.Files.ByteOrderMark,Generic.PHP.DisallowShortOpenTag',
+            ],
+        ];
+
+    }//end dataSniffSelection()
+
+
+    /**
+     * Test Helper to get a File object for use in these tests.
+     *
+     * @param string $sniffs  Sniff selection.
+     * @param string $exclude Sniff exclusions.
+     *
+     * @return \PHP_CodeSniffer\Files\DummyFile
+     */
+    private function getPhpcsFile($sniffs, $exclude)
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/AddMessageSelectiveInternalHandlingTest.xml';
+        $args     = ["--standard=$standard"];
+
+        if (empty($sniffs) === false) {
+            $args[] = "--sniffs=$sniffs";
+        }
+
+        if (empty($exclude) === false) {
+            $args[] = "--exclude=$exclude";
+        }
+
+        $config  = new ConfigDouble($args);
+        $ruleset = new Ruleset($config);
+
+        $content   = '<?php '."\necho 'hello!';\n";
+        $phpcsFile = new DummyFile($content, $ruleset, $config);
+        $phpcsFile->parse();
+
+        return $phpcsFile;
+
+    }//end getPhpcsFile()
+
+
+}//end class

--- a/tests/Core/File/AddMessageSelectiveInternalHandlingTest.xml
+++ b/tests/Core/File/AddMessageSelectiveInternalHandlingTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AddMessageSelectiveInternalHandlingTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Internal.NoCodeFound">
+        <severity>0</severity>
+    </rule>
+
+    <rule ref="PSR1"/>
+</ruleset>


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3915 + rebased against the 4.0 branch:

> ### ErrorSuppressionTest: prevent Internal errors
> 
> ... about a mismatch in line endings when the code "template" is defined using a heredoc with Linux line endings, while the code snippets being inserted into the code "template" were using line endings matching the OS on which the tests were being run.
> 
> ### File::addMessage(): do not ignore Internal errors when scanning selectively
> 
> When either the `--sniffs=...` CLI parameter is used, or the `--exclude=...` CLI parameter, the `File::addMessage()` method bows out when an error is passed which is not for one of the selected sniffs/is for one of the excluded sniffs.
> 
> Unfortunately, this "bowing out" did not take `Internal` errors into account, meaning those were now hidden, while those - IMO - should _always_ be thrown as they generally inform the end-user of something wrong with the file which impacts the scan results (mixed line endings/no code found etc).
> 
> Fixed now.
> 
> Includes updating two test files to allow for seeing internal errors.
> 
> 👉🏻 This _could_ be considered a breaking change, though I'm not sure whether it should be. Opinions welcome.
> 
> Most typically, this change may impact tests for external standards which don't expect `Internal` errors.

👆🏻 Note: I've decided to err on the side of caution and have moved this PR to the 4.0 branch now.



### Suggested changelog entry
Changed:
- Internal errors will no longer be suppressed when the `--sniffs` CLI argument is used.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [x] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

