### PR TITLE
4.0 | Composer: set conflict directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0"
     },
-    "replace": {
-        "squizlabs/php_codesniffer": "> 2.0"
+    "conflict": {
+        "squizlabs/php_codesniffer": "*"
     },
     "bin": [
         "bin/phpcs",

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,7 @@ use PHP_CodeSniffer\Util\Common;
  * @property bool     $stdin           Read content from STDIN instead of supplied files.
  * @property string   $stdinContent    Content passed directly to PHPCS on STDIN.
  * @property string   $stdinPath       The path to use for content passed on STDIN.
+ * @property bool     $trackTime       Whether or not to track sniff run time.
  *
  * @property array<string, string>      $extensions File extensions that should be checked.
  *                                                  E.g., array('php', 'inc');


### PR DESCRIPTION
## Description

Sister-PR to #113 for the 4.0 branch.

Set conflict directive to prevent the Squiz version of the package and this package being installed together.

Ref:
* https://getcomposer.org/doc/04-schema.md#conflict
