### PR TITLE
GH Actions: downgrade actions/[upload|download]-artifact back from 4 to 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: php scripts/build-phar.php
 
       - name: Upload the PHPCS phar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: phpcs-phar
           path: ./phpcs.phar
@@ -46,7 +46,7 @@ jobs:
           retention-days: 28
 
       - name: Upload the PHPCBF phar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: phpcbf-phar
           path: ./phpcbf.phar
@@ -163,7 +163,7 @@ jobs:
 
       - name: Download the PHPCS phar
         if: ${{ matrix.custom_ini == false }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: phpcs-phar
 


### PR DESCRIPTION
## Description

I'm getting sick and tired of having to restart builds due to artifacts not downloading correctly.

This bug has been reported to the action runner and upgrading to v4 should not be re-attempted until the issue has been resolved.

Effectively reverts Dependabot PR #172 (and #173).

## Suggested changelog entry
_N/A_

## Related issues/external references

Related issue: actions/download-artifact#249