### PR TITLE
Tests: all test classes should be either `final` or `abstract`

### DIFF
--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff
  */
-class ArrayIndentUnitTest extends AbstractSniffUnitTest
+final class ArrayIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowLongArraySyntaxSniff
  */
-class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowShortArraySyntaxSniff
  */
-class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\DuplicateClassNameSniff
  */
-class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
+final class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\OpeningBraceSameLineSniff
  */
-class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
+final class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff
  */
-class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
+final class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyPHPStatementSniff
  */
-class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
+final class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff
  */
-class EmptyStatementUnitTest extends AbstractSniffUnitTest
+final class EmptyStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopShouldBeWhileLoopSniff
  */
-class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffUnitTest
+final class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopWithTestFunctionCallSniff
  */
-class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffUnitTest
+final class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\JumbledIncrementerSniff
  */
-class JumbledIncrementerUnitTest extends AbstractSniffUnitTest
+final class JumbledIncrementerUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnconditionalIfStatementSniff
  */
-class UnconditionalIfStatementUnitTest extends AbstractSniffUnitTest
+final class UnconditionalIfStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnnecessaryFinalModifierSniff
  */
-class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
+final class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff
  */
-class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
+final class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UselessOverridingMethodSniff
  */
-class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
+final class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff
  */
-class DocCommentUnitTest extends AbstractSniffUnitTest
+final class DocCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\FixmeSniff
  */
-class FixmeUnitTest extends AbstractSniffUnitTest
+final class FixmeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff
  */
-class TodoUnitTest extends AbstractSniffUnitTest
+final class TodoUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\DisallowYodaConditionsSniff
  */
-class DisallowYodaConditionsUnitTest extends AbstractSniffUnitTest
+final class DisallowYodaConditionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff
  */
-class InlineControlStructureUnitTest extends AbstractSniffUnitTest
+final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\CSSLintSniff
  */
-class CSSLintUnitTest extends AbstractSniffUnitTest
+final class CSSLintUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\ClosureLinterSniff
  */
-class ClosureLinterUnitTest extends AbstractSniffUnitTest
+final class ClosureLinterUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\ESLintSniff
  */
