### PR TITLE
GH Actions/label mngmnt: various tweaks

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,9 +1,17 @@
 name: Check PRs for merge conflicts
 
 on:
+  # Check for new conflicts due to merges.
   push:
     branches:
       - master
+  # Check conflicts in new PRs and for resolved conflicts due to an open PR being updated.
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:

--- a/.github/workflows/label-remove-outdated.yml
+++ b/.github/workflows/label-remove-outdated.yml
@@ -39,6 +39,7 @@ jobs:
           labels: |
             Status: awaiting feedback
             Status: close candidate
+            Status: has merge conflict
             Status: needs investigation
             Status: triage
 


### PR DESCRIPTION
## Description

Some more label management tweaks, trying to get it balanced out right.

### GH Actions/label mngmnt: auto-remove merge conflict label on PR merge

... as a PR wouldn't have been merged if the merge conflict still existed.

(Adding the "merge conflict" labels works really well, but they don't always seem to get removed quickly enough)

### GH Actions/label mngmnt: add additional triggers for merge conflict check

... in an attempt to get the action runner to remove the "has conflict" label when a PR is updated (which hopefully would have resolved the conflict).

## Suggested changelog entry
_N/A_