### PR TITLE
Squiz/ControlSignature: add missing property reset

### DIFF
--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -305,6 +305,9 @@ $r = match ($x) {
 
 $r = match($x){1 => 1};
 
+// Reset property.
+// @codingStandardsChangeSetting Squiz.ControlStructures.ControlSignature requiredSpacesBeforeColon 1
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -309,6 +309,9 @@ $r = match ($x) {
 $r = match ($x) {
 1 => 1};
 
+// Reset property.
+// @codingStandardsChangeSetting Squiz.ControlStructures.ControlSignature requiredSpacesBeforeColon 1
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.


### PR DESCRIPTION
`requiredSpacesBeforeColon` wasn't being reset after the tests it applies to