### PR TITLE
CI/QA: start recording code coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -152,9 +152,8 @@ To help you with this, a number of convenience scripts are available:
 * `composer cs` will check for code style violations.
 * `composer cbf` will run the autofixers for code style violations.
 * `composer test` will run the unit tests.
-* `composer coverage` will run the unit tests with code coverage.
-    Note: you may want to use a custom `phpunit.xml` overload config file to tell PHPUnit where to place an HTML report.
-    Alternative run it like so: `composer coverage -- --coverage-html /path/to/report-dir/` to specify the location for the HTML report on the command line.
+* `composer coverage` will run the unit tests with code coverage and show a text summary.
+* `composer coverage-local` will run the unit tests with code coverage and generate an HTML coverage report, which will be placed in a `build/coverage-html` subdirectory.
 * `composer build` will build the phpcs.phar and phpcbf.phar files.
 
 N.B.: You can ignore any skipped tests as these are for external tools.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -54,7 +54,7 @@ jobs:
         run: php bin/phpcs --config-set php_path php
 
       - name: 'PHPUnit: run the tests'
-        run: vendor/bin/phpunit tests/AllTests.php
+        run: vendor/bin/phpunit tests/AllTests.php --no-coverage
 
       # Note: The code style check is run as an integration test.
       - name: 'PHPCS: check code style without cache, no parallel'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,14 @@ jobs:
         custom_ini: [false]
 
         include:
-          # Builds running the basic tests with different PHP ini settings.
+          # Skip test runs on builds which are also run for in the coverage job.
+          # Note: the tests on PHP 7.2 will still be run as the coverage build is uses custom_ini for that version.
+          - php: '5.4'
+            skip_tests: true
+          - php: '8.3'
+            skip_tests: true
+
+          # Extra builds running only the unit tests with different PHP ini settings.
           - php: '5.5'
             custom_ini: true
           - php: '7.0'
@@ -137,8 +144,9 @@ jobs:
       - name: 'PHPCS: set the path to PHP'
         run: php bin/phpcs --config-set php_path php
 
-      - name: 'PHPUnit: run the tests'
-        run: vendor/bin/phpunit tests/AllTests.php
+      - name: 'PHPUnit: run the tests without code coverage'
+        if: ${{ matrix.skip_tests != true }}
+        run: vendor/bin/phpunit tests/AllTests.php --no-coverage
 
       - name: 'PHPCS: check code style without cache, no parallel'
         if: ${{ matrix.custom_ini == false && matrix.php != '7.4' }}
