### PR TITLE
Tests/AttributesTest: use named data sets + activate a test

### DIFF
--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -69,14 +69,14 @@ final class AttributesTest extends AbstractMethodUnitTest
     public static function dataAttribute()
     {
         return [
-            'class attribute'                                                               => [
+            'class attribute'                                                                   => [
                 'testMarker' => '/* testAttribute */',
                 'length'     => 2,
                 'tokenCodes' => [
                     T_STRING
                 ],
             ],
-            'class attribute with param'                                                    => [
+            'class attribute with param'                                                        => [
                 'testMarker' => '/* testAttributeWithParams */',
                 'length'     => 7,
                 'tokenCodes' => [
@@ -88,7 +88,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            'class attribute with named param'                                              => [
+            'class attribute with named param'                                                  => [
                 'testMarker' => '/* testAttributeWithNamedParam */',
                 'length'     => 10,
                 'tokenCodes' => [
@@ -103,14 +103,14 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            'function attribute'                                                            => [
+            'function attribute'                                                                => [
                 'testMarker' => '/* testAttributeOnFunction */',
                 'length'     => 2,
                 'tokenCodes' => [
                     T_STRING
                 ],
             ],
-            'function attribute with params'                                                => [
+            'function attribute with params'                                                    => [
                 'testMarker' => '/* testAttributeOnFunctionWithParams */',
                 'length'     => 17,
                 'tokenCodes' => [
@@ -132,7 +132,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            'function attribute with arrow function as param'                               => [
+            'function attribute with arrow function as param'                                   => [
                 'testMarker' => '/* testAttributeWithShortClosureParameter */',
                 'length'     => 17,
                 'tokenCodes' => [
@@ -154,7 +154,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            'function attribute; multiple comma separated classes'                          => [
+            'function attribute; multiple comma separated classes'                              => [
                 'testMarker' => '/* testAttributeGrouping */',
                 'length'     => 26,
                 'tokenCodes' => [
@@ -185,7 +185,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            'function attribute; multiple comma separated classes, one per line'            => [
+            'function attribute; multiple comma separated classes, one per line'                => [
                 'testMarker' => '/* testAttributeMultiline */',
                 'length'     => 31,
                 'tokenCodes' => [
@@ -221,7 +221,46 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_WHITESPACE,
                 ],
             ],
-            'function attribute; using partially qualified and fully qualified class names' => [
+            'function attribute; multiple comma separated classes, one per line, with comments' => [
+                'testMarker' => '/* testAttributeMultilineWithComment */',
+                'length'     => 34,
+                'tokenCodes' => [
+                    T_WHITESPACE,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_COMMENT,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_COMMENT,
+                    T_WHITESPACE,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_PARENTHESIS,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_PARAM_NAME,
+                    T_COLON,
+                    T_WHITESPACE,
+                    T_OPEN_SHORT_ARRAY,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_WHITESPACE,
+                    T_DOUBLE_ARROW,
+                    T_WHITESPACE,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_SHORT_ARRAY,
+                    T_CLOSE_PARENTHESIS,
+                    T_WHITESPACE,
+                ],
+            ],
+            'function attribute; using partially qualified and fully qualified class names'     => [
                 'testMarker' => '/* testFqcnAttribute */',
                 'length'     => 13,
                 'tokenCodes' => [

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -18,9 +18,9 @@ final class AttributesTest extends AbstractMethodUnitTest
     /**
      * Test that attributes are parsed correctly.
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
-     * @param int    $length     The number of tokens between opener and closer.
-     * @param array  $tokenCodes The codes of tokens inside the attributes.
+     * @param string            $testMarker The comment which prefaces the target token in the test file.
+     * @param int               $length     The number of tokens between opener and closer.
+     * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
      *
      * @dataProvider dataAttribute
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -64,22 +64,22 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @see testAttribute()
      *
-     * @return array
+     * @return array<string, array<string, string|int|array<int|string>>>
      */
     public static function dataAttribute()
     {
         return [
-            [
-                '/* testAttribute */',
-                2,
-                [
-                    T_STRING,
+            'class attribute'                                                               => [
+                'testMarker' => '/* testAttribute */',
+                'length'     => 2,
+                'tokenCodes' => [
+                    T_STRING
                 ],
             ],
-            [
-                '/* testAttributeWithParams */',
-                7,
-                [
+            'class attribute with param'                                                    => [
+                'testMarker' => '/* testAttributeWithParams */',
+                'length'     => 7,
+                'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_STRING,
@@ -88,10 +88,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testAttributeWithNamedParam */',
-                10,
-                [
+            'class attribute with named param'                                              => [
+                'testMarker' => '/* testAttributeWithNamedParam */',
+                'length'     => 10,
+                'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_PARAM_NAME,
@@ -103,17 +103,17 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testAttributeOnFunction */',
-                2,
-                [
-                    T_STRING,
+            'function attribute'                                                            => [
+                'testMarker' => '/* testAttributeOnFunction */',
+                'length'     => 2,
+                'tokenCodes' => [
+                    T_STRING
                 ],
             ],
-            [
-                '/* testAttributeOnFunctionWithParams */',
-                17,
-                [
+            'function attribute with params'                                                => [
+                'testMarker' => '/* testAttributeOnFunctionWithParams */',
+                'length'     => 17,
+                'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_CONSTANT_ENCAPSED_STRING,
@@ -132,10 +132,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testAttributeWithShortClosureParameter */',
-                17,
-                [
+            'function attribute with arrow function as param'                               => [
+                'testMarker' => '/* testAttributeWithShortClosureParameter */',
+                'length'     => 17,
+                'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_STATIC,
@@ -154,10 +154,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testAttributeGrouping */',
-                26,
-                [
+            'function attribute; multiple comma separated classes'                          => [
+                'testMarker' => '/* testAttributeGrouping */',
+                'length'     => 26,
+                'tokenCodes' => [
                     T_STRING,
                     T_COMMA,
                     T_WHITESPACE,
@@ -185,10 +185,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testAttributeMultiline */',
-                31,
-                [
+            'function attribute; multiple comma separated classes, one per line'            => [
+                'testMarker' => '/* testAttributeMultiline */',
+                'length'     => 31,
+                'tokenCodes' => [
                     T_WHITESPACE,
                     T_WHITESPACE,
                     T_STRING,
@@ -221,10 +221,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_WHITESPACE,
                 ],
             ],
-            [
-                '/* testFqcnAttribute */',
-                13,
-                [
+            'function attribute; using partially qualified and fully qualified class names' => [
+                'testMarker' => '/* testFqcnAttribute */',
+                'length'     => 13,
+                'tokenCodes' => [
                     T_STRING,
                     T_NS_SEPARATOR,
                     T_STRING,
@@ -294,10 +294,10 @@ final class AttributesTest extends AbstractMethodUnitTest
     /**
      * Test that attributes on function declaration parameters are parsed correctly.
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
-     * @param int    $position   The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
-     * @param int    $length     The number of tokens between opener and closer.
-     * @param array  $tokenCodes The codes of tokens inside the attributes.
+     * @param string            $testMarker The comment which prefaces the target token in the test file.
+     * @param int               $position   The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
+     * @param int               $length     The number of tokens between opener and closer.
+     * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
      *
      * @dataProvider dataAttributeOnParameters
      *
@@ -347,24 +347,24 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @see testAttributeOnParameters()
      *
-     * @return array
+     * @return array<string, array<string, string|int|array<int|string>>>
      */
     public static function dataAttributeOnParameters()
     {
         return [
-            [
-                '/* testSingleAttributeOnParameter */',
-                4,
-                2,
-                [
-                    T_STRING,
+            'parameter attribute; single, inline'                   => [
+                'testMarker' => '/* testSingleAttributeOnParameter */',
+                'position'   => 4,
+                'length'     => 2,
+                'tokenCodes' => [
+                    T_STRING
                 ],
             ],
-            [
-                '/* testMultipleAttributesOnParameter */',
-                4,
-                10,
-                [
+            'parameter attribute; multiple comma separated, inline' => [
+                'testMarker' => '/* testMultipleAttributesOnParameter */',
+                'position'   => 4,
+                'length'     => 10,
+                'tokenCodes' => [
                     T_STRING,
                     T_COMMA,
                     T_WHITESPACE,
@@ -376,11 +376,11 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_PARENTHESIS,
                 ],
             ],
-            [
-                '/* testMultilineAttributesOnParameter */',
-                4,
-                13,
-                [
+            'parameter attribute; single, multiline'                => [
+                'testMarker' => '/* testMultilineAttributesOnParameter */',
+                'position'   => 4,
+                'length'     => 13,
+                'tokenCodes' => [
                     T_WHITESPACE,
                     T_WHITESPACE,
                     T_STRING,
@@ -403,10 +403,10 @@ final class AttributesTest extends AbstractMethodUnitTest
     /**
      * Test that an attribute containing text which looks like a PHP close tag is tokenized correctly.
      *
-     * @param string $testMarker              The comment which prefaces the target token in the test file.
-     * @param int    $length                  The number of tokens between opener and closer.
-     * @param array  $expectedTokensAttribute The codes of tokens inside the attributes.
-     * @param array  $expectedTokensAfter     The codes of tokens after the attributes.
+     * @param string               $testMarker              The comment which prefaces the target token in the test file.
+     * @param int                  $length                  The number of tokens between opener and closer.
+     * @param array<array<string>> $expectedTokensAttribute The codes of tokens inside the attributes.
+     * @param array<int|string>    $expectedTokensAfter     The codes of tokens after the attributes.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
      *
@@ -455,15 +455,15 @@ final class AttributesTest extends AbstractMethodUnitTest
      *
      * @see dataAttributeOnTextLookingLikeCloseTag()
      *
-     * @return array
+     * @return array<string, array<string, string|int|array<array<string>>|array<int|string>>>
      */
     public static function dataAttributeOnTextLookingLikeCloseTag()
     {
         return [
-            [
-                '/* testAttributeContainingTextLookingLikeCloseTag */',
-                5,
-                [
+            'function attribute; string param with "?>"'            => [
+                'testMarker'              => '/* testAttributeContainingTextLookingLikeCloseTag */',
+                'length'                  => 5,
+                'expectedTokensAttribute' => [
                     [
                         'T_STRING',
                         'DeprecationReason',
@@ -485,7 +485,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                         ']',
                     ],
                 ],
-                [
+                'expectedTokensAfter'     => [
                     T_WHITESPACE,
                     T_FUNCTION,
                     T_WHITESPACE,
@@ -497,10 +497,10 @@ final class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_CURLY_BRACKET,
                 ],
             ],
-            [
-                '/* testAttributeContainingMultilineTextLookingLikeCloseTag */',
-                8,
-                [
+            'function attribute; string param with "?>"; multiline' => [
+                'testMarker'              => '/* testAttributeContainingMultilineTextLookingLikeCloseTag */',
+                'length'                  => 8,
+                'expectedTokensAttribute' => [
                     [
                         'T_STRING',
                         'DeprecationReason',
@@ -534,7 +534,7 @@ final class AttributesTest extends AbstractMethodUnitTest
                         ']',
                     ],
                 ],
-                [
+                'expectedTokensAfter'     => [
                     T_WHITESPACE,
                     T_FUNCTION,
                     T_WHITESPACE,

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -72,7 +72,9 @@ final class AttributesTest extends AbstractMethodUnitTest
             [
                 '/* testAttribute */',
                 2,
-                [ T_STRING ],
+                [
+                    T_STRING,
+                ],
             ],
             [
                 '/* testAttributeWithParams */',
@@ -104,7 +106,9 @@ final class AttributesTest extends AbstractMethodUnitTest
             [
                 '/* testAttributeOnFunction */',
                 2,
-                [ T_STRING ],
+                [
+                    T_STRING,
+                ],
             ],
             [
                 '/* testAttributeOnFunctionWithParams */',
@@ -352,7 +356,9 @@ final class AttributesTest extends AbstractMethodUnitTest
                 '/* testSingleAttributeOnParameter */',
                 4,
                 2,
-                [T_STRING],
+                [
+                    T_STRING,
+                ],
             ],
             [
                 '/* testMultipleAttributesOnParameter */',


### PR DESCRIPTION
## Description

### Tests/AttributesTest: normalize data provider arrays

... to improve scannability of the test cases covered.

See #225

### Tests/AttributesTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes making the data types in the docblocks more specific.

### Tests/AttributesTest: activate a test

This test case already existed in the test case file, but was not being tested so far.

Fixed now.


## Suggested changelog entry
_N/A_