### PR TITLE
Replace the default value of the first parameter of getErrorList() and getWarningList() with an empty string

### DIFF
--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -27,11 +27,9 @@ class FixmeUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FixmeUnitTest.inc')
+    public function getErrorList()
     {
         return [
             3  => 1,
@@ -53,11 +51,9 @@ class FixmeUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='FixmeUnitTest.inc')
+    public function getWarningList()
     {
         return [];
 

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -26,11 +26,9 @@ class TodoUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='TodoUnitTest.inc')
+    public function getErrorList()
     {
         return [];
 
@@ -43,11 +41,9 @@ class TodoUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='TodoUnitTest.inc')
+    public function getWarningList()
     {
         return [
             3  => 1,

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -30,7 +30,7 @@ class InlineControlStructureUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='InlineControlStructureUnitTest.1.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'InlineControlStructureUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -45,7 +45,7 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='MultipleStatementAlignmentUnitTest.inc')
+    public function getWarningList($testFile='')
     {
         switch ($testFile) {
         case 'MultipleStatementAlignmentUnitTest.inc':

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -30,7 +30,7 @@ class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='LowerCaseConstantUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'LowerCaseConstantUnitTest.inc':

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -30,7 +30,7 @@ class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='UnnecessaryStringConcatUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'UnnecessaryStringConcatUnitTest.inc':

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -30,7 +30,7 @@ class GitMergeConflictUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='GitMergeConflictUnitTest.1.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'GitMergeConflictUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -49,7 +49,7 @@ class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='DisallowSpaceIndentUnitTest.1.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'DisallowSpaceIndentUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -30,7 +30,7 @@ class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='IncrementDecrementSpacingUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         $errors = [
             5  => 1,

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -50,7 +50,7 @@ class ScopeIndentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ScopeIndentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         if ($testFile === 'ScopeIndentUnitTest.1.js') {
             return [

--- a/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
+++ b/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
@@ -30,7 +30,7 @@ class FirebugConsoleUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FirebugConsoleUnitTest.js')
+    public function getErrorList($testFile='')
     {
         if ($testFile !== 'FirebugConsoleUnitTest.js') {
             return [];

--- a/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
@@ -30,7 +30,7 @@ class AssignThisUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='AssignThisUnitTest.js')
+    public function getErrorList($testFile='')
     {
         if ($testFile !== 'AssignThisUnitTest.js') {
             return [];

--- a/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
@@ -26,11 +26,9 @@ class CreateWidgetTypeCallbackUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='CreateWidgetTypeCallbackUnitTest.js')
+    public function getErrorList()
     {
         return [
             18  => 1,

--- a/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
+++ b/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
@@ -30,7 +30,7 @@ class JoinStringsUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='JoinStringsUnitTest.js')
+    public function getErrorList($testFile='')
     {
         if ($testFile !== 'JoinStringsUnitTest.js') {
             return [];

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -30,7 +30,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FileCommentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -74,7 +74,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='FileCommentUnitTest.inc')
+    public function getWarningList($testFile='')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -30,7 +30,7 @@ class MultiLineConditionUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='MultiLineConditionUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         $errors = [
             21  => 1,

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -30,7 +30,7 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FunctionCallSignatureUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         if ($testFile === 'FunctionCallSignatureUnitTest.js') {
             return [

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -30,7 +30,7 @@ class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FunctionDeclarationUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         if ($testFile === 'FunctionDeclarationUnitTest.inc') {
             $errors = [

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -30,7 +30,7 @@ class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='DocCommentAlignmentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         $errors = [
             3  => 1,

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -30,7 +30,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FileCommentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -30,7 +30,7 @@ class InlineCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='InlineCommentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'InlineCommentUnitTest.inc':

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -30,7 +30,7 @@ class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='LongConditionClosingCommentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'LongConditionClosingCommentUnitTest.inc':

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -30,7 +30,7 @@ class PostStatementCommentUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='PostStatementCommentUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'PostStatementCommentUnitTest.inc':

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -30,7 +30,7 @@ class ControlSignatureUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ControlSignatureUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         $errors = [
             7   => 1,

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -30,7 +30,7 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ForLoopDeclarationUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'ForLoopDeclarationUnitTest.inc':

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -118,7 +118,7 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='ForLoopDeclarationUnitTest.inc')
+    public function getWarningList($testFile='')
     {
         switch ($testFile) {
         case 'ForLoopDeclarationUnitTest.inc':

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -30,7 +30,7 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='SwitchDeclarationUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'SwitchDeclarationUnitTest.inc':

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -143,7 +143,7 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='SwitchDeclarationUnitTest.inc')
+    public function getWarningList($testFile='')
     {
         if ($testFile === 'SwitchDeclarationUnitTest.js') {
             return [273 => 1];

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -30,7 +30,7 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='OperatorBracketUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'OperatorBracketUnitTest.inc':

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -30,7 +30,7 @@ class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='MultiLineFunctionDeclarationUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         if ($testFile === 'MultiLineFunctionDeclarationUnitTest.inc') {
             $errors = [

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
@@ -30,7 +30,7 @@ class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='DisallowObjectStringIndexUnitTest.js')
+    public function getErrorList($testFile='')
     {
         if ($testFile !== 'DisallowObjectStringIndexUnitTest.js') {
             return [];

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -30,7 +30,7 @@ class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ComparisonOperatorUsageUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'ComparisonOperatorUsageUnitTest.inc':

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -45,7 +45,7 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='CommentedOutCodeUnitTest.inc')
+    public function getWarningList($testFile='')
     {
         switch ($testFile) {
         case 'CommentedOutCodeUnitTest.inc':

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -30,7 +30,7 @@ class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='DisallowInlineIfUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'DisallowInlineIfUnitTest.inc':

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -30,7 +30,7 @@ class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='DisallowSizeFunctionsInLoopsUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'DisallowSizeFunctionsInLoopsUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -30,7 +30,7 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ControlStructureSpacingUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'ControlStructureSpacingUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -30,7 +30,7 @@ class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FunctionClosingBraceSpaceUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'FunctionClosingBraceSpaceUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
@@ -30,7 +30,7 @@ class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='FunctionOpeningBraceSpaceUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'FunctionOpeningBraceSpaceUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
@@ -26,11 +26,9 @@ class LogicalOperatorSpacingUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='LogicalOperatorSpacingUnitTest.inc')
+    public function getErrorList()
     {
         return [
             4  => 2,

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -30,7 +30,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='OperatorSpacingUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'OperatorSpacingUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -30,7 +30,7 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='SemicolonSpacingUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'SemicolonSpacingUnitTest.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -30,7 +30,7 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='SuperfluousWhitespaceUnitTest.inc')
+    public function getErrorList($testFile='')
     {
         switch ($testFile) {
         case 'SuperfluousWhitespaceUnitTest.1.inc':


### PR DESCRIPTION
## Description

Per @jrfnl's suggestion [here](https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/163#discussion_r1426775588), this PR replaces the default value of the first parameter of getErrorList() and getWarningList() with an empty string. The default value is never used, [as the first parameter is always passed when those two methods are called](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/186814f868eef4ad30fb27ec631718bdf62d9a72/tests/Standards/AbstractSniffUnitTest.php#L228-L229).

While working on this, I noticed some cases where the first parameter was not used inside getErrorList() or getWarningList(). For those, instead of replacing the default value with an empty string, I removed the parameter from the method signature.

## Suggested changelog entry
Replace the default value of the first parameter of getErrorList() and getWarningList() with an empty string

## Related issues/external references

Discussed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/163#discussion_r1426775588


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
