### PR TITLE
Fix PHP Notice in `Squiz.PHP.NonExecutableCode`

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -109,7 +109,7 @@ class NonExecutableCodeSniff implements Sniff
             $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($tokens[$next]['code'] === T_SEMICOLON) {
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
-                if ($tokens[$next]['code'] === T_CLOSE_CURLY_BRACKET) {
+                if ($tokens[$next]['code'] === T_CLOSE_CURLY_BRACKET && isset($tokens[$next]['scope_condition']) === true) {
                     // If this is the closing brace of a function
                     // then this return statement doesn't return anything
                     // and is not required anyway.


### PR DESCRIPTION
## Description
(After applying the changes in #160 locally...)
While looking into https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/152, I ran the following command:
`phpcbf -p . --standard=Squiz --ignore="*/build/*,*/vendor/*" --basepath=. --extensions=inc --suffix=.conflictcheck`

Instead of a useful report, I got a PHP Fatal error:

```
EFFFFFFEFEEEEFFEFFEFFEFEEFFEEEFFEFFFFFFFFEFFFFFFFFPHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Undefined array key "scope_condition" in .../src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php on line 116 in .../src/Runner.php:608
Stack trace:
#0 .../src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php(116): PHP_CodeSniffer\Runner->handleErrors()
#1 .../src/Files/File.php(518): PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\NonExecutableCodeSniff->process()
#2 .../src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 .../src/Fixer.php(174): PHP_CodeSniffer\Files\LocalFile->process()
#4 .../src/Reports/Cbf.php(52): PHP_CodeSniffer\Fixer->fixFile()
#5 .../src/Reporter.php(285): PHP_CodeSniffer\Reports\Cbf->generateFileReport()
#6 .../src/Runner.php(691): PHP_CodeSniffer\Reporter->cacheFileReport()
#7 .../src/Runner.php(438): PHP_CodeSniffer\Runner->processFile()
#8 .../src/Runner.php(204): PHP_CodeSniffer\Runner->run()
#9 .../bin/phpcbf(18): PHP_CodeSniffer\Runner->runPHPCBF()
#10 {main}
  thrown in .../src/Runner.php on line 608
```

This pull request fixes this error, allowing the suggested command to produce a report.
I'm not adding any specific tests for this, as the integration test that will eventually be added as part of #152 will cover this case.

## Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->


## Related issues/external references

Related to https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/152


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.