### PR TITLE
Report Full: fix two line wrapping bugs

### DIFF
--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -137,10 +137,10 @@ class Full implements Report
 
                     if ($showSources === true) {
                         $lastMsg          = $errorMsg;
-                        $startPosLastLine = strrpos($errorMsg, $paddingLine2.$beforeMsg);
+                        $startPosLastLine = strrpos($errorMsg, PHP_EOL.$paddingLine2.$beforeMsg);
                         if ($startPosLastLine !== false) {
-                            // Message is multiline.
-                            $lastMsg = substr($errorMsg, ($startPosLastLine + strlen($paddingLine2.$beforeMsg)));
+                            // Message is multiline. Grab the text of last line of the message, including the color codes.
+                            $lastMsg = substr($errorMsg, ($startPosLastLine + strlen(PHP_EOL.$paddingLine2)));
                         }
 
                         // When show sources is used, the message itself will be bolded, so we need to correct the length.

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -122,6 +122,8 @@ class Full implements Report
             $afterMsg  = "\033[0m";
         }
 
+        $beforeAfterLength = strlen($beforeMsg.$afterMsg);
+
         foreach ($report['messages'] as $line => $lineErrors) {
             foreach ($lineErrors as $column => $colErrors) {
                 foreach ($colErrors as $error) {
@@ -150,7 +152,7 @@ class Full implements Report
                         // Add space + source suffix length.
                         $lastMsgPlusSourceLength += (1 + strlen($sourceSuffix));
                         // Correct for the color codes.
-                        $lastMsgPlusSourceLength -= 8;
+                        $lastMsgPlusSourceLength -= $beforeAfterLength;
 
                         if ($lastMsgPlusSourceLength > $maxErrorSpace) {
                             $errorMsg .= PHP_EOL.$paddingLine2.$sourceSuffix;


### PR DESCRIPTION
## Description

This is a re-creation of https://github.com/squizlabs/PHP_CodeSniffer/pull/3925:

> The first is that the ANSI escape codes applied to bold the message when `-s` is used were not being taken into account when wrapping the lines for width, causing some lines to be wrapped unnecessarily.
> 
> The second is that when lines were wrapped in the middle of a long message, the `|` characters making up the table were being bolded along with the message.

## Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
* Avoid unnecessarily wrapping lines in the full report when `-s` is used.
* Fix incorrect bolding of pipes in the full report tables when `-s` is used and messages wrap.

## Related issues/external references

Fixes #124
Fixes squizlabs/PHP_CodeSniffer#3924
Closes squizlabs/PHP_CodeSniffer#3925

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
  - I see no existing tests for any of the reporting formats.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
