### PR TITLE
File::findImplementedInterfaceNames() improve tests

### DIFF
--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -1,11 +1,13 @@
 <?php
 
-namespace PHP_CodeSniffer\Tests\Core\File;
-
-interface testFIINInterface2 {}
+/* testNotAClass */
+function notAClass() {}
 
 /* testPlainInterface */
 interface testFIINInterface {}
+
+/* testNonImplementedClass */
+class testFIINNonImplementedClass {}
 
 /* testClassImplementsSingle */
 class testFIINImplementedClass implements testFIINInterface {}
@@ -16,8 +18,8 @@ class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterf
 /* testImplementsFullyQualified */
 class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFIINInterface {}
 
-/* testNonImplementedClass */
-class testFIINNonImplementedClass {}
+/* testImplementsPartiallyQualified */
+class testFIINQualifiedClass implements Core\File\RelativeInterface {}
 
 /* testClassThatExtendsAndImplements */
 class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, \NameSpaced\Cat\InterfaceB {}
@@ -33,3 +35,13 @@ enum Suit implements Colorful {}
 
 /* testBackedEnumImplementsMulti */
 enum Suit: string implements Colorful, \Deck {}
+
+/* testAnonClassImplementsSingle */
+$anon = class() implements testFIINInterface {}
+
+/* testMissingImplementsName */
+class testMissingExtendsName implements { /* missing interface name */  } // Intentional parse error.
+
+// Intentional parse error. Has to be the last test in the file.
+/* testParseError */
+class testParseError implements testInterface

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -4,16 +4,16 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 
 interface testFIINInterface2 {}
 
-/* testInterface */
+/* testPlainInterface */
 interface testFIINInterface {}
 
-/* testImplementedClass */
+/* testClassImplementsSingle */
 class testFIINImplementedClass implements testFIINInterface {}
 
-/* testMultiImplementedClass */
+/* testClassImplementsMultiple */
 class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterface2 {}
 
-/* testNamespacedClass */
+/* testImplementsFullyQualified */
 class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFIINInterface {}
 
 /* testNonImplementedClass */
@@ -28,8 +28,8 @@ class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB e
 /* testBackedEnumWithoutImplements */
 enum Suit:string {}
 
-/* testEnumImplements */
+/* testEnumImplementsSingle */
 enum Suit implements Colorful {}
 
-/* testBackedEnumImplements */
+/* testBackedEnumImplementsMulti */
 enum Suit: string implements Colorful, \Deck {}

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -21,6 +21,33 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test getting a `false` result when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = self::$phpcsFile->findImplementedInterfaceNames(100000);
+        $this->assertFalse($result);
+
+    }//end testNonExistentToken()
+
+
+    /**
+     * Test getting a `false` result when a token other than one of the supported tokens is passed.
+     *
+     * @return void
+     */
+    public function testNotAClass()
+    {
+        $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
+        $result = self::$phpcsFile->findImplementedInterfaceNames($token);
+        $this->assertFalse($result);
+
+    }//end testNotAClass()
+
+
+    /**
      * Test retrieving the name(s) of the interfaces being implemented by a class.
      *
      * @param string              $identifier Comment which precedes the test case.
@@ -49,6 +76,14 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
     public function dataImplementedInterface()
     {
         return [
+            'interface declaration, no implements'                               => [
+                'identifier' => '/* testPlainInterface */',
+                'expected'   => false,
+            ],
+            'class does not implement'                                           => [
+                'identifier' => '/* testNonImplementedClass */',
+                'expected'   => false,
+            ],
             'class implements single interface, unqualified'                     => [
                 'identifier' => '/* testClassImplementsSingle */',
                 'expected'   => ['testFIINInterface'],
@@ -64,13 +99,9 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
                 'identifier' => '/* testImplementsFullyQualified */',
                 'expected'   => ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
             ],
