### PR TITLE
PSR12/ControlStructureSpacing: small tweak

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff as PSR2Spacing;
+use PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff as PSR2ControlStructureSpacing;
 use PHP_CodeSniffer\Util\Tokens;
 
 class ControlStructureSpacingSniff implements Sniff
@@ -23,6 +23,23 @@ class ControlStructureSpacingSniff implements Sniff
      * @var integer
      */
     public $indent = 4;
+
+    /**
+     * Instance of the PSR2 ControlStructureSpacingSniff sniff.
+     *
+     * @var \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff
+     */
+    private $psr2ControlStructureSpacing;
+
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->psr2ControlStructureSpacing = new PSR2ControlStructureSpacing();
+
+    }//end __construct()
 
 
     /**
@@ -70,8 +87,7 @@ class ControlStructureSpacingSniff implements Sniff
 
         if ($tokens[$parenOpener]['line'] === $tokens[$parenCloser]['line']) {
             // Conditions are all on the same line, so follow PSR2.
-            $sniff = new PSR2Spacing();
-            return $sniff->process($phpcsFile, $stackPtr);
+            return $this->psr2ControlStructureSpacing->process($phpcsFile, $stackPtr);
         }
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($parenOpener + 1), $parenCloser, true);


### PR DESCRIPTION
## Description

No need to create a new instance of the PSR2 sniff every single time the sniff is triggered. Re-using the same object, just like is done with sniffs in general, will work just as well. This will have a (tiny) positive impact on performance, though the impact is so small, it can be considered negligible.

## Suggested changelog entry
_N/A_