### PR TITLE
Generic/RequireStrictTypes: add XML documentation

### DIFF
--- a/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
@@ -1,11 +1,39 @@
 <documentation title="Require Strict Types">
     <standard>
     <![CDATA[
-    The strict_types declaration must be present and enabled.
+    The strict_types declaration must be present.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: strict_types declaration is present and enabled.">
+        <code title="Valid: strict_types declaration is present.">
+        <![CDATA[
+<?php
+declare(<em>strict_types=1</em>);
+
+<?php
+declare(ticks=1, <em>strict_types=1</em>);
+
+<?php
+declare(<em>strict_types=0</em>);
+        ]]>
+        </code>
+        <code title="Invalid: Missing strict_types declaration.">
+        <![CDATA[
+<?php
+declare(encoding='ISO-8859-1'<em></em>);
+
+<?php
+declare(strict_types=<em>0</em>);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    The strict_types declaration must be enabled.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: strict_types declaration is enabled.">
         <![CDATA[
 <?php
 declare(<em>strict_types=1</em>);
@@ -14,11 +42,8 @@ declare(<em>strict_types=1</em>);
 declare(ticks=1, <em>strict_types=1</em>);
         ]]>
         </code>
-        <code title="Invalid: Missing or disabled strict_types declaration.">
+        <code title="Invalid: strict_types declaration is disabled.">
         <![CDATA[
-<?php
-declare(encoding='ISO-8859-1'<em></em>);
-
 <?php
 declare(strict_types=<em>0</em>);
         ]]>

--- a/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
@@ -7,23 +7,16 @@
     <code_comparison>
         <code title="Valid: strict_types declaration is present.">
         <![CDATA[
-<?php
 declare(<em>strict_types=1</em>);
 
-<?php
-declare(ticks=1, <em>strict_types=1</em>);
-
-<?php
-declare(<em>strict_types=0</em>);
+declare(encoding='UTF-8', <em>strict_types=0</em>);
         ]]>
         </code>
         <code title="Invalid: Missing strict_types declaration.">
         <![CDATA[
-<?php
 declare(encoding='ISO-8859-1'<em></em>);
 
-<?php
-declare(strict_types=<em>0</em>);
+declare(ticks=1<em></em>);
         ]]>
         </code>
     </code_comparison>
@@ -35,16 +28,11 @@ declare(strict_types=<em>0</em>);
     <code_comparison>
         <code title="Valid: strict_types declaration is enabled.">
         <![CDATA[
-<?php
 declare(<em>strict_types=1</em>);
-
-<?php
-declare(ticks=1, <em>strict_types=1</em>);
         ]]>
         </code>
         <code title="Invalid: strict_types declaration is disabled.">
         <![CDATA[
-<?php
 declare(strict_types=<em>0</em>);
         ]]>
         </code>

--- a/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
@@ -1,0 +1,27 @@
+<documentation title="Require Strict Types">
+    <standard>
+    <![CDATA[
+    The strict_types declaration must be present and enabled.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: strict_types declaration is present and enabled.">
+        <![CDATA[
+<?php
+declare(<em>strict_types=1</em>);
+
+<?php
+declare(ticks=1, <em>strict_types=1</em>);
+        ]]>
+        </code>
+        <code title="Invalid: Missing or disabled strict_types declaration.">
+        <![CDATA[
+<?php
+declare(encoding='ISO-8859-1'<em></em>);
+
+<?php
+declare(strict_types=<em>0</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/RequireStrictTypesStandard.xml
@@ -15,8 +15,6 @@ declare(encoding='UTF-8', <em>strict_types=0</em>);
         <code title="Invalid: Missing strict_types declaration.">
         <![CDATA[
 declare(encoding='ISO-8859-1'<em></em>);
-
-declare(ticks=1<em></em>);
         ]]>
         </code>
     </code_comparison>
@@ -28,7 +26,7 @@ declare(ticks=1<em></em>);
     <code_comparison>
         <code title="Valid: strict_types declaration is enabled.">
         <![CDATA[
-declare(<em>strict_types=1</em>);
+declare(strict_types=<em>1</em>);
         ]]>
         </code>
         <code title="Invalid: strict_types declaration is disabled.">


### PR DESCRIPTION
## Description

This PR adds documentation for the Generic.PHP.RequireStrictTypes sniff.

## Suggested changelog entry

Add XML documentation for the Generic.PHP.RequireStrictTypes sniff.

## Related issues/external references

Part of #148 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
