### PR TITLE
File::getMethodProperties(): improve tests

### DIFF
--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -34,16 +34,23 @@ class MyClass {
     /* testMessyNullableReturnMethod */
     public function myFunction() /* comment
         */ :
-        /* comment */ ? //comment
+        /* comment */ ? // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
         array {}
 
     /* testReturnNamespace */
     function myFunction(): \MyNamespace\MyClass {}
 
     /* testReturnMultilineNamespace */
+    // Parse error in PHP 8.0.
     function myFunction(): \MyNamespace /** comment *\/ comment */
                            \MyClass /* comment */
                            \Foo {}
+
+    /* testReturnUnqualifiedName */
+    private function myFunction(): ?MyClass {}
+
+    /* testReturnPartiallyQualifiedName */
+    function myFunction(): Sub\Level\MyClass {}
 }
 
 abstract class MyClass
@@ -157,3 +164,27 @@ function pseudoTypeTrue(): ?true {}
 /* testPHP82PseudoTypeFalseAndTrue */
 // Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
 function pseudoTypeFalseAndTrue(): true|false {}
+
+/* testNotAFunction */
+return true;
+
+/* testPhpcsIssue1264 */
+function foo() : array {
+    echo $foo;
+}
+
+/* testArrowFunctionArrayReturnValue */
+$fn = fn(): array => [a($a, $b)];
+
+/* testArrowFunctionReturnByRef */
+fn&(?string $a) : ?string => $b;
+
+/* testFunctionCallFnPHPCS353-354 */
+$value = $obj->fn(true);
+
+/* testFunctionDeclarationNestedInTernaryPHPCS2975 */
+return (!$a ? [ new class { public function b(): c {} } ] : []);
+
+/* testArrowFunctionLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+$fn = fn

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -28,14 +28,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testBasicFunction()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -50,15 +52,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testReturnFunction()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'array',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'array',
+            'return_type_token'     => 11,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -73,15 +78,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNestedClosure()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -97,14 +105,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testBasicMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -120,14 +130,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testPrivateStaticMethod()
     {
         $expected = [
-            'scope'                => 'private',
-            'scope_specified'      => true,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => true,
-            'has_body'             => true,
+            'scope'                 => 'private',
+            'scope_specified'       => true,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => true,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -143,14 +155,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testFinalMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => true,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => true,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -165,15 +179,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testProtectedReturnMethod()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'protected',
-            'scope_specified'      => true,
-            'return_type'          => 'int',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'protected',
+            'scope_specified'       => true,
+            'return_type'           => 'int',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -188,15 +205,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPublicReturnMethod()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => 'array',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => 'array',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -211,15 +231,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNullableReturnMethod()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '?array',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '?array',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -234,15 +257,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testMessyNullableReturnMethod()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '?array',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '?array',
+            'return_type_token'     => 18,
+            'return_type_end_token' => 18,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -257,15 +283,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testReturnNamespace()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '\MyNamespace\MyClass',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '\MyNamespace\MyClass',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 10,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -280,15 +309,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testReturnMultilineNamespace()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '\MyNamespace\MyClass\Foo',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '\MyNamespace\MyClass\Foo',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 23,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -304,14 +336,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testAbstractMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => true,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -326,15 +360,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testAbstractReturnMethod()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'protected',
-            'scope_specified'      => true,
-            'return_type'          => 'bool',
-            'nullable_return_type' => false,
-            'is_abstract'          => true,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'protected',
+            'scope_specified'       => true,
+            'return_type'           => 'bool',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -350,14 +387,16 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     public function testInterfaceMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -372,15 +411,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testArrowFunction()
     {
+        // Offsets are relative to the T_FN token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => true,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int',
+            'return_type_token'     => 9,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => true,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -395,15 +437,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testReturnTypeStatic()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'private',
-            'scope_specified'      => true,
-            'return_type'          => 'static',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'private',
+            'scope_specified'       => true,
+            'return_type'           => 'static',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -418,15 +463,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8MixedTypeHint()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'mixed',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'mixed',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -441,15 +489,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8MixedTypeHintNullable()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?mixed',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?mixed',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -464,15 +515,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNamespaceOperatorTypeHint()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?namespace\Name',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?namespace\Name',
+            'return_type_token'     => 9,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -487,15 +541,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8UnionTypesSimple()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int|float',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int|float',
+            'return_type_token'     => 9,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -510,15 +567,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8UnionTypesTwoClasses()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'MyClassA|\Package\MyClassB',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'MyClassA|\Package\MyClassB',
+            'return_type_token'     => 6,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -533,15 +593,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8UnionTypesAllBaseTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'array|bool|callable|int|float|null|Object|string',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'array|bool|callable|int|float|null|Object|string',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 22,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -552,19 +615,24 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     /**
      * Verify recognition of PHP8 union type declaration with all pseudo types.
      *
+     * Note: "Resource" is not a type, but seen as a class name.
+     *
      * @return void
      */
     public function testPHP8UnionTypesAllPseudoTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'false|MIXED|self|parent|static|iterable|Resource|void',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'false|MIXED|self|parent|static|iterable|Resource|void',
+            'return_type_token'     => 9,
+            'return_type_end_token' => 23,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -579,15 +647,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8UnionTypesNullable()
     {
+        // Offsets are relative to the T_CLOSURE token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?int|float',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?int|float',
+            'return_type_token'     => 12,
+            'return_type_end_token' => 14,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -602,15 +673,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8PseudoTypeNull()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'null',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'null',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -625,15 +699,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8PseudoTypeFalse()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'false',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'false',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -648,15 +725,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8PseudoTypeFalseAndBool()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'bool|false',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'bool|false',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -671,15 +751,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8ObjectAndClass()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'object|ClassName',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'object|ClassName',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -694,15 +777,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8PseudoTypeIterableAndArray()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => 'iterable|array|Traversable',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => 'iterable|array|Traversable',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -717,15 +803,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8DuplicateTypeInUnionWhitespaceAndComment()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int|string|INT',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int|string|INT',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 17,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -740,15 +829,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81NeverType()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'never',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'never',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 7,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -763,15 +855,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81NullableNeverType()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?never',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?never',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -786,15 +881,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP8IntersectionTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'Foo&Bar',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'Foo&Bar',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -809,15 +907,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81MoreIntersectionTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'MyClassA&\Package\MyClassB&\Package\MyClassC',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'MyClassA&\Package\MyClassB&\Package\MyClassC',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 17,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -832,15 +933,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81IntersectionArrowFunction()
     {
+        // Offsets are relative to the T_FN token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'MyClassA&\Package\MyClassB',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'MyClassA&\Package\MyClassB',
+            'return_type_token'     => 6,
+            'return_type_end_token' => 11,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -855,15 +959,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81IllegalIntersectionTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'string&int',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'string&int',
+            'return_type_token'     => 6,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -878,15 +985,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP81NullableIntersectionTypes()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?Foo&Bar',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?Foo&Bar',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -901,15 +1011,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP82PseudoTypeTrue()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?true',
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?true',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -924,15 +1037,18 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
      */
     public function testPHP82PseudoTypeFalseAndTrue()
     {
+        // Offsets are relative to the T_FUNCTION token.
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'true|false',
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'true|false',
+            'return_type_token'     => 7,
+            'return_type_end_token' => 9,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -943,8 +1059,8 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     /**
      * Test helper.
      *
-     * @param string $commentString The comment which preceeds the test.
-     * @param array  $expected      The expected function output.
+     * @param string                         $commentString The comment which preceeds the test.
+     * @param array<string, string|int|bool> $expected      The expected function output.
      *
      * @return void
      */
@@ -953,8 +1069,14 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
         $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE, T_FN]);
         $found    = self::$phpcsFile->getMethodProperties($function);
 
-        // Unset those indexes which are not being tested.
-        unset($found['return_type_token'], $found['return_type_end_token']);
+        // Convert offsets to absolute positions in the token stream.
+        if (is_int($expected['return_type_token']) === true) {
+            $expected['return_type_token'] += $function;
+        }
+
+        if (is_int($expected['return_type_end_token']) === true) {
+            $expected['return_type_end_token'] += $function;
+        }
 
         $this->assertSame($expected, $found);
 


### PR DESCRIPTION
## Description

### Tests/GetMethodPropertiesTest: more thoroughly test existing tests

This adds testing of the `return_type_token` and `return_type_end_token` return value indexes to the pre-existing tests, same as was already being tested in PHPCSUtils.

:point_right: the diff will be easiest to review while ignoring whitespace differences due to the array alignment changes to comply with CS.

### Tests/GetMethodPropertiesTest: add extra tests

This adds some extra tests which were already in use in PHPCSUtils.

## Suggested changelog entry
_N/A_


## Related issues/external references

Related to #146