### PR TITLE
CS rules: tweak array rules for test files

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,6 +87,12 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Don't enforce single line arrays for single item arrays in test files. Readability over brevity. -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
+        <exclude-pattern>tests/*\.php$</exclude-pattern>
+        <exclude-pattern>Standards/*/Tests/*/*UnitTest\.php$</exclude-pattern>
+    </rule>
+
     <!-- Check var names, but we don't want leading underscores for private vars -->
     <rule ref="Squiz.NamingConventions.ValidVariableName"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">


### PR DESCRIPTION
## Description

Test files often use data providers (or should).
Data providers are provided as arrays (as `yield` is not supported in the minimum supported PHP version of PHPCS).

As things were, single item arrays would be forced to be single-line, while multi-item arrays would be forced to be multi-line.

For large data provider arrays which have a mix of single item and multi-item sub-arrays, this decreases the scannability of the test cases.

For that reason, I'm disabling the enforcement of "single item arrays should be single line" for all test files.

In practice this means that multi-item arrays still need to be multi-line, but that single item arrays can be either single line or multi-line, whichever is best for readability of the test data.


## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #155

