### PR TITLE
Filters/ExactMatch: deprecate the `getBlacklist()` and `getWhitelist()` methods

### DIFF
--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -47,22 +47,32 @@ abstract class ExactMatch extends Filter
         }
 
         if ($this->disallowedFiles === null) {
-            $this->disallowedFiles = $this->getblacklist();
+            $this->disallowedFiles = $this->getDisallowedFiles();
+
+            // BC-layer.
+            if ($this->disallowedFiles === null) {
+                $this->disallowedFiles = $this->getBlacklist();
+            }
         }
 
         if ($this->allowedFiles === null) {
-            $this->allowedFiles = $this->getwhitelist();
+            $this->allowedFiles = $this->getAllowedFiles();
+
+            // BC-layer.
+            if ($this->allowedFiles === null) {
+                $this->allowedFiles = $this->getWhitelist();
+            }
         }
 
         $filePath = Util\Common::realpath($this->current());
 
-        // If file is both disallowed and allowed, the disallowed files list takes precedence.
+        // If a file is both disallowed and allowed, the disallowed files list takes precedence.
         if (isset($this->disallowedFiles[$filePath]) === true) {
             return false;
         }
 
         if (empty($this->allowedFiles) === true && empty($this->disallowedFiles) === false) {
-            // We are only checking a disallowed files list, so everything else should be allowed.
+            // We are only checking the disallowed files list, so everything else should be allowed.
             return true;
         }
 
@@ -92,6 +102,11 @@ abstract class ExactMatch extends Filter
     /**
      * Get a list of file paths to exclude.
      *
+     * @deprecated 3.9.0 Implement the `getDisallowedFiles()` method instead.
+     *                   The `getDisallowedFiles()` method will be made abstract and therefore required
+     *                   in v4.0 and this method will be removed.
+     *                   If both methods are implemented, the new `getDisallowedFiles()` method will take precedence.
+     *
      * @return array
      */
     abstract protected function getBlacklist();
@@ -100,9 +115,42 @@ abstract class ExactMatch extends Filter
     /**
      * Get a list of file paths to include.
      *
+     * @deprecated 3.9.0 Implement the `getAllowedFiles()` method instead.
+     *                   The `getAllowedFiles()` method will be made abstract and therefore required
+     *                   in v4.0 and this method will be removed.
+     *                   If both methods are implemented, the new `getAllowedFiles()` method will take precedence.
+     *
      * @return array
      */
     abstract protected function getWhitelist();
+
+
+    /**
+     * Get a list of file paths to exclude.
+     *
+     * @since 3.9.0 Replaces the deprecated `getBlacklist()` method.
+     *
+     * @return array|null
+     */
+    protected function getDisallowedFiles()
+    {
+        return null;
+
+    }//end getDisallowedFiles()
+
+
+    /**
+     * Get a list of file paths to include.
+     *
+     * @since 3.9.0 Replaces the deprecated `getWhitelist()` method.
+     *
+     * @return array|null
+     */
+    protected function getAllowedFiles()
+    {
+        return null;
+
+    }//end getAllowedFiles()
 
 
 }//end class

--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -18,11 +18,29 @@ class GitModified extends ExactMatch
     /**
      * Get a list of file paths to exclude.
      *
+     * @since 3.9.0
+     *
+     * @return array
+     */
+    protected function getDisallowedFiles()
+    {
+        return [];
+
+    }//end getDisallowedFiles()
+
+
+    /**
+     * Get a list of file paths to exclude.
+     *
+     * @deprecated 3.9.0 Overload the `getDisallowedFiles()` method instead.
+     *
+     * @codeCoverageIgnore
+     *
      * @return array
      */
     protected function getBlacklist()
     {
-        return [];
+        return $this->getDisallowedFiles();
 
     }//end getBlacklist()
 
@@ -30,9 +48,11 @@ class GitModified extends ExactMatch
     /**
      * Get a list of file paths to include.
      *
+     * @since 3.9.0
+     *
      * @return array
      */
-    protected function getWhitelist()
+    protected function getAllowedFiles()
     {
         $modified = [];
 
@@ -58,6 +78,22 @@ class GitModified extends ExactMatch
         }
 
         return $modified;
+
+    }//end getAllowedFiles()
+
+
+    /**
+     * Get a list of file paths to include.
+     *
+     * @deprecated 3.9.0 Overload the `getAllowedFiles()` method instead.
+     *
+     * @codeCoverageIgnore
+     *
+     * @return array
+     */
+    protected function getWhitelist()
+    {
+        return $this->getAllowedFiles();
 
     }//end getWhitelist()
 

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -20,11 +20,29 @@ class GitStaged extends ExactMatch
     /**
      * Get a list of file paths to exclude.
      *
+     * @since 3.9.0
+     *
+     * @return array
+     */
+    protected function getDisallowedFiles()
+    {
+        return [];
+
+    }//end getDisallowedFiles()
+
+
+    /**
+     * Get a list of file paths to exclude.
+     *
+     * @deprecated 3.9.0 Overload the `getDisallowedFiles()` method instead.
+     *
+     * @codeCoverageIgnore
+     *
      * @return array
      */
     protected function getBlacklist()
     {
-        return [];
+        return $this->getDisallowedFiles();
 
     }//end getBlacklist()
 
@@ -32,9 +50,11 @@ class GitStaged extends ExactMatch
     /**
      * Get a list of file paths to include.
      *
+     * @since 3.9.0
+     *
      * @return array
      */
-    protected function getWhitelist()
+    protected function getAllowedFiles()
     {
         $modified = [];
 
@@ -60,6 +80,22 @@ class GitStaged extends ExactMatch
         }
 
         return $modified;
+
+    }//end getAllowedFiles()
+
+
+    /**
+     * Get a list of file paths to include.
+     *
+     * @deprecated 3.9.0 Overload the `getAllowedFiles()` method instead.
+     *
+     * @codeCoverageIgnore
+     *
+     * @return array
+     */
+    protected function getWhitelist()
+    {
+        return $this->getAllowedFiles();
 
     }//end getWhitelist()
 


### PR DESCRIPTION
## Description
Deprecate the `getBlacklist()` and `getWhitelist()` methods and introduce the ~~`getBlockedFiles()`~~ ++`getDisallowedFiles()`++ and `getAllowedFiles()` replacement methods.

When available in child classes, the ~~`getBlockedFiles()`~~ ++`getDisallowedFiles()`++ and `getAllowedFiles()` methods will take precedence over the deprecated `getBlacklist()` and `getWhitelist()` methods.

## Suggested changelog entry
* Issue 198: The abstract `ExactMatch::getBlacklist()` and `ExactMatch::getWhitelist()` methods are deprecated and will be removed in the 4.0 release.
    - In version 4.0, these methods will be replaced with abstract `ExactMatch::getDisallowedFiles()` and `ExactMatch::getAllowedFiles()` methods
    - To make Filters extending `ExactMatch` cross-version compatible with both PHP_CodeSniffer 3.9.0+ as well as 4.0+, implement the new `getDisallowedFiles()` and `getAllowedFiles()` methods.
        - When both the `getDisallowedFiles()` and `getAllowedFiles()` methods as well as the `getBlacklist()` and `getWhitelist()` are available, the new methods will take precedence over the old methods.


## Related issues/external references

Fixes #198
Covered by the tests which were added in #201
