### PR TITLE
Squiz/OperatorSpacing: minor tweak to the tests

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -269,7 +269,7 @@ fn&($x) => $x;
 
 // phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments false
 $a  =  3;
-
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments true
 yield -1;
 echo -1;
 $a = -1;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -263,7 +263,7 @@ fn&($x) => $x;
 
 // phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments false
 $a = 3;
-
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments true
 yield -1;
 echo -1;
 $a = -1;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
@@ -101,3 +101,4 @@ var foo = bar.map(baz=> baz.length);
 
 // phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments false
 a  =  3;
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments true

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
@@ -95,3 +95,4 @@ var foo = bar.map(baz => baz.length);
 
 // phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments false
 a = 3;
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing ignoreSpacingBeforeAssignments true


### PR DESCRIPTION
## Description

PR squizlabs/PHP_CodeSniffer#2515 introduced a new public property to the sniff, including tests, but the property was not reset after that particular test, which means it could affect all tests added after it.

Fixed now.


## Suggested changelog entry
_N/A_ (test only change)