### PR TITLE
Docs: improve type declarations

### DIFF
--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -19,7 +19,7 @@ abstract class AbstractArraySniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     final public function register()
     {

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -78,7 +78,7 @@ abstract class AbstractPatternSniff implements Sniff
      * Classes extending <i>AbstractPatternTest</i> should implement the
      * <i>getPatterns()</i> method to register the patterns they wish to test.
      *
-     * @return int[]
+     * @return array<int|string>
      * @see    process()
      */
     final public function register()

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -104,7 +104,7 @@ abstract class AbstractScopeSniff implements Sniff
      * DO NOT OVERRIDE THIS METHOD. Use the constructor of this class to register
      * for the desired tokens and scope.
      *
-     * @return int[]
+     * @return array<int|string>
      * @see    __constructor()
      */
     final public function register()

--- a/src/Sniffs/Sniff.php
+++ b/src/Sniffs/Sniff.php
@@ -28,13 +28,13 @@ interface Sniff
      *
      * <code>
      *    return array(
-     *            T_WHITESPACE,
-     *            T_DOC_COMMENT,
-     *            T_COMMENT,
-     *           );
+     *        T_WHITESPACE,
+     *        T_DOC_COMMENT,
+     *        T_COMMENT,
+     *    );
      * </code>
      *
-     * @return mixed[]
+     * @return array<int|string>
      * @see    Tokens.php
      */
     public function register();

