### PR TITLE
File::findExtendedClassName(): improve tests

### DIFF
--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -4,22 +4,22 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 class testFECNClass {}
 
-/* testExtendedClass */
+/* testExtendsUnqualifiedClass */
 class testFECNExtendedClass extends testFECNClass {}
 
-/* testNamespacedClass */
+/* testExtendsFullyQualifiedClass */
 class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNClass {}
 
 /* testNonExtendedClass */
 class testFECNNonExtendedClass {}
 
-/* testInterface */
+/* testNonExtendedInterface */
 interface testFECNInterface {}
 
-/* testInterfaceThatExtendsInterface */
+/* testInterfaceExtendsUnqualifiedInterface */
 interface testInterfaceThatExtendsInterface extends testFECNInterface{}
 
-/* testInterfaceThatExtendsFQCNInterface */
+/* testInterfaceExtendsFullyQualifiedInterface */
 interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
 
 /* testNestedExtendedClass */

--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -1,8 +1,10 @@
 <?php
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+/* testNotAClass */
+function notAClass() {}
 
-class testFECNClass {}
+/* testNonExtendedClass */
+class testFECNNonExtendedClass {}
 
 /* testExtendsUnqualifiedClass */
 class testFECNExtendedClass extends testFECNClass {}
@@ -10,8 +12,8 @@ class testFECNExtendedClass extends testFECNClass {}
 /* testExtendsFullyQualifiedClass */
 class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNClass {}
 
-/* testNonExtendedClass */
-class testFECNNonExtendedClass {}
+/* testExtendsPartiallyQualifiedClass */
+class testFECNQualifiedClass extends Core\File\RelativeClass {}
 
 /* testNonExtendedInterface */
 interface testFECNInterface {}
@@ -21,6 +23,9 @@ interface testInterfaceThatExtendsInterface extends testFECNInterface{}
 
 /* testInterfaceExtendsFullyQualifiedInterface */
 interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
