### PR TITLE
Respect all sniffs when reviewing PHP_CodeSniffer itself

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,12 +15,7 @@
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
-    <arg value="np"/>
-
-    <!-- Don't hide tokenizer exceptions -->
-    <rule ref="Internal.Tokenizer.Exception">
-        <type>error</type>
-    </rule>
+    <arg value="p"/>
 
     <!-- Include the whole PEAR standard -->
     <rule ref="PEAR">
@@ -32,6 +27,7 @@
         <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
         <exclude name="PEAR.Commenting.InlineComment"/>
+        <exclude name="Generic.Files.LineLength"/>
     </rule>
 
     <!-- Include some sniffs from other standards that don't conflict with PEAR -->
@@ -76,13 +72,6 @@
     <rule ref="PSR12.Files.OpenTag"/>
     <rule ref="Zend.Files.ClosingTag"/>
 
-    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
-    <rule ref="Generic.ControlStructures.InlineControlStructure">
-        <properties>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
-
     <!-- We use custom indent rules for arrays -->
     <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
@@ -111,11 +100,10 @@
         </properties>
     </rule>
 
-    <!-- Have 12 chars padding maximum and always show as errors -->
+    <!-- Have 12 chars padding maximum -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
             <property name="maxPadding" value="12"/>
-            <property name="error" value="true"/>
         </properties>
     </rule>
 
@@ -132,20 +120,8 @@
         </properties>
     </rule>
 
-    <!-- Private methods MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-        <type>error</type>
-    </rule>
-
-    <!-- Private properties MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
-        <type>error</type>
-    </rule>
-
     <!-- Do not allow unreachable code. -->
-    <rule ref="Squiz.PHP.NonExecutableCode">
-        <type>error</type>
-    </rule>
+    <rule ref="Squiz.PHP.NonExecutableCode"/>
 
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
@@ -157,4 +133,14 @@
         <exclude-pattern>tests/Core/Tokenizer/StableCommentWhitespaceWinTest\.php</exclude-pattern>
     </rule>
 
+    <!-- Avoid false positive with this sniff detecting itself -->
+    <rule ref="Generic.Commenting.Todo">
+        <exclude-pattern>src/Standards/Generic/Sniffs/Commenting/TodoSniff\.php</exclude-pattern>
+        <exclude-pattern>src/Standards/Generic/Tests/Commenting/TodoUnitTest\.php</exclude-pattern>
+    </rule>
+
+    <!-- @see https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/122#discussion_r1414167897 -->
+    <rule ref="Squiz.Commenting.VariableComment">
+        <exclude-pattern>src/Util/Tokens\.php</exclude-pattern>
+    </rule>
 </ruleset>


### PR DESCRIPTION
## Description
This is a re-creation of https://github.com/squizlabs/PHP_CodeSniffer/pull/3914

While working on another task, I noticed that warnings are ignored by default. This seems unintentional. Some discussion regarding this has taken place in https://github.com/squizlabs/PHP_CodeSniffer/pull/3914

## Suggested changelog entry
Respect warnings as well as errors from sniffs within the coding standard for PHP_CodeSniffer itself.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that the code complies with the projects coding standards.
