### PR TITLE
PEAR/FunctionCallSignature: minor tweaks

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -340,7 +340,8 @@ class FunctionCallSignatureSniff implements Sniff
         // call itself is, so we can work out how far to
         // indent the arguments.
         $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);
-        if ($tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
+        if ($first !== false
+            && $tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
             && $tokens[($first - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
         ) {
             // We are in a multi-line string, so find the start and use
@@ -386,8 +387,10 @@ class FunctionCallSignatureSniff implements Sniff
 
             $fix = $phpcsFile->addFixableError($error, $first, 'OpeningIndent', $data);
             if ($fix === true) {
+                // Set adjustment for use later to determine whether argument indentation is correct when fixing.
                 $adjustment = ($functionIndent - $foundFunctionIndent);
-                $padding    = str_repeat(' ', $functionIndent);
+
+                $padding = str_repeat(' ', $functionIndent);
                 if ($foundFunctionIndent === 0) {
                     $phpcsFile->fixer->addContentBefore($first, $padding);
                 } else if ($tokens[$first]['code'] === T_INLINE_HTML) {

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
@@ -567,3 +567,10 @@ content
       <p><?php require get_theme_file_path(
       '/theme_extra/test_block.php'
 ); ?></p>
+
+<!-- If the first token is inline HTML, the token itself should be adjusted, not the token before. -->
+<?php if (check_me() == 'value'): ?>
+  <?php include get_file_path(
+    'my_file.php'
+  ); ?>
+<?php endif; ?>

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
@@ -582,3 +582,10 @@ content
     <p><?php require get_theme_file_path(
         '/theme_extra/test_block.php'
 ); ?></p>
+
+<!-- If the first token is inline HTML, the token itself should be adjusted, not the token before. -->
+<?php if (check_me() == 'value'): ?>
+<?php include get_file_path(
+    'my_file.php'
+); ?>
+<?php endif; ?>

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -134,6 +134,8 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
             559 => 1,
             567 => 1,
             568 => 1,
+            573 => 1,
+            574 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description
Recreation of upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3667:

> Minor defensive coding and documentation improvements + an additional unit test.

The original PR was bigger and contained a bug fix, but was fixed in parallel via another commit.

> Fixed by commit https://github.com/squizlabs/PHP_CodeSniffer/commit/9445108a57b46f4e84a890788de5d2388346460a in response to issue https://github.com/squizlabs/PHP_CodeSniffer/issues/3666, though this PR still contains some minimal differences (defensive coding, comment + minor difference in the fix) which may be worth having a look at.

## Suggested changelog entry
_N/A_

