### PR TITLE
skip tests requiring git repository

### DIFF
--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -211,6 +211,10 @@ final class GitModifiedTest extends AbstractFilterTestCase
      */
     public function testExecAlwaysReturnsArray($cmd, $expected)
     {
+        if (is_dir(__DIR__.'/../../../.git') === false) {
+            $this->markTestSkipped('Not a git repository');
+        }
+
         $fakeDI = new RecursiveArrayIterator(self::getFakeFileList());
         $filter = new GitModified($fakeDI, '/', self::$config, self::$ruleset);
 

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -211,6 +211,10 @@ final class GitStagedTest extends AbstractFilterTestCase
      */
     public function testExecAlwaysReturnsArray($cmd, $expected)
     {
+        if (is_dir(__DIR__.'/../../../.git') === false) {
+            $this->markTestSkipped('Not a git repository');
+        }
+
         $fakeDI = new RecursiveArrayIterator(self::getFakeFileList());
         $filter = new GitStaged($fakeDI, '/', self::$config, self::$ruleset);
 


### PR DESCRIPTION
Test are failing badly

```
............................................................. 1708 / 2115 ( 80%)
............................................................. 1769 / 2115 ( 83%)
....................................fatal: not a git repository (or any parent up to mount point /dev)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
.fatal: not a git repository (or any parent up to mount point /dev)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
F........error: unknown option `cached'
usage: git diff --no-index [<options>] <path> <path>

Diff output format options
    -p, --patch           generate patch
    -s, --no-patch        suppress diff output
    -u                    generate patch
    -U, --unified[=<n>]   generate diffs with <n> lines context
    -W, --[no-]function-context
                          generate diffs with <n> lines context
    --raw                 generate the diff in raw format
    --patch-with-raw      synonym for '-p --raw'
    --patch-with-stat     synonym for '-p --stat'
    --numstat             machine friendly --stat
    --shortstat           output only the last line of --stat
    -X, --dirstat[=<param1,param2>...]
                          output the distribution of relative amount of changes for each sub-directory
    --cumulative          synonym for --dirstat=cumulative
    --dirstat-by-file[=<param1,param2>...]
                          synonym for --dirstat=files,param1,param2...
    --check               warn if changes introduce conflict markers or whitespace errors
    --summary             condensed summary such as creations, renames and mode changes
    --name-only           show only names of changed files
    --name-status         show only names and status of changed files
    --stat[=<width>[,<name-width>[,<count>]]]
                          generate diffstat
    --stat-width <width>  generate diffstat with a given width
    --stat-name-width <width>
                          generate diffstat with a given name width
    --stat-graph-width <width>
                          generate diffstat with a given graph width
    --stat-count <count>  generate diffstat with limited lines
    --[no-]compact-summary
                          generate compact summary in diffstat
    --binary              output a binary diff that can be applied
    --[no-]full-index     show full pre- and post-image object names on the "index" lines
    --[no-]color[=<when>] show colored diff
    --ws-error-highlight <kind>
                          highlight whitespace errors in the 'context', 'old' or 'new' lines in the diff
    -z                    do not munge pathnames and use NULs as output field terminators in --raw or --numstat
    --[no-]abbrev[=<n>]   use <n> digits to display object names
    --src-prefix <prefix> show the given source prefix instead of "a/"
    --dst-prefix <prefix> show the given destination prefix instead of "b/"
    --line-prefix <prefix>
                          prepend an additional prefix to every line of output
    --no-prefix           do not show any source or destination prefix
    --default-prefix      use default prefixes a/ and b/
    --inter-hunk-context <n>
                          show context between diff hunks up to the specified number of lines
    --output-indicator-new <char>
                          specify the character to indicate a new line instead of '+'
    --output-indicator-old <char>
                          specify the character to indicate an old line instead of '-'
    --output-indicator-context <char>
                          specify the character to indicate a context instead of ' '

Diff rename options
    -B, --break-rewrites[=<n>[/<m>]]
                          break complete rewrite changes into pairs of delete and create
    -M, --find-renames[=<n>]
                          detect renames
    -D, --irreversible-delete
                          omit the preimage for deletes
    -C, --find-copies[=<n>]
                          detect copies
    --[no-]find-copies-harder
                          use unmodified files as source to find copies
    --no-renames          disable rename detection
    --[no-]rename-empty   use empty blobs as rename source
    --[no-]follow         continue listing the history of a file beyond renames
    -l <n>                prevent rename/copy detection if the number of rename/copy targets exceeds given limit

Diff algorithm options
    --minimal             produce the smallest possible diff
    -w, --ignore-all-space
                          ignore whitespace when comparing lines
    -b, --ignore-space-change
                          ignore changes in amount of whitespace
    --ignore-space-at-eol ignore changes in whitespace at EOL
    --ignore-cr-at-eol    ignore carrier-return at the end of line
    --ignore-blank-lines  ignore changes whose lines are all blank
    -I, --[no-]ignore-matching-lines <regex>
                          ignore changes whose all lines match <regex>
    --[no-]indent-heuristic
                          heuristic to shift diff hunk boundaries for easy reading
    --patience            generate diff using the "patience diff" algorithm
    --histogram           generate diff using the "histogram diff" algorithm
    --diff-algorithm <algorithm>
                          choose a diff algorithm
    --anchored <text>     generate diff using the "anchored diff" algorithm
    --word-diff[=<mode>]  show word diff, using <mode> to delimit changed words
    --word-diff-regex <regex>
                          use <regex> to decide what a word is
    --color-words[=<regex>]
                          equivalent to --word-diff=color --word-diff-regex=<regex>
    --[no-]color-moved[=<mode>]
                          moved lines of code are colored differently
    --[no-]color-moved-ws <mode>
                          how white spaces are ignored in --color-moved

Other diff options
    --[no-]relative[=<prefix>]
                          when run from subdir, exclude changes outside and show relative paths
    -a, --[no-]text       treat all files as text
    -R                    swap two inputs, reverse the diff
    --[no-]exit-code      exit with 1 if there were differences, 0 otherwise
    --[no-]quiet          disable all output of the program
    --[no-]ext-diff       allow an external diff helper to be executed
    --[no-]textconv       run external text conversion filters when comparing binary files
    --ignore-submodules[=<when>]
                          ignore changes to submodules in the diff generation
    --submodule[=<format>]
                          specify how differences in submodules are shown
    --ita-invisible-in-index
                          hide 'git add -N' entries from the index
    --ita-visible-in-index
                          treat 'git add -N' entries as real in the index
    -S <string>           look for differences that change the number of occurrences of the specified string
    -G <regex>            look for differences that change the number of occurrences of the specified regex
    --pickaxe-all         show all changes in the changeset with -S or -G
    --pickaxe-regex       treat <string> in -S as extended POSIX regular expression
    -O <file>             control the order in which files appear in the output
    --rotate-to <path>    show the change in the specified path first
    --skip-to <path>      skip the output to the specified path
    --find-object <object-id>
                          look for differences that change the number of occurrences of the specified object
    --diff-filter [(A|C|D|M|R|T|U|X|B)...[*]]
                          select files by diff type
    --output <file>       output to a specific file

.fatal: not a git repository (or any parent up to mount point /dev)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
F............. 1830 / 2115 ( 86%)
.......................................S..................... 1891 / 2115 ( 89%)
.SSS.......S................................................. 1952 / 2115 ( 92%)
.....................................................SS...... 2013 / 2115 ( 95%)
............................................................. 2074 / 2115 ( 98%)
.........................................                     2115 / 2115 (100%)

500 sniff test files generated 800 unique error codes; 456 were fixable (57%)

Time: 00:01.847, Memory: 36.00 MB

There was 1 warning:

1) PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest::testDirectCallWithOldArrayFormatThrowsDeprecationNotice
Expecting E_DEPRECATED and E_USER_DEPRECATED is deprecated and will no longer be possible in PHPUnit 10.

/dev/shm/BUILD/PHP_CodeSniffer-14f5fff1e64118595db5408e946f3a22c75807f7/tests/TestSuite7.php:28

--

There were 2 failures:

1) PHP_CodeSniffer\Tests\Core\Filters\GitModifiedTest::testExecAlwaysReturnsArray with data set "valid command which will have output" ('git ls-files --exclude-standa...7/bin'', array('bin/phpcbf', 'bin/phpcbf.bat', 'bin/phpcs', 'bin/phpcs.bat'))
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 (
-    0 => 'bin/phpcbf'
-    1 => 'bin/phpcbf.bat'
-    2 => 'bin/phpcs'
-    3 => 'bin/phpcs.bat'
-)
+Array &0 ()

/dev/shm/BUILD/PHP_CodeSniffer-14f5fff1e64118595db5408e946f3a22c75807f7/tests/Core/Filters/GitModifiedTest.php:221
/dev/shm/BUILD/PHP_CodeSniffer-14f5fff1e64118595db5408e946f3a22c75807f7/tests/TestSuite7.php:28

2) PHP_CodeSniffer\Tests\Core\Filters\GitStagedTest::testExecAlwaysReturnsArray with data set "valid command which will have output" ('git ls-files --exclude-standa...7/bin'', array('bin/phpcbf', 'bin/phpcbf.bat', 'bin/phpcs', 'bin/phpcs.bat'))
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 (
-    0 => 'bin/phpcbf'
-    1 => 'bin/phpcbf.bat'
-    2 => 'bin/phpcs'
-    3 => 'bin/phpcs.bat'
-)
+Array &0 ()

/dev/shm/BUILD/PHP_CodeSniffer-14f5fff1e64118595db5408e946f3a22c75807f7/tests/Core/Filters/GitStagedTest.php:221
/dev/shm/BUILD/PHP_CodeSniffer-14f5fff1e64118595db5408e946f3a22c75807f7/tests/TestSuite7.php:28

FAILURES!

```