### PR TITLE
Tests/BackfillReadonlyTest: use named data sets and other tweaks

### DIFF
--- a/tests/Core/Tokenizer/BackfillReadonlyTest.inc
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.inc
@@ -130,7 +130,7 @@ class ReadonlyWithDisjunctiveNormalForm
     public function __construct(
         /* testReadonlyConstructorPropertyPromotionWithDNF */
         private readonly (B&C)|A $b1,
-        /* testReadonlyConstructorPropertyPromotionWithDNFAndRefence */
+        /* testReadonlyConstructorPropertyPromotionWithDNFAndReference */
         readonly (B&C)|A &$b2,
     ) {}
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -19,14 +19,15 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      * Test that the "readonly" keyword is tokenized as such.
      *
      * @param string $testMarker  The comment which prefaces the target token in the test file.
-     * @param string $testContent The token content to look for.
+     * @param string $testContent Optional. The token content to look for.
+     *                            Defaults to lowercase "readonly".
      *
      * @dataProvider dataReadonly
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
      *
      * @return void
      */
-    public function testReadonly($testMarker, $testContent)
+    public function testReadonly($testMarker, $testContent='readonly')
     {
         $tokens = self::$phpcsFile->getTokens();
 
@@ -49,87 +50,66 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
         return [
             [
                 '/* testReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testVarReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testReadonlyVarProperty */',
-                'readonly',
             ],
             [
                 '/* testStaticReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testReadonlyStaticProperty */',
-                'readonly',
             ],
             [
                 '/* testConstReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyWithoutType */',
-                'readonly',
             ],
             [
                 '/* testPublicReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testProtectedReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testPrivateReadonlyProperty */',
-                'readonly',
             ],
             [
                 '/* testPublicReadonlyPropertyWithReadonlyFirst */',
-                'readonly',
             ],
             [
                 '/* testProtectedReadonlyPropertyWithReadonlyFirst */',
-                'readonly',
             ],
             [
                 '/* testPrivateReadonlyPropertyWithReadonlyFirst */',
-                'readonly',
             ],
             [
                 '/* testReadonlyWithCommentsInDeclaration */',
-                'readonly',
             ],
             [
                 '/* testReadonlyWithNullableProperty */',
-                'readonly',
             ],
             [
                 '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullFirst */',
-                'readonly',
             ],
             [
                 '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullLast */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyWithArrayTypeHint */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyWithSelfTypeHint */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyWithParentTypeHint */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyWithFullyQualifiedTypeHint */',
-                'readonly',
             ],
             [
                 '/* testReadonlyIsCaseInsensitive */',
@@ -137,7 +117,6 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyConstructorPropertyPromotion */',
-                'readonly',
             ],
             [
                 '/* testReadonlyConstructorPropertyPromotionWithReference */',
@@ -145,47 +124,36 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyPropertyInAnonymousClass */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeUnqualified */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeFullyQualified */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypePartiallyQualified */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeRelativeName */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeMultipleSets */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeWithArray */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyDNFTypeWithSpacesAndComments */',
-                'readonly',
             ],
             [
                 '/* testReadonlyConstructorPropertyPromotionWithDNF */',
-                'readonly',
             ],
             [
                 '/* testReadonlyConstructorPropertyPromotionWithDNFAndReference */',
-                'readonly',
             ],
             [
                 '/* testParseErrorLiveCoding */',
-                'readonly',
             ],
         ];
 
@@ -196,14 +164,15 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      * Test that "readonly" when not used as the keyword is still tokenized as `T_STRING`.
      *
      * @param string $testMarker  The comment which prefaces the target token in the test file.
-     * @param string $testContent The token content to look for.
+     * @param string $testContent Optional. The token content to look for.
+     *                            Defaults to lowercase "readonly".
      *
      * @dataProvider dataNotReadonly
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
      *
      * @return void
      */
-    public function testNotReadonly($testMarker, $testContent)
+    public function testNotReadonly($testMarker, $testContent='readonly')
     {
         $tokens = self::$phpcsFile->getTokens();
 
@@ -230,23 +199,18 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyUsedAsMethodName */',
-                'readonly',
             ],
             [
                 '/* testReadonlyUsedAsPropertyName */',
-                'readonly',
             ],
             [
                 '/* testReadonlyPropertyInTernaryOperator */',
-                'readonly',
             ],
             [
                 '/* testReadonlyUsedAsFunctionName */',
-                'readonly',
             ],
             [
                 '/* testReadonlyUsedAsFunctionNameWithReturnByRef */',
-                'readonly',
             ],
             [
                 '/* testReadonlyUsedAsNamespaceName */',
@@ -258,11 +222,9 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyAsFunctionCall */',
-                'readonly',
             ],
             [
                 '/* testReadonlyAsNamespacedFunctionCall */',
-                'readonly',
             ],
             [
                 '/* testReadonlyAsNamespaceRelativeFunctionCall */',
@@ -270,7 +232,6 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyAsMethodCall */',
-                'readonly',
             ],
             [
                 '/* testReadonlyAsNullsafeMethodCall */',
@@ -278,7 +239,6 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyAsStaticMethodCallWithSpace */',
-                'readonly',
             ],
             [
                 '/* testClassConstantFetchWithReadonlyAsConstantName */',
@@ -286,11 +246,9 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
             ],
             [
                 '/* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */',
-                'readonly',
             ],
             [
                 '/* testReadonlyUsedAsMethodNameWithDNFParam */',
-                'readonly',
             ],
         ];
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -43,117 +43,117 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      *
      * @see testReadonly()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataReadonly()
     {
         return [
-            [
-                '/* testReadonlyProperty */',
+            'property declaration, no visibility'                                             => [
+                'testMarker' => '/* testReadonlyProperty */',
             ],
-            [
-                '/* testVarReadonlyProperty */',
+            'property declaration, var keyword before'                                        => [
+                'testMarker' => '/* testVarReadonlyProperty */',
             ],
-            [
-                '/* testReadonlyVarProperty */',
+            'property declaration, var keyword after'                                         => [
+                'testMarker' => '/* testReadonlyVarProperty */',
             ],
-            [
-                '/* testStaticReadonlyProperty */',
+            'property declaration, static before'                                             => [
+                'testMarker' => '/* testStaticReadonlyProperty */',
             ],
-            [
-                '/* testReadonlyStaticProperty */',
+            'property declaration, static after'                                              => [
+                'testMarker' => '/* testReadonlyStaticProperty */',
             ],
-            [
-                '/* testConstReadonlyProperty */',
+            'constant declaration, with visibility'                                           => [
+                'testMarker' => '/* testConstReadonlyProperty */',
             ],
-            [
-                '/* testReadonlyPropertyWithoutType */',
+            'property declaration, missing type'                                              => [
+                'testMarker' => '/* testReadonlyPropertyWithoutType */',
             ],
-            [
-                '/* testPublicReadonlyProperty */',
+            'property declaration, public before'                                             => [
+                'testMarker' => '/* testPublicReadonlyProperty */',
             ],
-            [
-                '/* testProtectedReadonlyProperty */',
+            'property declaration, protected before'                                          => [
+                'testMarker' => '/* testProtectedReadonlyProperty */',
             ],
-            [
-                '/* testPrivateReadonlyProperty */',
+            'property declaration, private before'                                            => [
+                'testMarker' => '/* testPrivateReadonlyProperty */',
             ],
-            [
-                '/* testPublicReadonlyPropertyWithReadonlyFirst */',
+            'property declaration, public after'                                              => [
+                'testMarker' => '/* testPublicReadonlyPropertyWithReadonlyFirst */',
             ],
-            [
-                '/* testProtectedReadonlyPropertyWithReadonlyFirst */',
+            'property declaration, protected after'                                           => [
+                'testMarker' => '/* testProtectedReadonlyPropertyWithReadonlyFirst */',
             ],
-            [
-                '/* testPrivateReadonlyPropertyWithReadonlyFirst */',
+            'property declaration, private after'                                             => [
+                'testMarker' => '/* testPrivateReadonlyPropertyWithReadonlyFirst */',
             ],
-            [
-                '/* testReadonlyWithCommentsInDeclaration */',
+            'property declaration, private before, comments in declaration'                   => [
+                'testMarker' => '/* testReadonlyWithCommentsInDeclaration */',
             ],
-            [
-                '/* testReadonlyWithNullableProperty */',
+            'property declaration, private before, nullable type'                             => [
+                'testMarker' => '/* testReadonlyWithNullableProperty */',
             ],
-            [
-                '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullFirst */',
+            'property declaration, private before, union type, null first'                    => [
+                'testMarker' => '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullFirst */',
             ],
-            [
-                '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullLast */',
+            'property declaration, private before, union type, null last'                     => [
+                'testMarker' => '/* testReadonlyNullablePropertyWithUnionTypeHintAndNullLast */',
             ],
-            [
-                '/* testReadonlyPropertyWithArrayTypeHint */',
+            'property declaration, private before, array type'                                => [
+                'testMarker' => '/* testReadonlyPropertyWithArrayTypeHint */',
             ],
-            [
-                '/* testReadonlyPropertyWithSelfTypeHint */',
+            'property declaration, private before, self type'                                 => [
+                'testMarker' => '/* testReadonlyPropertyWithSelfTypeHint */',
             ],
-            [
-                '/* testReadonlyPropertyWithParentTypeHint */',
+            'property declaration, private before, parent type'                               => [
+                'testMarker' => '/* testReadonlyPropertyWithParentTypeHint */',
             ],
-            [
-                '/* testReadonlyPropertyWithFullyQualifiedTypeHint */',
+            'property declaration, private before, FQN type'                                  => [
+                'testMarker' => '/* testReadonlyPropertyWithFullyQualifiedTypeHint */',
             ],
-            [
-                '/* testReadonlyIsCaseInsensitive */',
-                'ReAdOnLy',
+            'property declaration, public before, mixed case'                                 => [
+                'testMarker'  => '/* testReadonlyIsCaseInsensitive */',
+                'testContent' => 'ReAdOnLy',
             ],
-            [
-                '/* testReadonlyConstructorPropertyPromotion */',
+            'property declaration, constructor property promotion'                            => [
+                'testMarker' => '/* testReadonlyConstructorPropertyPromotion */',
             ],
-            [
-                '/* testReadonlyConstructorPropertyPromotionWithReference */',
-                'ReadOnly',
+            'property declaration, constructor property promotion with reference, mixed case' => [
+                'testMarker'  => '/* testReadonlyConstructorPropertyPromotionWithReference */',
+                'testContent' => 'ReadOnly',
             ],
-            [
-                '/* testReadonlyPropertyInAnonymousClass */',
+            'property declaration, in anonymous class'                                        => [
+                'testMarker' => '/* testReadonlyPropertyInAnonymousClass */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeUnqualified */',
+            'property declaration, no visibility, DNF type, unqualified'                      => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeUnqualified */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeFullyQualified */',
+            'property declaration, public before, DNF type, fully qualified'                  => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeFullyQualified */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypePartiallyQualified */',
+            'property declaration, protected before, DNF type, partially qualified'           => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypePartiallyQualified */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeRelativeName */',
+            'property declaration, private before, DNF type, namespace relative name'         => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeRelativeName */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeMultipleSets */',
+            'property declaration, private before, DNF type, multiple sets'                   => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeMultipleSets */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeWithArray */',
+            'property declaration, private before, DNF type, union with array'                => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeWithArray */',
             ],
-            [
-                '/* testReadonlyPropertyDNFTypeWithSpacesAndComments */',
+            'property declaration, private before, DNF type, with spaces and comment'         => [
+                'testMarker' => '/* testReadonlyPropertyDNFTypeWithSpacesAndComments */',
             ],
-            [
-                '/* testReadonlyConstructorPropertyPromotionWithDNF */',
+            'property declaration, constructor property promotion, DNF type'                  => [
+                'testMarker' => '/* testReadonlyConstructorPropertyPromotionWithDNF */',
             ],
-            [
-                '/* testReadonlyConstructorPropertyPromotionWithDNFAndReference */',
+            'property declaration, constructor property promotion, DNF type and reference'    => [
+                'testMarker' => '/* testReadonlyConstructorPropertyPromotionWithDNFAndReference */',
             ],
-            [
-                '/* testParseErrorLiveCoding */',
+            'live coding / parse error'                                                       => [
+                'testMarker' => '/* testParseErrorLiveCoding */',
             ],
         ];
 
@@ -188,67 +188,67 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      *
      * @see testNotReadonly()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotReadonly()
     {
         return [
-            [
-                '/* testReadonlyUsedAsClassConstantName */',
-                'READONLY',
+            'name of a constant, context: declaration using "const" keyword, uppercase'           => [
+                'testMarker'  => '/* testReadonlyUsedAsClassConstantName */',
+                'testContent' => 'READONLY',
             ],
-            [
-                '/* testReadonlyUsedAsMethodName */',
+            'name of a method, context: declaration'                                              => [
+                'testMarker' => '/* testReadonlyUsedAsMethodName */',
             ],
-            [
-                '/* testReadonlyUsedAsPropertyName */',
+            'name of a property, context: property access'                                        => [
+                'testMarker' => '/* testReadonlyUsedAsPropertyName */',
             ],
-            [
-                '/* testReadonlyPropertyInTernaryOperator */',
+            'name of a property, context: property access in ternary'                             => [
+                'testMarker' => '/* testReadonlyPropertyInTernaryOperator */',
             ],
-            [
-                '/* testReadonlyUsedAsFunctionName */',
+            'name of a function, context: declaration'                                            => [
+                'testMarker' => '/* testReadonlyUsedAsFunctionName */',
             ],
-            [
-                '/* testReadonlyUsedAsFunctionNameWithReturnByRef */',
+            'name of a function, context: declaration with return by ref'                         => [
+                'testMarker' => '/* testReadonlyUsedAsFunctionNameWithReturnByRef */',
             ],
-            [
-                '/* testReadonlyUsedAsNamespaceName */',
-                'Readonly',
+            'name of namespace, context: declaration, mixed case'                                 => [
+                'testMarker'  => '/* testReadonlyUsedAsNamespaceName */',
+                'testContent' => 'Readonly',
             ],
-            [
-                '/* testReadonlyUsedAsPartOfNamespaceName */',
-                'Readonly',
+            'partial name of namespace, context: declaration, mixed case'                         => [
+                'testMarker'  => '/* testReadonlyUsedAsPartOfNamespaceName */',
+                'testContent' => 'Readonly',
             ],
-            [
-                '/* testReadonlyAsFunctionCall */',
+            'name of a function, context: call'                                                   => [
+                'testMarker' => '/* testReadonlyAsFunctionCall */',
             ],
-            [
-                '/* testReadonlyAsNamespacedFunctionCall */',
+            'name of a namespaced function, context: partially qualified call'                    => [
+                'testMarker' => '/* testReadonlyAsNamespacedFunctionCall */',
             ],
-            [
-                '/* testReadonlyAsNamespaceRelativeFunctionCall */',
-                'ReadOnly',
+            'name of a function, context: namespace relative call, mixed case'                    => [
+                'testMarker'  => '/* testReadonlyAsNamespaceRelativeFunctionCall */',
+                'testContent' => 'ReadOnly',
             ],
-            [
-                '/* testReadonlyAsMethodCall */',
+            'name of a method, context: method call on object'                                    => [
+                'testMarker' => '/* testReadonlyAsMethodCall */',
             ],
-            [
-                '/* testReadonlyAsNullsafeMethodCall */',
-                'readOnly',
+            'name of a method, context: nullsafe method call on object'                           => [
+                'testMarker'  => '/* testReadonlyAsNullsafeMethodCall */',
+                'testContent' => 'readOnly',
             ],
-            [
-                '/* testReadonlyAsStaticMethodCallWithSpace */',
+            'name of a method, context: static method call with space after'                      => [
+                'testMarker' => '/* testReadonlyAsStaticMethodCallWithSpace */',
             ],
-            [
-                '/* testClassConstantFetchWithReadonlyAsConstantName */',
-                'READONLY',
+            'name of a constant, context: constant access - uppercase'                            => [
+                'testMarker'  => '/* testClassConstantFetchWithReadonlyAsConstantName */',
+                'testContent' => 'READONLY',
             ],
-            [
-                '/* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */',
+            'name of a function, context: call with space and comment between keyword and parens' => [
+                'testMarker' => '/* testReadonlyUsedAsFunctionCallWithSpaceBetweenKeywordAndParens */',
             ],
-            [
-                '/* testReadonlyUsedAsMethodNameWithDNFParam */',
+            'name of a method, context: declaration with DNF parameter'                           => [
+                'testMarker' => '/* testReadonlyUsedAsMethodNameWithDNFParam */',
             ],
         ];
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -180,7 +180,7 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
                 'readonly',
             ],
             [
-                '/* testReadonlyConstructorPropertyPromotionWithDNFAndRefence */',
+                '/* testReadonlyConstructorPropertyPromotionWithDNFAndReference */',
                 'readonly',
             ],
             [


### PR DESCRIPTION
## Description

### Tests/BackfillReadonlyTest: fix typo in test case name

### Tests/BackfillReadonlyTest: simplify data providers

The token content for the "target token" of these tests is the same in most cases, but was explicitly provided in all cases.

This simplifies the data provider arrays by making the `$testContent` test parameters optional with a `'readonly'` default value, allowing for removing a significant number of the `$testContent` parameter values from the data providers.

### Tests/BackfillReadonlyTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes making the data types in the docblocks more specific.


## Suggested changelog entry
_N/A_