### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -267,7 +267,7 @@ final class ReportWidthTest extends TestCase
      *
      * @return array
      */
-    public function dataReportWidthInputHandling()
+    public static function dataReportWidthInputHandling()
     {
         return [
             'No value (empty string)'                                 => [

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -65,7 +65,7 @@ final class ErrorSuppressionTest extends TestCase
      *
      * @return array
      */
-    public function dataSuppressError()
+    public static function dataSuppressError()
     {
         return [
             'no suppression'                                                           => [
@@ -204,7 +204,7 @@ EOD;
      *
      * @return array
      */
-    public function dataSuppressSomeErrors()
+    public static function dataSuppressSomeErrors()
     {
         return [
             'no suppression'                               => [
@@ -296,7 +296,7 @@ EOD;
      *
      * @return array
      */
-    public function dataSuppressWarning()
+    public static function dataSuppressWarning()
     {
         return [
             'no suppression'                               => [
@@ -381,7 +381,7 @@ EOD;
      *
      * @return array
      */
-    public function dataSuppressLine()
+    public static function dataSuppressLine()
     {
         return [
             'no suppression'                             => [
@@ -532,7 +532,7 @@ EOD;
      *
      * @return array
      */
-    public function dataNestedSuppressLine()
+    public static function dataNestedSuppressLine()
     {
         return [
             // Process with disable/enable suppression and no single line suppression.
@@ -627,7 +627,7 @@ EOD;
      *
      * @return array
      */
-    public function dataSuppressScope()
+    public static function dataSuppressScope()
     {
         return [
             'no suppression'                                       => [
@@ -722,7 +722,7 @@ EOD;
      *
      * @return array
      */
-    public function dataSuppressFile()
+    public static function dataSuppressFile()
     {
         return [
             'no suppression'                                          => [
@@ -821,7 +821,7 @@ EOD;
      *
      * @return array
      */
-    public function dataDisableSelected()
+    public static function dataDisableSelected()
     {
         return [
             // Single sniff.
@@ -928,7 +928,7 @@ EOD;
      *
      * @return array
      */
-    public function dataEnableSelected()
+    public static function dataEnableSelected()
     {
         return [
             'disable/enable: a single sniff'                                                                                => [
@@ -1108,7 +1108,7 @@ EOD;
      *
      * @return array
      */
-    public function dataIgnoreSelected()
+    public static function dataIgnoreSelected()
     {
         return [
             'no suppression'                              => [
@@ -1195,7 +1195,7 @@ EOD;
      *
      * @return array
      */
-    public function dataCommenting()
+    public static function dataCommenting()
     {
         return [
             'ignore: single sniff'                                                                         => [

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -74,7 +74,7 @@ final class FindExtendedClassNameTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string, string|false>>
      */
-    public function dataExtendedClass()
+    public static function dataExtendedClass()
     {
         return [
             'class does not extend'                                       => [

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -73,7 +73,7 @@ final class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string, string|array<string>>>
      */
-    public function dataImplementedInterface()
+    public static function dataImplementedInterface()
     {
         return [
             'interface declaration, no implements'                               => [

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -47,7 +47,7 @@ final class GetClassPropertiesTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string, string|int>>
      */
-    public function dataNotAClassException()
+    public static function dataNotAClassException()
     {
         return [
             'interface'  => [
@@ -93,7 +93,7 @@ final class GetClassPropertiesTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string, string|array<string, bool|int>>>
      */
-    public function dataGetClassProperties()
+    public static function dataGetClassProperties()
     {
         return [
             'no-properties'               => [

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -60,7 +60,7 @@ final class GetMemberPropertiesTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string|array<string, string|int|bool>>>
      */
-    public function dataGetMemberProperties()
+    public static function dataGetMemberProperties()
     {
         return [
             'var-modifier'                                                 => [
@@ -1106,7 +1106,7 @@ final class GetMemberPropertiesTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string>>
      */
-    public function dataNotClassProperty()
+    public static function dataNotClassProperty()
     {
         return [
             'method parameter'                                       => ['/* testMethodParam */'],

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -59,7 +59,7 @@ final class IsReferenceTest extends AbstractMethodUnitTest
      *
      * @return array<string, array<string, string|bool>>
      */
-    public function dataIsReference()
+    public static function dataIsReference()
     {
         return [
             'issue-1971-list-first-in-file'                                                                     => [

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -131,7 +131,7 @@ final class RuleInclusionTest extends TestCase
      *
      * @return array
      */
-    public function dataRegisteredSniffCodes()
+    public static function dataRegisteredSniffCodes()
     {
         return [
             [
@@ -364,7 +364,7 @@ final class RuleInclusionTest extends TestCase
      *
      * @return array
      */
-    public function dataSettingProperties()
+    public static function dataSettingProperties()
     {
         return [
             'Set property for complete standard: PSR2 ClassDeclaration'                                  => [
@@ -455,7 +455,7 @@ final class RuleInclusionTest extends TestCase
      *
      * @return array
      */
-    public function dataSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
+    public static function dataSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
     {
         return [
             'Set property for complete standard: PSR2 ClassDeclaration'      => [

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -74,7 +74,7 @@ final class SetSniffPropertyTest extends TestCase
      *
      * @return array
      */
-    public function dataSniffPropertiesGetSetWhenAllowed()
+    public static function dataSniffPropertiesGetSetWhenAllowed()
     {
         return [
             'Property allowed as explicitly declared'            => ['SetPropertyAllowedAsDeclared'],
@@ -315,7 +315,7 @@ final class SetSniffPropertyTest extends TestCase
      *
      * @return array
      */
-    public function dataDirectCallWithOldArrayFormatSetsProperty()
+    public static function dataDirectCallWithOldArrayFormatSetsProperty()
     {
         return [
             'Property value is not an array (boolean)'                       => [false],

--- a/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
@@ -72,7 +72,7 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataAnonClassNoParentheses()
+    public static function dataAnonClassNoParentheses()
     {
         return [
             ['/* testNoParentheses */'],
@@ -131,7 +131,7 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataAnonClassWithParentheses()
+    public static function dataAnonClassWithParentheses()
     {
         return [
             ['/* testWithParentheses */'],

--- a/tests/Core/Tokenizer/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizer/ArrayKeywordTest.php
@@ -51,7 +51,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataArrayKeyword()
+    public static function dataArrayKeyword()
     {
         return [
             'empty array'                           => ['/* testEmptyArray */'],
@@ -103,7 +103,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataArrayType()
+    public static function dataArrayType()
     {
         return [
             'closure return type'        => [
@@ -154,7 +154,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotArrayKeyword()
+    public static function dataNotArrayKeyword()
     {
         return [
             'class-constant-name' => [

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -66,7 +66,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataAttribute()
+    public static function dataAttribute()
     {
         return [
             [
@@ -345,7 +345,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataAttributeOnParameters()
+    public static function dataAttributeOnParameters()
     {
         return [
             [
@@ -451,7 +451,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataAttributeOnTextLookingLikeCloseTag()
+    public static function dataAttributeOnTextLookingLikeCloseTag()
     {
         return [
             [

--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -75,7 +75,7 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataEnums()
+    public static function dataEnums()
     {
         return [
             [
@@ -154,7 +154,7 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotEnums()
+    public static function dataNotEnums()
     {
         return [
             [

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -49,7 +49,7 @@ final class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataExplicitOctalNotation()
+    public static function dataExplicitOctalNotation()
     {
         return [
             [

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -581,7 +581,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataInMatchValue()
+    public static function dataInMatchValue()
     {
         return [
             'not_last_value'                      => [
@@ -671,7 +671,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotAnArrowFunction()
+    public static function dataNotAnArrowFunction()
     {
         return [
             ['/* testFunctionName */'],

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.php
@@ -53,7 +53,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataMatchExpression()
+    public static function dataMatchExpression()
     {
         return [
             'simple_match'                              => [
@@ -243,7 +243,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotAMatchStructure()
+    public static function dataNotAMatchStructure()
     {
         return [
             'static_method_call'                   => ['/* testNoMatchStaticMethodCall */'],
@@ -346,7 +346,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataSwitchExpression()
+    public static function dataSwitchExpression()
     {
         return [
             'switch_containing_match'   => [
@@ -399,7 +399,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataSwitchCaseVersusMatch()
+    public static function dataSwitchCaseVersusMatch()
     {
         return [
             'switch_with_nested_match_case_1'       => [

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -44,7 +44,7 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataTestBackfill()
+    public static function dataTestBackfill()
     {
         $testHexType = 'T_LNUMBER';
         if (PHP_INT_MAX < 0xCAFEF00D) {
@@ -191,7 +191,7 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNoBackfill()
+    public static function dataNoBackfill()
     {
         return [
             [

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -44,7 +44,7 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataReadonly()
+    public static function dataReadonly()
     {
         return [
             [
@@ -221,7 +221,7 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotReadonly()
+    public static function dataNotReadonly()
     {
         return [
             [

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -43,7 +43,7 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataBitwiseOr()
+    public static function dataBitwiseOr()
     {
         return [
             ['/* testBitwiseOr1 */'],
@@ -94,7 +94,7 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataTypeUnion()
+    public static function dataTypeUnion()
     {
         return [
             ['/* testTypeUnionPropertySimple */'],

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -45,7 +45,7 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataStrings()
+    public static function dataStrings()
     {
         return [
             ['/* testAbstract */'],
@@ -187,7 +187,7 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataKeywords()
+    public static function dataKeywords()
     {
         return [
             [

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -55,7 +55,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataMatchDefault()
+    public static function dataMatchDefault()
     {
         return [
             'simple_match_default'                                    => ['/* testSimpleMatchDefault */'],
@@ -171,7 +171,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataSwitchDefault()
+    public static function dataSwitchDefault()
     {
         return [
             'simple_switch_default'                  => [
@@ -246,7 +246,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotDefaultKeyword()
+    public static function dataNotDefaultKeyword()
     {
         return [
             'class-constant-as-short-array-key'                   => ['/* testClassConstantAsShortArrayKey */'],

--- a/tests/Core/Tokenizer/DoubleArrowTest.php
+++ b/tests/Core/Tokenizer/DoubleArrowTest.php
@@ -47,7 +47,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataDoubleArrow()
+    public static function dataDoubleArrow()
     {
         return [
             'simple_long_array'                          => ['/* testLongArrayArrowSimple */'],
@@ -132,7 +132,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataMatchArrow()
+    public static function dataMatchArrow()
     {
         return [
             'single_case'                             => ['/* testMatchArrowSimpleSingleCase */'],
@@ -219,7 +219,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataFnArrow()
+    public static function dataFnArrow()
     {
         return [
             'simple_fn'                             => ['/* testFnArrowSimple */'],

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -44,7 +44,7 @@ final class DoubleQuotedStringTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataDoubleQuotedString()
+    public static function dataDoubleQuotedString()
     {
         return [
             [

--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -49,7 +49,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataEnumCases()
+    public static function dataEnumCases()
     {
         return [
             ['/* testPureEnumCase */'],
@@ -98,7 +98,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotEnumCases()
+    public static function dataNotEnumCases()
     {
         return [
             ['/* testCaseWithSemicolonIsNotEnumCase */'],
@@ -142,7 +142,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataKeywordAsEnumCaseNameShouldBeString()
+    public static function dataKeywordAsEnumCaseNameShouldBeString()
     {
         return [
             ['/* testKeywordAsEnumCaseNameShouldBeString1 */'],

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -43,7 +43,7 @@ final class FinallyTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataFinallyKeyword()
+    public static function dataFinallyKeyword()
     {
         return [
             ['/* testTryCatchFinally */'],
@@ -82,7 +82,7 @@ final class FinallyTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataFinallyNonKeyword()
+    public static function dataFinallyNonKeyword()
     {
         return [
             ['/* testFinallyUsedAsClassConstantName */'],

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -45,7 +45,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataGotoStatement()
+    public static function dataGotoStatement()
     {
         return [
             [
@@ -91,7 +91,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataGotoDeclaration()
+    public static function dataGotoDeclaration()
     {
         return [
             [
@@ -136,7 +136,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNotAGotoDeclaration()
+    public static function dataNotAGotoDeclaration()
     {
         return [
             [

--- a/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
@@ -93,7 +93,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataHeredocNowdocCloserTabReplacement()
+    public static function dataHeredocNowdocCloserTabReplacement()
     {
         return [
             [

--- a/tests/Core/Tokenizer/HeredocStringTest.php
+++ b/tests/Core/Tokenizer/HeredocStringTest.php
@@ -66,7 +66,7 @@ final class HeredocStringTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataHeredocString()
+    public static function dataHeredocString()
     {
         return [
             [

--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
@@ -76,7 +76,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNamedFunctionCallArguments()
+    public static function dataNamedFunctionCallArguments()
     {
         return [
             [
@@ -296,7 +296,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataOtherTstringInFunctionCall()
+    public static function dataOtherTstringInFunctionCall()
     {
         return [
             [
@@ -746,7 +746,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataReservedKeywordsAsName()
+    public static function dataReservedKeywordsAsName()
     {
         $reservedKeywords = [
             // '__halt_compiler', NOT TESTABLE

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
@@ -73,7 +73,7 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataNullsafeObjectOperator()
+    public static function dataNullsafeObjectOperator()
     {
         return [
             ['/* testNullsafeObjectOperator */'],
@@ -119,7 +119,7 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataTernaryThen()
+    public static function dataTernaryThen()
     {
         return [
             ['/* testTernaryThen */'],

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
@@ -61,7 +61,7 @@ final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataScopeSetting()
+    public static function dataScopeSetting()
     {
         return [
             [

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -49,7 +49,7 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataSquareBrackets()
+    public static function dataSquareBrackets()
     {
         return [
             'array access 1'                                => ['/* testArrayAccess1 */'],
@@ -114,7 +114,7 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataShortArrays()
+    public static function dataShortArrays()
     {
         return [
             'short array empty'                              => ['/* testShortArrayDeclarationEmpty */'],

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -56,7 +56,7 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataCommentTokenization()
+    public static function dataCommentTokenization()
     {
         return [
             [

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -53,7 +53,7 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataCommentTokenization()
+    public static function dataCommentTokenization()
     {
         return [
             [

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -44,7 +44,7 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataBitwiseAnd()
+    public static function dataBitwiseAnd()
     {
         return [
             ['/* testBitwiseAnd1 */'],
@@ -97,7 +97,7 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataTypeIntersection()
+    public static function dataTypeIntersection()
     {
         return [
             ['/* testTypeIntersectionPropertySimple */'],

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -59,7 +59,7 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
      *
      * @return array
      */
-    public function dataIdentifierTokenization()
+    public static function dataIdentifierTokenization()
     {
         return [
             [

--- a/tests/Core/Util/SuggestTypeTest.php
+++ b/tests/Core/Util/SuggestTypeTest.php
@@ -57,7 +57,7 @@ final class SuggestTypeTest extends TestCase
      *
      * @return array<string, array<string>>
      */
-    public function dataSuggestTypeAllowedType()
+    public static function dataSuggestTypeAllowedType()
     {
         $data = [];
         foreach (Common::$allowedTypes as $type) {
@@ -94,7 +94,7 @@ final class SuggestTypeTest extends TestCase
      *
      * @return array<string, array<string, string>>
      */
-    public function dataSuggestTypeAllowedTypeWrongCase()
+    public static function dataSuggestTypeAllowedTypeWrongCase()
     {
         $data = [];
         foreach (Common::$allowedTypes as $type) {
@@ -138,7 +138,7 @@ final class SuggestTypeTest extends TestCase
      *
      * @return array<string, array<string, string>>
      */
-    public function dataSuggestTypeOther()
+    public static function dataSuggestTypeOther()
     {
         return [
             // Short forms.


### PR DESCRIPTION

## Description
As of PHPUnit 10, data providers are (again) expected to be `static` methods. While the test suite does not (yet) support PHPUnit 10, it's still not a bad idea to already start complying with this.

## Suggested changelog entry
_N/A_

## Related issues/external references

Loosely related to #25