--- a/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
@@ -19,7 +19,7 @@ class DisallowLongArraySyntaxSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -26,7 +26,7 @@ class DuplicateClassNameSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -19,7 +19,7 @@ class OpeningBraceSameLineSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -40,7 +40,7 @@ class AssignmentInConditionSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -23,7 +23,7 @@ class EmptyPHPStatementSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -34,7 +34,7 @@ class EmptyStatementSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
@@ -33,7 +33,7 @@ class ForLoopShouldBeWhileLoopSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
@@ -37,7 +37,7 @@ class ForLoopWithTestFunctionCallSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -39,7 +39,7 @@ class JumbledIncrementerSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
@@ -37,7 +37,7 @@ class UnconditionalIfStatementSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
@@ -32,7 +32,7 @@ class UnnecessaryFinalModifierSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -60,7 +60,7 @@ class UnusedFunctionParameterSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -32,7 +32,7 @@ class UselessOverridingMethodSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -30,7 +30,7 @@ class DocCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -31,7 +31,7 @@ class FixmeSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -30,7 +30,7 @@ class TodoSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -21,7 +21,7 @@ class DisallowYodaConditionsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -37,7 +37,7 @@ class InlineControlStructureSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -28,7 +28,7 @@ class CSSLintSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -44,7 +44,7 @@ class ClosureLinterSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
@@ -35,7 +35,7 @@ class ESLintSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -29,7 +29,7 @@ class JSHintSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
@@ -33,7 +33,7 @@ class ByteOrderMarkSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/EndFileNewlineSniff.php
@@ -30,7 +30,7 @@ class EndFileNewlineSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/EndFileNoNewlineSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/EndFileNoNewlineSniff.php
@@ -30,7 +30,7 @@ class EndFileNoNewlineSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/ExecutableFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ExecutableFileSniff.php
@@ -19,7 +19,7 @@ class ExecutableFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
@@ -32,7 +32,7 @@ class InlineHTMLSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -37,7 +37,7 @@ class LineEndingsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -50,7 +50,7 @@ class LineLengthSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
@@ -19,7 +19,7 @@ class LowercasedFilenameSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
@@ -19,7 +19,7 @@ class OneClassPerFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
@@ -19,7 +19,7 @@ class OneInterfacePerFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
@@ -19,7 +19,7 @@ class OneObjectStructurePerFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
@@ -19,7 +19,7 @@ class OneTraitPerFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
@@ -19,7 +19,7 @@ class DisallowMultipleStatementsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -58,7 +58,7 @@ class MultipleStatementAlignmentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
@@ -23,7 +23,7 @@ class NoSpaceAfterCastSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
@@ -34,7 +34,7 @@ class SpaceAfterCastSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -44,7 +44,7 @@ class SpaceAfterNotSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
@@ -20,7 +20,7 @@ class SpaceBeforeCastSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -20,7 +20,7 @@ class CallTimePassByReferenceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -20,7 +20,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -34,7 +34,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -38,7 +38,7 @@ class CyclomaticComplexitySniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
@@ -34,7 +34,7 @@ class NestingLevelSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/NamingConventions/AbstractClassNamePrefixSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/AbstractClassNamePrefixSniff.php
@@ -18,7 +18,7 @@ class AbstractClassNamePrefixSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/NamingConventions/InterfaceNameSuffixSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/InterfaceNameSuffixSniff.php
@@ -18,7 +18,7 @@ class InterfaceNameSuffixSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/NamingConventions/TraitNameSuffixSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/TraitNameSuffixSniff.php
@@ -18,7 +18,7 @@ class TraitNameSuffixSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -20,7 +20,7 @@ class UpperCaseConstantNameSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
@@ -19,7 +19,7 @@ class BacktickOperatorSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
@@ -32,7 +32,7 @@ class CharacterBeforePHPOpeningTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
@@ -19,7 +19,7 @@ class ClosingPHPTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -36,7 +36,7 @@ class DisallowAlternativePHPTagsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
@@ -19,7 +19,7 @@ class DisallowRequestSuperglobalSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -20,7 +20,7 @@ class DisallowShortOpenTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
@@ -19,7 +19,7 @@ class DiscourageGotoSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -56,7 +56,7 @@ class ForbiddenFunctionsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -64,7 +64,7 @@ class LowerCaseConstantSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -21,7 +21,7 @@ class LowerCaseKeywordSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -46,7 +46,7 @@ class LowerCaseTypeSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -33,7 +33,7 @@ class NoSilencedErrorsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -20,7 +20,7 @@ class RequireStrictTypesSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
@@ -19,7 +19,7 @@ class SAPIUsageSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -29,7 +29,7 @@ class SyntaxSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -47,7 +47,7 @@ class UnnecessaryStringConcatSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -30,7 +30,7 @@ class GitMergeConflictSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -34,7 +34,7 @@ class SubversionPropertiesSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -45,7 +45,7 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -37,7 +37,7 @@ class DisallowSpaceIndentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -37,7 +37,7 @@ class DisallowTabIndentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -30,7 +30,7 @@ class IncrementDecrementSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -21,7 +21,7 @@ class LanguageConstructSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -102,7 +102,7 @@ class ScopeIndentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -34,7 +34,7 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
@@ -20,7 +20,7 @@ class DisallowSelfActionsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
@@ -19,7 +19,7 @@ class IncludeOwnSystemSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
@@ -19,7 +19,7 @@ class UnusedSystemSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
@@ -19,7 +19,7 @@ class DebugCodeSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
@@ -26,7 +26,7 @@ class FirebugConsoleSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
@@ -26,7 +26,7 @@ class AssignThisSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
@@ -27,7 +27,7 @@ class CreateWidgetTypeCallbackSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
@@ -19,7 +19,7 @@ class DisallowNewWidgetSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
@@ -22,7 +22,7 @@ class AjaxNullComparisonSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
@@ -20,7 +20,7 @@ class EvalObjectFactorySniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
@@ -19,7 +19,7 @@ class GetRequestDataSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
@@ -19,7 +19,7 @@ class ReturnFunctionValueSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
+++ b/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
@@ -27,7 +27,7 @@ class JoinStringsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -19,7 +19,7 @@ class ClassDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -18,7 +18,7 @@ class ClassCommentSniff extends FileCommentSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -72,7 +72,7 @@ class FileCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -39,7 +39,7 @@ class FunctionCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/InlineCommentSniff.php
@@ -19,7 +19,7 @@ class InlineCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -37,7 +37,7 @@ class MultiLineConditionSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
+++ b/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
@@ -22,7 +22,7 @@ class IncludingFileSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -26,7 +26,7 @@ class MultiLineAssignmentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -58,7 +58,7 @@ class FunctionCallSignatureSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -39,7 +39,7 @@ class FunctionDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -19,7 +19,7 @@ class ValidDefaultValueSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -19,7 +19,7 @@ class ValidClassNameSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -43,7 +43,7 @@ class ObjectOperatorIndentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -24,11 +24,11 @@ class ScopeClosingBraceSniff implements Sniff
     public $indent = 4;
 
 
