### PR TITLE
Squiz/NonExecutableCode: move parse error test to its own file

### DIFF
--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -418,6 +418,3 @@ $closure = function ()
     echo 'foo';
     return; // This return should be flagged as not required.
 };
-
-// Intentional syntax error.
-return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.4.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.4.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Intentional syntax error. See issue #2990.
+// Testing that no "Undefined array key "parenthesis_closer"" notice is thrown.
+// This must be the only test in this file.
+return array_map(


### PR DESCRIPTION
## Description

See #143


## Suggested changelog entry
_N/A_