### PR TITLE
GH Actions/merge conflict check: don't cancel on higher prio

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -12,12 +12,6 @@ on:
       - synchronize
       - reopened
 
-# Cancels all previous workflow runs for the same branch that have not yet completed.
-concurrency:
-  # The concurrency group contains the workflow name and the branch name.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check-prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
When this workflow is triggered on the `pull_request_target` event, the branch will identify as `master` (`github.ref`), which means that any push to `master` AND any other PR being opened will cancel the workflow.

That is not the intention, jobs for PRs triggering this workflow should always run to completion.

However, as the `push` event and the `pull_request_target` events don't really have much overlap in available info, it is not straight forward to set a group name which will prevent the above from happening.

With that in mind, I'm removing the concurrency cancellation from this workflow.

## Suggested changelog entry
_N/A_
