### PR TITLE
GH Actions/label new PRs: use v1 floating tag

### DIFF
--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Label new PRs
-        uses: srvaroa/labeler@master
+        uses: srvaroa/labeler@v1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Verify changes to the labeling logic
-        uses: srvaroa/labeler@master
+        uses: srvaroa/labeler@v1
         with:
           use_local_config: true
           fail_on_error: true


### PR DESCRIPTION
## Description

Using `master` for action runners is bad practice (as it opens you up to unexpectedly moving to a new major containing breaking changes), but so far, the `srvaroa/labeler` action did not have a floating/moving `v1` tag.

This tag has now been added, so updating the workflow to use it.

The action has also tagged version `v1.7.2`, which should fix an issue I previously reported where tags were being removed, even though the config forbids this.

## Suggested changelog entry
_N/A_


## Related issues/external references

Refs:
* srvaroa/labeler#104
* srvaroa/labeler#110
* https://github.com/srvaroa/labeler/releases/tag/v1.7.2

