### PR TITLE
New error code for `Squiz.Commenting.FunctionComment`: `MissingParamType`

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -463,7 +463,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     }
                 }
 
-                if ($suggestedTypeHint !== '' && isset($realParams[$pos]) === true) {
+                if ($suggestedTypeHint !== '' && isset($realParams[$pos]) === true && $param['var'] !== '') {
                     $typeHint = $realParams[$pos]['type_hint'];
 
                     // Remove namespace prefixes when comparing.

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -366,6 +366,9 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                         $phpcsFile->addError($error, $tag, 'MissingParamComment');
                         $commentLines[] = ['comment' => ''];
                     }//end if
+                } else if ($tokens[($tag + 2)]['content'][0] === '$') {
+                    $error = 'Missing parameter type';
+                    $phpcsFile->addError($error, $tag, 'MissingParamType');
                 } else {
                     $error = 'Missing parameter name';
                     $phpcsFile->addError($error, $tag, 'MissingParamName');

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1134,3 +1134,27 @@ public function variableOrderMismatch($bar, $baz, $foo) {
  * @return never
  */
 function foo() {}
+
+/**
+ * @param $noTypeNoComment
+ * @return void
+ */
+function paramVariation1($noTypeNoComment): void {}
+
+/**
+ * @param $noTypeWithComment This parameter has no type specified.
+ * @return void
+ */
+function paramVariation2($noTypeWithComment): void {}
+
+/**
+ * @param integer $hasTypeNoComment
+ * @return void
+ */
+function paramVariation3($hasTypeNoComment): void {}
+
+/**
+ * @param integer $hasTypehasComment This parameter has type.
+ * @return void
+ */
+function paramVariation4($hasTypehasComment): void {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1134,3 +1134,27 @@ public function variableOrderMismatch($bar, $baz, $foo) {
  * @return never
  */
 function foo() {}
+
+/**
+ * @param $noTypeNoComment
+ * @return void
+ */
+function paramVariation1($noTypeNoComment): void {}
+
+/**
+ * @param $noTypeWithComment This parameter has no type specified.
+ * @return void
+ */
+function paramVariation2($noTypeWithComment): void {}
+
+/**
+ * @param integer $hasTypeNoComment
+ * @return void
+ */
+function paramVariation3($hasTypeNoComment): void {}
+
+/**
+ * @param integer $hasTypehasComment This parameter has type.
+ * @return void
+ */
+function paramVariation4($hasTypehasComment): void {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -137,6 +137,13 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest
             1123 => 1,
             1124 => 1,
             1125 => 1,
+            1138 => 1,
+            1139 => 1,
+            1142 => 1,
+            1144 => 1,
+            1145 => 1,
+            1148 => 1,
+            1151 => 1,
         ];
 
         // Scalar type hints only work from PHP 7 onwards.
@@ -156,6 +163,8 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest
             $errors[1089] = 3;
             $errors[1107] = 8;
             $errors[1129] = 3;
+            $errors[1154] = 1;
+            $errors[1160] = 1;
         } else {
             $errors[729] = 4;
             $errors[740] = 2;

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -107,7 +107,6 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest
             792  => 1,
             794  => 1,
             797  => 1,
-            801  => 1,
             828  => 1,
             840  => 1,
             852  => 1,
@@ -139,10 +138,8 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest
             1125 => 1,
             1138 => 1,
             1139 => 1,
-            1142 => 1,
             1144 => 1,
             1145 => 1,
-            1148 => 1,
             1151 => 1,
         ];
 


### PR DESCRIPTION
## Description
When a docblock comment is provided for a function parameter, but no valid type information is supplied\*, the error message (and code) from PHP_CodeSniffer is misleading. This pull request aims to fix this by introducing a new error code for these cases. This could be considered a breaking change as rulesets may need to be adjusted to accommodate this new error code.

\* Some editors will create boiler-plate docblocks like this, expecting the developer to write the correct information.

Additionally, while working on the above change, I noticed that in some cases an invalid suggestion of adding a type hint for this specific case was being provided. I have included a fix for this in this pull request.

Before this change, the following code would be annotated as 

    2 | ERROR | Doc comment for parameter "$bar" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
    3 | ERROR | Missing parameter name (Squiz.Commenting.FunctionComment.MissingParamName)
    6 | ERROR | Type hint "bar" missing for  (Squiz.Commenting.FunctionComment.TypeHintMissing)

after this change, the same code would be annotated as

    2 | ERROR | Doc comment for parameter "$bar" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
    3 | ERROR | Missing parameter type (Squiz.Commenting.FunctionComment.MissingParamType)

(Note the difference for line 3 ("Missing parameter **name**" versus "Missing parameter **type**"), and the lack of error for line 6.)

```php
<?php
/**
 * @param $bar
 * @return void
 */
function foo($bar) {}
```

Here's an example from the existing test file for this sniff:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/d84144d368f14b9faf494352cab26b974223e387/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc#L789-L802


## Suggested changelog entry
\[Squiz.Commenting.FunctionComment\] New error code `MissingParamType` will be used instead of `MissingParamName` when a parameter name is provided, but not its type. Additionally, invalid type hint suggestion will no longer be provided in these cases.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.