### PR TITLE
Generic/EmptyPHPStatement: add XML documentation

### DIFF
--- a/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
+++ b/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
@@ -13,7 +13,7 @@
         </code>
         <code title="Invalid: There is no statement inside the PHP tag pair.">
         <![CDATA[
-<?php <em>// some comment</em> ?>
+<?php <em>;</em> ?>
 <?= <em></em> ?>
         ]]>
         </code>

--- a/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
+++ b/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
@@ -1,0 +1,44 @@
+<documentation title="Empty PHP Statement">
+    <standard>
+    <![CDATA[
+    Empty PHP tags are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: There is at least one statement inside the PHP tag pair.">
+        <![CDATA[
+<?php <em>echo 'Hello World';</em> ?>
+<?= <em>'Hello World';</em> ?>
+        ]]>
+        </code>
+        <code title="Invalid: There is no statement inside the PHP tag pair.">
+        <![CDATA[
+<?php <em>// some comment</em> ?>
+<?= <em></em> ?>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Superfluous semi-colons are not allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: There is no superfluous semi-colon after a PHP statement.">
+            <![CDATA[
+function_call()<em>;</em>
+if (true) {
+    echo 'Hello World'<em>;</em>
+}
+        ]]>
+        </code>
+        <code title="Invalid: There are one or more superfluous semi-colons after a PHP statement.">
+            <![CDATA[
+function_call()<em>;;;</em>
+if (true) {
+    echo 'Hello World';
+}<em>;</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
## Description

This PR adds documentation for the Generic/EmptyPHPStatement sniff.

I added one `<standard>` block per warning generated by this sniff. I considered adding another `<standard>` block to the beginning of the file summarizing what this sniff does. Something like:

```xml
<documentation title="Empty PHP Statement">
    <standard>
    <![CDATA[
    Empty PHP tags and superfluous semi-colons are not allowed.
    ]]>
    </standard>
    (...)
</documentation>
```

It does duplicate the content of the other `<standard>` blocks, but it provides a nice summary at the top of the documentation. Without the summary, there is a chance that someone skimming through the documentation might assume that this sniff is only about empty PHP tags and doesn't cover superfluous semi-colons.

I ended up not including the "summary" `<standard>` most of the other sniffs that contain multiple `<standard>` blocks don't contain a summary at the top. The only exception that I found is [ArrayDeclarationStandard.xml](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/e9ebf5253a3e6dd3cc4b584ce54b1f4c34fcb1f3/src/Standards/Squiz/Docs/Arrays/ArrayDeclarationStandard.xml). Any thoughts on this?

## Suggested changelog entry
Add documentation for the Generic.CodeAnalysis.EmptyPHPStatement sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.