### PR TITLE
Filters/ExactMatch: rename some private properties

### DIFF
--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -2,7 +2,7 @@
 /**
  * An abstract filter class for checking files and folders against exact matches.
  *
- * Supports both whitelists and blacklists.
+ * Supports both allowed files and blocked files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -21,22 +21,22 @@ abstract class ExactMatch extends Filter
      *
      * @var array
      */
-    private $blacklist = null;
+    private $blockedFiles = null;
 
     /**
      * A list of files to include.
      *
-     * If the whitelist is empty, only files in the blacklist will be excluded.
+     * If the allowed files list is empty, only files in the blocked files list will be excluded.
      *
      * @var array
      */
-    private $whitelist = null;
+    private $allowedFiles = null;
 
 
     /**
      * Check whether the current element of the iterator is acceptable.
      *
-     * If a file is both blacklisted and whitelisted, it will be deemed unacceptable.
+     * If a file is both blocked and allowed, it will be deemed unacceptable.
      *
      * @return bool
      */
@@ -46,27 +46,27 @@ abstract class ExactMatch extends Filter
             return false;
         }
 
-        if ($this->blacklist === null) {
-            $this->blacklist = $this->getblacklist();
+        if ($this->blockedFiles === null) {
+            $this->blockedFiles = $this->getblacklist();
         }
 
-        if ($this->whitelist === null) {
-            $this->whitelist = $this->getwhitelist();
+        if ($this->allowedFiles === null) {
+            $this->allowedFiles = $this->getwhitelist();
         }
 
         $filePath = Util\Common::realpath($this->current());
 
-        // If file is both blacklisted and whitelisted, the blacklist takes precedence.
-        if (isset($this->blacklist[$filePath]) === true) {
+        // If file is both blocked and allowed, the blocked files list takes precedence.
+        if (isset($this->blockedFiles[$filePath]) === true) {
             return false;
         }
 
-        if (empty($this->whitelist) === true && empty($this->blacklist) === false) {
-            // We are only checking a blacklist, so everything else should be whitelisted.
+        if (empty($this->allowedFiles) === true && empty($this->blockedFiles) === false) {
+            // We are only checking a blocked files list, so everything else should be allowed.
             return true;
         }
 
-        return isset($this->whitelist[$filePath]);
+        return isset($this->allowedFiles[$filePath]);
 
     }//end accept()
 
@@ -74,23 +74,23 @@ abstract class ExactMatch extends Filter
     /**
      * Returns an iterator for the current entry.
      *
-     * Ensures that the blacklist and whitelist are preserved so they don't have
+     * Ensures that the blocked files list and the allowed files list are preserved so they don't have
      * to be generated each time.
      *
      * @return \RecursiveIterator
      */
     public function getChildren()
     {
-        $children            = parent::getChildren();
-        $children->blacklist = $this->blacklist;
-        $children->whitelist = $this->whitelist;
+        $children = parent::getChildren();
+        $children->blockedFiles = $this->blockedFiles;
+        $children->allowedFiles = $this->allowedFiles;
         return $children;
 
     }//end getChildren()
 
 
     /**
-     * Get a list of blacklisted file paths.
+     * Get a list of file paths to exclude.
      *
      * @return array
      */
@@ -98,7 +98,7 @@ abstract class ExactMatch extends Filter
 
 
     /**
-     * Get a list of whitelisted file paths.
+     * Get a list of file paths to include.
      *
      * @return array
      */

--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -16,7 +16,7 @@ class GitModified extends ExactMatch
 
 
     /**
-     * Get a list of blacklisted file paths.
+     * Get a list of file paths to exclude.
      *
      * @return array
      */
@@ -28,7 +28,7 @@ class GitModified extends ExactMatch
 
 
     /**
-     * Get a list of whitelisted file paths.
+     * Get a list of file paths to include.
      *
      * @return array
      */

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -18,7 +18,7 @@ class GitStaged extends ExactMatch
 
 
     /**
-     * Get a list of blacklisted file paths.
+     * Get a list of file paths to exclude.
      *
      * @return array
      */
@@ -30,7 +30,7 @@ class GitStaged extends ExactMatch
 
 
     /**
-     * Get a list of whitelisted file paths.
+     * Get a list of file paths to include.
      *
      * @return array
      */


### PR DESCRIPTION
## Description

Remove the needless use of culturally insensitive blacklist/whitelist terminology used in the property names and the documentation.

As these properties are `private`, this is a change which doesn't affect the API and is therefore non-breaking.


## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #198