### PR TITLE
Tests/HeredocNowdocCloserTest: clean up + use named data sets

### DIFF
--- a/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the tokenization of goto declarations and statements.
+ * Tests the tokenization of heredoc/nowdoc closer tokens.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -23,8 +23,8 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
     /**
      * Verify that leading (indent) whitespace in a heredoc/nowdoc closer token get the tab replacement treatment.
      *
-     * @param string $testMarker The comment prefacing the target token.
-     * @param array  $expected   Expectations for the token array.
+     * @param string                         $testMarker The comment prefacing the target token.
+     * @param array<string, int|string|null> $expected   Expectations for the token array.
      *
      * @dataProvider dataHeredocNowdocCloserTabReplacement
      * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
@@ -55,12 +55,12 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
      *
      * @see testHeredocNowdocCloserTabReplacement()
      *
-     * @return array
+     * @return array<string, array<string, string|array<string, int|string|null>>>
      */
     public static function dataHeredocNowdocCloserTabReplacement()
     {
         return [
-            [
+            'Heredoc closer without indent'      => [
                 'testMarker' => '/* testHeredocCloserNoIndent */',
                 'expected'   => [
                     'length'       => 3,
@@ -68,7 +68,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
                     'orig_content' => null,
                 ],
             ],
-            [
+            'Nowdoc closer without indent'       => [
                 'testMarker' => '/* testNowdocCloserNoIndent */',
                 'expected'   => [
                     'length'       => 3,
@@ -76,7 +76,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
                     'orig_content' => null,
                 ],
             ],
-            [
+            'Heredoc closer with indent, spaces' => [
                 'testMarker' => '/* testHeredocCloserSpaceIndent */',
                 'expected'   => [
                     'length'       => 7,
@@ -84,7 +84,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
                     'orig_content' => null,
                 ],
             ],
-            [
+            'Nowdoc closer with indent, spaces'  => [
                 'testMarker' => '/* testNowdocCloserSpaceIndent */',
                 'expected'   => [
                     'length'       => 8,
@@ -92,7 +92,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
                     'orig_content' => null,
                 ],
             ],
-            [
+            'Heredoc closer with indent, tabs'   => [
                 'testMarker' => '/* testHeredocCloserTabIndent */',
                 'expected'   => [
                     'length'       => 8,
@@ -100,7 +100,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
                     'orig_content' => '	 END',
                 ],
             ],
-            [
+            'Nowdoc closer with indent, tabs'    => [
                 'testMarker' => '/* testNowdocCloserTabIndent */',
                 'expected'   => [
                     'length'       => 7,

--- a/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
@@ -9,9 +9,6 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
 /**
@@ -21,39 +18,6 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  */
 final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
 {
-
-
-    /**
-     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
-     *
-     * {@internal This is a near duplicate of the original method. Only difference is that
-     * tab replacement is enabled for this test.}
-     *
-     * @beforeClass
-     *
-     * @return void
-     */
-    public static function initializeFile()
-    {
-        $config            = new Config();
-        $config->standards = ['PSR1'];
-        $config->tabWidth  = 4;
-
-        $ruleset = new Ruleset($config);
-
-        // Default to a file with the same name as the test class. Extension is property based.
-        $relativeCN     = str_replace(__NAMESPACE__, '', get_called_class());
-        $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
-        $pathToTestFile = realpath(__DIR__).$relativePath.'.'.static::$fileExtension;
-
-        // Make sure the file gets parsed correctly based on the file type.
-        $contents  = 'phpcs_input_file: '.$pathToTestFile.PHP_EOL;
-        $contents .= file_get_contents($pathToTestFile);
-
-        self::$phpcsFile = new DummyFile($contents, $ruleset, $config);
-        self::$phpcsFile->process();
-
-    }//end initializeFile()
 
 
     /**


### PR DESCRIPTION
## Description

### Tests/HeredocNowdocCloserTest: remove overloaded "setUpBeforeClass" method

Follow up on #220 / commit 5aa4362 .

As the `tabWidth` setting is now available via the `AbstractMethodUnitTest`, the `initializeFile()` method no longer needs to be overloaded for this test.

### Tests/HeredocNowdocCloserTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Includes making the data type in the docblock more specific.
Includes fixing up the docblock description for the file.

## Suggested changelog entry
_N/A_