-class ESLintUnitTest extends AbstractSniffUnitTest
+final class ESLintUnitTest extends AbstractSniffUnitTest
 {
 
     /**

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\JSHintSniff
  */
-class JSHintUnitTest extends AbstractSniffUnitTest
+final class JSHintUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff
  */
-class ByteOrderMarkUnitTest extends AbstractSniffUnitTest
+final class ByteOrderMarkUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff
  */
-class EndFileNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNewlineUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNoNewlineSniff
  */
-class EndFileNoNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNoNewlineUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ExecutableFileSniff
  */
-class ExecutableFileUnitTest extends AbstractSniffUnitTest
+final class ExecutableFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\InlineHTMLSniff
  */
-class InlineHTMLUnitTest extends AbstractSniffUnitTest
+final class InlineHTMLUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff
  */
-class LineEndingsUnitTest extends AbstractSniffUnitTest
+final class LineEndingsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff
  */
-class LineLengthUnitTest extends AbstractSniffUnitTest
+final class LineLengthUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LowercasedFilenameSniff
  */
-class LowercasedFilenameUnitTest extends AbstractSniffUnitTest
+final class LowercasedFilenameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneClassPerFileSniff
  */
-class OneClassPerFileUnitTest extends AbstractSniffUnitTest
+final class OneClassPerFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneInterfacePerFileSniff
  */
-class OneInterfacePerFileUnitTest extends AbstractSniffUnitTest
+final class OneInterfacePerFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneObjectStructurePerFileSniff
  */
-class OneObjectStructurePerFileUnitTest extends AbstractSniffUnitTest
+final class OneObjectStructurePerFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneTraitPerFileSniff
  */
-class OneTraitPerFileUnitTest extends AbstractSniffUnitTest
+final class OneTraitPerFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\DisallowMultipleStatementsSniff
  */
-class DisallowMultipleStatementsUnitTest extends AbstractSniffUnitTest
+final class DisallowMultipleStatementsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff
  */
-class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
+final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\NoSpaceAfterCastSniff
  */
-class NoSpaceAfterCastUnitTest extends AbstractSniffUnitTest
+final class NoSpaceAfterCastUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff
  */
-class SpaceAfterCastUnitTest extends AbstractSniffUnitTest
+final class SpaceAfterCastUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff
  */
-class SpaceAfterNotUnitTest extends AbstractSniffUnitTest
+final class SpaceAfterNotUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceBeforeCastSniff
  */
-class SpaceBeforeCastUnitTest extends AbstractSniffUnitTest
+final class SpaceBeforeCastUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\CallTimePassByReferenceSniff
  */
-class CallTimePassByReferenceUnitTest extends AbstractSniffUnitTest
+final class CallTimePassByReferenceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\FunctionCallArgumentSpacingSniff
  */
-class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceBsdAllmanSniff
  */
-class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
+final class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceKernighanRitchieSniff
  */
-class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffUnitTest
+final class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff
  */
-class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
+final class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff
  */
-class NestingLevelUnitTest extends AbstractSniffUnitTest
+final class NestingLevelUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\AbstractClassNamePrefixSniff
  */
-class AbstractClassNamePrefixUnitTest extends AbstractSniffUnitTest
+final class AbstractClassNamePrefixUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff
  */
-class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
+final class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\ConstructorNameSniff
  */
-class ConstructorNameUnitTest extends AbstractSniffUnitTest
+final class ConstructorNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\InterfaceNameSuffixSniff
  */
-class InterfaceNameSuffixUnitTest extends AbstractSniffUnitTest
+final class InterfaceNameSuffixUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\TraitNameSuffixSniff
  */
-class TraitNameSuffixUnitTest extends AbstractSniffUnitTest
+final class TraitNameSuffixUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff
  */
-class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
+final class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\BacktickOperatorSniff
  */
-class BacktickOperatorUnitTest extends AbstractSniffUnitTest
+final class BacktickOperatorUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\CharacterBeforePHPOpeningTagSniff
  */
-class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffUnitTest
+final class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ClosingPHPTagSniff
  */
-class ClosingPHPTagUnitTest extends AbstractSniffUnitTest
+final class ClosingPHPTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff
  */
-class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
+final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowAlternativePHPTagsSniff
  */
-class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
+final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowRequestSuperglobalSniff
  */
-class DisallowRequestSuperglobalUnitTest extends AbstractSniffUnitTest
+final class DisallowRequestSuperglobalUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowShortOpenTagSniff
  */
-class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
+final class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DiscourageGotoSniff
  */
-class DiscourageGotoUnitTest extends AbstractSniffUnitTest
+final class DiscourageGotoUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff
  */
-class ForbiddenFunctionsUnitTest extends AbstractSniffUnitTest
+final class ForbiddenFunctionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff
  */
-class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
+final class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseKeywordSniff
  */
-class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
+final class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseTypeSniff
  */
-class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
+final class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff
  */
-class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest
+final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\RequireStrictTypesSniff
  */
-class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
+final class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SAPIUsageSniff
  */
-class SAPIUsageUnitTest extends AbstractSniffUnitTest
+final class SAPIUsageUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SyntaxSniff
  */
-class SyntaxUnitTest extends AbstractSniffUnitTest
+final class SyntaxUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\UpperCaseConstantSniff
  */
-class UpperCaseConstantUnitTest extends AbstractSniffUnitTest
+final class UpperCaseConstantUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff
  */
-class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
+final class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\GitMergeConflictSniff
  */
-class GitMergeConflictUnitTest extends AbstractSniffUnitTest
+final class GitMergeConflictUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\SubversionPropertiesSniff
  */
-class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
+final class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ArbitraryParenthesesSpacingSniff
  */
-class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest
+final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowSpaceIndentSniff
  */
-class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
+final class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff
  */
-class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
+final class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\IncrementDecrementSpacingSniff
  */
-class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
+final class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\LanguageConstructSpacingSniff
  */
-class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
+final class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff
  */
-class ScopeIndentUnitTest extends AbstractSniffUnitTest
+final class ScopeIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\SpreadOperatorSpacingAfterSniff
  */
-class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
+final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/CSS/BrowserSpecificStylesUnitTest.php
+++ b/src/Standards/MySource/Tests/CSS/BrowserSpecificStylesUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\CSS\BrowserSpecificStylesSniff
  */
-class BrowserSpecificStylesUnitTest extends AbstractSniffUnitTest
+final class BrowserSpecificStylesUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Channels/DisallowSelfActionsUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/DisallowSelfActionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\DisallowSelfActionsSniff
  */
-class DisallowSelfActionsUnitTest extends AbstractSniffUnitTest
+final class DisallowSelfActionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\IncludeSystemSniff
  */
-class IncludeSystemUnitTest extends AbstractSniffUnitTest
+final class IncludeSystemUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Channels/UnusedSystemUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/UnusedSystemUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Channels\UnusedSystemSniff
  */
-class UnusedSystemUnitTest extends AbstractSniffUnitTest
+final class UnusedSystemUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/MySource/Tests/Commenting/FunctionCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Commenting\FunctionCommentSniff
  */
-class FunctionCommentUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Debug/DebugCodeUnitTest.php
+++ b/src/Standards/MySource/Tests/Debug/DebugCodeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Debug\DebugCodeSniff
  */
-class DebugCodeUnitTest extends AbstractSniffUnitTest
+final class DebugCodeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
+++ b/src/Standards/MySource/Tests/Debug/FirebugConsoleUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Debug\FirebugConsoleSniff
  */
-class FirebugConsoleUnitTest extends AbstractSniffUnitTest
+final class FirebugConsoleUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/AssignThisUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\AssignThisSniff
  */
-class AssignThisUnitTest extends AbstractSniffUnitTest
+final class AssignThisUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/CreateWidgetTypeCallbackUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\CreateWidgetTypeCallbackSniff
  */
-class CreateWidgetTypeCallbackUnitTest extends AbstractSniffUnitTest
+final class CreateWidgetTypeCallbackUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Objects/DisallowNewWidgetUnitTest.php
+++ b/src/Standards/MySource/Tests/Objects/DisallowNewWidgetUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Objects\DisallowNewWidgetSniff
  */
-class DisallowNewWidgetUnitTest extends AbstractSniffUnitTest
+final class DisallowNewWidgetUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/PHP/AjaxNullComparisonUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/AjaxNullComparisonUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\AjaxNullComparisonSniff
  */
-class AjaxNullComparisonUnitTest extends AbstractSniffUnitTest
+final class AjaxNullComparisonUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/PHP/EvalObjectFactoryUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/EvalObjectFactoryUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\EvalObjectFactorySniff
  */
-class EvalObjectFactoryUnitTest extends AbstractSniffUnitTest
+final class EvalObjectFactoryUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/PHP/GetRequestDataUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/GetRequestDataUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\GetRequestDataSniff
  */
-class GetRequestDataUnitTest extends AbstractSniffUnitTest
+final class GetRequestDataUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/PHP/ReturnFunctionValueUnitTest.php
+++ b/src/Standards/MySource/Tests/PHP/ReturnFunctionValueUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\ReturnFunctionValueSniff
  */
-class ReturnFunctionValueUnitTest extends AbstractSniffUnitTest
+final class ReturnFunctionValueUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
+++ b/src/Standards/MySource/Tests/Strings/JoinStringsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers PHP_CodeSniffer\Standards\MySource\Sniffs\Strings\JoinStringsSniff
  */
-class JoinStringsUnitTest extends AbstractSniffUnitTest
+final class JoinStringsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff
  */
-class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff
  */
-class ClassCommentUnitTest extends AbstractSniffUnitTest
+final class ClassCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff
  */
-class FileCommentUnitTest extends AbstractSniffUnitTest
+final class FileCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff
  */
-class FunctionCommentUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\InlineCommentSniff
  */
-class InlineCommentUnitTest extends AbstractSniffUnitTest
+final class InlineCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\ControlSignatureSniff
  */
-class ControlSignatureUnitTest extends AbstractSniffUnitTest
+final class ControlSignatureUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\MultiLineConditionSniff
  */
-class MultiLineConditionUnitTest extends AbstractSniffUnitTest
+final class MultiLineConditionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
+++ b/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Files\IncludingFileSniff
  */
-class IncludingFileUnitTest extends AbstractSniffUnitTest
+final class IncludingFileUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Formatting\MultiLineAssignmentSniff
  */
-class MultiLineAssignmentUnitTest extends AbstractSniffUnitTest
+final class MultiLineAssignmentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionCallSignatureSniff
  */
-class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
+final class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionDeclarationSniff
  */
-class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff
  */
-class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
+final class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidClassNameSniff
  */
-class ValidClassNameUnitTest extends AbstractSniffUnitTest
+final class ValidClassNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
+final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ObjectOperatorIndentSniff
  */
-class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
+final class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeClosingBraceSniff
  */
-class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeIndentSniff
  */
-class ScopeIndentUnitTest extends AbstractSniffUnitTest
+final class ScopeIndentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff
  */
-class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff
  */
-class SideEffectsUnitTest extends AbstractSniffUnitTest
+final class SideEffectsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff
  */
-class CamelCapsMethodNameUnitTest extends AbstractSniffUnitTest
+final class CamelCapsMethodNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\AnonClassDeclarationSniff
  */
-class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClassInstantiationSniff
  */
-class ClassInstantiationUnitTest extends AbstractSniffUnitTest
+final class ClassInstantiationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClosingBraceSniff
  */
-class ClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\OpeningBraceSpaceSniff
  */
-class OpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class OpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlacementSniff
  */
-class BooleanOperatorPlacementUnitTest extends AbstractSniffUnitTest
+final class BooleanOperatorPlacementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\ControlStructureSpacingSniff
  */
-class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\DeclareStatementSniff
  */
-class DeclareStatementUnitTest extends AbstractSniffUnitTest
+final class DeclareStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff
  */
-class FileHeaderUnitTest extends AbstractSniffUnitTest
+final class FileHeaderUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\ImportStatementSniff
  */
-class ImportStatementUnitTest extends AbstractSniffUnitTest
+final class ImportStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\OpenTagSniff
  */
-class OpenTagUnitTest extends AbstractSniffUnitTest
+final class OpenTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff
  */
-class NullableTypeDeclarationUnitTest extends AbstractSniffUnitTest
+final class NullableTypeDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\ReturnTypeDeclarationSniff
  */
-class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+final class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Keywords\ShortFormTypeKeywordsSniff
  */
-class ShortFormTypeKeywordsUnitTest extends AbstractSniffUnitTest
+final class ShortFormTypeKeywordsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
+++ b/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Namespaces\CompoundNamespaceDepthSniff
  */
-class CompoundNamespaceDepthUnitTest extends AbstractSniffUnitTest
+final class CompoundNamespaceDepthUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff
  */
-class OperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class OperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Properties\ConstantVisibilitySniff
  */
-class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
+final class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Traits\UseDeclarationSniff
  */
-class UseDeclarationUnitTest extends AbstractSniffUnitTest
+final class UseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff
  */
-class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff
  */
-class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
+final class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff
  */
-class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ElseIfDeclarationSniff
  */
-class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSniff
  */
-class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
+final class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\ClosingTagSniff
  */
-class ClosingTagUnitTest extends AbstractSniffUnitTest
+final class ClosingTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\EndFileNewlineSniff
  */
-class EndFileNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNewlineUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff
  */
-class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
+final class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionClosingBraceSniff
  */
-class FunctionClosingBraceUnitTest extends AbstractSniffUnitTest
+final class FunctionClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
  */
-class MethodDeclarationUnitTest extends AbstractSniffUnitTest
+final class MethodDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\NamespaceDeclarationSniff
  */
-class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest
+final class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\UseDeclarationSniff
  */
-class UseDeclarationUnitTest extends AbstractSniffUnitTest
+final class UseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
  */
-class ArrayBracketSpacingUnitTest extends AbstractSniffUnitTest
+final class ArrayBracketSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff
  */
-class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
+final class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionClosingBraceSpaceSniff
  */
-class ClassDefinitionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class ClassDefinitionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionNameSpacingSniff
  */
-class ClassDefinitionNameSpacingUnitTest extends AbstractSniffUnitTest
+final class ClassDefinitionNameSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionOpeningBraceSpaceSniff
  */
-class ClassDefinitionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class ClassDefinitionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ColonSpacingSniff
  */
-class ColonSpacingUnitTest extends AbstractSniffUnitTest
+final class ColonSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ColourDefinitionSniff
  */
-class ColourDefinitionUnitTest extends AbstractSniffUnitTest
+final class ColourDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DisallowMultipleStyleDefinitionsSniff
  */
-class DisallowMultipleStyleDefinitionsUnitTest extends AbstractSniffUnitTest
+final class DisallowMultipleStyleDefinitionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DuplicateClassDefinitionSniff
  */
-class DuplicateClassDefinitionUnitTest extends AbstractSniffUnitTest
+final class DuplicateClassDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\DuplicateStyleDefinitionSniff
  */
-class DuplicateStyleDefinitionUnitTest extends AbstractSniffUnitTest
+final class DuplicateStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/EmptyClassDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/EmptyClassDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\EmptyClassDefinitionSniff
  */
-class EmptyClassDefinitionUnitTest extends AbstractSniffUnitTest
+final class EmptyClassDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\EmptyStyleDefinitionSniff
  */
-class EmptyStyleDefinitionUnitTest extends AbstractSniffUnitTest
+final class EmptyStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ForbiddenStylesSniff
  */
-class ForbiddenStylesUnitTest extends AbstractSniffUnitTest
+final class ForbiddenStylesUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\IndentationSniff
  */
-class IndentationUnitTest extends AbstractSniffUnitTest
+final class IndentationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/LowercaseStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/LowercaseStyleDefinitionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\LowercaseStyleDefinitionSniff
  */
-class LowercaseStyleDefinitionUnitTest extends AbstractSniffUnitTest
+final class LowercaseStyleDefinitionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\MissingColonSniff
  */
-class MissingColonUnitTest extends AbstractSniffUnitTest
+final class MissingColonUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/NamedColoursUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/NamedColoursUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\NamedColoursSniff
  */
-class NamedColoursUnitTest extends AbstractSniffUnitTest
+final class NamedColoursUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/OpacityUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/OpacityUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\OpacitySniff
  */
-class OpacityUnitTest extends AbstractSniffUnitTest
+final class OpacityUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\SemicolonSpacingSniff
  */
-class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
+final class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ShorthandSizeSniff
  */
-class ShorthandSizeUnitTest extends AbstractSniffUnitTest
+final class ShorthandSizeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassDeclarationSniff
  */
-class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassFileNameSniff
  */
-class ClassFileNameUnitTest extends AbstractSniffUnitTest
+final class ClassFileNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/DuplicatePropertyUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/DuplicatePropertyUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\DuplicatePropertySniff
  */
-class DuplicatePropertyUnitTest extends AbstractSniffUnitTest
+final class DuplicatePropertyUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\LowercaseClassKeywordsSniff
  */
-class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
+final class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\SelfMemberReferenceSniff
  */
-class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
+final class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ValidClassNameSniff
  */
-class ValidClassNameUnitTest extends AbstractSniffUnitTest
+final class ValidClassNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\BlockCommentSniff
  */
-class BlockCommentUnitTest extends AbstractSniffUnitTest
+final class BlockCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClassCommentSniff
  */
-class ClassCommentUnitTest extends AbstractSniffUnitTest
+final class ClassCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClosingDeclarationCommentSniff
  */
-class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
+final class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff
  */
-class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
+final class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\EmptyCatchCommentSniff
  */
-class EmptyCatchCommentUnitTest extends AbstractSniffUnitTest
+final class EmptyCatchCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FileCommentSniff
  */
-class FileCommentUnitTest extends AbstractSniffUnitTest
+final class FileCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentThrowTagSniff
  */
-class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff
  */
-class FunctionCommentUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\InlineCommentSniff
  */
-class InlineCommentUnitTest extends AbstractSniffUnitTest
+final class InlineCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\LongConditionClosingCommentSniff
  */
-class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
+final class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\PostStatementCommentSniff
  */
-class PostStatementCommentUnitTest extends AbstractSniffUnitTest
+final class PostStatementCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\VariableCommentSniff
  */
-class VariableCommentUnitTest extends AbstractSniffUnitTest
+final class VariableCommentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff
  */
-class ControlSignatureUnitTest extends AbstractSniffUnitTest
+final class ControlSignatureUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ElseIfDeclarationSniff
  */
-class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForEachLoopDeclarationSniff
  */
-class ForEachLoopDeclarationUnitTest extends AbstractSniffUnitTest
+final class ForEachLoopDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForLoopDeclarationSniff
  */
-class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
+final class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\InlineIfDeclarationSniff
  */
-class InlineIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class InlineIfDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\LowercaseDeclarationSniff
  */
-class LowercaseDeclarationUnitTest extends AbstractSniffUnitTest
+final class LowercaseDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\SwitchDeclarationSniff
  */
-class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
+final class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug\JSLintSniff
  */
-class JSLintUnitTest extends AbstractSniffUnitTest
+final class JSLintUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug\JavaScriptLintSniff
  */
-class JavaScriptLintUnitTest extends AbstractSniffUnitTest
+final class JavaScriptLintUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Files\FileExtensionSniff
  */
-class FileExtensionUnitTest extends AbstractSniffUnitTest
+final class FileExtensionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Formatting\OperatorBracketSniff
  */
-class OperatorBracketUnitTest extends AbstractSniffUnitTest
+final class OperatorBracketUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff
  */
-class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationSniff
  */
-class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDuplicateArgumentSniff
  */
-class FunctionDuplicateArgumentUnitTest extends AbstractSniffUnitTest
+final class FunctionDuplicateArgumentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\GlobalFunctionSniff
  */
-class GlobalFunctionUnitTest extends AbstractSniffUnitTest
+final class GlobalFunctionUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\LowercaseFunctionKeywordsSniff
  */
-class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
+final class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\MultiLineFunctionDeclarationSniff
  */
-class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
+final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\DisallowObjectStringIndexSniff
  */
-class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
+final class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\ObjectInstantiationSniff
  */
-class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
+final class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\ObjectMemberCommaSniff
  */
-class ObjectMemberCommaUnitTest extends AbstractSniffUnitTest
+final class ObjectMemberCommaUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ComparisonOperatorUsageSniff
  */
-class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
+final class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\IncrementDecrementUsageSniff
  */
-class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
+final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
  */
-class ValidLogicalOperatorsUnitTest extends AbstractSniffUnitTest
+final class ValidLogicalOperatorsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff
  */
-class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
+final class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowBooleanStatementSniff
  */
-class DisallowBooleanStatementUnitTest extends AbstractSniffUnitTest
+final class DisallowBooleanStatementUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowComparisonAssignmentSniff
  */
-class DisallowComparisonAssignmentUnitTest extends AbstractSniffUnitTest
+final class DisallowComparisonAssignmentUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowInlineIfSniff
  */
-class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
+final class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff
  */
-class DisallowMultipleAssignmentsUnitTest extends AbstractSniffUnitTest
+final class DisallowMultipleAssignmentsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowSizeFunctionsInLoopsSniff
  */
-class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
+final class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DiscouragedFunctionsSniff
  */
-class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest
+final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EmbeddedPhpSniff
  */
-class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
+final class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EvalSniff
  */
-class EvalUnitTest extends AbstractSniffUnitTest
+final class EvalUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\GlobalKeywordSniff
  */
-class GlobalKeywordUnitTest extends AbstractSniffUnitTest
+final class GlobalKeywordUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\HeredocSniff
  */
-class HeredocUnitTest extends AbstractSniffUnitTest
+final class HeredocUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\InnerFunctionsSniff
  */
-class InnerFunctionsUnitTest extends AbstractSniffUnitTest
+final class InnerFunctionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\LowercasePHPFunctionsSniff
  */
-class LowercasePHPFunctionsUnitTest extends AbstractSniffUnitTest
+final class LowercasePHPFunctionsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\NonExecutableCodeSniff
  */
-class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
+final class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff
  */
-class MemberVarScopeUnitTest extends AbstractSniffUnitTest
+final class MemberVarScopeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff
  */
-class MethodScopeUnitTest extends AbstractSniffUnitTest
+final class MethodScopeUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\StaticThisUsageSniff
  */
-class StaticThisUsageUnitTest extends AbstractSniffUnitTest
+final class StaticThisUsageUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff
  */
-class ConcatenationSpacingUnitTest extends AbstractSniffUnitTest
+final class ConcatenationSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\DoubleQuoteUsageSniff
  */
-class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
+final class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\EchoedStringsSniff
  */
-class EchoedStringsUnitTest extends AbstractSniffUnitTest
+final class EchoedStringsUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\CastSpacingSniff
  */
-class CastSpacingUnitTest extends AbstractSniffUnitTest
+final class CastSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff
  */
-class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionClosingBraceSpaceSniff
  */
-class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionOpeningBraceSpaceSniff
  */
-class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionSpacingSniff
  */
-class FunctionSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff
  */
-class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
+final class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LogicalOperatorSpacingSniff
  */
-class LogicalOperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class LogicalOperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\MemberVarSpacingSniff
  */
-class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
+final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
  */
-class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff
  */
-class OperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class OperatorSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/PropertyLabelSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/PropertyLabelSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\PropertyLabelSpacingSniff
  */
-class PropertyLabelSpacingUnitTest extends AbstractSniffUnitTest
+final class PropertyLabelSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff
  */
-class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeKeywordSpacingSniff
  */
-class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
+final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff
  */
-class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
+final class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff
  */
-class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
+final class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
+++ b/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Config;
  *
  * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\Debug\CodeAnalyzerSniff
  */
-class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
+final class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\Files\ClosingTagSniff
  */
-class ClosingTagUnitTest extends AbstractSniffUnitTest
+final class ClosingTagUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
  *
  * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/tests/Core/Autoloader/DetermineLoadedClassTest.php
+++ b/tests/Core/Autoloader/DetermineLoadedClassTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Autoload::determineLoadedClass
  */
-class DetermineLoadedClassTest extends TestCase
+final class DetermineLoadedClassTest extends TestCase
 {
 
 

--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
  *
  * @covers \PHP_CodeSniffer\Config::__get
  */
-class ReportWidthTest extends TestCase
+final class ReportWidthTest extends TestCase
 {
 
 

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @coversNothing
  */
-class ErrorSuppressionTest extends TestCase
+final class ErrorSuppressionTest extends TestCase
 {
 
 

--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::findEndOfStatement
  */
-class FindEndOfStatementTest extends AbstractMethodUnitTest
+final class FindEndOfStatementTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::findExtendedClassName
  */
-class FindExtendedClassNameTest extends AbstractMethodUnitTest
+final class FindExtendedClassNameTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames
  */
-class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
+final class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::findStartOfStatement
  */
-class FindStartOfStatementTest extends AbstractMethodUnitTest
+final class FindStartOfStatementTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getClassProperties
  */
-class GetClassPropertiesTest extends AbstractMethodUnitTest
+final class GetClassPropertiesTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetConditionTest.php
+++ b/tests/Core/File/GetConditionTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @covers \PHP_CodeSniffer\Files\File::getCondition
  * @covers \PHP_CodeSniffer\Files\File::hasCondition
  */
-class GetConditionTest extends AbstractMethodUnitTest
+final class GetConditionTest extends AbstractMethodUnitTest
 {
 
     /**

--- a/tests/Core/File/GetDeclarationNameJSTest.php
+++ b/tests/Core/File/GetDeclarationNameJSTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
  */
-class GetDeclarationNameJSTest extends AbstractMethodUnitTest
+final class GetDeclarationNameJSTest extends AbstractMethodUnitTest
 {
 
     /**

--- a/tests/Core/File/GetDeclarationNameTest.php
+++ b/tests/Core/File/GetDeclarationNameTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
  */
-class GetDeclarationNameTest extends AbstractMethodUnitTest
+final class GetDeclarationNameTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getMemberProperties
  */
-class GetMemberPropertiesTest extends AbstractMethodUnitTest
+final class GetMemberPropertiesTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetMethodParametersParseError1Test.php
+++ b/tests/Core/File/GetMethodParametersParseError1Test.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-class GetMethodParametersParseError1Test extends AbstractMethodUnitTest
+final class GetMethodParametersParseError1Test extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetMethodParametersParseError2Test.php
+++ b/tests/Core/File/GetMethodParametersParseError2Test.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-class GetMethodParametersParseError2Test extends AbstractMethodUnitTest
+final class GetMethodParametersParseError2Test extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-class GetMethodParametersTest extends AbstractMethodUnitTest
+final class GetMethodParametersTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodProperties
  */
-class GetMethodPropertiesTest extends AbstractMethodUnitTest
+final class GetMethodPropertiesTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/GetTokensAsStringTest.php
+++ b/tests/Core/File/GetTokensAsStringTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::getTokensAsString
  */
-class GetTokensAsStringTest extends AbstractMethodUnitTest
+final class GetTokensAsStringTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Files\File::isReference
  */
-class IsReferenceTest extends AbstractMethodUnitTest
+final class IsReferenceTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -21,7 +21,7 @@ use RecursiveArrayIterator;
  *
  * @covers \PHP_CodeSniffer\Filters\Filter
  */
-class AcceptTest extends AbstractFilterTestCase
+final class AcceptTest extends AbstractFilterTestCase
 {
 
 

--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -19,7 +19,7 @@ use ReflectionMethod;
  *
  * @covers \PHP_CodeSniffer\Filters\GitModified
  */
-class GitModifiedTest extends AbstractFilterTestCase
+final class GitModifiedTest extends AbstractFilterTestCase
 {
 
 

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -19,7 +19,7 @@ use ReflectionMethod;
  *
  * @covers \PHP_CodeSniffer\Filters\GitStaged
  */
-class GitStagedTest extends AbstractFilterTestCase
+final class GitStagedTest extends AbstractFilterTestCase
 {
 
 

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Ruleset::explain
  */
-class ExplainTest extends TestCase
+final class ExplainTest extends TestCase
 {
 
 

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Ruleset
  */
-class RuleInclusionAbsoluteLinuxTest extends TestCase
+final class RuleInclusionAbsoluteLinuxTest extends TestCase
 {
 
     /**

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Ruleset
  */
-class RuleInclusionAbsoluteWindowsTest extends TestCase
+final class RuleInclusionAbsoluteWindowsTest extends TestCase
 {
 
     /**

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -19,7 +19,7 @@ use ReflectionObject;
  *
  * @covers \PHP_CodeSniffer\Ruleset
  */
-class RuleInclusionTest extends TestCase
+final class RuleInclusionTest extends TestCase
 {
 
     /**

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -19,7 +19,7 @@ use ReflectionObject;
  *
  * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
  */
-class SetSniffPropertyTest extends TestCase
+final class SetSniffPropertyTest extends TestCase
 {
 
 

--- a/tests/Core/Sniffs/AbstractArraySniffTest.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTest.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @covers \PHP_CodeSniffer\Sniffs\AbstractArraySniff
  */
-class AbstractArraySniffTest extends AbstractMethodUnitTest
+final class AbstractArraySniffTest extends AbstractMethodUnitTest
 {
 
     /**

--- a/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
+final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizer/ArrayKeywordTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class ArrayKeywordTest extends AbstractMethodUnitTest
+final class ArrayKeywordTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class AttributesTest extends AbstractMethodUnitTest
+final class AttributesTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BackfillEnumTest extends AbstractMethodUnitTest
+final class BackfillEnumTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
+final class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BackfillFnTokenTest extends AbstractMethodUnitTest
+final class BackfillFnTokenTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.php
@@ -13,7 +13,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class BackfillMatchTokenTest extends AbstractMethodUnitTest
+final class BackfillMatchTokenTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
+final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BackfillReadonlyTest extends AbstractMethodUnitTest
+final class BackfillReadonlyTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class BitwiseOrTest extends AbstractMethodUnitTest
+final class BitwiseOrTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
+final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class DefaultKeywordTest extends AbstractMethodUnitTest
+final class DefaultKeywordTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/DoubleArrowTest.php
+++ b/tests/Core/Tokenizer/DoubleArrowTest.php
@@ -13,7 +13,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class DoubleArrowTest extends AbstractMethodUnitTest
+final class DoubleArrowTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class DoubleQuotedStringTest extends AbstractMethodUnitTest
+final class DoubleQuotedStringTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class EnumCaseTest extends AbstractMethodUnitTest
+final class EnumCaseTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class FinallyTest extends AbstractMethodUnitTest
+final class FinallyTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class GotoLabelTest extends AbstractMethodUnitTest
+final class GotoLabelTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  *
  * @requires PHP 7.3
  */
-class HeredocNowdocCloserTest extends AbstractMethodUnitTest
+final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/HeredocStringTest.php
+++ b/tests/Core/Tokenizer/HeredocStringTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class HeredocStringTest extends AbstractMethodUnitTest
+final class HeredocStringTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
+final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
+final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
 {
 
     /**

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
+final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class ShortArrayTest extends AbstractMethodUnitTest
+final class ShortArrayTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -18,7 +18,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class StableCommentWhitespaceTest extends AbstractMethodUnitTest
+final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -15,7 +15,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
+final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class TypeIntersectionTest extends AbstractMethodUnitTest
+final class TypeIntersectionTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -21,7 +21,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
+final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
 {
 
 

--- a/tests/Core/Util/IsCamelCapsTest.php
+++ b/tests/Core/Util/IsCamelCapsTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Util\Common::isCamelCaps
  */
-class IsCamelCapsTest extends TestCase
+final class IsCamelCapsTest extends TestCase
 {
 
 

--- a/tests/Core/Util/SuggestTypeTest.php
+++ b/tests/Core/Util/SuggestTypeTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Util\Common::suggestType
  */
-class SuggestTypeTest extends TestCase
+final class SuggestTypeTest extends TestCase
 {
 
 


### PR DESCRIPTION
### Description

Declare all test classes as `final`.

Classes belonging to the test _framework_ have been exempted at this time.

This may be revisited at a later point in time when addressing issue #25.

_Note: by rights, the same should be done for most other classes, but as sniffs are often extended (even though that's not a good idea in most cases), that would be a breaking change, so will have to wait until a later point in time._


## Suggested changelog entry
_N/A_

