### PR TITLE
Report Full: fix delimiter line bug

### DIFF
--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -64,15 +64,28 @@ class Full implements Report
         foreach ($report['messages'] as $line => $lineErrors) {
             foreach ($lineErrors as $column => $colErrors) {
                 foreach ($colErrors as $error) {
-                    $length = strlen($error['message']);
+                    // Start with the presumption of a single line error message.
+                    $length    = strlen($error['message']);
+                    $srcLength = (strlen($error['source']) + 3);
                     if ($showSources === true) {
-                        $length += (strlen($error['source']) + 3);
+                        $length += $srcLength;
+                    }
+
+                    // ... but also handle multi-line messages correctly.
+                    if (strpos($error['message'], "\n") !== false) {
+                        $errorLines = explode("\n", $error['message']);
+                        $length     = max(array_map('strlen', $errorLines));
+
+                        if ($showSources === true) {
+                            $lastLine = array_pop($errorLines);
+                            $length   = max($length, (strlen($lastLine) + $srcLength));
+                        }
                     }
 
                     $maxErrorLength = max($maxErrorLength, ($length + 1));
-                }
-            }
-        }
+                }//end foreach
+            }//end foreach
+        }//end foreach
 
         $file       = $report['filename'];
         $fileLength = strlen($file);


### PR DESCRIPTION
## Description
When determining the max message length, the calculation did not take potential explicit multi-line messages into account and would base the delimiter line length on the length of the complete message, not on the length of the individual lines.

Fixed now.

## Suggested changelog entry
* Report Full: fixed bug in delimiter line calculation


## Related issues/external references

Discovered while reviewing #125
Related to squizlabs/PHP_CodeSniffer#2093


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_


## Additional information

Testing this fix manually is not that easy and there are no unit/integration tests for the reports yet either.

How I tested this myself is by taking the test code from squizlabs/PHP_CodeSniffer#2093 and adding it (temporarily) to a random sniff:

```php
$message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nAenean felis urna, dictum vitae lobortis vitae, maximus nec enim. Etiam euismod placerat efficitur. Nulla eu felis ipsum.\nCras vitae ultrices turpis. Ut consectetur ligula in justo tincidunt mattis.\n\nAliquam fermentum magna id venenatis placerat. Curabitur lobortis nulla sit amet consequat fermentum. Aenean malesuada tristique aliquam. Donec eget placerat nisl.\n\nMorbi mollis, risus vel venenatis accumsan, urna dolor faucibus risus, ut congue purus augue vel ipsum.\nCurabitur nec dolor est. Suspendisse nec quam non ligula aliquam tempus. Donec laoreet maximus leo, in eleifend odio interdum vitae.";

$phpcsFile->addWarning($message, 0, 'Test');
```

and then running it over the simple test file from #124:

```php
<?php

$x=1;
```

using the following command:
```bash
phpcs -s ./phpcs-3924.php --report-width=100000 --basepath=. --standard=universal
```
(the `universal` is because the random sniff I added the code to was in that standard)

Result when running this on `master`:
![image](https://github.com/PHPCSStandards/PHP_CodeSniffer/assets/663378/924cf43d-eec8-47fc-a3a6-89a095a7d0ff)

Result when running this against the PR branch:
![image](https://github.com/PHPCSStandards/PHP_CodeSniffer/assets/663378/586a50b2-8291-47a6-9497-c413cb734c23)
