### PR TITLE
Tests/ExplainTest: expand the tests

### DIFF
--- a/tests/Core/Ruleset/ExplainCustomRulesetTest.xml
+++ b/tests/Core/Ruleset/ExplainCustomRulesetTest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ExplainCustomRulesetTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="PSR12.ControlStructures"/>
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="PSR1">
+        <exclude name="PSR1.Files.SideEffects"/>
+    </rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/ExplainSingleSniffTest.xml
+++ b/tests/Core/Ruleset/ExplainSingleSniffTest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ExplainSingleSniffTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Squiz.Scope.MethodScope"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Runner;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +31,7 @@ final class ExplainTest extends TestCase
     public function testExplain()
     {
         // Set up the ruleset.
-        $config  = new Config(['--standard=PSR1', '-e']);
+        $config  = new Config(['--standard=PSR1', '-e', '--report-width=80']);
         $ruleset = new Ruleset($config);
 
         $expected  = PHP_EOL;
@@ -55,6 +56,161 @@ final class ExplainTest extends TestCase
         $ruleset->explain();
 
     }//end testExplain()
+
+
+    /**
+     * Test the output of the "explain" command is not influenced by a user set report width.
+     *
+     * @return void
+     */
+    public function testExplainAlwaysDisplaysCompleteSniffName()
+    {
+        // Set up the ruleset.
+        $config  = new Config(['--standard=PSR1', '-e', '--report-width=30']);
+        $ruleset = new Ruleset($config);
+
+        $expected  = PHP_EOL;
+        $expected .= 'The PSR1 standard contains 8 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'Generic (4 sniffs)'.PHP_EOL;
+        $expected .= '------------------'.PHP_EOL;
+        $expected .= '  Generic.Files.ByteOrderMark'.PHP_EOL;
+        $expected .= '  Generic.NamingConventions.UpperCaseConstantName'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowAlternativePHPTags'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowShortOpenTag'.PHP_EOL.PHP_EOL;
+        $expected .= 'PSR1 (3 sniffs)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  PSR1.Classes.ClassDeclaration'.PHP_EOL;
+        $expected .= '  PSR1.Files.SideEffects'.PHP_EOL;
+        $expected .= '  PSR1.Methods.CamelCapsMethodName'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Classes.ValidClassName'.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        $ruleset->explain();
+
+    }//end testExplainAlwaysDisplaysCompleteSniffName()
+
+
+    /**
+     * Test the output of the "explain" command when a ruleset only contains a single sniff.
+     *
+     * This is mostly about making sure that the summary line uses the correct grammar.
+     *
+     * @return void
+     */
+    public function testExplainSingleSniff()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/ExplainSingleSniffTest.xml';
+        $config   = new Config(["--standard=$standard", '-e', '--report-width=80']);
+        $ruleset  = new Ruleset($config);
+
+        $expected  = PHP_EOL;
+        $expected .= 'The ExplainSingleSniffTest standard contains 1 sniff'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Scope.MethodScope'.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        $ruleset->explain();
+
+    }//end testExplainSingleSniff()
+
+
+    /**
+     * Test that "explain" works correctly with custom rulesets.
+     *
+     * Verifies that:
+     * - The "standard" name is taken from the custom ruleset.
+     * - Any and all sniff additions and exclusions in the ruleset are taken into account correctly.
+     * - That the displayed list will have both the standards as well as the sniff names
+     *   ordered alphabetically.
+     *
+     * @return void
+     */
+    public function testExplainCustomRuleset()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/ExplainCustomRulesetTest.xml';
+        $config   = new Config(["--standard=$standard", '-e', '--report-width=80']);
+        $ruleset  = new Ruleset($config);
+
+        $expected  = PHP_EOL;
+        $expected .= 'The ExplainCustomRulesetTest standard contains 10 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'Generic (4 sniffs)'.PHP_EOL;
+        $expected .= '------------------'.PHP_EOL;
+        $expected .= '  Generic.Files.ByteOrderMark'.PHP_EOL;
+        $expected .= '  Generic.NamingConventions.UpperCaseConstantName'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowAlternativePHPTags'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowShortOpenTag'.PHP_EOL.PHP_EOL;
+        $expected .= 'PSR1 (2 sniffs)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  PSR1.Classes.ClassDeclaration'.PHP_EOL;
+        $expected .= '  PSR1.Methods.CamelCapsMethodName'.PHP_EOL.PHP_EOL;
+        $expected .= 'PSR12 (2 sniffs)'.PHP_EOL;
+        $expected .= '----------------'.PHP_EOL;
+        $expected .= '  PSR12.ControlStructures.BooleanOperatorPlacement'.PHP_EOL;
+        $expected .= '  PSR12.ControlStructures.ControlStructureSpacing'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (2 sniffs)'.PHP_EOL;
+        $expected .= '----------------'.PHP_EOL;
+        $expected .= '  Squiz.Classes.ValidClassName'.PHP_EOL;
+        $expected .= '  Squiz.Scope.MethodScope'.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        $ruleset->explain();
+
+    }//end testExplainCustomRuleset()
+
+
+    /**
+     * Test that each standard passed on the command-line is explained separately.
+     *
+     * @covers \PHP_CodeSniffer\Runner::runPHPCS
+     *
+     * @return void
+     */
+    public function testExplainWillExplainEachStandardSeparately()
+    {
+        $standard        = __DIR__.'/ExplainSingleSniffTest.xml';
+        $_SERVER['argv'] = [
+            'phpcs',
+            '-e',
+            "--standard=PSR1,$standard",
+            '--report-width=80',
+        ];
+
+        $expected  = PHP_EOL;
+        $expected .= 'The PSR1 standard contains 8 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'Generic (4 sniffs)'.PHP_EOL;
+        $expected .= '------------------'.PHP_EOL;
+        $expected .= '  Generic.Files.ByteOrderMark'.PHP_EOL;
+        $expected .= '  Generic.NamingConventions.UpperCaseConstantName'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowAlternativePHPTags'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowShortOpenTag'.PHP_EOL.PHP_EOL;
+        $expected .= 'PSR1 (3 sniffs)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  PSR1.Classes.ClassDeclaration'.PHP_EOL;
+        $expected .= '  PSR1.Files.SideEffects'.PHP_EOL;
+        $expected .= '  PSR1.Methods.CamelCapsMethodName'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Classes.ValidClassName'.PHP_EOL.PHP_EOL;
+
+        $expected .= 'The ExplainSingleSniffTest standard contains 1 sniff'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Scope.MethodScope'.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        $runner   = new Runner();
+        $exitCode = $runner->runPHPCS();
+
+    }//end testExplainWillExplainEachStandardSeparately()
 
 
 }//end class


### PR DESCRIPTION
## Description
These additional tests test different aspects of the explain command functionality, as well as document the behaviour of the command.

Related to #146

## Suggested changelog entry
_N/A_
