### PR TITLE
[Documentation] PSR12 - File Header

### DIFF
--- a/src/Standards/PSR12/Docs/Files/FileHeaderStandard.xml
+++ b/src/Standards/PSR12/Docs/Files/FileHeaderStandard.xml
@@ -1,0 +1,157 @@
+<documentation title="File Header">
+    <standard>
+    <![CDATA[
+    Ensures that the PHP file header is properly formatted.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: The file header is the first content in the file.">
+        <![CDATA[
+<?php
+
+/**
+ * This is a file comment.
+ */
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+        <code title="Invalid: The file header is not the first content in the file.">
+        <![CDATA[
+<em><?php echo 'Some content'; ?></em>
+<?php
+
+/**
+ * The header is not the first thing
+ * in the file.
+ */
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: If the header blocks are present, they are separated by a single blank line and don't contain blank lines.">
+        <![CDATA[
+<?php
+
+/**
+ * This is a file comment.
+ */
+
+declare(strict_types=1);
+
+namespace Vendor\Package;
+
+use Vendor\Package\SomeNamespace\ClassD as D;
+use Vendor\Package\SomeNamespace\{
+    SubnamespaceOne\ClassA,
+    SubnamespaceOne\ClassB,
+    SubnamespaceTwo\ClassY,
+    ClassZ,
+};
+
+use function Vendor\Package\{funcA};
+use function Another\Vendor\funcD;
+
+use const Vendor\Package\{
+    CONST_A, CONST_B
+};
+use const Another\Vendor\CONST_D;
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+        <code title="Invalid: The header blocks are not separated by a single blank line or contain blank lines between blocks.">
+        <![CDATA[
+<?php
+
+/**
+ * This is a file comment.
+ */<em></em>
+declare(strict_types=1);
+
+namespace Vendor\Package;<em></em>
+use Vendor\Package\{ClassA as A, ClassB};
+<em></em>
+<em></em>
+use function Vendor\Package\funcA;
+// Blank line between the function imports.
+<em></em>
+use function Another\Vendor\funcD;
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: If the header blocks are present, they are ordered correctly as shown below.">
+        <![CDATA[
+<?php
+
+/**
+ * This is a file-level docblock.
+ *
+ * Only thing before it is the
+ * opening <?php tag.
+ */
+
+// One or more declare statements.
+declare(strict_types=1);
+
+// Namespace declaration of the file.
+namespace Vendor\Package;
+
+// Class-based use import statements.
+use Vendor\Package\{ClassA as A, ClassB};
+use Vendor\Package\SomeNamespace\ClassD as D;
+use Vendor\Package\SomeNamespace\{
+    SubnamespaceOne\ClassA,
+    ClassZ,
+};
+
+// Function-based use import statements.
+use function Vendor\Package\{funcA};
+use function Another\Vendor\funcD;
+
+// Constant-based use import statements.
+use const Vendor\Package\{
+    CONST_A, CONST_B
+};
+use const Another\Vendor\CONST_D;
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+        <code title="Invalid: The header blocks are not in the correct order.">
+        <![CDATA[
+<?php
+
+/**
+ * Incorrect order of the imports.
+ */
+
+declare(strict_types=1);
+
+use Vendor\Package\{ClassA as A, ClassB};
+use Vendor\Package\SomeNamespace\ClassD as D;
+
+// Namespace declaration
+// after the class-based use import statements.
+namespace Vendor\Package;
+
+use Vendor\Package\AnotherNamespace\ClassE as E;
+
+// Constant-based use imports statements
+// before the function-based ones.
+<em>use const Vendor\Package\{CONST_A, CONST_B};
+use const Another\Vendor\CONST_D;</em>
+
+use function Vendor\Package\{funcA, funcB};
+use function Another\Vendor\funcD;
+
+// Remainder of the code in the file.
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
The PR contains the documentation for the PSR12/Files/FileHeader sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements).

## Suggested changelog entry
Add documentation for the PSR12 FileHeader sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.