### PR TITLE
Tests/EnumCaseTest: use named data sets + activate three extra tests

### DIFF
--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -149,6 +149,9 @@ final class EnumCaseTest extends AbstractMethodUnitTest
             ['/* testKeywordAsEnumCaseNameShouldBeString2 */'],
             ['/* testKeywordAsEnumCaseNameShouldBeString3 */'],
             ['/* testKeywordAsEnumCaseNameShouldBeString4 */'],
+            ['/* testKeywordAsEnumCaseNameShouldBeString5 */'],
+            ['/* testKeywordAsEnumCaseNameShouldBeString6 */'],
+            ['/* testKeywordAsEnumCaseNameShouldBeString7 */'],
         ];
 
     }//end dataKeywordAsEnumCaseNameShouldBeString()

--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -47,18 +47,18 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @see testEnumCases()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataEnumCases()
     {
         return [
-            ['/* testPureEnumCase */'],
-            ['/* testBackingIntegerEnumCase */'],
-            ['/* testBackingStringEnumCase */'],
-            ['/* testEnumCaseInComplexEnum */'],
-            ['/* testEnumCaseIsCaseInsensitive */'],
-            ['/* testEnumCaseAfterSwitch */'],
-            ['/* testEnumCaseAfterSwitchWithEndSwitch */'],
+            'enum case, no value'                                        => ['/* testPureEnumCase */'],
+            'enum case, integer value'                                   => ['/* testBackingIntegerEnumCase */'],
+            'enum case, string value'                                    => ['/* testBackingStringEnumCase */'],
+            'enum case, integer value in more complex enum'              => ['/* testEnumCaseInComplexEnum */'],
+            'enum case, keyword in mixed case'                           => ['/* testEnumCaseIsCaseInsensitive */'],
+            'enum case, after switch statement'                          => ['/* testEnumCaseAfterSwitch */'],
+            'enum case, after switch statement using alternative syntax' => ['/* testEnumCaseAfterSwitchWithEndSwitch */'],
         ];
 
     }//end dataEnumCases()
@@ -96,18 +96,18 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @see testNotEnumCases()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataNotEnumCases()
     {
         return [
-            ['/* testCaseWithSemicolonIsNotEnumCase */'],
-            ['/* testCaseWithConstantIsNotEnumCase */'],
-            ['/* testCaseWithConstantAndIdenticalIsNotEnumCase */'],
-            ['/* testCaseWithAssigmentToConstantIsNotEnumCase */'],
-            ['/* testIsNotEnumCaseIsCaseInsensitive */'],
-            ['/* testCaseInSwitchWhenCreatingEnumInSwitch1 */'],
-            ['/* testCaseInSwitchWhenCreatingEnumInSwitch2 */'],
+            'switch case with constant, semicolon condition end' => ['/* testCaseWithSemicolonIsNotEnumCase */'],
+            'switch case with constant, colon condition end'     => ['/* testCaseWithConstantIsNotEnumCase */'],
+            'switch case with constant, comparison'              => ['/* testCaseWithConstantAndIdenticalIsNotEnumCase */'],
+            'switch case with constant, assignment'              => ['/* testCaseWithAssigmentToConstantIsNotEnumCase */'],
+            'switch case with constant, keyword in mixed case'   => ['/* testIsNotEnumCaseIsCaseInsensitive */'],
+            'switch case, body in curlies declares enum'         => ['/* testCaseInSwitchWhenCreatingEnumInSwitch1 */'],
+            'switch case, body after semicolon declares enum'    => ['/* testCaseInSwitchWhenCreatingEnumInSwitch2 */'],
         ];
 
     }//end dataNotEnumCases()
@@ -140,18 +140,18 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      *
      * @see testKeywordAsEnumCaseNameShouldBeString()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataKeywordAsEnumCaseNameShouldBeString()
     {
         return [
-            ['/* testKeywordAsEnumCaseNameShouldBeString1 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString2 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString3 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString4 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString5 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString6 */'],
-            ['/* testKeywordAsEnumCaseNameShouldBeString7 */'],
+            '"interface" as case name' => ['/* testKeywordAsEnumCaseNameShouldBeString1 */'],
+            '"trait" as case name'     => ['/* testKeywordAsEnumCaseNameShouldBeString2 */'],
+            '"enum" as case name'      => ['/* testKeywordAsEnumCaseNameShouldBeString3 */'],
+            '"function" as case name'  => ['/* testKeywordAsEnumCaseNameShouldBeString4 */'],
+            '"false" as case name'     => ['/* testKeywordAsEnumCaseNameShouldBeString5 */'],
+            '"default" as case name'   => ['/* testKeywordAsEnumCaseNameShouldBeString6 */'],
+            '"array" as case name'     => ['/* testKeywordAsEnumCaseNameShouldBeString7 */'],
         ];
 
     }//end dataKeywordAsEnumCaseNameShouldBeString()


### PR DESCRIPTION
## Description

### Tests/EnumCaseTest: activate three test cases

These test cases already existed in the test case file, but were not being run as tests.

Fixed now.

### Tests/EnumCaseTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Includes making the data type in the docblock more specific.

## Suggested changelog entry
_N/A_