### PR TITLE
Add phpcs baseline support

### DIFF
--- a/src/Baseline/BaselineSet.php
+++ b/src/Baseline/BaselineSet.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Baseline collection class to store and query baselined violations
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Baseline;
+
+class BaselineSet
+{
+
+    /**
+     * A collection of a baselined violations
+     *
+     * @var array<string, ViolationBaseline[]>
+     */
+    private $violations = [];
+
+
+    /**
+     * Add a single entry to the baseline set
+     *
+     * @param ViolationBaseline $entry the entry to add to the collection
+     *
+     * @return void
+     */
+    public function addEntry(ViolationBaseline $entry)
+    {
+        $this->violations[$entry->getSniffName()][$entry->getSignature()][] = $entry;
+
+    }//end addEntry()
+
+
+    /**
+     * Test if the given sniff and filename is in the baseline collection
+     *
+     * @param string $sniffName the name of the sniff to search for
+     * @param string $fileName  the full filename of the file to match
+     * @param string $signature the code signature of the violation
+     *
+     * @return bool
+     */
+    public function contains($sniffName, $fileName, $signature)
+    {
+        if (isset($this->violations[$sniffName][$signature]) === false) {
+            return false;
+        }
+
+        // Normalize slashes in file name.
+        $fileName = str_replace('\\', '/', $fileName);
+
+        foreach ($this->violations[$sniffName][$signature] as $baseline) {
+            if ($baseline->matches($fileName) === true) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end contains()
+
+
+}//end class

--- a/src/Baseline/BaselineSetFactory.php
+++ b/src/Baseline/BaselineSetFactory.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * A factory to create a baseline collection from a given file
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Baseline;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+class BaselineSetFactory
+{
+
+
+    /**
+     * Read the baseline violations from the given filename path.
+     *
+     * @param string $fileName the baseline file to import
+     *
+     * @return BaselineSet|null
+     * @throws RuntimeException
+     */
+    public static function fromFile($fileName)
+    {
+        if (file_exists($fileName) === false) {
+            return null;
+        }
+
+        $xml = @simplexml_load_string(file_get_contents($fileName));
+        if ($xml === false) {
+            throw new RuntimeException('Unable to read xml from: '.$fileName);
+        }
+
+        $baselineSet = new BaselineSet();
+
+        foreach ($xml->children() as $node) {
+            if ($node->getName() !== 'violation') {
+                continue;
+            }
+
+            if (isset($node['sniff']) === false) {
+                throw new RuntimeException('Missing `sniff` attribute in `violation` in '.$fileName);
+            }
+
+            if (isset($node['file']) === false) {
+                throw new RuntimeException('Missing `file` attribute in `violation` in '.$fileName);
+            }
+
+            if (isset($node['signature']) === false) {
+                throw new RuntimeException('Missing `signature` attribute in `violation` in '.$fileName);
+            }
+
+            // Normalize filepath (if needed).
+            $filePath = '/'.ltrim(str_replace('\\', '/', (string) $node['file']), '/');
+
+            $baselineSet->addEntry(new ViolationBaseline((string) $node['sniff'], $filePath, (string) $node['signature']));
+        }//end foreach
+
+        return $baselineSet;
+
+    }//end fromFile()
+
+
+}//end class

--- a/src/Baseline/ViolationBaseline.php
+++ b/src/Baseline/ViolationBaseline.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * A class to manage a single baselined violation
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Baseline;
+
+class ViolationBaseline
+{
+
+    /**
+     * The name of the sniff
+     *
+     * @var string
+     */
+    private $sniffName;
+
+    /**
+     * The relative file path
+     *
+     * @var string
+     */
+    private $fileName;
+
+    /**
+     * The length of the filename to improve comparison performance
+     *
+     * @var integer
+     */
+    private $fileNameLength;
+
+    /**
+     * The code signature for the baseline
+     *
+     * @var string
+     */
+    private $signature;
+
+
+    /**
+     * Initialize the violation baseline
+     *
+     * @param string $sniffName The name of the sniff that's baselined.
+     * @param string $fileName  The relative file path.
+     * @param string $signature The code signature for the baseline.
+     */
+    public function __construct($sniffName, $fileName, $signature)
+    {
+        $this->sniffName      = $sniffName;
+        $this->fileName       = $fileName;
+        $this->fileNameLength = strlen($fileName);
+        $this->signature      = $signature;
+
+    }//end __construct()
+
+
+    /**
+     * Get the sniff name that was baselined
+     *
+     * @return string
+     */
+    public function getSniffName()
+    {
+        return $this->sniffName;
+
+    }//end getSniffName()
+
+
+    /**
+     * Get the code signature for this baseline
+     *
+     * @return string
+     */
+    public function getSignature()
+    {
+        return $this->signature;
+
+    }//end getSignature()
+
+
+    /**
+     * Test if the given filepath matches the relative filename in the baseline
+     *
+     * @param string $filepath the full filepath to match against
+     *
+     * @return bool
+     */
+    public function matches($filepath)
+    {
+        return substr($filepath, -$this->fileNameLength) === $this->fileName;
+
+    }//end matches()
+
+
+}//end class

--- a/src/Config.php
+++ b/src/Config.php
@@ -1054,7 +1054,7 @@ class Config
                     $error .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
-            } else if (substr($arg, 0, 13) === 'baselineFile=') {
+            } else if (substr($arg, 0, 13) === 'baseline-file=') {
                 if (substr($arg, 13) === '') {
                     $this->basepath = null;
                     break;
@@ -1389,7 +1389,7 @@ class Config
         echo 'Usage: phpcs [-nwlsaepqvi] [-d key[=value]] [--colors] [--no-colors]'.PHP_EOL;
         echo '  [--cache[=<cacheFile>]] [--no-cache] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '  [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>]'.PHP_EOL;
-        echo '  [--report-width=<reportWidth>] [--basepath=<basepath>] [--baselineFile=<baselineFile>]'.PHP_EOL;
+        echo '  [--report-width=<reportWidth>] [--basepath=<basepath>] [--baseline-file=<baselineFile>]'.PHP_EOL;
         echo '  [--bootstrap=<bootstrap>] [--severity=<severity>] [--error-severity=<severity>]'.PHP_EOL;
         echo '  [--warning-severity=<severity>] [--runtime-set key value]'.PHP_EOL;
         echo '  [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1054,15 +1054,15 @@ class Config
                     $error .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
-            } else if (substr($arg, 0, 13) === 'baseline-file=') {
-                if (substr($arg, 13) === '') {
-                    $this->basepath = null;
+            } else if (substr($arg, 0, 14) === 'baseline-file=') {
+                if (substr($arg, 14) === '') {
+                    $this->baselineFile = null;
                     break;
                 }
 
-                $this->baselineFile = Util\Common::realpath(substr($arg, 13));
+                $this->baselineFile = Util\Common::realpath(substr($arg, 14));
                 if (is_file($this->baselineFile) === false) {
-                    $error  = 'ERROR: The specified baselineFile "'.substr($arg, 13).'" points to a non-existent file'.PHP_EOL.PHP_EOL;
+                    $error  = 'ERROR: The specified baseline-file "'.substr($arg, 14).'" points to a non-existent file'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1037,6 +1037,14 @@ class File
             return false;
         }
 
+        // The message is part of the baselined violations.
+        if ($this->config->baseline !== null) {
+            $signature = Util\CodeSignature::createSignature($this->getTokens(), $line);
+            if ($this->config->baseline->contains($sniffCode, $this->path, $signature) === true) {
+                return false;
+            }
+        }
+
         $messageCount++;
         if ($fixable === true) {
             $this->fixableCount++;

--- a/src/Reports/Baseline.php
+++ b/src/Reports/Baseline.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Baseline report for PHP_CodeSniffer.
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Reports;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util;
+use XMLWriter;
+
+class Baseline implements Report
+{
+
+
+    /**
+     * Generate a partial report for a single processed file.
+     * Function should return TRUE if it printed or stored data about the file
+     * and FALSE if it ignored the file. Returning TRUE indicates that the file and
+     * its data should be counted in the grand totals.
+     *
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
+     *
+     * @return bool
+     */
+    public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
+    {
+        $out = new XMLWriter;
+        $out->openMemory();
+        $out->setIndent(true);
+        $out->setIndentString('    ');
+        $out->startDocument('1.0', 'UTF-8');
+
+        if ($report['errors'] === 0 && $report['warnings'] === 0) {
+            // Nothing to print.
+            return false;
+        }
+
+        foreach ($report['messages'] as $lineNr => $lineErrors) {
+            $signature = Util\CodeSignature::createSignature($phpcsFile->getTokens(), $lineNr);
+
+            foreach ($lineErrors as $colErrors) {
+                foreach ($colErrors as $error) {
+                    $out->startElement('violation');
+                    $out->writeAttribute('file', $report['filename']);
+                    $out->writeAttribute('sniff', $error['source']);
+                    $out->writeAttribute('signature', $signature);
+
+                    $out->endElement();
+                }
+            }
+        }
+
+        // Remove the start of the document because we will
+        // add that manually later. We only have it in here to
+        // properly set the encoding.
+        $content = $out->flush();
+        $content = preg_replace("/[\n\r]/", PHP_EOL, $content);
+        $content = substr($content, (strpos($content, PHP_EOL) + strlen(PHP_EOL)));
+
+        echo $content;
+
+        return true;
+
+    }//end generateFileReport()
+
+
+    /**
+     * Prints all violations for processed files, in a proprietary XML format.
+     *
+     * @param string $cachedData    Any partial report data that was returned from
+     *                              generateFileReport during the run.
+     * @param int    $totalFiles    Total number of files processed during the run.
+     * @param int    $totalErrors   Total number of errors found during the run.
+     * @param int    $totalWarnings Total number of warnings found during the run.
+     * @param int    $totalFixable  Total number of problems that can be fixed.
+     * @param bool   $showSources   Show sources?
+     * @param int    $width         Maximum allowed line width.
+     * @param bool   $interactive   Are we running in interactive mode?
+     * @param bool   $toScreen      Is the report being printed to screen?
+     *
+     * @return void
+     */
+    public function generate(
+        $cachedData,
+        $totalFiles,
+        $totalErrors,
+        $totalWarnings,
+        $totalFixable,
+        $showSources=false,
+        $width=80,
+        $interactive=false,
+        $toScreen=true
+    ) {
+        echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
+        echo '<phpcs-baseline version="'.Config::VERSION.'">';
+
+        // Split violations on line-ending, make them unique and sort them.
+        if ($cachedData !== "") {
+            $lines = explode(PHP_EOL, $cachedData);
+            $lines = array_unique($lines);
+            sort($lines);
+            $cachedData = implode(PHP_EOL, $lines);
+        }
+
+        echo $cachedData;
+        echo PHP_EOL.'</phpcs-baseline>'.PHP_EOL;
+
+    }//end generate()
+
+
+}//end class

--- a/src/Util/CodeSignature.php
+++ b/src/Util/CodeSignature.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Function for generating the code signature used in the baseline.
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Util;
+
+class CodeSignature
+{
+
+
+    /**
+     * Generate the sha1 code signature for the tokens around the given line.
+     *
+     * @param array<int|string> $tokens All tokens of a given file.
+     * @param int               $lineNr The lineNr to search for tokens.
+     *
+     * @return string The sha1 hash of the tokens around the given line
+     */
+    public static function createSignature(array $tokens, $lineNr)
+    {
+        // Get all tokens one line before and after.
+        $start = ($lineNr - 1);
+        $end   = ($lineNr + 1);
+
+        $content = '';
+        foreach ($tokens as $token) {
+            if ($token['line'] > $end) {
+                break;
+            }
+
+            // Concat content excluding line endings.
+            if ($token['line'] >= $start && isset($token['content']) === true) {
+                $content .= trim($token['content'], "\r\n");
+            }
+        }
+
+        // Generate sha1 hash.
+        return hash('sha1', $content);
+
+    }//end createSignature()
+
+
+}//end class

--- a/tests/Core/Baseline/BaselineSetFactoryTest.php
+++ b/tests/Core/Baseline/BaselineSetFactoryTest.php
@@ -74,8 +74,13 @@ class BaselineSetFactoryTest extends TestCase
      */
     public function testFromFileShouldThrowExceptionForOnInvalidXML()
     {
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
-        $this->expectExceptionMessage('Unable to read xml from');
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+            $this->expectExceptionMessage('Unable to read xml from');
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Unable to read xml from');
+        }
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/invalid-baseline.xml');
 
     }//end testFromFileShouldThrowExceptionForOnInvalidXML()
@@ -89,8 +94,13 @@ class BaselineSetFactoryTest extends TestCase
      */
     public function testFromFileViolationMissingSniffShouldThrowException()
     {
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
-        $this->expectExceptionMessage('Missing `sniff` attribute in `violation`');
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+            $this->expectExceptionMessage('Missing `sniff` attribute in `violation`');
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `sniff` attribute in `violation`');
+        }
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-sniff-baseline.xml');
 
     }//end testFromFileViolationMissingSniffShouldThrowException()
@@ -104,8 +114,13 @@ class BaselineSetFactoryTest extends TestCase
      */
     public function testFromFileViolationMissingSignatureShouldThrowException()
     {
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
-        $this->expectExceptionMessage('Missing `signature` attribute in `violation` in');
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+            $this->expectExceptionMessage('Missing `signature` attribute in `violation` in');
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `signature` attribute in `violation` in');
+        }
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-signature-baseline.xml');
 
     }//end testFromFileViolationMissingSignatureShouldThrowException()
@@ -119,8 +134,13 @@ class BaselineSetFactoryTest extends TestCase
      */
     public function testFromFileViolationMissingFileShouldThrowException()
     {
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
-        $this->expectExceptionMessage('Missing `file` attribute in `violation` in');
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+            $this->expectExceptionMessage('Missing `file` attribute in `violation` in');
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `file` attribute in `violation` in');
+        }
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-file-baseline.xml');
 
     }//end testFromFileViolationMissingFileShouldThrowException()

--- a/tests/Core/Baseline/BaselineSetFactoryTest.php
+++ b/tests/Core/Baseline/BaselineSetFactoryTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for the BaselineSetFactory
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Baseline;
+
+use PHP_CodeSniffer\Baseline\BaselineSetFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcases for the reading the baseline set from file
+ *
+ * @coversDefaultClass \PHP_CodeSniffer\Baseline\BaselineSetFactory
+ */
+class BaselineSetFactoryTest extends TestCase
+{
+
+
+    /**
+     * Read the baseline from a file
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileShouldSucceed()
+    {
+        $filename = __DIR__.'/TestFiles/baseline.xml';
+        $set      = BaselineSetFactory::fromFile($filename);
+
+        static::assertTrue($set->contains('Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen', '/test/src/foo/bar', 'foobar'));
+
+    }//end testFromFileShouldSucceed()
+
+
+    /**
+     * Read the baseline from a file with different slashes
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileShouldSucceedWithBackAndForwardSlashes()
+    {
+        $filename = __DIR__.'/TestFiles/baseline.xml';
+        $set      = BaselineSetFactory::fromFile($filename);
+
+        static::assertTrue($set->contains('Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen', '/test\\src\\foo/bar', 'foobar'));
+
+    }//end testFromFileShouldSucceedWithBackAndForwardSlashes()
+
+
+    /**
+     * Test that reading absent file returns null
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileShouldReturnNullIfAbsent()
+    {
+        static::assertNull(BaselineSetFactory::fromFile('foobar.xml'));
+
+    }//end testFromFileShouldReturnNullIfAbsent()
+
+
+    /**
+     * Test that reading invalid xml throws exception
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileShouldThrowExceptionForOnInvalidXML()
+    {
+        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Unable to read xml from');
+        BaselineSetFactory::fromFile(__DIR__.'/TestFiles/invalid-baseline.xml');
+
+    }//end testFromFileShouldThrowExceptionForOnInvalidXML()
+
+
+    /**
+     * Test that missing attributes throws exception
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileViolationMissingSniffShouldThrowException()
+    {
+        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Missing `sniff` attribute in `violation`');
+        BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-sniff-baseline.xml');
+
+    }//end testFromFileViolationMissingSniffShouldThrowException()
+
+
+    /**
+     * Test that missing signature attribute throws exception
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileViolationMissingSignatureShouldThrowException()
+    {
+        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Missing `signature` attribute in `violation` in');
+        BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-signature-baseline.xml');
+
+    }//end testFromFileViolationMissingSignatureShouldThrowException()
+
+
+    /**
+     * Test that missing attributes throws exception
+     *
+     * @covers ::fromFile
+     * @return void
+     */
+    public function testFromFileViolationMissingFileShouldThrowException()
+    {
+        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Missing `file` attribute in `violation` in');
+        BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-file-baseline.xml');
+
+    }//end testFromFileViolationMissingFileShouldThrowException()
+
+
+}//end class

--- a/tests/Core/Baseline/BaselineSetFactoryTest.php
+++ b/tests/Core/Baseline/BaselineSetFactoryTest.php
@@ -81,6 +81,7 @@ class BaselineSetFactoryTest extends TestCase
             // PHPUnit < 5.2.0.
             $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Unable to read xml from');
         }
+
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/invalid-baseline.xml');
 
     }//end testFromFileShouldThrowExceptionForOnInvalidXML()
@@ -101,6 +102,7 @@ class BaselineSetFactoryTest extends TestCase
             // PHPUnit < 5.2.0.
             $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `sniff` attribute in `violation`');
         }
+
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-sniff-baseline.xml');
 
     }//end testFromFileViolationMissingSniffShouldThrowException()
@@ -121,6 +123,7 @@ class BaselineSetFactoryTest extends TestCase
             // PHPUnit < 5.2.0.
             $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `signature` attribute in `violation` in');
         }
+
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-signature-baseline.xml');
 
     }//end testFromFileViolationMissingSignatureShouldThrowException()
@@ -141,6 +144,7 @@ class BaselineSetFactoryTest extends TestCase
             // PHPUnit < 5.2.0.
             $this->setExpectedException('PHP_CodeSniffer\Exceptions\RuntimeException', 'Missing `file` attribute in `violation` in');
         }
+
         BaselineSetFactory::fromFile(__DIR__.'/TestFiles/missing-file-baseline.xml');
 
     }//end testFromFileViolationMissingFileShouldThrowException()

--- a/tests/Core/Baseline/BaselineSetTest.php
+++ b/tests/Core/Baseline/BaselineSetTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for the BaselineSet
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Baseline;
+
+use PHP_CodeSniffer\Baseline\BaselineSet;
+use PHP_CodeSniffer\Baseline\ViolationBaseline;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the logic of the baseline set
+ *
+ * @coversDefaultClass \PHP_CodeSniffer\Baseline\BaselineSet
+ */
+class BaselineSetTest extends TestCase
+{
+
+
+    /**
+     * Test that contains find the correct sniff
+     *
+     * @covers ::addEntry
+     * @covers ::contains
+     * @return void
+     */
+    public function testSetContainsEntry()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('sniff', 'foobar', 'signature'));
+
+        static::assertTrue($set->contains('sniff', 'foobar', 'signature'));
+
+    }//end testSetContainsEntry()
+
+
+    /**
+     * Test that contains differentiates between types
+     *
+     * @covers ::addEntry
+     * @covers ::contains
+     * @return void
+     */
+    public function testShouldFindEntryForIdenticalRules()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('sniff', 'foo', 'signA'));
+        $set->addEntry(new ViolationBaseline('sniff', 'bar', 'signB'));
+
+        static::assertTrue($set->contains('sniff', 'foo', 'signA'));
+        static::assertTrue($set->contains('sniff', 'bar', 'signB'));
+        static::assertFalse($set->contains('sniff', 'unknown', 'signA'));
+        static::assertFalse($set->contains('sniff', 'foo', 'signB'));
+
+    }//end testShouldFindEntryForIdenticalRules()
+
+
+    /**
+     * Test that unknown sniffs are not found
+     *
+     * @covers ::addEntry
+     * @covers ::contains
+     * @return void
+     */
+    public function testShouldNotFindEntryForNonExistingRule()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('sniff', 'foo', 'signature'));
+
+        static::assertFalse($set->contains('unknown', 'foo', 'signature'));
+
+    }//end testShouldNotFindEntryForNonExistingRule()
+
+
+}//end class

--- a/tests/Core/Baseline/TestFiles/baseline.xml
+++ b/tests/Core/Baseline/TestFiles/baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<phpcs-baseline>
+    <skip/>
+    <violation file="src/foo/bar" sniff="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" signature="foobar"/>
+</phpcs-baseline>

--- a/tests/Core/Baseline/TestFiles/invalid-baseline.xml
+++ b/tests/Core/Baseline/TestFiles/invalid-baseline.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<phpcs-baseline>

--- a/tests/Core/Baseline/TestFiles/missing-file-baseline.xml
+++ b/tests/Core/Baseline/TestFiles/missing-file-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpcs-baseline>
+    <violation sniff="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" signature="foobar"/>
+</phpcs-baseline>

--- a/tests/Core/Baseline/TestFiles/missing-signature-baseline.xml
+++ b/tests/Core/Baseline/TestFiles/missing-signature-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpcs-baseline>
+    <violation file="src/foo/bar" sniff="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen"/>
+</phpcs-baseline>

--- a/tests/Core/Baseline/TestFiles/missing-sniff-baseline.xml
+++ b/tests/Core/Baseline/TestFiles/missing-sniff-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpcs-baseline>
+    <violation file="src/foo/bar" signature="foobar"/>
+</phpcs-baseline>

--- a/tests/Core/Baseline/ViolationBaselineTest.php
+++ b/tests/Core/Baseline/ViolationBaselineTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for the ViolationBaseline
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Baseline;
+
+use PHP_CodeSniffer\Baseline\ViolationBaseline;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the violation baseline data model
+ *
+ * @coversDefaultClass \PHP_CodeSniffer\Baseline\ViolationBaseline
+ */
+class ViolationBaselineTest extends TestCase
+{
+
+
+    /**
+     * Test the sniff name and signature is returned
+     *
+     * @covers ::__construct
+     * @covers ::getSniffName
+     * @covers ::getSignature
+     * @return void
+     */
+    public function testAccessors()
+    {
+        $violation = new ViolationBaseline('sniff', 'foobar', 'signature');
+        static::assertSame('sniff', $violation->getSniffName());
+        static::assertSame('signature', $violation->getSignature());
+
+    }//end testAccessors()
+
+
+    /**
+     * Test the give file matches the baseline correctly
+     *
+     * @covers ::__construct
+     * @covers ::matches
+     * @return void
+     */
+    public function testMatches()
+    {
+        $violation = new ViolationBaseline('sniff', 'foobar.txt', 'signature');
+        static::assertTrue($violation->matches('foobar.txt'));
+        static::assertTrue($violation->matches('/test/foobar.txt'));
+        static::assertFalse($violation->matches('foo.txt'));
+
+    }//end testMatches()
+
+
+}//end class

--- a/tests/Core/Reports/BaselineTest.php
+++ b/tests/Core/Reports/BaselineTest.php
@@ -10,10 +10,8 @@
 namespace PHP_CodeSniffer\Tests\Core\Reports;
 
 use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Reports\Baseline;
 use PHP_CodeSniffer\Util;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,25 +21,6 @@ use PHPUnit\Framework\TestCase;
  */
 class BaselineTest extends TestCase
 {
-
-    /**
-     * The mock file object
-     *
-     * @var File|MockObject
-     */
-    private $file;
-
-
-    /**
-     * Setup the test mock object
-     *
-     * @return void
-     */
-    protected function setup()
-    {
-        $this->file = $this->createMock('PHP_CodeSniffer\Files\File');
-
-    }//end setup()
 
 
     /**
@@ -53,7 +32,7 @@ class BaselineTest extends TestCase
     public function testGenerateFileReportEmptyShouldReturnFalse()
     {
         $report = new Baseline();
-        static::assertFalse($report->generateFileReport(['errors' => 0, 'warnings' => 0], $this->file));
+        static::assertFalse($report->generateFileReport(['errors' => 0, 'warnings' => 0], new MockFile([])));
 
     }//end testGenerateFileReportEmptyShouldReturnFalse()
 
@@ -80,11 +59,12 @@ class BaselineTest extends TestCase
             ],
         ];
         $signature = Util\CodeSignature::createSignature($tokens, 5);
-        $this->file->method('getTokens')->willReturn($tokens);
+
+        $file = new MockFile($tokens);
 
         $report = new Baseline();
         ob_start();
-        static::assertTrue($report->generateFileReport($reportData, $this->file));
+        static::assertTrue($report->generateFileReport($reportData, $file));
         $result = ob_get_clean();
         static::assertSame('<violation file="/test/foobar.txt" sniff="MySniff" signature="'.$signature.'"/>'.PHP_EOL, $result);
 

--- a/tests/Core/Reports/BaselineTest.php
+++ b/tests/Core/Reports/BaselineTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for the Baseline report file
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Reports;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Reports\Baseline;
+use PHP_CodeSniffer\Util;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcases for the baseline report output file
+ *
+ * @coversDefaultClass \PHP_CodeSniffer\Reports\Baseline
+ */
+class BaselineTest extends TestCase
+{
+
+    /**
+     * The mock file object
+     *
+     * @var File|MockObject
+     */
+    private $file;
+
+
+    /**
+     * Setup the test mock object
+     *
+     * @return void
+     */
+    protected function setup()
+    {
+        $this->file = $this->createMock('PHP_CodeSniffer\Files\File');
+
+    }//end setup()
+
+
+    /**
+     * Test that generation is skipped when there are no errors
+     *
+     * @covers ::generateFileReport
+     * @return void
+     */
+    public function testGenerateFileReportEmptyShouldReturnFalse()
+    {
+        $report = new Baseline();
+        static::assertFalse($report->generateFileReport(['errors' => 0, 'warnings' => 0], $this->file));
+
+    }//end testGenerateFileReportEmptyShouldReturnFalse()
+
+
+    /**
+     * Test the generation of a single error message
+     *
+     * @covers ::generateFileReport
+     * @return void
+     */
+    public function testGenerateFileReportShouldPrintReport()
+    {
+        $reportData = [
+            'filename' => '/test/foobar.txt',
+            'errors'   => 1,
+            'warnings' => 0,
+            'messages' => [5 => [[['source' => 'MySniff']]]],
+        ];
+
+        $tokens    = [
+            [
+                'content' => 'foobar',
+                'line'    => 5,
+            ],
+        ];
+        $signature = Util\CodeSignature::createSignature($tokens, 5);
+        $this->file->method('getTokens')->willReturn($tokens);
+
+        $report = new Baseline();
+        ob_start();
+        static::assertTrue($report->generateFileReport($reportData, $this->file));
+        $result = ob_get_clean();
+        static::assertSame('<violation file="/test/foobar.txt" sniff="MySniff" signature="'.$signature.'"/>'.PHP_EOL, $result);
+
+    }//end testGenerateFileReportShouldPrintReport()
+
+
+    /**
+     * Test the generation of the complete file
+     *
+     * @covers ::generate
+     * @return void
+     */
+    public function testGenerate()
+    {
+        $expected  = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".PHP_EOL;
+        $expected .= "<phpcs-baseline version=\"".Config::VERSION."\">";
+        $expected .= "<violation file=\"/test/foobar.txt\" sniff=\"MySniff\"/>".PHP_EOL;
+        $expected .= "</phpcs-baseline>".PHP_EOL;
+
+        $report = new Baseline();
+        ob_start();
+        $report->generate('<violation file="/test/foobar.txt" sniff="MySniff"/>', 1, 1, 0, 1);
+        $result = ob_get_clean();
+        static::assertSame($expected, $result);
+
+    }//end testGenerate()
+
+
+}//end class

--- a/tests/Core/Reports/MockFile.php
+++ b/tests/Core/Reports/MockFile.php
@@ -7,13 +7,15 @@ use PHP_CodeSniffer\Files\File;
 class MockFile extends File
 {
 
+
     /**
      * @param array $tokens
      */
     public function __construct(array $tokens)
     {
         $this->tokens = $tokens;
-    } //end __construct()
+
+    }//end __construct()
 
 
     /**
@@ -22,6 +24,7 @@ class MockFile extends File
     public function getTokens()
     {
         return $this->tokens;
+
     }//end getTokens()
 
 

--- a/tests/Core/Reports/MockFile.php
+++ b/tests/Core/Reports/MockFile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PHP_CodeSniffer\Tests\Core\Reports;
+
+use PHP_CodeSniffer\Files\File;
+
+class MockFile extends File
+{
+
+    /**
+     * @param array $tokens
+     */
+    public function __construct(array $tokens)
+    {
+        $this->tokens = $tokens;
+    } //end __construct()
+
+
+    /**
+     * @return array
+     */
+    public function getTokens()
+    {
+        return $this->tokens;
+    }//end getTokens()
+
+
+}//end class

--- a/tests/Core/Util/CodeSignatureTest.php
+++ b/tests/Core/Util/CodeSignatureTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests the generation of code signature based on tokens
+ *
+ * @author    Frank Dekker <fdekker@123inkt.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Util;
+
+use PHP_CodeSniffer\Util\CodeSignature;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the generation of code signature based on tokens
+ *
+ * @coversDefaultClass \PHP_CodeSniffer\Util\CodeSignature
+ */
+class CodeSignatureTest extends TestCase
+{
+
+
+    /**
+     * Test the code signature hash generation
+     *
+     * @param int    $lineNr   the line nr within the file
+     * @param string $expected the expected signature
+     *
+     * @return void
+     *
+     * @covers       ::createSignature
+     * @dataProvider dataProvider
+     */
+    public function testCreateSignature($lineNr, $expected)
+    {
+        $tokens = [
+            [
+                'content' => 'line1',
+                'line'    => 1,
+            ],
+            [
+                'content' => 'line2',
+                'line'    => 2,
+            ],
+            [
+                'content' => 'line3',
+                'line'    => 3,
+            ],
+            [
+                'content' => "\r\n",
+                'line'    => 3,
+            ],
+            [
+                'content' => 'line4',
+                'line'    => 4,
+            ],
+            [
+                'content' => 'line5',
+                'line'    => 5,
+            ],
+        ];
+
+        $signature = CodeSignature::createSignature($tokens, $lineNr);
+        static::assertSame($expected, $signature);
+
+    }//end testCreateSignature()
+
+
+    /**
+     * Provide edge case scenario's for the code signature
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function dataProvider()
+    {
+        return [
+            'first line of file'  => [
+                1,
+                hash('sha1', 'line1line2'),
+            ],
+            'middle line of file' => [
+                3,
+                hash('sha1', 'line2line3line4'),
+            ],
+            'last line of file'   => [
+                5,
+                hash('sha1', 'line4line5'),
+            ],
+        ];
+
+    }//end dataProvider()
+
+
+}//end class


### PR DESCRIPTION
Added the ability to baseline violations.
Original PR: https://github.com/squizlabs/PHP_CodeSniffer/pull/3387

## Features
**Create baseline**
```shell
phpcs src --report-baseline=phpcs.baseline.xml --basepath=./
```

- Writes `phpcs.baseline.xml` in the current working directory. Pref be the root of the project
- `basepath` will be subtracted from the filepaths in the baseline xml.

**Use default baseline**
Will by default search in the working directory for `phpcs.baseline.xml`
```shell
phpcs src
```

**Use custom location baseline**
```shell
phpcs src --baseline-file=<path/to/baseline.xml>
```

## Changes
Added classes to read the baseline file and setup data structure.
Added check in File::addMessage to check if the message is baselined.
Added `--baseline-file` to cli options
Added unit tests for the newly added files.



# More precise baseline improvements

Improved the baseline calculation based on the approach I suggested in [#2543](https://github.com/squizlabs/PHP_CodeSniffer/issues/2543)

Now a code signature will be calculated and added to the baseline report file. The code signature is the hash of the code on the line of the violation, and 1 line before and after.

During standard inspection when comparing against the baseline, the same signature will be calculated for encountered violations and compared against the baseline signature. The violation will _only_ be skipped if the code signature is identical to the one in the baseline.

As mentioned, this will prevent a sniff being disabled for the entire file. The sniff will now be specifically disabled for the calculated code signature. Modifications in the file won't break the baseline, unless you edit one of the 3 lines around the baseline. At this point I feel it's quite useful to resolve the violation anyway, as you're editing that close to it.

### Example baseline:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<phpcs-baseline version="3.6.1">
<violation file="src\Baseline\BaselineSet.php" sniff="PEAR.Commenting.FunctionComment.MissingParamName" signature="54accce13bb236dc361cf9d75895c274fce619d5"/>
<violation file="src\Baseline\BaselineSet.php" sniff="PEAR.Commenting.FunctionComment.MissingParamTag" signature="25a91da1dadc60a04a9a6615502ad4aa4fd397c2"/>
<violation file="src\Baseline\BaselineSet.php" sniff="PEAR.Functions.FunctionDeclaration.SpaceBeforeOpenParen" signature="edcfdf132eb46b842349404740ba7b8f224d82e1"/>
</phpcs-baseline>
```


