### PR TITLE
update readme installation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ php phpcbf.phar -h
 ### Composer
 If you use Composer, you can install PHP_CodeSniffer system-wide with the following command:
 ```bash
-composer global require "squizlabs/php_codesniffer=*"
+composer global require "phpcsstandards/php_codesniffer=*"
 ```
 Make sure you have the composer bin dir in your PATH. The default value is `~/.composer/vendor/bin/`, but you can check the value that you need to use by running `composer global config bin-dir --absolute`.
 
-Or alternatively, include a dependency for `squizlabs/php_codesniffer` in your `composer.json` file. For example:
+Or alternatively, include a dependency for `phpcsstandards/php_codesniffer` in your `composer.json` file. For example:
 
 ```json
 {
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpcsstandards/php_codesniffer": "^3.0"
     }
 }
 ```


### PR DESCRIPTION
## Description
Since the project has been moved to `PHPCSStandards` organization, we need start updating docs. I feel that the most important are installation rules, so I've updated composer commands to use [the new version](https://packagist.org/packages/phpcsstandards/php_codesniffer). It's not too much, but at least something to start :)

## Suggested changelog entry
No need for changelog entry.

## Related issues/external references
none

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.