### PR TITLE
[Documentation] PSR12 - Boolean Operator Placement

### DIFF
--- a/src/Standards/PSR12/Docs/ControlStructures/BooleanOperatorPlacementStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/BooleanOperatorPlacementStandard.xml
@@ -1,0 +1,59 @@
+<documentation title="Boolean Operator Placement">
+    <standard>
+    <![CDATA[
+    Boolean operators between conditions in control structures must always be at the beginning or at the end of the line, not a mix of both.
+
+    This rule applies to if/else conditions, while loops and switch/match statements.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Boolean operator between conditions consistently at the beginning of the line.">
+        <![CDATA[
+if (
+    $expr1
+    && $expr2
+    && ($expr3
+    || $expr4)
+    && $expr5
+) {
+    // if body.
+}
+        ]]>
+        </code>
+        <code title="Invalid: Mix of boolean operators at the beginning and the end of the line.">
+        <![CDATA[
+if (
+    $expr1 &&
+    ($expr2 || $expr3)
+    && $expr4
+) {
+    // if body.
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Boolean operator between conditions consistently at the end of the line.">
+        <![CDATA[
+if (
+    $expr1 ||
+    ($expr2 || $expr3) &&
+    $expr4
+) {
+    // if body.
+}
+        ]]>
+        </code>
+        <code title="Invalid: Mix of boolean operators at the beginning and the end of the line.">
+        <![CDATA[
+match (
+    $expr1
+    && $expr2 ||
+    $expr3
+) {
+    // structure body.
+};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
The PR contains the documentation for the PSR12/CotrolStructures/BooleanOperatorPlacement sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#51-if-elseif-else).

## Suggested changelog entry
Add documentation for the PSR12 BooleanOperatorPlacement sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.