-            'class does not implement'                                           => [
-                'identifier' => '/* testNonImplementedClass */',
-                'expected'   => false,
-            ],
-            'interface declaration, no implements'                               => [
-                'identifier' => '/* testPlainInterface */',
-                'expected'   => false,
+            'class implements single interface, partially qualified'             => [
+                'identifier' => '/* testImplementsPartiallyQualified */',
+                'expected'   => ['Core\File\RelativeInterface'],
             ],
             'class extends and implements'                                       => [
                 'identifier' => '/* testClassThatExtendsAndImplements */',
@@ -100,6 +131,18 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
                     'Colorful',
                     '\Deck',
                 ],
+            ],
+            'anon class implements single interface, unqualified'                => [
+                'identifier' => '/* testAnonClassImplementsSingle */',
+                'expected'   => ['testFIINInterface'],
+            ],
+            'parse error - implements keyword, but no interface name'            => [
+                'identifier' => '/* testMissingImplementsName */',
+                'expected'   => false,
+            ],
+            'parse error - live coding - no curly braces'                        => [
+                'identifier' => '/* testParseError */',
+                'expected'   => false,
             ],
         ];
 

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -50,18 +50,18 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
     {
         return [
             [
-                '/* testImplementedClass */',
+                '/* testClassImplementsSingle */',
                 ['testFIINInterface'],
             ],
             [
-                '/* testMultiImplementedClass */',
+                '/* testClassImplementsMultiple */',
                 [
                     'testFIINInterface',
                     'testFIINInterface2',
                 ],
             ],
             [
-                '/* testNamespacedClass */',
+                '/* testImplementsFullyQualified */',
                 ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
             ],
             [
@@ -69,7 +69,7 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
                 false,
             ],
             [
-                '/* testInterface */',
+                '/* testPlainInterface */',
                 false,
             ],
             [
@@ -91,11 +91,11 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
                 false,
             ],
             [
-                '/* testEnumImplements */',
+                '/* testEnumImplementsSingle */',
                 ['Colorful'],
             ],
             [
-                '/* testBackedEnumImplements */',
+                '/* testBackedEnumImplementsMulti */',
                 [
                     'Colorful',
                     '\Deck',

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -23,8 +23,8 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
     /**
      * Test retrieving the name(s) of the interfaces being implemented by a class.
      *
-     * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param string              $identifier Comment which precedes the test case.
+     * @param array<string>|false $expected   Expected function output.
      *
      * @dataProvider dataImplementedInterface
      *
@@ -44,59 +44,59 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
      *
      * @see testFindImplementedInterfaceNames()
      *
-     * @return array
+     * @return array<string, array<string, string|array<string>>>
      */
     public function dataImplementedInterface()
     {
         return [
-            [
-                '/* testClassImplementsSingle */',
-                ['testFIINInterface'],
+            'class implements single interface, unqualified'                     => [
+                'identifier' => '/* testClassImplementsSingle */',
+                'expected'   => ['testFIINInterface'],
             ],
-            [
-                '/* testClassImplementsMultiple */',
-                [
+            'class implements multiple interfaces'                               => [
+                'identifier' => '/* testClassImplementsMultiple */',
+                'expected'   => [
                     'testFIINInterface',
                     'testFIINInterface2',
                 ],
             ],
-            [
-                '/* testImplementsFullyQualified */',
-                ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
+            'class implements single interface, fully qualified'                 => [
+                'identifier' => '/* testImplementsFullyQualified */',
+                'expected'   => ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
             ],
-            [
-                '/* testNonImplementedClass */',
-                false,
+            'class does not implement'                                           => [
+                'identifier' => '/* testNonImplementedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testPlainInterface */',
-                false,
+            'interface declaration, no implements'                               => [
+                'identifier' => '/* testPlainInterface */',
+                'expected'   => false,
             ],
-            [
-                '/* testClassThatExtendsAndImplements */',
-                [
+            'class extends and implements'                                       => [
+                'identifier' => '/* testClassThatExtendsAndImplements */',
+                'expected'   => [
                     'InterfaceA',
                     '\NameSpaced\Cat\InterfaceB',
                 ],
             ],
-            [
-                '/* testClassThatImplementsAndExtends */',
-                [
+            'class implements and extends'                                       => [
+                'identifier' => '/* testClassThatImplementsAndExtends */',
+                'expected'   => [
                     '\InterfaceA',
                     'InterfaceB',
                 ],
             ],
-            [
-                '/* testBackedEnumWithoutImplements */',
-                false,
+            'enum does not implement'                                            => [
+                'identifier' => '/* testBackedEnumWithoutImplements */',
+                'expected'   => false,
             ],
-            [
-                '/* testEnumImplementsSingle */',
-                ['Colorful'],
+            'enum implements single interface, unqualified'                      => [
+                'identifier' => '/* testEnumImplementsSingle */',
+                'expected'   => ['Colorful'],
             ],
-            [
-                '/* testBackedEnumImplementsMulti */',
-                [
+            'enum implements multiple interfaces, unqualified + fully qualified' => [
+                'identifier' => '/* testBackedEnumImplementsMulti */',
+                'expected'   => [
                     'Colorful',
                     '\Deck',
                 ],


### PR DESCRIPTION

## Description

### Tests/FindImplementedInterfaceNamesTest: improve test markers

Make the test marker names more descriptive

### Tests/FindImplementedInterfaceNamesTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes fixing the data types in the docblocks and making them more specific, where relevant.

### Tests/FindImplementedInterfaceNamesTest: add extra tests

This adds some extra tests which were already in use in PHPCSUtils. This brings test coverage for this method up to 100%.

It also cleans up the test case file a little by removing some code which isn't actually used in the tests (namespace declaration) and moves the "class not implementing" test up.


## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #146
