### PR TITLE
Composer: revert package name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The file documents changes to the PHP_CodeSniffer project.
 
 ### Breaking Changes
 - The `squizlabs/PHP_CodeSniffer` repository has been abandoned. This repository will serve as the continuation of the project.
-    - Composer users will need to `require-dev` the `phpcsstandards/php_codesniffer` package instead.
+    - For Composer users, nothing changes.
+        - **In contrast to earlier information, the `squizlabs/php_codesniffer` package will now point to the new repo and everything will continue to work as before.**
     - PHIVE users may need to clear the PHIVE URL cache.
         - PHIVE users who don't use the package alias, but refer to the package URL, will need to update the URL from `https://squizlabs.github.io/PHP_CodeSniffer/phars/` to `https://phars.phpcodesniffer.com/phars/`.
     - Users who download the PHAR files using curl or wget, will need to update the URL from `https://squizlabs.github.io/PHP_CodeSniffer/[phpcs|phpcbf].phar` to `https://phars.phpcodesniffer.com/[phpcs|phpcbf].phar`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PHP_CodeSniffer
 [![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml)
 [![License](http://poser.pugx.org/phpcsstandards/php_codesniffer/license)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt)
 
-![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/php_codesniffer.svg?maxAge=3600)
+![Minimum PHP Version](https://img.shields.io/packagist/php-v/squizlabs/php_codesniffer.svg?maxAge=3600)
 [![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml)
 
 </div>
@@ -48,16 +48,16 @@ php phpcbf.phar -h
 ### Composer
 If you use Composer, you can install PHP_CodeSniffer system-wide with the following command:
 ```bash
-composer global require "phpcsstandards/php_codesniffer=*"
+composer global require "squizlabs/php_codesniffer=*"
 ```
 Make sure you have the composer bin dir in your PATH. The default value is `~/.composer/vendor/bin/`, but you can check the value that you need to use by running `composer global config bin-dir --absolute`.
 
-Or alternatively, include a dependency for `phpcsstandards/php_codesniffer` in your `composer.json` file. For example:
+Or alternatively, include a dependency for `squizlabs/php_codesniffer` in your `composer.json` file. For example:
 
 ```json
 {
     "require-dev": {
-        "phpcsstandards/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpcsstandards/php_codesniffer",
+    "name": "squizlabs/php_codesniffer",
     "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
     "type": "library",
     "keywords": [
@@ -42,9 +42,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
-    },
-    "replace": {
-        "squizlabs/php_codesniffer": "> 2.0"
     },
     "bin": [
         "bin/phpcs",


### PR DESCRIPTION
## Description

:warning: **_To be merged once the Packagist edit has been made._** :warning:

This reverts commit f6dc841498ab8b056ba0bb8f6785ed634700b34e and updates the information in the changelog for the 3.8.0 release.

**Users who already changed the package name in _their_ `composer.json` dependencies, should switch back to the original package name.**

Refs:
* See [the conversation from this comment down](https://github.com/squizlabs/PHP_CodeSniffer/issues/3932#issuecomment-1841873639).

Closes #113, #114, #116

