### PR TITLE
PHP 8.2 | Squiz/VariableComment: allow for stand-alone null/true/false types and more

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -42,6 +42,9 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_NULLABLE          => T_NULLABLE,
             T_TYPE_UNION        => T_TYPE_UNION,
             T_TYPE_INTERSECTION => T_TYPE_INTERSECTION,
+            T_NULL              => T_NULL,
+            T_TRUE              => T_TRUE,
+            T_FALSE             => T_FALSE,
         ];
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -39,12 +39,15 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_WHITESPACE        => T_WHITESPACE,
             T_STRING            => T_STRING,
             T_NS_SEPARATOR      => T_NS_SEPARATOR,
+            T_NAMESPACE         => T_NAMESPACE,
             T_NULLABLE          => T_NULLABLE,
             T_TYPE_UNION        => T_TYPE_UNION,
             T_TYPE_INTERSECTION => T_TYPE_INTERSECTION,
             T_NULL              => T_NULL,
             T_TRUE              => T_TRUE,
             T_FALSE             => T_FALSE,
+            T_SELF              => T_SELF,
+            T_PARENT            => T_PARENT,
         ];
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -418,3 +418,21 @@ class IntersectionTypes
      */
     private \Iterator&\Countable $variableName;
 }
+
+class StandaloneNullTrueFalseTypes
+{
+    /**
+     * @var null
+     */
+    public null $variableName = null;
+
+    /**
+     * @var true
+     */
+    protected true $variableName = true;
+
+    /**
+     * @var false
+     */
+    private false $variableName = false;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -436,3 +436,21 @@ class StandaloneNullTrueFalseTypes
      */
     private false $variableName = false;
 }
+
+class MoreMissingButSupportedTypes
+{
+    /**
+     * @var parent
+     */
+    public parent $variableName;
+
+    /**
+     * @var self
+     */
+    protected self $variableName;
+
+    /**
+     * @var SomeClass
+     */
+    private namespace\SomeClass $variableName;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -418,3 +418,21 @@ class IntersectionTypes
      */
     private \Iterator&\Countable $variableName;
 }
+
+class StandaloneNullTrueFalseTypes
+{
+    /**
+     * @var null
+     */
+    public null $variableName = null;
+
+    /**
+     * @var true
+     */
+    protected true $variableName = true;
+
+    /**
+     * @var false
+     */
+    private false $variableName = false;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -436,3 +436,21 @@ class StandaloneNullTrueFalseTypes
      */
     private false $variableName = false;
 }
+
+class MoreMissingButSupportedTypes
+{
+    /**
+     * @var parent
+     */
+    public parent $variableName;
+
+    /**
+     * @var self
+     */
+    protected self $variableName;
+
+    /**
+     * @var SomeClass
+     */
+    private namespace\SomeClass $variableName;
+}


### PR DESCRIPTION
## Description

### PHP 8.2 | Squiz/VariableComment: allow for stand-alone null/true/false types

Since PHP 8.2, stand-alone use of `true`, `false` and `null` is allowed.

However, if these were used as the type for a property, the docblock would not be found.

Fixed now.

Includes unit tests.

### Squiz/VariableComment: allow for various other missing types

There were some more allowed types missing from the list of tokens to skip over to find a docblock.

Fixed now.

Includes unit tests.

## Suggested changelog entry
* Squiz.Commenting.VariableComment : docblocks were incorrectly being flagged as missing when a property declaration used PHP 8.2+ stand-alone `true`/`false`/`null` type declarations
* Squiz.Commenting.VariableComment : docblocks were incorrectly being flagged as missing when a property declaration used PHP native `parent`, `self` or a namespace relative class name type declaration


## Related issues/external references

Related to #178 and #209


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

