### PR TITLE
[Documentation] PSR12 - Return Type Declaration

### DIFF
--- a/src/Standards/PSR12/Docs/Functions/ReturnTypeDeclarationStandard.xml
+++ b/src/Standards/PSR12/Docs/Functions/ReturnTypeDeclarationStandard.xml
@@ -1,0 +1,41 @@
+<documentation title="Return Type Declaration">
+    <standard>
+    <![CDATA[
+    For function and closure return type declarations, there must be one space after the colon followed by the type declaration, and no space before the colon.
+
+    The colon and the return type declaration have to be on the same line as the argument list closing parenthesis.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: A single space between the colon and type in a return type declaration.">
+        <![CDATA[
+$closure = function ( $arg ):<em> </em>string {
+   // Closure body.
+};
+        ]]>
+        </code>
+        <code title="Invalid: No space between the colon and the type in a return type declaration.">
+        <![CDATA[
+$closure = function ( $arg ):<em></em>string {
+   // Closure body.
+};
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: No space before the colon in a return type declaration.">
+        <![CDATA[
+function someFunction( $arg )<em></em>: string {
+   // Function body.
+};
+        ]]>
+        </code>
+        <code title="Invalid: One or more spaces before the colon in a return type declaration.">
+        <![CDATA[
+function someFunction( $arg )<em>   </em>: string {
+   // Function body.
+};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>


### PR DESCRIPTION
The PR contains the documentation for the PSR12/Functions/ReturnTypeDeclaration sniff.

## Description
This PR will add the documentation for the above-mentioned sniff, according to the [official standard definitions](https://www.php-fig.org/psr/psr-12/#45-method-and-function-arguments).

## Suggested changelog entry
Add documentation for the PSR12 ReturnTypeDeclaration sniff

## Related issues/external references

Part of #148

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.