### PR TITLE
[Documentation] PSR12 - Control Structure Spacing

### DIFF
--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -7,7 +7,7 @@
     <code_comparison>
         <code title="Valid: No space after the opening parenthesis.">
         <![CDATA[
-if ($expr) {
+if <em>(</em>$expr) {
 }
         ]]>
         </code>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -63,7 +63,7 @@ while (
 }
         ]]>
         </code>
-        <code title="Invalid: First expression of a multi-line control structure is on the same line as the opening parenthesis.">
+        <code title="Invalid: First expression of a multi-line control structure condition block is on the same line as the opening parenthesis.">
         <![CDATA[
 while (<em></em>$expr1
     && $expr2

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -92,7 +92,7 @@ while (
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: The closing parenthesis of a multi-line control structure is indented to the same level as start of the control structure.">
+        <code title="Valid: The closing parenthesis of a multi-line control structure condition block is indented to the same level as start of the control structure.">
         <![CDATA[
 while (
     $expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -1,0 +1,114 @@
+<documentation title="Control Structure Spacing">
+    <standard>
+    <![CDATA[
+    Control structures MUST have correct spacing.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space after the opening parenthesis.">
+        <![CDATA[
+if ($expr) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: Space after the opening parenthesis.">
+        <![CDATA[
+if (<em> </em>$expr) {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: No space before the closing parenthesis.">
+        <![CDATA[
+if ($expr) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: Space before the closing parenthesis.">
+        <![CDATA[
+if ($expr<em> </em>) {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Each line in a multi-line control structure indented at least once. Default indentation is 4 spaces.">
+        <![CDATA[
+while (
+<em>    </em>$expr1
+<em>    </em>&& $expr2
+) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: Some lines in a multi-line control structure not indented correctly.">
+        <![CDATA[
+while (
+<em></em>$expr1
+    && $expr2
+<em>  </em>&& $expr3
+) {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: First expression of a multi-line control structure is on the line after the opening parenthesis.">
+        <![CDATA[
+while (
+    $expr1
+    && $expr2
+) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: First expression of a multi-line control structure is on the same line as the opening parenthesis.">
+        <![CDATA[
+while (<em></em>$expr1
+    && $expr2
+) {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: The closing parenthesis of a multi-line control structure is on the line after the last expression.">
+        <![CDATA[
+while (
+    $expr1
+    && $expr2
+<em>)</em> {
+}
+        ]]>
+        </code>
+        <code title="Invalid: The closing parenthesis of a multi-line control structure is on the same line as the last expression.">
+        <![CDATA[
+while (
+    $expr1
+    && $expr2<em>)</em> {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: The closing parenthesis of a multi-line control structure is indented to the same level as start of the control structure.">
+        <![CDATA[
+while (
+    $expr1
+    && $expr2
+) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: The closing parenthesis of a multi-line control structure is not indented to the same level as start of the control structure.">
+        <![CDATA[
+while (
+    $expr1
+    && $expr2
+<em>  </em>) {
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -42,7 +42,7 @@ while (
 }
         ]]>
         </code>
-        <code title="Invalid: Some lines in a multi-line control structure not indented correctly.">
+        <code title="Invalid: Some lines in a multi-line control structure condition block not indented correctly.">
         <![CDATA[
 while (
 <em></em>$expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Control Structure Spacing">
     <standard>
     <![CDATA[
-    Control structures MUST have correct spacing.
+    The control structures must have one space after the control structure keyword, no spaces after the opening parenthesis and before the closing parenthesis, and one space between the closing parenthesis and the opening brace.
     ]]>
     </standard>
     <code_comparison>
@@ -32,6 +32,30 @@ if ($expr<em> </em>) {
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    The body of the multi-line control structure must be indented once, placing the body on the next line after the opening brace.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: First expression of a multi-line control structure condition block is on the line after the opening parenthesis.">
+        <![CDATA[
+while (
+    <em>$expr1</em>
+    && $expr2
+) {
+}
+        ]]>
+        </code>
+        <code title="Invalid: First expression of a multi-line control structure condition block is on the same line as the opening parenthesis.">
+        <![CDATA[
+while (<em></em>$expr1
+    && $expr2
+) {
+}
+        ]]>
+        </code>
+    </code_comparison>
     <code_comparison>
         <code title="Valid: Each line in a multi-line control structure condition block indented at least once. Default indentation is 4 spaces.">
         <![CDATA[
@@ -53,25 +77,11 @@ while (
         ]]>
         </code>
     </code_comparison>
-    <code_comparison>
-        <code title="Valid: First expression of a multi-line control structure condition block is on the line after the opening parenthesis.">
-        <![CDATA[
-while (
-    $expr1
-    && $expr2
-) {
-}
-        ]]>
-        </code>
-        <code title="Invalid: First expression of a multi-line control structure condition block is on the same line as the opening parenthesis.">
-        <![CDATA[
-while (<em></em>$expr1
-    && $expr2
-) {
-}
-        ]]>
-        </code>
-    </code_comparison>
+    <standard>
+    <![CDATA[
+    The closing parenthesis of the multi-line control structure must be on the next line after the body, indented to the same level as the start of the control structure.
+    ]]>
+    </standard>
     <code_comparison>
         <code title="Valid: The closing parenthesis of a multi-line control structure condition block is on the line after the last expression.">
         <![CDATA[
@@ -97,7 +107,7 @@ while (
 while (
     $expr1
     && $expr2
-) {
+<em>)</em> {
 }
         ]]>
         </code>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Control Structure Spacing">
     <standard>
     <![CDATA[
-    The control structures must have one space after the control structure keyword, no spaces after the opening parenthesis and before the closing parenthesis, and one space between the closing parenthesis and the opening brace.
+    Single line control structures must have one space after the control structure keyword, no spaces after the condition opening parenthesis and before the closing parenthesis, and one space between the closing parenthesis and the opening brace.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -21,7 +21,7 @@ if <em>( </em>$expr) {
     <code_comparison>
         <code title="Valid: No space before the closing parenthesis in a single-line condition.">
         <![CDATA[
-if ($expr) {
+if <em>(</em>$expr) {
 }
         ]]>
         </code>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -13,7 +13,7 @@ if <em>(</em>$expr) {
         </code>
         <code title="Invalid: Space after the opening parenthesis.">
         <![CDATA[
-if (<em> </em>$expr) {
+if <em>( </em>$expr) {
 }
         ]]>
         </code>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -25,7 +25,7 @@ if ($expr) {
 }
         ]]>
         </code>
-        <code title="Invalid: Space before the closing parenthesis.">
+        <code title="Invalid: Space before the closing parenthesis in a single-line condition.">
         <![CDATA[
 if ($expr<em> </em>) {
 }

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -73,7 +73,7 @@ while (<em></em>$expr1
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: The closing parenthesis of a multi-line control structure is on the line after the last expression.">
+        <code title="Valid: The closing parenthesis of a multi-line control structure condition block is on the line after the last expression.">
         <![CDATA[
 while (
     $expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -33,7 +33,7 @@ if ($expr<em> </em>) {
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: Each line in a multi-line control structure indented at least once. Default indentation is 4 spaces.">
+        <code title="Valid: Each line in a multi-line control structure condition block indented at least once. Default indentation is 4 spaces.">
         <![CDATA[
 while (
 <em>    </em>$expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -54,7 +54,7 @@ while (
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: First expression of a multi-line control structure is on the line after the opening parenthesis.">
+        <code title="Valid: First expression of a multi-line control structure condition block is on the line after the opening parenthesis.">
         <![CDATA[
 while (
     $expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Control Structure Spacing">
     <standard>
     <![CDATA[
-    Single line control structures must have one space after the control structure keyword, no spaces after the condition opening parenthesis and before the closing parenthesis, and one space between the closing parenthesis and the opening brace.
+    Single line control structures must have no spaces after the condition opening parenthesis and before the condition closing parenthesis.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -19,7 +19,7 @@ if <em>( </em>$expr) {
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Valid: No space before the closing parenthesis.">
+        <code title="Valid: No space before the closing parenthesis in a single-line condition.">
         <![CDATA[
 if ($expr) {
 }

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -82,7 +82,7 @@ while (
 }
         ]]>
         </code>
-        <code title="Invalid: The closing parenthesis of a multi-line control structure is on the same line as the last expression.">
+        <code title="Invalid: The closing parenthesis of a multi-line control structure condition block is on the same line as the last expression.">
         <![CDATA[
 while (
     $expr1

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -34,7 +34,7 @@ if ($expr<em> )</em> {
     </code_comparison>
     <standard>
     <![CDATA[
-    The condition of the multi-line control structure must be indented once, placing the first expression on the next line after the opening brace.
+    The condition of the multi-line control structure must be indented once, placing the first expression on the next line after the opening parenthesis.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -5,7 +5,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: No space after the opening parenthesis.">
+        <code title="Valid: No space after the opening parenthesis in a single-line condition.">
         <![CDATA[
 if <em>(</em>$expr) {
 }

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -27,14 +27,14 @@ if <em>(</em>$expr) {
         </code>
         <code title="Invalid: Space before the closing parenthesis in a single-line condition.">
         <![CDATA[
-if ($expr<em> </em>) {
+if ($expr<em> )</em> {
 }
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    The body of the multi-line control structure must be indented once, placing the body on the next line after the opening brace.
+    The condition of the multi-line control structure must be indented once, placing the first expression on the next line after the opening brace.
     ]]>
     </standard>
     <code_comparison>
@@ -49,7 +49,7 @@ while (
         </code>
         <code title="Invalid: First expression of a multi-line control structure condition block is on the same line as the opening parenthesis.">
         <![CDATA[
-while (<em></em>$expr1
+while <em>($expr1</em>
     && $expr2
 ) {
 }
@@ -69,9 +69,9 @@ while (
         <code title="Invalid: Some lines in a multi-line control structure condition block not indented correctly.">
         <![CDATA[
 while (
-<em></em>$expr1
+<em>$expr1</em>
     && $expr2
-<em>  </em>&& $expr3
+<em>  && $expr3</em>
 ) {
 }
         ]]>
@@ -79,7 +79,7 @@ while (
     </code_comparison>
     <standard>
     <![CDATA[
-    The closing parenthesis of the multi-line control structure must be on the next line after the body, indented to the same level as the start of the control structure.
+    The closing parenthesis of the multi-line control structure must be on the next line after the last condition, indented to the same level as the start of the control structure.
     ]]>
     </standard>
     <code_comparison>
@@ -96,7 +96,7 @@ while (
         <![CDATA[
 while (
     $expr1
-    && $expr2<em>)</em> {
+    <em>&& $expr2)</em> {
 }
         ]]>
         </code>
@@ -116,7 +116,7 @@ while (
 while (
     $expr1
     && $expr2
-<em>  </em>) {
+<em>  )</em> {
 }
         ]]>
         </code>

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -11,7 +11,7 @@ if <em>(</em>$expr) {
 }
         ]]>
         </code>
-        <code title="Invalid: Space after the opening parenthesis.">
+        <code title="Invalid: Space after the opening parenthesis in a single-line condition.">
         <![CDATA[
 if <em>( </em>$expr) {
 }

--- a/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
+++ b/src/Standards/PSR12/Docs/ControlStructures/ControlStructureSpacingStandard.xml
@@ -101,7 +101,7 @@ while (
 }
         ]]>
         </code>
-        <code title="Invalid: The closing parenthesis of a multi-line control structure is not indented to the same level as start of the control structure.">
+        <code title="Invalid: The closing parenthesis of a multi-line control structure condition block is not indented to the same level as start of the control structure.">
         <![CDATA[
 while (
     $expr1


### PR DESCRIPTION
The PR contains the documentation for the PSR12/ControlStructures/ControlStructureSpacing sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#5-control-structures).

Note that some rules mentioned in the above definitions are covered by other rulesets. So they were not added to the documentation, as they are not a part of the Control Structure Spacing sniff.

## Suggested changelog entry
Add documentation for the PSR12 ControlStructureSpacing sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.