### PR TITLE
Composer: sort of "normalize" the file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,13 @@
 {
     "name": "squizlabs/php_codesniffer",
     "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+    "license": "BSD-3-Clause",
     "type": "library",
     "keywords": [
         "phpcs",
         "standards",
         "static analysis"
     ],
-    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
-    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Greg Sherwood",
@@ -19,34 +18,35 @@
             "role": "Current lead"
         },
         {
-            "name" : "Contributors",
-            "homepage" : "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+            "name": "Contributors",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
         }
     ],
+    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
     "support": {
         "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
         "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki",
         "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
         "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
-        }
-    },
     "require": {
         "php": ">=5.4.0",
+        "ext-simplexml": "*",
         "ext-tokenizer": "*",
-        "ext-xmlwriter": "*",
-        "ext-simplexml": "*"
+        "ext-xmlwriter": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "bin": [
-        "bin/phpcs",
-        "bin/phpcbf"
+        "bin/phpcbf",
+        "bin/phpcs"
     ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
+    },
     "scripts": {
         "cs": [
             "@php ./bin/phpcs"


### PR DESCRIPTION
## Description

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=space --indent-size=4`.

Ref: https://github.com/ergebnis/composer-normalize


## Suggested changelog entry
_N/A_

