### PR TITLE
Add `community-cc-list.md` file

### DIFF
--- a/.github/community-cc-list.md
+++ b/.github/community-cc-list.md
@@ -1,0 +1,16 @@
+<!--
+PHP_CodeSniffer Community CC List
+
+This list will be used on select tickets to ping the wider PHP_CodeSniffer community for input.
+
+If you want to be on this list, feel free to submit a PR to add yourself.
+If you want to be removed from the list, dito, submit a PR to remove yourself and it will be merged without questions.
+
+PRs adding/removing other people to/from the list will only be merged if the people being added/removed leave a comment on the PR consenting to it.
+
+When updating the list, please list GitHub handles in alphabetical order.
+
+For more context, see https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/227
+-->
+
+/cc @asispts @dingo-d @fredden @GaryJones @greg0ire @kukulich @michalbundyra @Ocramius @sirbrillig @stronk7 @weierophinney @wimg


### PR DESCRIPTION
## Description
This adds the initial wider PHP_CodeSniffer community cc list file as proposed in #227.


## Suggested changelog entry
_N/A_


## Related issues/external references

Closes #227