### PR TITLE
[Documentation] PSR12 - Declare Statement

### DIFF
--- a/src/Standards/PSR12/Docs/Files/DeclareStatementStandard.xml
+++ b/src/Standards/PSR12/Docs/Files/DeclareStatementStandard.xml
@@ -1,0 +1,111 @@
+<documentation title="Declare Statement">
+    <standard>
+    <![CDATA[
+    Declare statement must be correctly formatted.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space after the declare statement.">
+        <![CDATA[
+declare(ticks=1);
+        ]]>
+        </code>
+        <code title="Invalid: One or more spaces after the declare statement.">
+        <![CDATA[
+declare<em>   </em>(ticks=1);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: No space before and after the declare directive.">
+        <![CDATA[
+declare(strict_type=1);
+        ]]>
+        </code>
+        <code title="Invalid: One or more spaces before or after the declare directive.">
+        <![CDATA[
+declare(<em> </em>strict_type<em>   </em>=1);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: No space before and after the declare directive value.">
+        <![CDATA[
+declare(encoding='ISO-8859-1');
+        ]]>
+        </code>
+        <code title="Invalid: One or more spaces before or after the declare directive value.">
+        <![CDATA[
+declare(encoding=<em> </em>'ISO-8859-1'<em>   </em>);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: No space after the semicolon.">
+        <![CDATA[
+declare(ticks=1);
+        ]]>
+        </code>
+        <code title="Invalid: One or more spaces after the semicolon.">
+        <![CDATA[
+declare(ticks=1)<em> /* test */</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: One space after closing parenthesis and opening curly bracket in a declare statement.">
+        <![CDATA[
+declare(ticks=1)<em> </em>{
+}
+        ]]>
+        </code>
+        <code title="Invalid: More spaces after closing parenthesis and opening curly bracket in a declare statement.">
+        <![CDATA[
+declare(ticks=1)<em>     </em>{
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: The directive of a declare statement is written in lowercase letters.">
+        <![CDATA[
+declare(strict_type=1);
+        ]]>
+        </code>
+        <code title="Invalid: The directive of a declare statement is written in mixed case letters (or all upper case letters).">
+        <![CDATA[
+declare(strICt_TYpe=1);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: There is no code after opening curly bracket.">
+        <![CDATA[
+declare(ticks=1) {
+
+}
+        ]]>
+        </code>
+        <code title="Invalid: There is code after opening curly bracket.">
+        <![CDATA[
+declare(ticks=1) {<em> $test = true;</em>
+
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: The closing curly bracket of a declare statement is on a new line and aligned with the declare keyword.">
+        <![CDATA[
+declare(ticks=1) {
+
+}
+        ]]>
+        </code>
+        <code title="Invalid: The closing curly bracket of a declare statement is not on a new line.">
+        <![CDATA[
+declare(ticks=1) {<em> }</em>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
The PR contains the documentation for the PSR12/Files/DeclareStatement sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements).

## Suggested changelog entry
Add documentation for the PSR12 DeclareStatement sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.