### PR TITLE
Tests/AbstractMethodUnitTest: new `expectRunTimeException()` helper method

### DIFF
--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -179,4 +179,28 @@ abstract class AbstractMethodUnitTest extends TestCase
     }//end getTargetToken()
 
 
+    /**
+     * Helper method to tell PHPUnit to expect a PHPCS RuntimeException in a PHPUnit cross-version
+     * compatible manner.
+     *
+     * @param string $message The expected exception message.
+     *
+     * @return void
+     */
+    public function expectRunTimeException($message)
+    {
+        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $message);
+        }
+
+    }//end expectRunTimeException()
+
+
 }//end class

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -32,17 +32,7 @@ class GetClassPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNotAClassException($testMarker, $tokenType)
     {
-        $msg       = '$stackPtr must be of type T_CLASS';
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-
-        if (\method_exists($this, 'expectException') === true) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectRunTimeException('$stackPtr must be of type T_CLASS');
 
         $target = $this->getTargetToken($testMarker, $tokenType);
         self::$phpcsFile->getClassProperties($target);

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -870,17 +870,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNotClassPropertyException($identifier)
     {
-        $msg       = '$stackPtr is not a class member var';
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-
-        if (\method_exists($this, 'expectException') === true) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectRunTimeException('$stackPtr is not a class member var');
 
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
         $result   = self::$phpcsFile->getMemberProperties($variable);
@@ -917,17 +907,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNotAVariableException()
     {
-        $msg       = '$stackPtr must be of type T_VARIABLE';
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-
-        if (\method_exists($this, 'expectException') === true) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectRunTimeException('$stackPtr must be of type T_VARIABLE');
 
         $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
         $result = self::$phpcsFile->getMemberProperties($next);


### PR DESCRIPTION
## Description
This commit introduces a new `expectRunTimeException()` test helper method to allow for expecting a PHPCS native `PHP_CodeSniffer\Exceptions\RuntimeException` in a PHPUnit cross-version compatible manner.

Includes implementation of the new method in the few test classes which currently need it (and which extend the `AbstractMethodUnitTest` class).


## Suggested changelog entry
_N/A_
