### PR TITLE
GH Actions: minor tweak to merge conflict workflow

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -9,7 +9,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - edited
       - synchronize
       - reopened
 


### PR DESCRIPTION
## Description
Follow up on #141 which added the `pull_request_target` trigger with types to the merge conflict check.

The `edited` type seems to include changes to the PR labels, which means that the workflow keeps getting cancelled and retriggered on new PRs due to the label workflow running and adding labels, so let's remove the `edited` type.


## Suggested changelog entry
_N/A_
