### PR TITLE
Tests/SetSniffPropertyTest: various improvements

### DIFF
--- a/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedAsDeclaredSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedAsDeclaredSniff.php
@@ -5,14 +5,16 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\Category;
+namespace Fixtures\Sniffs\SetProperty;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use stdClass;
 
-class SetPropertyAllowedViaStdClassSniff extends stdClass implements Sniff
+class AllowedAsDeclaredSniff implements Sniff
 {
+
+    public $arbitrarystring;
+    public $arbitraryarray;
 
     public function register()
     {

--- a/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php
@@ -5,12 +5,12 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\Category;
+namespace Fixtures\Sniffs\SetProperty;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class SetPropertyAllowedViaMagicMethodSniff implements Sniff
+class AllowedViaMagicMethodSniff implements Sniff
 {
     private $magic = [];
 

--- a/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaStdClassSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaStdClassSniff.php
@@ -5,14 +5,13 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\Category;
+namespace Fixtures\Sniffs\SetProperty;
 
-use AllowDynamicProperties;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use stdClass;
 
-#[AllowDynamicProperties]
-class SetPropertyNotAllowedViaAttributeSniff implements Sniff
+class AllowedViaStdClassSniff extends stdClass implements Sniff
 {
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php
@@ -5,16 +5,15 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\Category;
+namespace Fixtures\Sniffs\SetProperty;
 
+use AllowDynamicProperties;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class SetPropertyAllowedAsDeclaredSniff implements Sniff
+#[AllowDynamicProperties]
+class NotAllowedViaAttributeSniff implements Sniff
 {
-
-    public $arbitrarystring;
-    public $arbitraryarray;
 
     public function register()
     {

--- a/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedAsDeclaredSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaStdClassSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
+++ b/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
         </properties>

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -72,7 +72,7 @@ final class SetSniffPropertyTest extends TestCase
      *
      * @see self::testSniffPropertiesGetSetWhenAllowed()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataSniffPropertiesGetSetWhenAllowed()
     {
@@ -313,34 +313,40 @@ final class SetSniffPropertyTest extends TestCase
      *
      * @see self::testDirectCallWithOldArrayFormatSetsProperty()
      *
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     public static function dataDirectCallWithOldArrayFormatSetsProperty()
     {
         return [
-            'Property value is not an array (boolean)'                       => [false],
-            'Property value is not an array (string)'                        => ['a string'],
-            'Property value is an empty array'                               => [[]],
+            'Property value is not an array (boolean)'                       => [
+                'propertyValue' => false,
+            ],
+            'Property value is not an array (string)'                        => [
+                'propertyValue' => 'a string',
+            ],
+            'Property value is an empty array'                               => [
+                'propertyValue' => [],
+            ],
             'Property value is an array without keys'                        => [
-                [
+                'propertyValue' => [
                     'value',
                     false,
                 ],
             ],
             'Property value is an array without the "scope" or "value" keys' => [
-                [
+                'propertyValue' => [
                     'key1' => 'value',
                     'key2' => false,
                 ],
             ],
             'Property value is an array without the "scope" key'             => [
-                [
+                'propertyValue' => [
                     'key1'  => 'value',
                     'value' => true,
                 ],
             ],
             'Property value is an array without the "value" key'             => [
-                [
+                'propertyValue' => [
                     'scope' => 'value',
                     'key2'  => 1234,
                 ],

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -34,8 +34,8 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testSniffPropertiesGetSetWhenAllowed($name)
     {
-        $sniffCode  = "Fixtures.Category.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\Category\\'.$name.'Sniff';
+        $sniffCode  = "Fixtures.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
         $properties = [
             'arbitrarystring' => 'arbitraryvalue',
             'arbitraryarray'  => [
@@ -45,7 +45,7 @@ final class SetSniffPropertyTest extends TestCase
         ];
 
         // Set up the ruleset.
-        $standard = __DIR__."/{$name}Test.xml";
+        $standard = __DIR__."/SetProperty{$name}Test.xml";
         $config   = new Config(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
@@ -77,9 +77,9 @@ final class SetSniffPropertyTest extends TestCase
     public static function dataSniffPropertiesGetSetWhenAllowed()
     {
         return [
-            'Property allowed as explicitly declared'            => ['SetPropertyAllowedAsDeclared'],
-            'Property allowed as sniff extends stdClass'         => ['SetPropertyAllowedViaStdClass'],
-            'Property allowed as sniff has magic __set() method' => ['SetPropertyAllowedViaMagicMethod'],
+            'Property allowed as explicitly declared'            => ['AllowedAsDeclared'],
+            'Property allowed as sniff extends stdClass'         => ['AllowedViaStdClass'],
+            'Property allowed as sniff has magic __set() method' => ['AllowedViaMagicMethod'],
         ];
 
     }//end dataSniffPropertiesGetSetWhenAllowed()
@@ -163,7 +163,7 @@ final class SetSniffPropertyTest extends TestCase
     public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
     {
         $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff Fixtures.Category.SetPropertyNotAllowedViaAttribute';
+        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff Fixtures.SetProperty.NotAllowedViaAttribute';
         if (method_exists($this, 'expectException') === true) {
             $this->expectException($exceptionClass);
             $this->expectExceptionMessage($exceptionMsg);
@@ -224,12 +224,12 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testDirectCallWithNewArrayFormatSetsProperty()
     {
-        $name       = 'SetPropertyAllowedAsDeclared';
-        $sniffCode  = "Fixtures.Category.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\Category\\'.$name.'Sniff';
+        $name       = 'AllowedAsDeclared';
+        $sniffCode  = "Fixtures.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
-        $standard = __DIR__."/{$name}Test.xml";
+        $standard = __DIR__."/SetProperty{$name}Test.xml";
         $config   = new Config(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
@@ -275,12 +275,12 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testDirectCallWithOldArrayFormatSetsProperty($propertyValue)
     {
-        $name       = 'SetPropertyAllowedAsDeclared';
-        $sniffCode  = "Fixtures.Category.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\Category\\'.$name.'Sniff';
+        $name       = 'AllowedAsDeclared';
+        $sniffCode  = "Fixtures.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
-        $standard = __DIR__."/{$name}Test.xml";
+        $standard = __DIR__."/SetProperty{$name}Test.xml";
         $config   = new Config(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
@@ -376,12 +376,12 @@ final class SetSniffPropertyTest extends TestCase
             $this->setExpectedException($exceptionClass, $exceptionMsg);
         }
 
-        $name       = 'SetPropertyAllowedAsDeclared';
-        $sniffCode  = "Fixtures.Category.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\Category\\'.$name.'Sniff';
+        $name       = 'AllowedAsDeclared';
+        $sniffCode  = "Fixtures.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
-        $standard = __DIR__."/{$name}Test.xml";
+        $standard = __DIR__."/SetProperty{$name}Test.xml";
         $config   = new Config(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 


### PR DESCRIPTION
## Description

### Tests/SetSniffPropertyTest: rename fixtures

With an eye on adding additional tests for the Ruleset class, which would require additional test fixtures, this commit renames the `Category` subdirectory to `SetProperty` to directly link the fixtures in that folder to the `SetSniffPropertyTest`.

It also removes the `SetProperty` prefix from the dummy sniffs in that folder as it is not necessary anymore what with the folder being renamed.

Includes making the necessary updates to the dummy sniffs and the tests to allow for the rename.

### Tests/SetSniffPropertyTest: use named data within data sets

This commit adds the parameter name for each item in the data set in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes minor array normalization.
Includes making the data type in the docblock more specific.

## Suggested changelog entry
_N/A_
