### PR TITLE
QA: fix up license links in newly merged files

### DIFF
--- a/src/Reports/Performance.php
+++ b/src/Reports/Performance.php
@@ -4,7 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHP_CodeSniffer\Reports;

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -4,7 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;


### PR DESCRIPTION
## Description

Follow up on #1.

Some PRs which were ported over from the Squizlabs repo introduced new files in which the old license link was still included.

Fixed now.

## Suggested changelog entry
_N/A_