### PR TITLE
Tests/ErrorSuppressionTest: various improvements

### DIFF
--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -17,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for PHP_CodeSniffer error suppression tags.
  *
- * @coversNothing
+ * @covers PHP_CodeSniffer\Files\File::addMessage
+ * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
  */
 final class ErrorSuppressionTest extends TestCase
 {
@@ -32,7 +33,6 @@ final class ErrorSuppressionTest extends TestCase
      *                               Defaults to 0.
      *
      * @dataProvider dataSuppressError
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -165,7 +165,6 @@ final class ErrorSuppressionTest extends TestCase
      *                               Defaults to 1.
      *
      * @dataProvider dataSuppressSomeErrors
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -258,7 +257,6 @@ EOD;
      *                                 Defaults to 0.
      *
      * @dataProvider dataSuppressWarning
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -343,7 +341,6 @@ EOD;
      *                               Defaults to 1.
      *
      * @dataProvider dataSuppressLine
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -444,8 +441,6 @@ EOD;
     /**
      * Test suppressing a single error using a single line ignore in the middle of a line.
      *
-     * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
-     *
      * @return void
      */
     public function testSuppressLineMidLine()
@@ -468,8 +463,6 @@ EOD;
 
     /**
      * Test suppressing a single error using a single line ignore within a docblock.
-     *
-     * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -507,7 +500,6 @@ EOD;
      * @param string $after  Annotation to place after the code.
      *
      * @dataProvider dataNestedSuppressLine
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -598,7 +590,6 @@ EOD;
      *                               Defaults to 0.
      *
      * @dataProvider dataSuppressScope
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -696,7 +687,6 @@ EOD;
      *                                 Defaults to 0.
      *
      * @dataProvider dataSuppressFile
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -811,7 +801,6 @@ EOD;
      *                                 Defaults to 0.
      *
      * @dataProvider dataDisableSelected
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -929,7 +918,6 @@ EOD;
      * @param int    $expectedWarnings Number of warnings expected.
      *
      * @dataProvider dataEnableSelected
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -1104,7 +1092,6 @@ EOD;
      * @param int    $expectedWarnings Number of warnings expected.
      *
      * @dataProvider dataIgnoreSelected
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */
@@ -1196,7 +1183,6 @@ EOD;
      * @param int    $expectedWarnings Number of warnings expected.
      *
      * @dataProvider dataCommenting
-     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
      *
      * @return void
      */

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -391,12 +391,24 @@ EOD;
             ],
 
             // With suppression on line before.
-            'ignore: line before, slash comment'         => ['before' => '// phpcs:ignore'],
-            'ignore: line before, slash comment, with @' => ['before' => '// @phpcs:ignore'],
-            'ignore: line before, hash comment'          => ['before' => '# phpcs:ignore'],
-            'ignore: line before, hash comment, with @'  => ['before' => '# @phpcs:ignore'],
-            'ignore: line before, star comment'          => ['before' => '/* phpcs:ignore */'],
-            'ignore: line before, star comment, with @'  => ['before' => '/* @phpcs:ignore */'],
+            'ignore: line before, slash comment'         => [
+                'before' => '// phpcs:ignore',
+            ],
+            'ignore: line before, slash comment, with @' => [
+                'before' => '// @phpcs:ignore',
+            ],
+            'ignore: line before, hash comment'          => [
+                'before' => '# phpcs:ignore',
+            ],
+            'ignore: line before, hash comment, with @'  => [
+                'before' => '# @phpcs:ignore',
+            ],
+            'ignore: line before, star comment'          => [
+                'before' => '/* phpcs:ignore */',
+            ],
+            'ignore: line before, star comment, with @'  => [
+                'before' => '/* @phpcs:ignore */',
+            ],
 
             // With suppression as trailing comment on code line.
             'ignore: end of line, slash comment'         => [
@@ -417,7 +429,9 @@ EOD;
             ],
 
             // Deprecated syntax.
-            'old style: line before, slash comment'      => ['before' => '// @codingStandardsIgnoreLine'],
+            'old style: line before, slash comment'      => [
+                'before' => '// @codingStandardsIgnoreLine',
+            ],
             'old style: end of line, slash comment'      => [
                 'before' => '',
                 'after'  => ' // @codingStandardsIgnoreLine',
@@ -732,16 +746,30 @@ EOD;
             ],
 
             // Process with suppression.
-            'ignoreFile: start of file, slash comment'                => ['before' => '// phpcs:ignoreFile'],
-            'ignoreFile: start of file, slash comment, with @'        => ['before' => '// @phpcs:ignoreFile'],
-            'ignoreFile: start of file, slash comment, mixed case'    => ['before' => '// PHPCS:Ignorefile'],
-            'ignoreFile: start of file, hash comment'                 => ['before' => '# phpcs:ignoreFile'],
-            'ignoreFile: start of file, hash comment, with @'         => ['before' => '# @phpcs:ignoreFile'],
-            'ignoreFile: start of file, single-line star comment'     => ['before' => '/* phpcs:ignoreFile */'],
+            'ignoreFile: start of file, slash comment'                => [
+                'before' => '// phpcs:ignoreFile',
+            ],
+            'ignoreFile: start of file, slash comment, with @'        => [
+                'before' => '// @phpcs:ignoreFile',
+            ],
+            'ignoreFile: start of file, slash comment, mixed case'    => [
+                'before' => '// PHPCS:Ignorefile',
+            ],
+            'ignoreFile: start of file, hash comment'                 => [
+                'before' => '# phpcs:ignoreFile',
+            ],
+            'ignoreFile: start of file, hash comment, with @'         => [
+                'before' => '# @phpcs:ignoreFile',
+            ],
+            'ignoreFile: start of file, single-line star comment'     => [
+                'before' => '/* phpcs:ignoreFile */',
+            ],
             'ignoreFile: start of file, multi-line star comment'      => [
                 'before' => '/*'.PHP_EOL.' phpcs:ignoreFile'.PHP_EOL.' */',
             ],
-            'ignoreFile: start of file, single-line docblock comment' => ['before' => '/** phpcs:ignoreFile */'],
+            'ignoreFile: start of file, single-line docblock comment' => [
+                'before' => '/** phpcs:ignoreFile */',
+            ],
 
             // Process late comment.
             'ignoreFile: late comment, slash comment'                 => [
@@ -750,12 +778,18 @@ EOD;
             ],
 
             // Deprecated syntax.
-            'old style: start of file, slash comment'                 => ['before' => '// @codingStandardsIgnoreFile'],
-            'old style: start of file, single-line star comment'      => ['before' => '/* @codingStandardsIgnoreFile */'],
+            'old style: start of file, slash comment'                 => [
+                'before' => '// @codingStandardsIgnoreFile',
+            ],
+            'old style: start of file, single-line star comment'      => [
+                'before' => '/* @codingStandardsIgnoreFile */',
+            ],
             'old style: start of file, multi-line star comment'       => [
                 'before' => '/*'.PHP_EOL.' @codingStandardsIgnoreFile'.PHP_EOL.' */',
             ],
-            'old style: start of file, single-line docblock comment'  => ['before' => '/** @codingStandardsIgnoreFile */'],
+            'old style: start of file, single-line docblock comment'  => [
+                'before' => '/** @codingStandardsIgnoreFile */',
+            ],
 
             // Deprecated syntax, late comment.
             'old style: late comment, slash comment'                  => [
@@ -843,7 +877,9 @@ EOD;
             ],
 
             // Multiple sniffs.
-            'disable: multiple sniffs in one comment'      => ['before' => '// phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant'],
+            'disable: multiple sniffs in one comment'      => [
+                'before' => '// phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant',
+            ],
             'disable: multiple sniff in multiple comments' => [
                 'before' => '// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'// phpcs:disable Generic.PHP.LowerCaseConstant',
             ],
@@ -853,12 +889,16 @@ EOD;
                 'before'         => '// phpcs:disable Generic.Commenting',
                 'expectedErrors' => 1,
             ],
-            'disable: whole standard'                      => ['before' => '// phpcs:disable Generic'],
+            'disable: whole standard'                      => [
+                'before' => '// phpcs:disable Generic',
+            ],
             'disable: single errorcode'                    => [
                 'before'         => '# @phpcs:disable Generic.Commenting.Todo.TaskFound',
                 'expectedErrors' => 1,
             ],
-            'disable: single errorcode and a category'     => ['before' => '// phpcs:disable Generic.PHP.LowerCaseConstant.Found,Generic.Commenting'],
+            'disable: single errorcode and a category'     => [
+                'before' => '// phpcs:disable Generic.PHP.LowerCaseConstant.Found,Generic.Commenting',
+            ],
 
             // Wrong category/sniff/code.
             'disable: wrong error code and category'       => [

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -63,7 +63,7 @@ final class ErrorSuppressionTest extends TestCase
      *
      * @see testSuppressError()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressError()
     {
@@ -202,7 +202,7 @@ EOD;
      *
      * @see testSuppressSomeErrors()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressSomeErrors()
     {
@@ -294,7 +294,7 @@ EOD;
      *
      * @see testSuppressWarning()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressWarning()
     {
@@ -379,7 +379,7 @@ EOD;
      *
      * @see testSuppressLine()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressLine()
     {
@@ -544,7 +544,7 @@ EOD;
      *
      * @see testNestedSuppressLine()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNestedSuppressLine()
     {
@@ -639,7 +639,7 @@ EOD;
      *
      * @see testSuppressScope()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressScope()
     {
@@ -734,7 +734,7 @@ EOD;
      *
      * @see testSuppressFile()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSuppressFile()
     {
@@ -853,7 +853,7 @@ EOD;
      *
      * @see testDisableSelected()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataDisableSelected()
     {
@@ -966,7 +966,7 @@ EOD;
      *
      * @see testEnableSelected()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataEnableSelected()
     {
@@ -1146,7 +1146,7 @@ EOD;
      *
      * @see testIgnoreSelected()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataIgnoreSelected()
     {
@@ -1233,7 +1233,7 @@ EOD;
      *
      * @see testCommenting()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataCommenting()
     {


### PR DESCRIPTION
## Description

### Tests/ErrorSuppressionTest: normalize data provider arrays

... to improve scannability of the test cases covered.

See #225

### Tests/ErrorSuppressionTest: improve doc type specificity
### Tests/ErrorSuppressionTest: improve `@covers` tag 

## Suggested changelog entry
_N/A_