@@ -163,3 +171,92 @@ jobs:
       - name: 'PHPCS: check code style using the Phar file'
         if: ${{ matrix.custom_ini == false }}
         run: php phpcs.phar
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - php: '5.4'
+            custom_ini: false
+          - php: '7.2'
+            custom_ini: true
+          - php: '8.3'
+            custom_ini: false
+
+    name: "Coverage: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup ini config
+        id: set_ini
+        run: |
+          # Set the "short_open_tag" ini to make sure specific conditions are tested.
+          # Also turn on error_reporting to ensure all notices are shown.
+          if [[ ${{ matrix.custom_ini }} == true && "${{ startsWith( matrix.php, '5.' ) }}" == true ]]; then
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On' >> $GITHUB_OUTPUT
+          elif [[ ${{ matrix.custom_ini }} == true && "${{ startsWith( matrix.php, '7.' ) }}" == true ]]; then
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On' >> $GITHUB_OUTPUT
+          else
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          coverage: xdebug
+
+      # This action also handles the caching of the dependencies.
+      - name: Set up node
+        if: ${{ matrix.custom_ini == false }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install external tools used in tests
+        if: ${{ matrix.custom_ini == false }}
+        run: >
+          npm install -g --fund false
+          csslint
+          eslint
+          jshint
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: 'PHPCS: set the path to PHP'
+        run: php bin/phpcs --config-set php_path php
+
+      - name: 'PHPUnit: run the tests with code coverage'
+        run: vendor/bin/phpunit tests/AllTests.php
+
+      - name: Upload coverage results to Coveralls
+        if: ${{ success() }}
+        uses: coverallsapp/github-action@v2
+        with:
+          format: clover
+          file: build/logs/clover.xml
+          flag-name: php-${{ matrix.php }}-custom-ini-${{ matrix.custom_ini }}
+          parallel: true
+
+  coveralls-finish:
+    needs: coverage
+    if: always() && needs.coverage.result == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /phpcs.xml
 /phpunit.xml
 .phpunit.result.cache
+/build/
 .idea/*
 /vendor/
 composer.lock

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ PHP_CodeSniffer
 [![Latest Stable Version](http://poser.pugx.org/phpcsstandards/php_codesniffer/v)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
 [![Validate](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml)
 [![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHP_CodeSniffer/badge.svg?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
 [![License](http://poser.pugx.org/phpcsstandards/php_codesniffer/license)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt)
 
 ![Minimum PHP Version](https://img.shields.io/packagist/php-v/squizlabs/php_codesniffer.svg?maxAge=3600)

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,10 @@
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit tests/AllTests.php -d max_execution_time=0"
         ],
+        "coverage-local": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit tests/AllTests.php --coverage-html ./build/coverage-html -d max_execution_time=0"
+        ],
         "build": [
             "Composer\\Config::disableProcessTimeout",
             "@php -d phar.readonly=0 -f ./scripts/build-phar.php"
@@ -76,6 +80,7 @@
         "cbf": "Fix code style violations.",
         "test": "Run the unit tests without code coverage.",
         "coverage": "Run the unit tests with code coverage.",
+        "coverage-local": "Run the unit tests with code coverage and generate an HTML report in a 'build' directory.",
         "build": "Create PHAR files for PHPCS and PHPCBF.",
         "check-all": "Run all checks (phpcs, tests)."
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,10 +9,26 @@
     convertWarningsToExceptions="true"
     convertNoticesToExceptions="true"
     convertDeprecationsToExceptions="true"
+    forceCoversAnnotation="true"
     >
     <testsuites>
         <testsuite name="PHP_CodeSniffer Test Suite">
             <file>tests/AllTests.php</file>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">./src</directory>
+            <file>./autoload.php</file>
+            <exclude>
+                <directory suffix="UnitTest.php">./src/Standards</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ArrayIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff
+ */
 class ArrayIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowLongArraySyntax sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowLongArraySyntaxSniff
+ */
 class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowShortArraySyntax sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowShortArraySyntaxSniff
+ */
 class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DuplicateClassName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\DuplicateClassNameSniff
+ */
 class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OpeningBraceSameLine sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\OpeningBraceSameLineSniff
+ */
 class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the AssignmentInCondition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff
+ */
 class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit test class for the EmptyStatement sniff.
+ * Unit test class for the EmptyPHPStatement sniff.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmptyPHPStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyPHPStatementSniff
+ */
 class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmptyStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff
+ */
 class EmptyStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForLoopShouldBeWhileLoop sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopShouldBeWhileLoopSniff
+ */
 class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForLoopWithTestFunctionCall sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopWithTestFunctionCallSniff
+ */
 class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the JumbledIncrementer sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\JumbledIncrementerSniff
+ */
 class JumbledIncrementerUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UnconditionalIfStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnconditionalIfStatementSniff
+ */
 class UnconditionalIfStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UnnecessaryFinalModifier sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnnecessaryFinalModifierSniff
+ */
 class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UnusedFunctionParameter sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff
+ */
 class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UselessOverridingMethod sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UselessOverridingMethodSniff
+ */
 class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DocCommentSniff sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff
+ */
 class DocCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Fixme sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\FixmeSniff
+ */
 class FixmeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Todo sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff
+ */
 class TodoUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowYodaConditions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\DisallowYodaConditionsSniff
+ */
 class DisallowYodaConditionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InlineControlStructure sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff
+ */
 class InlineControlStructureUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the CSSLint sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\CSSLintSniff
+ */
 class CSSLintUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the ClosureLinter sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\ClosureLinterSniff
+ */
 class ClosureLinterUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the ESLint sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\ESLintSniff
+ */
 class ESLintUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the JSHint sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\JSHintSniff
+ */
 class JSHintUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ByteOrderMark sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff
+ */
 class ByteOrderMarkUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EndFileNewline sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff
+ */
 class EndFileNewlineUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EndFileNoNewline sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNoNewlineSniff
+ */
 class EndFileNoNewlineUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ExecutableFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ExecutableFileSniff
+ */
 class ExecutableFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InlineHTML sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\InlineHTMLSniff
+ */
 class InlineHTMLUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LineEndings sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff
+ */
 class LineEndingsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LineLength sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff
+ */
 class LineLengthUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercasedFilename sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LowercasedFilenameSniff
+ */
 class LowercasedFilenameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OneClassPerFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneClassPerFileSniff
+ */
 class OneClassPerFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OneInterfacePerFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneInterfacePerFileSniff
+ */
 class OneInterfacePerFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OneInterfacePerFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneObjectStructurePerFileSniff
+ */
 class OneObjectStructurePerFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OneTraitPerFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneTraitPerFileSniff
+ */
 class OneTraitPerFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowMultipleStatements sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\DisallowMultipleStatementsSniff
+ */
 class DisallowMultipleStatementsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MultipleStatementAlignment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff
+ */
 class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NoSpaceAfterCast sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\NoSpaceAfterCastSniff
+ */
 class NoSpaceAfterCastUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SpaceAfterCast sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff
+ */
 class SpaceAfterCastUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SpaceAfterNot sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff
+ */
 class SpaceAfterNotUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SpaceBeforeCast sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceBeforeCastSniff
+ */
 class SpaceBeforeCastUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CallTimePassByReference sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\CallTimePassByReferenceSniff
+ */
 class CallTimePassByReferenceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionCallArgumentSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\FunctionCallArgumentSpacingSniff
+ */
 class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OpeningFunctionBraceBsdAllman sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceBsdAllmanSniff
+ */
 class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OpeningFunctionBraceKernighanRitchie sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceKernighanRitchieSniff
+ */
 class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Metrics;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CyclomaticComplexity sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff
+ */
 class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Metrics;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NestingLevel sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff
+ */
 class NestingLevelUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
@@ -10,6 +10,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the AbstractClassNamePrefix sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\AbstractClassNamePrefixSniff
+ */
 class AbstractClassNamePrefixUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CamelCapsFunctionName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff
+ */
 class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ConstructorName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\ConstructorNameSniff
+ */
 class ConstructorNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
@@ -10,6 +10,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InterfaceNameSuffix sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\InterfaceNameSuffixSniff
+ */
 class InterfaceNameSuffixUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
@@ -10,6 +10,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the TraitNameSuffix sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\TraitNameSuffixSniff
+ */
 class TraitNameSuffixUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidConstantName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff
+ */
 class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the BacktickOperator sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\BacktickOperatorSniff
+ */
 class BacktickOperatorUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CharacterBeforePHPOpeningTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\CharacterBeforePHPOpeningTagSniff
+ */
 class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClosingPHPTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ClosingPHPTagSniff
+ */
 class ClosingPHPTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DeprecatedFunctions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff
+ */
 class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowAlternativePHPTags sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowAlternativePHPTagsSniff
+ */
 class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
@@ -10,6 +10,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowRequestSuperglobal sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowRequestSuperglobalSniff
+ */
 class DisallowRequestSuperglobalUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowShortOpenTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowShortOpenTagSniff
+ */
 class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DiscourageGoto sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DiscourageGotoSniff
+ */
 class DiscourageGotoUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForbiddenFunctions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff
+ */
 class ForbiddenFunctionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowerCaseConstant sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff
+ */
 class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowerCaseKeyword sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseKeywordSniff
+ */
 class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowerCaseType sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseTypeSniff
+ */
 class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NoSilencedErrors sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff
+ */
 class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the RequireStrictType sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\RequireStrictTypesSniff
+ */
 class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SAPIUsage sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SAPIUsageSniff
+ */
 class SAPIUsageUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Syntax sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SyntaxSniff
+ */
 class SyntaxUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UpperCaseConstant sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\UpperCaseConstantSniff
+ */
 class UpperCaseConstantUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Strings;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UnnecessaryStringConcat sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff
+ */
 class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\VersionControl;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the GitMergeConflict sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\GitMergeConflictSniff
+ */
 class GitMergeConflictUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\VersionControl;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SubversionProperties sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\SubversionPropertiesSniff
+ */
 class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ArbitraryParenthesesSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ArbitraryParenthesesSpacingSniff
+ */
 class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowSpaceIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowSpaceIndentSniff
+ */
 class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowTabIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff
+ */
 class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the IncrementDecrementSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\IncrementDecrementSpacingSniff
+ */
 class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LanguageConstructSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\LanguageConstructSpacingSniff
+ */
 class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ScopeIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff
+ */
 class ScopeIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SpreadOperatorSpacingAfter sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\SpreadOperatorSpacingAfterSniff
+ */
 class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/CSS/BrowserSpecificStylesUnitTest.php
+++ b/src/Standards/MySource/Tests/CSS/BrowserSpecificStylesUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the BrowserSpecificStyles sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\CSS\BrowserSpecificStylesSniff
+ */
 class BrowserSpecificStylesUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Channels/DisallowSelfActionsUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/DisallowSelfActionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Channels;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowSelfActions sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\DisallowSelfActionsSniff
+ */
 class DisallowSelfActionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Channels;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the IncludeSystem sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\IncludeSystemSniff
+ */
 class IncludeSystemUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Channels/UnusedSystemUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/UnusedSystemUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Channels;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UnusedSystem sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\UnusedSystemSniff
+ */
 class UnusedSystemUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/MySource/Tests/Commenting/FunctionCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionComment sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Commenting\FunctionCommentSniff
+ */
 class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Debug/DebugCodeUnitTest.php
+++ b/src/Standards/MySource/Tests/Debug/DebugCodeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Debug;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DebugCode sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Debug\DebugCodeSniff
+ */
 class DebugCodeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
+++ b/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Debug;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FirebugConsole sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Debug\FirebugConsoleSniff
+ */
 class FirebugConsoleUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the AssignThis sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\AssignThisSniff
+ */
 class AssignThisUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CreateWidgetTypeCallback sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\CreateWidgetTypeCallbackSniff
+ */
 class CreateWidgetTypeCallbackUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Objects/DisallowNewWidgetUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/DisallowNewWidgetUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowNewWidget sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\DisallowNewWidgetSniff
+ */
 class DisallowNewWidgetUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/PHP/AjaxNullComparisonUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/AjaxNullComparisonUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the AjaxNullComparison sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\AjaxNullComparisonSniff
+ */
 class AjaxNullComparisonUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/PHP/EvalObjectFactoryUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/EvalObjectFactoryUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EvalObjectFactory sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\EvalObjectFactorySniff
+ */
 class EvalObjectFactoryUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/PHP/GetRequestDataUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/GetRequestDataUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the GetRequestData sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\GetRequestDataSniff
+ */
 class GetRequestDataUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/PHP/ReturnFunctionValueUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/ReturnFunctionValueUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ReturnFunctionValue sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\ReturnFunctionValueSniff
+ */
 class ReturnFunctionValueUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
+++ b/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\MySource\Tests\Strings;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the JoinStrings sniff.
+ *
+ * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Strings\JoinStringsSniff
+ */
 class JoinStringsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff
+ */
 class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff
+ */
 class ClassCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FileComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff
+ */
 class FileCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff
+ */
 class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InlineComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\InlineCommentSniff
+ */
 class InlineCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ControlSignature sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\ControlSignatureSniff
+ */
 class ControlSignatureUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MultiLineCondition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\MultiLineConditionSniff
+ */
 class MultiLineConditionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
+++ b/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the IncludingFile sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Files\IncludingFileSniff
+ */
 class IncludingFileUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MultiLineAssignment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Formatting\MultiLineAssignmentSniff
+ */
 class MultiLineAssignmentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionCallSignature sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionCallSignatureSniff
+ */
 class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionDeclarationSniff
+ */
 class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidDefaultValue sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff
+ */
 class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidClassName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidClassNameSniff
+ */
 class ValidClassNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidFunctionName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff
+ */
 class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidVariableName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidVariableNameSniff
+ */
 class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ObjectOperatorIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ObjectOperatorIndentSniff
+ */
 class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ScopeClosingBrace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeClosingBraceSniff
+ */
 class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ScopeIndent sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeIndentSniff
+ */
 class ScopeIndentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR1\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff
+ */
 class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR1\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SideEffects sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff
+ */
 class SideEffectsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR1\Tests\Methods;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CamelCapsMethodName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff
+ */
 class CamelCapsMethodNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the AnonClassDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\AnonClassDeclarationSniff
+ */
 class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassInstantiation sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClassInstantiationSniff
+ */
 class ClassInstantiationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClosingBrace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClosingBraceSniff
+ */
 class ClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OpeningBraceSpace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\OpeningBraceSpaceSniff
+ */
 class OpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the BooleanOperatorPlacement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlacementSniff
+ */
 class BooleanOperatorPlacementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ControlStructureSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\ControlStructureSpacingSniff
+ */
 class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DeclareStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\DeclareStatementSniff
+ */
 class DeclareStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FileHeader sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff
+ */
 class FileHeaderUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ImportStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\ImportStatementSniff
+ */
 class ImportStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OpenTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\OpenTagSniff
+ */
 class OpenTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NullableWhitespace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff
+ */
 class NullableTypeDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ReturnTypeDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\ReturnTypeDeclarationSniff
+ */
 class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Keywords;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ShortFormTypeKeywords sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Keywords\ShortFormTypeKeywordsSniff
+ */
 class ShortFormTypeKeywordsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
+++ b/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Namespaces;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CompoundNamespaceDepth sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Namespaces\CompoundNamespaceDepthSniff
+ */
 class CompoundNamespaceDepthUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Operators;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OperatorSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff
+ */
 class OperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Properties;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ConstantVisibility sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Properties\ConstantVisibilitySniff
+ */
 class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Traits;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UseDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Traits\UseDeclarationSniff
+ */
 class UseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff
+ */
 class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the PropertyDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff
+ */
 class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff
+ */
 class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ElseIfDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ElseIfDeclarationSniff
+ */
 class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SwitchDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSniff
+ */
 class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClosingTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\ClosingTagSniff
+ */
 class ClosingTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EndFileNewline sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\EndFileNewlineSniff
+ */
 class EndFileNewlineUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionCallSignature sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff
+ */
 class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionClosingBrace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionClosingBraceSniff
+ */
 class FunctionClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MethodDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
+ */
 class MethodDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Namespaces;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NamespaceDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\NamespaceDeclarationSniff
+ */
 class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\PSR2\Tests\Namespaces;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the UseDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\UseDeclarationSniff
+ */
 class UseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ArrayBracketSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
+ */
 class ArrayBracketSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Arrays;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ArrayDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff
+ */
 class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDefinitionClosingBraceSpace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionClosingBraceSpaceSniff
+ */
 class ClassDefinitionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDefinitionNameSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionNameSpacingSniff
+ */
 class ClassDefinitionNameSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDefinitionOpeningBraceSpace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionOpeningBraceSpaceSniff
+ */
 class ClassDefinitionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ColonSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ColonSpacingSniff
+ */
 class ColonSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ColourDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ColourDefinitionSniff
+ */
 class ColourDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowMultipleStyleDefinitions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DisallowMultipleStyleDefinitionsSniff
+ */
 class DisallowMultipleStyleDefinitionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DuplicateClassDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DuplicateClassDefinitionSniff
+ */
 class DuplicateClassDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DuplicateStyleDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DuplicateStyleDefinitionSniff
+ */
 class DuplicateStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/EmptyClassDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/EmptyClassDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmptyClassDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\EmptyClassDefinitionSniff
+ */
 class EmptyClassDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmptyStyleDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\EmptyStyleDefinitionSniff
+ */
 class EmptyStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForbiddenStyles sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ForbiddenStylesSniff
+ */
 class ForbiddenStylesUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Indentation sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\IndentationSniff
+ */
 class IndentationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/LowercaseStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/LowercaseStyleDefinitionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercaseStyleDefinition sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\LowercaseStyleDefinitionSniff
+ */
 class LowercaseStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MissingColon sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\MissingColonSniff
+ */
 class MissingColonUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/NamedColoursUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/NamedColoursUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NamedColours sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\NamedColoursSniff
+ */
 class NamedColoursUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/OpacityUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/OpacityUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Opacity sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\OpacitySniff
+ */
 class OpacityUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SemicolonSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\SemicolonSpacingSniff
+ */
 class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\CSS;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ShorthandSize sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ShorthandSizeSniff
+ */
 class ShorthandSizeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassDeclarationSniff
+ */
 class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassFileName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassFileNameSniff
+ */
 class ClassFileNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/DuplicatePropertyUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/DuplicatePropertyUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DuplicateProperty sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\DuplicatePropertySniff
+ */
 class DuplicatePropertyUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercaseClassKeywords sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\LowercaseClassKeywordsSniff
+ */
 class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SelfMemberReference sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\SelfMemberReferenceSniff
+ */
 class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidClassName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ValidClassNameSniff
+ */
 class ValidClassNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the BlockComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\BlockCommentSniff
+ */
 class BlockCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClassComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClassCommentSniff
+ */
 class ClassCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClosingDeclarationComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClosingDeclarationCommentSniff
+ */
 class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DocCommentAlignment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff
+ */
 class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmptyCatchComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\EmptyCatchCommentSniff
+ */
 class EmptyCatchCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FileComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FileCommentSniff
+ */
 class FileCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionCommentThrowTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentThrowTagSniff
+ */
 class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff
+ */
 class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InlineComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\InlineCommentSniff
+ */
 class InlineCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LongConditionClosingComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\LongConditionClosingCommentSniff
+ */
 class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the PostStatementComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\PostStatementCommentSniff
+ */
 class PostStatementCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the VariableComment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\VariableCommentSniff
+ */
 class VariableCommentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ControlSignature sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff
+ */
 class ControlSignatureUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ElseIfDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ElseIfDeclarationSniff
+ */
 class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForEachLoopDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForEachLoopDeclarationSniff
+ */
 class ForEachLoopDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ForLoopDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForLoopDeclarationSniff
+ */
 class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InlineIfDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\InlineIfDeclarationSniff
+ */
 class InlineIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercaseDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\LowercaseDeclarationSniff
+ */
 class LowercaseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SwitchDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\SwitchDeclarationSniff
+ */
 class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the JSLint sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug\JSLintSniff
+ */
 class JSLintUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the JavaScriptLint sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug\JavaScriptLintSniff
+ */
 class JavaScriptLintUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FileExtension sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Files\FileExtensionSniff
+ */
 class FileExtensionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Formatting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OperatorBracket sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Formatting\OperatorBracketSniff
+ */
 class OperatorBracketUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionDeclarationArgumentSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff
+ */
 class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationSniff
+ */
 class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionDuplicateArgument sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDuplicateArgumentSniff
+ */
 class FunctionDuplicateArgumentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the GlobalFunction sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\GlobalFunctionSniff
+ */
 class GlobalFunctionUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercaseFunctionKeywords sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\LowercaseFunctionKeywordsSniff
+ */
 class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MultiLineFunctionDeclaration sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\MultiLineFunctionDeclarationSniff
+ */
 class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidFunctionName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff
+ */
 class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidVariableName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff
+ */
 class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowObjectStringIndex sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\DisallowObjectStringIndexSniff
+ */
 class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ObjectInstantiation sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\ObjectInstantiationSniff
+ */
 class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Objects;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ObjectMemberComma sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\ObjectMemberCommaSniff
+ */
 class ObjectMemberCommaUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ComparisonOperatorUsage sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ComparisonOperatorUsageSniff
+ */
 class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the IncrementDecrementUsage sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\IncrementDecrementUsageSniff
+ */
 class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidLogicalOperators sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
+ */
 class ValidLogicalOperatorsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CommentedOutCode sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff
+ */
 class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowBooleanStatement sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowBooleanStatementSniff
+ */
 class DisallowBooleanStatementUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowComparisonAssignment sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowComparisonAssignmentSniff
+ */
 class DisallowComparisonAssignmentUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowObEndFlush sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowInlineIfSniff
+ */
 class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowMultipleAssignments sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff
+ */
 class DisallowMultipleAssignmentsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DisallowSizeFunctionsInLoops sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowSizeFunctionsInLoopsSniff
+ */
 class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DiscouragedFunctions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DiscouragedFunctionsSniff
+ */
 class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EmbeddedPhp sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EmbeddedPhpSniff
+ */
 class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Eval sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EvalSniff
+ */
 class EvalUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the GlobalKeyword sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\GlobalKeywordSniff
+ */
 class GlobalKeywordUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the Heredoc sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\HeredocSniff
+ */
 class HeredocUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the InnerFunctions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\InnerFunctionsSniff
+ */
 class InnerFunctionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LowercasePHPFunctions sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\LowercasePHPFunctionsSniff
+ */
 class LowercasePHPFunctionsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the NonExecutableCode sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\NonExecutableCodeSniff
+ */
 class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MemberVarScope sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff
+ */
 class MemberVarScopeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MethodScope sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff
+ */
 class MethodScopeUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the StaticThisUsage sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\StaticThisUsageSniff
+ */
 class StaticThisUsageUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ConcatenationSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff
+ */
 class ConcatenationSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the DoubleQuoteUsage sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\DoubleQuoteUsageSniff
+ */
 class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the EchoedStrings sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\EchoedStringsSniff
+ */
 class EchoedStringsUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the CastSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\CastSpacingSniff
+ */
 class CastSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ControlStructureSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff
+ */
 class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionClosingBraceSpace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionClosingBraceSpaceSniff
+ */
 class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionOpeningBraceSpace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionOpeningBraceSpaceSniff
+ */
 class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the FunctionSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionSpacingSniff
+ */
 class FunctionSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LanguageConstructSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff
+ */
 class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the LogicalOperatorSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LogicalOperatorSpacingSniff
+ */
 class LogicalOperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the MemberVarSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\MemberVarSpacingSniff
+ */
 class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ObjectOperatorSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
+ */
 class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the OperatorSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff
+ */
 class OperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/PropertyLabelSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/PropertyLabelSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the PropertyLabel sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\PropertyLabelSpacingSniff
+ */
 class PropertyLabelSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ScopeClosingBrace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff
+ */
 class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ScopeKeywordSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeKeywordSpacingSniff
+ */
 class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SemicolonSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff
+ */
 class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the SuperfluousWhitespace sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff
+ */
 class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
+++ b/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Standards\Zend\Tests\Debug;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 use PHP_CodeSniffer\Config;
 
+/**
+ * Unit test class for the CodeAnalyzer sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\Debug\CodeAnalyzerSniff
+ */
 class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Zend\Tests\Files;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ClosingTag sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\Files\ClosingTagSniff
+ */
 class ClosingTagUnitTest extends AbstractSniffUnitTest
 {
 

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Standards\Zend\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
+/**
+ * Unit test class for the ValidVariableName sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff
+ */
 class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 

--- a/tests/Core/Autoloader/DetermineLoadedClassTest.php
+++ b/tests/Core/Autoloader/DetermineLoadedClassTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Tests\Core\Autoloader;
 use PHP_CodeSniffer\Autoload;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Autoload::determineLoadedClass method.
+ *
+ * @covers \PHP_CodeSniffer\Autoload::determineLoadedClass
+ */
 class DetermineLoadedClassTest extends TestCase
 {
 

--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -13,6 +13,11 @@ use PHP_CodeSniffer\Config;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Config reportWidth value.
+ *
+ * @covers \PHP_CodeSniffer\Config::__get
+ */
 class ReportWidthTest extends TestCase
 {
 
@@ -76,6 +81,9 @@ class ReportWidthTest extends TestCase
     /**
      * Test that report width without overrules will always be set to a non-0 positive integer.
      *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::restoreDefaults
+     *
      * @return void
      */
     public function testReportWidthDefault()
@@ -91,6 +99,9 @@ class ReportWidthTest extends TestCase
 
     /**
      * Test that the report width will be set to a non-0 positive integer when not found in the CodeSniffer.conf file.
+     *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::restoreDefaults
      *
      * @return void
      */
@@ -115,6 +126,10 @@ class ReportWidthTest extends TestCase
     /**
      * Test that the report width will be set correctly when found in the CodeSniffer.conf file.
      *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::getConfigData
+     * @covers \PHP_CodeSniffer\Config::restoreDefaults
+     *
      * @return void
      */
     public function testReportWidthCanBeSetFromConfFile()
@@ -135,6 +150,9 @@ class ReportWidthTest extends TestCase
     /**
      * Test that the report width will be set correctly when passed as a CLI argument.
      *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::processLongArgument
+     *
      * @return void
      */
     public function testReportWidthCanBeSetFromCLI()
@@ -152,6 +170,9 @@ class ReportWidthTest extends TestCase
 
     /**
      * Test that the report width will be set correctly when multiple report widths are passed on the CLI.
+     *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::processLongArgument
      *
      * @return void
      */
@@ -171,6 +192,10 @@ class ReportWidthTest extends TestCase
 
     /**
      * Test that a report width passed as a CLI argument will overrule a report width set in a CodeSniffer.conf file.
+     *
+     * @covers \PHP_CodeSniffer\Config::__set
+     * @covers \PHP_CodeSniffer\Config::processLongArgument
+     * @covers \PHP_CodeSniffer\Config::getConfigData
      *
      * @return void
      */
@@ -200,6 +225,8 @@ class ReportWidthTest extends TestCase
     /**
      * Test that the report width will be set to a non-0 positive integer when set to "auto".
      *
+     * @covers \PHP_CodeSniffer\Config::__set
+     *
      * @return void
      */
     public function testReportWidthInputHandlingForAuto()
@@ -221,6 +248,7 @@ class ReportWidthTest extends TestCase
      * @param int   $expected Expected report width.
      *
      * @dataProvider dataReportWidthInputHandling
+     * @covers       \PHP_CodeSniffer\Config::__set
      *
      * @return void
      */

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -14,6 +14,11 @@ use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for PHP_CodeSniffer error suppression tags.
+ *
+ * @coversNothing
+ */
 class ErrorSuppressionTest extends TestCase
 {
 

--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:findEndOfStatement method.
+ * Tests for the \PHP_CodeSniffer\Files\File::findEndOfStatement method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::findEndOfStatement method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::findEndOfStatement
+ */
 class FindEndOfStatementTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:findExtendedClassName method.
+ * Tests for the \PHP_CodeSniffer\Files\File::findExtendedClassName method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::findExtendedClassName method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::findExtendedClassName
+ */
 class FindExtendedClassNameTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:findImplementedInterfaceNames method.
+ * Tests for the \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames
+ */
 class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:findStartOfStatement method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::findStartOfStatement
+ */
 class FindStartOfStatementTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getClassProperties method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getClassProperties
+ */
 class GetClassPropertiesTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getMemberProperties
+ */
 class GetMemberPropertiesTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:getMethodParameters method.
+ * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
+ */
 class GetMethodParametersTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:getMethodProperties method.
+ * Tests for the \PHP_CodeSniffer\Files\File::getMethodProperties method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getMethodProperties method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getMethodProperties
+ */
 class GetMethodPropertiesTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:isReference method.
+ * Tests for the \PHP_CodeSniffer\Files\File::isReference method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::isReference method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::isReference
+ */
 class IsReferenceTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -15,6 +15,11 @@ use PHP_CodeSniffer\Filters\Filter;
 use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Filters\Filter::accept method.
+ *
+ * @covers \PHP_CodeSniffer\Filters\Filter
+ */
 class AcceptTest extends TestCase
 {
 

--- a/tests/Core/IsCamelCapsTest.php
+++ b/tests/Core/IsCamelCapsTest.php
@@ -12,6 +12,11 @@ namespace PHP_CodeSniffer\Tests\Core;
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Util\Common::isCamelCaps method.
+ *
+ * @covers \PHP_CodeSniffer\Util\Common::isCamelCaps
+ */
 class IsCamelCapsTest extends TestCase
 {
 

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -13,6 +13,11 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class using a Linux-style absolute path to include a sniff.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset
+ */
 class RuleInclusionAbsoluteLinuxTest extends TestCase
 {
 

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -13,6 +13,11 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class using a Windows-style absolute path to include a sniff.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset
+ */
 class RuleInclusionAbsoluteWindowsTest extends TestCase
 {
 

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -14,6 +14,11 @@ use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset
+ */
 class RuleInclusionTest extends TestCase
 {
 

--- a/tests/Core/Sniffs/AbstractArraySniffTest.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTest.php
@@ -11,6 +11,11 @@ namespace PHP_CodeSniffer\Tests\Core\Sniffs;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
+/**
+ * Tests for the \PHP_CodeSniffer\Sniffs\AbstractArraySniff.
+ *
+ * @covers \PHP_CodeSniffer\Sniffs\AbstractArraySniff
+ */
 class AbstractArraySniffTest extends AbstractMethodUnitTest
 {
 

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -283,6 +283,9 @@ class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/3326
      *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
+     *
      * @return void
      */
     public function testIssue3326()


### PR DESCRIPTION
## Description

### Unit tests: add `@covers` annotation to all sniff tests

### Unit tests: add `@covers` annotation to all utility method tests

### PHPUnit config: set up to allow for recording code coverage

The `forceCoversAnnotation` attribute will prevent code coverage from being recorded for tests without a `@covers` tag.

As for recording the code coverage:
By default, a code coverage text summary will be shown and a `clover.xml` file will be generated in a `build/logs` directory.
The clover file can be used to generate code coverage reports via a service like Coveralls.

For local development, the `clover.xml` is not very human readable-friendly and the summary is a little too minimal, so an HTML report would be better.

To that end, a `coverage-local` script has been added to the `composer.json` to make it straight forward for contributors to generate the HTML report.
The HTML report will be placed in a `build/coverage-html` directory.

The `build` directory is now excluded via the `.gitignore` file.

### GH Actions: start recording code coverage

This commit reworks the `test` workflow to start running the tests with code coverage for low/medium/high PHP and upload the generated reports to Coveralls.

* It adds an extra "coverage" job which runs only the unit tests with code coverage against low/medium/high PHP.
    This job does not run the CS check as an integration test.
* Makes minor tweaks to the pre-existing "test" job to prevent duplicate test runs for the exact same PHP/custom ini combinations.
    No need to run the same check twice.

The recorded code coverage reports will be available on: https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer

Includes adding a code coverage badge to the README..

## Suggested changelog entry
_N/A_


