### PR TITLE
Tests/BackfillNumericSeparatorTest: simplify data sets + use named data sets

### DIFF
--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -44,7 +44,7 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      *
      * @see testBackfill()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataTestBackfill()
     {
@@ -64,67 +64,67 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
         }
 
         return [
-            [
+            'decimal integer'                                            => [
                 'marker' => '/* testSimpleLNumber */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '1_000_000_000',
             ],
-            [
+            'float'                                                      => [
                 'marker' => '/* testSimpleDNumber */',
                 'type'   => 'T_DNUMBER',
                 'value'  => '107_925_284.88',
             ],
-            [
+            'float, scientific notation, negative exponent with sigh'    => [
                 'marker' => '/* testFloat */',
                 'type'   => 'T_DNUMBER',
                 'value'  => '6.674_083e-11',
             ],
-            [
+            'float, scientific notation, positive exponent with sign'    => [
                 'marker' => '/* testFloat2 */',
                 'type'   => 'T_DNUMBER',
                 'value'  => '6.674_083e+11',
             ],
-            [
+            'float, scientific notation, positive exponent without sign' => [
                 'marker' => '/* testFloat3 */',
                 'type'   => 'T_DNUMBER',
                 'value'  => '1_2.3_4e1_23',
             ],
-            [
+            'hexidecimal integer/float'                                  => [
                 'marker' => '/* testHex */',
                 'type'   => $testHexType,
                 'value'  => '0xCAFE_F00D',
             ],
-            [
+            'hexidecimal integer/float with multiple underscores'        => [
                 'marker' => '/* testHexMultiple */',
                 'type'   => $testHexMultipleType,
                 'value'  => '0x42_72_6F_77_6E',
             ],
-            [
+            'hexidecimal integer'                                        => [
                 'marker' => '/* testHexInt */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '0x42_72_6F',
             ],
-            [
+            'binary integer'                                             => [
                 'marker' => '/* testBinary */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '0b0101_1111',
             ],
-            [
+            'octal integer'                                              => [
                 'marker' => '/* testOctal */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '0137_041',
             ],
-            [
+            'octal integer using explicit octal notation'                => [
                 'marker' => '/* testExplicitOctal */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '0o137_041',
             ],
-            [
+            'octal integer using explicit octal notation with capital O' => [
                 'marker' => '/* testExplicitOctalCapitalised */',
                 'type'   => 'T_LNUMBER',
                 'value'  => '0O137_041',
             ],
-            [
+            'integer more than PHP_INT_MAX becomes a float'              => [
                 'marker' => '/* testIntMoreThanMax */',
                 'type'   => $testIntMoreThanMaxType,
                 'value'  => '10_223_372_036_854_775_807',
@@ -138,8 +138,8 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      * Test that numbers using numeric separators which are considered parse errors and/or
      * which aren't relevant to the backfill, do not incorrectly trigger the backfill anyway.
      *
-     * @param string $testMarker     The comment which prefaces the target token in the test file.
-     * @param array  $expectedTokens The token type and content of the expected token sequence.
+     * @param string                           $testMarker     The comment which prefaces the target token in the test file.
+     * @param array<array<string, int|string>> $expectedTokens The token type and content of the expected token sequence.
      *
      * @dataProvider dataNoBackfill
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -165,14 +165,14 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      *
      * @see testBackfill()
      *
-     * @return array
+     * @return array<string, array<string, string|array<array<string, int|string>>>>
      */
     public static function dataNoBackfill()
     {
         return [
-            [
-                '/* testInvalid1 */',
-                [
+            'invalid: trailing underscore'                                      => [
+                'testMarker'     => '/* testInvalid1 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '100',
@@ -183,9 +183,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid2 */',
-                [
+            'invalid: two consecutive underscores'                              => [
+                'testMarker'     => '/* testInvalid2 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '1',
@@ -196,9 +196,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid3 */',
-                [
+            'invalid: underscore directly before decimal point'                 => [
+                'testMarker'     => '/* testInvalid3 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '1',
@@ -213,9 +213,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid4 */',
-                [
+            'invalid: underscore directly after decimal point'                  => [
+                'testMarker'     => '/* testInvalid4 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_DNUMBER,
                         'content' => '1.',
@@ -226,9 +226,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid5 */',
-                [
+            'invalid: hex int - underscore directly after x'                    => [
+                'testMarker'     => '/* testInvalid5 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '0',
@@ -239,9 +239,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid6 */',
-                [
+            'invalid: binary int - underscore directly after b'                 => [
+                'testMarker'     => '/* testInvalid6 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '0',
@@ -252,9 +252,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid7 */',
-                [
+            'invalid: scientific float - underscore directly before e'          => [
+                'testMarker'     => '/* testInvalid7 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '1',
@@ -265,9 +265,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid8 */',
-                [
+            'invalid: scientific float - underscore directly after e'           => [
+                'testMarker'     => '/* testInvalid8 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '1',
@@ -278,9 +278,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid9 */',
-                [
+            'invalid: space between parts of the number'                        => [
+                'testMarker'     => '/* testInvalid9 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '107_925_284',
@@ -295,9 +295,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid10 */',
-                [
+            'invalid: comment within the number'                                => [
+                'testMarker'     => '/* testInvalid10 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '107_925_284',
@@ -312,9 +312,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid11 */',
-                [
+            'invalid: explicit octal int - underscore directly after o'         => [
+                'testMarker'     => '/* testInvalid11 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '0',
@@ -325,9 +325,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalid12 */',
-                [
+            'invalid: explicit octal int - underscore directly after capital O' => [
+                'testMarker'     => '/* testInvalid12 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '0',
@@ -338,9 +338,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCalc1 */',
-                [
+            'calculations should be untouched - int - int'                      => [
+                'testMarker'     => '/* testCalc1 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_LNUMBER,
                         'content' => '667_083',
@@ -363,9 +363,9 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* test Calc2 */',
-                [
+            'calculations should be untouched - scientific float + int'         => [
+                'testMarker'     => '/* test Calc2 */',
+                'expectedTokens' => [
                     [
                         'code'    => T_DNUMBER,
                         'content' => '6.674_08e3',

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -18,21 +18,23 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
     /**
      * Test that numbers using numeric separators are tokenized correctly.
      *
-     * @param array $testData The data required for the specific test case.
+     * @param string $marker The comment which prefaces the target token in the test file.
+     * @param string $type   The expected token type.
+     * @param string $value  The expected token content.
      *
      * @dataProvider dataTestBackfill
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
      *
      * @return void
      */
-    public function testBackfill($testData)
+    public function testBackfill($marker, $type, $value)
     {
         $tokens = self::$phpcsFile->getTokens();
-        $number = $this->getTargetToken($testData['marker'], [T_LNUMBER, T_DNUMBER]);
+        $number = $this->getTargetToken($marker, [T_LNUMBER, T_DNUMBER]);
 
-        $this->assertSame(constant($testData['type']), $tokens[$number]['code']);
-        $this->assertSame($testData['type'], $tokens[$number]['type']);
-        $this->assertSame($testData['value'], $tokens[$number]['content']);
+        $this->assertSame(constant($type), $tokens[$number]['code']);
+        $this->assertSame($type, $tokens[$number]['type']);
+        $this->assertSame($value, $tokens[$number]['content']);
 
     }//end testBackfill()
 
@@ -63,95 +65,69 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 
         return [
             [
-                [
-                    'marker' => '/* testSimpleLNumber */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '1_000_000_000',
-                ],
+                'marker' => '/* testSimpleLNumber */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '1_000_000_000',
             ],
             [
-                [
-                    'marker' => '/* testSimpleDNumber */',
-                    'type'   => 'T_DNUMBER',
-                    'value'  => '107_925_284.88',
-                ],
+                'marker' => '/* testSimpleDNumber */',
+                'type'   => 'T_DNUMBER',
+                'value'  => '107_925_284.88',
             ],
             [
-                [
-                    'marker' => '/* testFloat */',
-                    'type'   => 'T_DNUMBER',
-                    'value'  => '6.674_083e-11',
-                ],
+                'marker' => '/* testFloat */',
+                'type'   => 'T_DNUMBER',
+                'value'  => '6.674_083e-11',
             ],
             [
-                [
-                    'marker' => '/* testFloat2 */',
-                    'type'   => 'T_DNUMBER',
-                    'value'  => '6.674_083e+11',
-                ],
+                'marker' => '/* testFloat2 */',
+                'type'   => 'T_DNUMBER',
+                'value'  => '6.674_083e+11',
             ],
             [
-                [
-                    'marker' => '/* testFloat3 */',
-                    'type'   => 'T_DNUMBER',
-                    'value'  => '1_2.3_4e1_23',
-                ],
+                'marker' => '/* testFloat3 */',
+                'type'   => 'T_DNUMBER',
+                'value'  => '1_2.3_4e1_23',
             ],
             [
-                [
-                    'marker' => '/* testHex */',
-                    'type'   => $testHexType,
-                    'value'  => '0xCAFE_F00D',
-                ],
+                'marker' => '/* testHex */',
+                'type'   => $testHexType,
+                'value'  => '0xCAFE_F00D',
             ],
             [
-                [
-                    'marker' => '/* testHexMultiple */',
-                    'type'   => $testHexMultipleType,
-                    'value'  => '0x42_72_6F_77_6E',
-                ],
+                'marker' => '/* testHexMultiple */',
+                'type'   => $testHexMultipleType,
+                'value'  => '0x42_72_6F_77_6E',
             ],
             [
-                [
-                    'marker' => '/* testHexInt */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '0x42_72_6F',
-                ],
+                'marker' => '/* testHexInt */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '0x42_72_6F',
             ],
             [
-                [
-                    'marker' => '/* testBinary */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '0b0101_1111',
-                ],
+                'marker' => '/* testBinary */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '0b0101_1111',
             ],
             [
-                [
-                    'marker' => '/* testOctal */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '0137_041',
-                ],
+                'marker' => '/* testOctal */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '0137_041',
             ],
             [
-                [
-                    'marker' => '/* testExplicitOctal */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '0o137_041',
-                ],
+                'marker' => '/* testExplicitOctal */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '0o137_041',
             ],
             [
-                [
-                    'marker' => '/* testExplicitOctalCapitalised */',
-                    'type'   => 'T_LNUMBER',
-                    'value'  => '0O137_041',
-                ],
+                'marker' => '/* testExplicitOctalCapitalised */',
+                'type'   => 'T_LNUMBER',
+                'value'  => '0O137_041',
             ],
             [
-                [
-                    'marker' => '/* testIntMoreThanMax */',
-                    'type'   => $testIntMoreThanMaxType,
-                    'value'  => '10_223_372_036_854_775_807',
-                ],
+                'marker' => '/* testIntMoreThanMax */',
+                'type'   => $testIntMoreThanMaxType,
+                'value'  => '10_223_372_036_854_775_807',
             ],
         ];
 


### PR DESCRIPTION
## Description

### Tests/BackfillNumericSeparatorTest::dataTestBackfill(): simplify data sets

The data for each set was previously passed as an array instead of as values, even though the number of array items was known and stable.

Fixed now.

### Tests/BackfillNumericSeparatorTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes making the data type in the docblock more specific.


## Suggested changelog entry
_N/A_