### PR TITLE
[Documentation] PSR12 - Open Tag

### DIFF
--- a/src/Standards/PSR12/Docs/Files/OpenTagStandard.xml
+++ b/src/Standards/PSR12/Docs/Files/OpenTagStandard.xml
@@ -1,0 +1,40 @@
+<documentation title="Open PHP Tag">
+    <standard>
+    <![CDATA[
+    When the opening <?php tag is on the first line of the file, it must be on its own line with no other statements unless it is a file containing markup outside of PHP opening and closing tags.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Opening PHP tag on a line by itself.">
+        <![CDATA[
+<em><?php</em>
+
+echo 'hi';
+        ]]>
+        </code>
+        <code title="Invalid: Opening PHP tag not on a line by itself.">
+        <![CDATA[
+<?php <em>echo 'hi';</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Opening PHP tag not on a line by itself, but has markup outside the closing PHP tag.">
+        <![CDATA[
+<?php declare(strict_types=1); ?>
+<html>
+<body>
+    <?php
+        // ... additional PHP code ...
+    ?>
+</body>
+</html>
+        ]]>
+        </code>
+        <code title="Invalid: Opening PHP tag not on a line by itself without any markup in the file.">
+        <![CDATA[
+<?php declare(strict_types=1); ?>
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
The PR contains the documentation for the PSR12/Files/OpenTag sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements).

## Suggested changelog entry
Add documentation for the PSR12 OpenTag sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.