### PR TITLE
[Documentation] PSR12 - Closing Brace

### DIFF
--- a/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
+++ b/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
@@ -18,7 +18,7 @@ function bar()
 }<em></em>
         ]]>
         </code>
-        <code title="Invalid: Content on the line with the closing brace.">
+        <code title="Invalid: Comment or statement following the closing brace on the same line.">
         <![CDATA[
 interface Foo2
 {

--- a/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
+++ b/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
@@ -1,0 +1,35 @@
+<documentation title="Closing Brace">
+    <standard>
+    <![CDATA[
+    Any closing brace must not be followed by any comment or statement on the same line.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No content on the line with the closing brace.">
+        <![CDATA[
+class Foo
+{
+    // Class content.
+}<em></em>
+
+function bar()
+{
+    // Function content.
+}<em></em>
+        ]]>
+        </code>
+        <code title="Invalid: Content on the line with the closing brace.">
+        <![CDATA[
+interface Foo2
+{
+    // Interface content.
+} <em>echo 'Hello!';</em>
+
+function bar()
+{
+    // Function content.
+} <em>//end bar()</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
+++ b/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Closing Brace">
     <standard>
     <![CDATA[
-    Any closing brace must not be followed by any comment or statement on the same line.
+    The closing brace of object-oriented constructs and functions must not be followed by any comment or statement on the same line.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
+++ b/src/Standards/PSR12/Docs/Classes/ClosingBraceStandard.xml
@@ -5,7 +5,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: No content on the line with the closing brace.">
+        <code title="Valid: Closing brace is the last content on the line.">
         <![CDATA[
 class Foo
 {


### PR DESCRIPTION
The PR contains the documentation for the PSR12/Classes/ClosingBrace sniff.

## Description

This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#4-classes-properties-and-methods).

## Suggested changelog entry

Add documentation for the PSR12 ClosingBrace sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.