### PR TITLE
Squiz/VariableComment: allow union and intersection types to be detected

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -30,16 +30,18 @@ class VariableCommentSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
         $ignore = [
-            T_PUBLIC       => T_PUBLIC,
-            T_PRIVATE      => T_PRIVATE,
-            T_PROTECTED    => T_PROTECTED,
-            T_VAR          => T_VAR,
-            T_STATIC       => T_STATIC,
-            T_READONLY     => T_READONLY,
-            T_WHITESPACE   => T_WHITESPACE,
-            T_STRING       => T_STRING,
-            T_NS_SEPARATOR => T_NS_SEPARATOR,
-            T_NULLABLE     => T_NULLABLE,
+            T_PUBLIC            => T_PUBLIC,
+            T_PRIVATE           => T_PRIVATE,
+            T_PROTECTED         => T_PROTECTED,
+            T_VAR               => T_VAR,
+            T_STATIC            => T_STATIC,
+            T_READONLY          => T_READONLY,
+            T_WHITESPACE        => T_WHITESPACE,
+            T_STRING            => T_STRING,
+            T_NS_SEPARATOR      => T_NS_SEPARATOR,
+            T_NULLABLE          => T_NULLABLE,
+            T_TYPE_UNION        => T_TYPE_UNION,
+            T_TYPE_INTERSECTION => T_TYPE_INTERSECTION,
         ];
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -402,3 +402,19 @@ class ReadOnlyProps
 
      private readonly string $variable;
 }
+
+class UnionTypes
+{
+    /**
+     * @var array|boolean
+     */
+    private array|bool $variableName = array();
+}
+
+class IntersectionTypes
+{
+    /**
+     * @var \Iterator|\Countable
+     */
+    private \Iterator&\Countable $variableName;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -402,3 +402,19 @@ class ReadOnlyProps
 
      private readonly string $variable;
 }
+
+class UnionTypes
+{
+    /**
+     * @var array|boolean
+     */
+    private array|bool $variableName = array();
+}
+
+class IntersectionTypes
+{
+    /**
+     * @var \Iterator|\Countable
+     */
+    private \Iterator&\Countable $variableName;
+}


### PR DESCRIPTION
If one uses a union type for an object property, the doc-type-hint could not be related to the variable type.

Fixed now.

Includes unit test.

This is a continuation of [#3757](https://github.com/squizlabs/PHP_CodeSniffer/pull/3757)

Closes #178
Closes squizlabs/PHP_CodeSniffer#3757
