### PR TITLE
Correct spelling issues in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you use Phive, you can install PHP_CodeSniffer as a project tool using the fo
 phive install phpcs
 phive install phpcbf
 ```
-You will then be able to run PHP_CodeSniffer from the tools directory:
+You will then be able to run PHP_CodeSniffer from the `tools` directory:
 ```bash
 ./tools/phpcs -h
 ./tools/phpcbf -h
@@ -107,11 +107,11 @@ Full usage information and example reports are available on the [usage page](htt
 
 ## Documentation
 
-The documentation for PHP_CodeSniffer is available on the [Github wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki).
+The documentation for PHP_CodeSniffer is available on the [GitHub wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki).
 
 ## Issues
 
-Bug reports and feature requests can be submitted on the [Github Issue Tracker](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues).
+Bug reports and feature requests can be submitted on the [GitHub Issue Tracker](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues).
 
 ## Contributing
 


### PR DESCRIPTION
Corrects spelling issues in `README.md`

## Description
Corrects the spelling to `GitHub` (as the brand name is with capital `H`)  and wraps the directory name `tools` with backticks to clarify the directory is referenced. 

## Suggested changelog entry
Correct spelling issues in `README.md`

## Related issues/external references
**N/A**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [X] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [X] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.