-     /**
-      * Returns an array of tokens this test wants to listen for.
-      *
-      * @return int[]
-      */
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
     public function register()
     {
         return Tokens::$scopeOpeners;

--- a/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -19,7 +19,7 @@ class ClassDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -20,7 +20,7 @@ class SideEffectsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
@@ -36,7 +36,7 @@ class AnonClassDeclarationSniff extends ClassDeclarationSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -20,7 +20,7 @@ class ClassInstantiationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
@@ -19,7 +19,7 @@ class ClosingBraceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
@@ -20,7 +20,7 @@ class OpeningBraceSpaceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -28,7 +28,7 @@ class BooleanOperatorPlacementSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -28,7 +28,7 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -20,7 +20,7 @@ class DeclareStatementSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -20,7 +20,7 @@ class FileHeaderSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
@@ -20,7 +20,7 @@ class ImportStatementSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
@@ -19,7 +19,7 @@ class OpenTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
@@ -36,7 +36,7 @@ class NullableTypeDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -19,7 +19,7 @@ class ReturnTypeDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Keywords/ShortFormTypeKeywordsSniff.php
+++ b/src/Standards/PSR12/Sniffs/Keywords/ShortFormTypeKeywordsSniff.php
@@ -19,7 +19,7 @@ class ShortFormTypeKeywordsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
+++ b/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
@@ -26,7 +26,7 @@ class CompoundNamespaceDepthSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
@@ -20,7 +20,7 @@ class OperatorSpacingSniff extends SquizOperatorSpacingSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
+++ b/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
@@ -20,7 +20,7 @@ class ConstantVisibilitySniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -20,7 +20,7 @@ class UseDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -34,7 +34,7 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -19,7 +19,7 @@ class ElseIfDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -27,7 +27,7 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
@@ -20,7 +20,7 @@ class ClosingTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -19,7 +19,7 @@ class EndFileNewlineSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionClosingBraceSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionClosingBraceSniff.php
@@ -19,7 +19,7 @@ class FunctionClosingBraceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -20,7 +20,7 @@ class NamespaceDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -20,7 +20,7 @@ class UseDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -19,7 +19,7 @@ class ArrayBracketSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -20,7 +20,7 @@ class ArrayDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -27,7 +27,7 @@ class DuplicateClassDefinitionSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -66,7 +66,7 @@ class ForbiddenStylesSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
@@ -34,7 +34,7 @@ class IndentationSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
@@ -53,7 +53,7 @@ class NamedColoursSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -19,7 +19,7 @@ class ClassFileNameSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
@@ -26,7 +26,7 @@ class DuplicatePropertySniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -20,7 +20,7 @@ class LowercaseClassKeywordsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -20,7 +20,7 @@ class ValidClassNameSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -27,7 +27,7 @@ class BlockCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -27,7 +27,7 @@ class ClassCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -19,7 +19,7 @@ class ClosingDeclarationCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -30,7 +30,7 @@ class DocCommentAlignmentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
@@ -19,7 +19,7 @@ class EmptyCatchCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -29,7 +29,7 @@ class FileCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -20,7 +20,7 @@ class FunctionCommentThrowTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -30,7 +30,7 @@ class InlineCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -62,7 +62,7 @@ class LongConditionClosingCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -47,7 +47,7 @@ class PostStatementCommentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -37,7 +37,7 @@ class ControlSignatureSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -19,7 +19,7 @@ class ElseIfDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -33,7 +33,7 @@ class ForEachLoopDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -51,7 +51,7 @@ class ForLoopDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
@@ -19,7 +19,7 @@ class InlineIfDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
@@ -19,7 +19,7 @@ class LowercaseDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -37,7 +37,7 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -28,7 +28,7 @@ class JSLintSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -29,7 +29,7 @@ class JavaScriptLintSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
@@ -19,7 +19,7 @@ class FileExtensionSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -30,7 +30,7 @@ class OperatorBracketSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -41,7 +41,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
@@ -19,7 +19,7 @@ class FunctionDuplicateArgumentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Functions/GlobalFunctionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/GlobalFunctionSniff.php
@@ -19,7 +19,7 @@ class GlobalFunctionSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
@@ -20,7 +20,7 @@ class LowercaseFunctionKeywordsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
@@ -26,7 +26,7 @@ class DisallowObjectStringIndexSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -20,7 +20,7 @@ class ObjectInstantiationSniff implements Sniff
     /**
      * Registers the token types that this sniff wishes to listen to.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
@@ -27,7 +27,7 @@ class ObjectMemberCommaSniff implements Sniff
     /**
      * Registers the token types that this sniff wishes to listen to.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -62,7 +62,7 @@ class ComparisonOperatorUsageSniff implements Sniff
     /**
      * Registers the token types that this sniff wishes to listen to.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -20,7 +20,7 @@ class IncrementDecrementUsageSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Operators/ValidLogicalOperatorsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ValidLogicalOperatorsSniff.php
@@ -19,7 +19,7 @@ class ValidLogicalOperatorsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -38,7 +38,7 @@ class CommentedOutCodeSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
@@ -20,7 +20,7 @@ class DisallowBooleanStatementSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
@@ -20,7 +20,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowInlineIfSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowInlineIfSniff.php
@@ -29,7 +29,7 @@ class DisallowInlineIfSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -20,7 +20,7 @@ class DisallowMultipleAssignmentsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
@@ -43,7 +43,7 @@ class DisallowSizeFunctionsInLoopsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -20,7 +20,7 @@ class EmbeddedPhpSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/EvalSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EvalSniff.php
@@ -19,7 +19,7 @@ class EvalSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/GlobalKeywordSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/GlobalKeywordSniff.php
@@ -19,7 +19,7 @@ class GlobalKeywordSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
@@ -19,7 +19,7 @@ class HeredocSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
@@ -20,7 +20,7 @@ class InnerFunctionsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -39,7 +39,7 @@ class LowercasePHPFunctionsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -36,7 +36,7 @@ class NonExecutableCodeSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -34,7 +34,7 @@ class ConcatenationSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -19,7 +19,7 @@ class DoubleQuoteUsageSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
@@ -20,7 +20,7 @@ class EchoedStringsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
@@ -20,7 +20,7 @@ class CastSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -30,7 +30,7 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
@@ -29,7 +29,7 @@ class FunctionClosingBraceSpaceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
@@ -29,7 +29,7 @@ class FunctionOpeningBraceSpaceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -48,7 +48,7 @@ class FunctionSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -20,7 +20,7 @@ class LanguageConstructSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
@@ -30,7 +30,7 @@ class LogicalOperatorSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -26,7 +26,7 @@ class ObjectOperatorSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -53,7 +53,7 @@ class OperatorSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
@@ -26,7 +26,7 @@ class PropertyLabelSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -20,7 +20,7 @@ class ScopeClosingBraceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -20,7 +20,7 @@ class ScopeKeywordSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -30,7 +30,7 @@ class SemicolonSpacingSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -43,7 +43,7 @@ class SuperfluousWhitespaceSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -23,7 +23,7 @@ class CodeAnalyzerSniff implements Sniff
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return int[]
+     * @return array<int|string>
      */
     public function register()
     {

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -20,7 +20,7 @@ class ClosingTagSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {


### PR DESCRIPTION
## Description
This commit addresses the `@return` tag for all sniff `register()` methods. Future commits may follow for other parts of the codebase.

PHP native tokens will always be integers.
PHP_CodeSniffer polyfilled and PHP_CodeSniffer native tokens will always be strings.

While some sniffs only return one or the other, I've chosen to update these tags to be the same across all sniffs for consistency.

## Suggested changelog entry
_N/A_