### PR TITLE
Runner::processFile(): remove stray passed params

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -688,7 +688,7 @@ class Runner
             $file->addErrorOnLine($error, 1, 'Internal.Exception');
         }//end try
 
-        $this->reporter->cacheFileReport($file, $this->config);
+        $this->reporter->cacheFileReport($file);
 
         if ($this->config->interactive === true) {
             /*
@@ -723,7 +723,7 @@ class Runner
                     $file->ruleset->populateTokenListeners();
                     $file->reloadContent();
                     $file->process();
-                    $this->reporter->cacheFileReport($file, $this->config);
+                    $this->reporter->cacheFileReport($file);
                     break;
                 }
             }//end while


### PR DESCRIPTION
## Description
The `Reporter::cacheFileReport()` method only takes one parameter.


## Suggested changelog entry
_N/A_