### PR TITLE
GH Actions: test workflow improvements

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -1,0 +1,54 @@
+name: Build PHARs
+
+on:
+  # Run on pushes to master and on all pull requests.
+  # Prevent the build from running when there are only irrelevant changes.
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Deliberately missing PHP 8.0 as that PHAR is build and used in the test workflow.
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.1', '8.2', '8.3', '8.4']
+
+    name: "Build Phar on PHP: ${{ matrix.php }}"
+
+    continue-on-error: ${{ matrix.php == '8.4' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
+
+      - name: Build the phars
+        run: php scripts/build-phar.php
+
+      # Both the below only check a file which is rarely changed and therefore unlikely to have issues.
+      # This test is about testing that the phars are functional, *not* about whether the code style complies.
+      - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
+        run: php phpcs.phar ./scripts
+
+      - name: 'PHPCBF: fix code style using the Phar file to test the Phar is functional'
+        run: php phpcbf.phar ./scripts

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -1,0 +1,61 @@
+name: Quicktest
+
+on:
+  # Run on pushes to all branches except for `master`.
+  push:
+    branches-ignore:
+      - master
+    paths-ignore:
+      - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  #### QUICK TEST ####
+  # This is a much quicker test run which only runs the unit tests against the low/medium/high
+  # supported PHP versions and skips the PHAR test and the tests for external JS/CSS tooling.
+  # These are basically the same builds as in the Test->Coverage workflow, but then without doing
+  # the code-coverage.
+  quicktest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.4', '7.2', 'latest']
+
+    name: "QuickTest: PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: 'error_reporting=-1, display_errors=On'
+          coverage: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: 'PHPCS: set the path to PHP'
+        run: php bin/phpcs --config-set php_path php
+
+      - name: 'PHPUnit: run the tests'
+        run: vendor/bin/phpunit tests/AllTests.php
+
+      # Note: The code style check is run as an integration test.
+      - name: 'PHPCS: check code style without cache, no parallel'
+        run: php bin/phpcs --no-cache --parallel=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-
-    name: "Build Phar on PHP: ${{ matrix.php }}"
-
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    name: "Build Phar on PHP: 8.0"
 
     steps:
       - name: Checkout code
@@ -35,7 +28,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.0'
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
 
@@ -44,7 +37,6 @@ jobs:
 
       - name: Upload the PHPCS phar
         uses: actions/upload-artifact@v3
-        if: ${{ success() && matrix.php == '8.0' }}
         with:
           name: phpcs-phar
           path: ./phpcs.phar
@@ -53,14 +45,13 @@ jobs:
 
       - name: Upload the PHPCBF phar
         uses: actions/upload-artifact@v3
-        if: ${{ success() && matrix.php == '8.0' }}
         with:
           name: phpcbf-phar
           path: ./phpcbf.phar
           if-no-files-found: error
           retention-days: 28
 
-      # Both the below only check a few files which are rarely changed and therefore unlikely to have issues.
+      # Both the below only check a file which is rarely changed and therefore unlikely to have issues.
       # This test is about testing that the phars are functional, *not* about whether the code style complies.
       - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
         run: php phpcs.phar ./scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Test
 
 on:
-  # Run on all pushes and on all pull requests.
+  # Run on pushes to `master` and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
+    branches:
+      - master
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
## Description

### GH Actions: split PHAR building task off to own script

While it is still a good idea to make sure the PHAR building script works on all supported PHP versions, it is not necessary to run this task against all PHP versions on all pushes, nor to have the test runs wait until all PHAR building builds are done, as for the tests we only need the PHARs generated on PHP 8.0, which are the ones used in a release.

This commit splits the PHAR building job off to its own script, only keeping the PHAR build against PHP 8.0 in the `test` workflow.

While this does mean there is now some duplication in the scripts, I find it more relevant to make the builds faster.

### GH Actions: introduce a quicktest workflow

... which runs only against low/medium/high PHP versions and does not run:
- the tests using custom PHP ini settings
- the tests related to sniffs using external JS/CSS tooling
- test CS check (integration test) using the PHAR

This quick test workflow will now run on pushes to all branches except `master`. For pushes to `master`, the full test build will still be run.

In the fast majority of cases, this quicktest will already surface any issues and it saves a lot of resources when the same builds don't run twice for every PR.

## Suggested changelog entry
_N/A_