+
+/* testExtendedAnonClass */
+$anon = new class( $a, $b ) extends testFECNExtendedAnonClass {};
 
 /* testNestedExtendedClass */
 class testFECNNestedExtendedClass {
@@ -35,3 +40,13 @@ class testFECNClassThatExtendsAndImplements extends testFECNClass implements Int
 
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements InterfaceA, InterfaceB extends testFECNClass {}
+
+/* testInterfaceMultiExtends */
+interface Multi extends \Package\FooInterface, \BarInterface {};
+
+/* testMissingExtendsName */
+class testMissingExtendsName extends { /* missing classname */ } // Intentional parse error.
+
+// Intentional parse error. Has to be the last test in the file.
+/* testParseError */
+class testParseError extends testFECNClass

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -24,8 +24,8 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
      * Test retrieving the name of the class being extended by another class
      * (or interface).
      *
-     * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param string       $identifier Comment which precedes the test case.
+     * @param string|false $expected   Expected function output.
      *
      * @dataProvider dataExtendedClass
      *
@@ -45,50 +45,50 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
      *
      * @see testFindExtendedClassName()
      *
-     * @return array
+     * @return array<string, array<string, string|false>>
      */
     public function dataExtendedClass()
     {
         return [
-            [
-                '/* testExtendsUnqualifiedClass */',
-                'testFECNClass',
+            'class extends unqualified class'                             => [
+                'identifier' => '/* testExtendsUnqualifiedClass */',
+                'expected'   => 'testFECNClass',
             ],
-            [
-                '/* testExtendsFullyQualifiedClass */',
-                '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
+            'class extends fully qualified class'                         => [
+                'identifier' => '/* testExtendsFullyQualifiedClass */',
+                'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
-            [
-                '/* testNonExtendedClass */',
-                false,
+            'class does not extend'                                       => [
+                'identifier' => '/* testNonExtendedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testNonExtendedInterface */',
-                false,
+            'interface does not extend'                                   => [
+                'identifier' => '/* testNonExtendedInterface */',
+                'expected'   => false,
             ],
-            [
-                '/* testInterfaceExtendsUnqualifiedInterface */',
-                'testFECNInterface',
+            'interface extends unqualified interface'                     => [
+                'identifier' => '/* testInterfaceExtendsUnqualifiedInterface */',
+                'expected'   => 'testFECNInterface',
             ],
-            [
-                '/* testInterfaceExtendsFullyQualifiedInterface */',
-                '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
+            'interface extends fully qualified interface'                 => [
+                'identifier' => '/* testInterfaceExtendsFullyQualifiedInterface */',
+                'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
             ],
-            [
-                '/* testNestedExtendedClass */',
-                false,
+            'class does not extend but contains anon class which extends' => [
+                'identifier' => '/* testNestedExtendedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testNestedExtendedAnonClass */',
-                'testFECNAnonClass',
+            'anon class extends, nested in non-extended class'            => [
+                'identifier' => '/* testNestedExtendedAnonClass */',
+                'expected'   => 'testFECNAnonClass',
             ],
-            [
-                '/* testClassThatExtendsAndImplements */',
-                'testFECNClass',
+            'class extends and implements'                                => [
+                'identifier' => '/* testClassThatExtendsAndImplements */',
+                'expected'   => 'testFECNClass',
             ],
-            [
-                '/* testClassThatImplementsAndExtends */',
-                'testFECNClass',
+            'class implements and extends'                                => [
+                'identifier' => '/* testClassThatImplementsAndExtends */',
+                'expected'   => 'testFECNClass',
             ],
         ];
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -21,6 +21,33 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test getting a `false` result when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = self::$phpcsFile->findExtendedClassName(100000);
+        $this->assertFalse($result);
+
+    }//end testNonExistentToken()
+
+
+    /**
+     * Test getting a `false` result when a token other than one of the supported tokens is passed.
+     *
+     * @return void
+     */
+    public function testNotAClass()
+    {
+        $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
+        $result = self::$phpcsFile->findExtendedClassName($token);
+        $this->assertFalse($result);
+
+    }//end testNotAClass()
+
+
+    /**
      * Test retrieving the name of the class being extended by another class
      * (or interface).
      *
@@ -50,6 +77,10 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
     public function dataExtendedClass()
     {
         return [
+            'class does not extend'                                       => [
+                'identifier' => '/* testNonExtendedClass */',
+                'expected'   => false,
+            ],
             'class extends unqualified class'                             => [
                 'identifier' => '/* testExtendsUnqualifiedClass */',
                 'expected'   => 'testFECNClass',
@@ -58,9 +89,9 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
                 'identifier' => '/* testExtendsFullyQualifiedClass */',
                 'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
-            'class does not extend'                                       => [
-                'identifier' => '/* testNonExtendedClass */',
-                'expected'   => false,
+            'class extends partially qualified class'                     => [
+                'identifier' => '/* testExtendsPartiallyQualifiedClass */',
+                'expected'   => 'Core\File\RelativeClass',
             ],
             'interface does not extend'                                   => [
                 'identifier' => '/* testNonExtendedInterface */',
@@ -73,6 +104,10 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
             'interface extends fully qualified interface'                 => [
                 'identifier' => '/* testInterfaceExtendsFullyQualifiedInterface */',
                 'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
+            ],
+            'anon class extends unqualified class'                        => [
+                'identifier' => '/* testExtendedAnonClass */',
+                'expected'   => 'testFECNExtendedAnonClass',
             ],
             'class does not extend but contains anon class which extends' => [
                 'identifier' => '/* testNestedExtendedClass */',
@@ -89,6 +124,18 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
             'class implements and extends'                                => [
                 'identifier' => '/* testClassThatImplementsAndExtends */',
                 'expected'   => 'testFECNClass',
+            ],
+            'interface extends multiple interfaces (not supported)'       => [
+                'identifier' => '/* testInterfaceMultiExtends */',
+                'expected'   => '\Package\FooInterface',
+            ],
+            'parse error - extends keyword, but no class name'            => [
+                'identifier' => '/* testMissingExtendsName */',
+                'expected'   => false,
+            ],
+            'parse error - live coding - no curly braces'                 => [
+                'identifier' => '/* testParseError */',
+                'expected'   => false,
             ],
         ];
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -51,11 +51,11 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
     {
         return [
             [
-                '/* testExtendedClass */',
+                '/* testExtendsUnqualifiedClass */',
                 'testFECNClass',
             ],
             [
-                '/* testNamespacedClass */',
+                '/* testExtendsFullyQualifiedClass */',
                 '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
             [
@@ -63,15 +63,15 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
                 false,
             ],
             [
-                '/* testInterface */',
+                '/* testNonExtendedInterface */',
                 false,
             ],
             [
-                '/* testInterfaceThatExtendsInterface */',
+                '/* testInterfaceExtendsUnqualifiedInterface */',
                 'testFECNInterface',
             ],
             [
-                '/* testInterfaceThatExtendsFQCNInterface */',
+                '/* testInterfaceExtendsFullyQualifiedInterface */',
                 '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
             ],
             [


### PR DESCRIPTION
## Description

### Tests/FindExtendedClassNameTest: improve test markers

Make the test marker names more descriptive

### Tests/FindExtendedClassNameTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes fixing the data types in the docblocks and making them more specific, where relevant.

### Tests/FindExtendedClassNameTest: add extra tests

This adds some extra tests which were already in use in PHPCSUtils. This brings test coverage for this method up to 100%.

It also cleans up the test case file a little by removing some code which isn't actually used in the tests (namespace declaration) and moves the "class not extended" test up.

## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #146