### PR TITLE
Tests/UndoNamespacedNameSingleTokenTest: use named data sets

### DIFF
--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc
@@ -79,7 +79,7 @@ class MyClass
             /* testFunctionCallUnqualified */
             echo function_name();
 
-            /* testFunctionPartiallyQualified */
+            /* testFunctionCallPartiallyQualified */
             echo Level\function_name();
 
         /* testCatchRelative */

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -831,7 +831,7 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                 ],
             ],
             [
-                '/* testFunctionPartiallyQualified */',
+                '/* testFunctionCallPartiallyQualified */',
                 [
                     [
                         'type'    => 'T_STRING',

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -28,8 +28,8 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
     /**
      * Test that identifier names are tokenized the same across PHP versions, based on the PHP 5/7 tokenization.
      *
-     * @param string $testMarker     The comment prefacing the test.
-     * @param array  $expectedTokens The tokenization expected.
+     * @param string                       $testMarker     The comment prefacing the test.
+     * @param array<array<string, string>> $expectedTokens The tokenization expected.
      *
      * @dataProvider dataIdentifierTokenization
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -57,14 +57,14 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
      *
      * @see testIdentifierTokenization()
      *
-     * @return array
+     * @return array<string, array<string, string|array<array<string, string>>>>
      */
     public static function dataIdentifierTokenization()
     {
         return [
-            [
-                '/* testNamespaceDeclaration */',
-                [
+            'namespace declaration'                                                                       => [
+                'testMarker'     => '/* testNamespaceDeclaration */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Package',
@@ -75,9 +75,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testNamespaceDeclarationWithLevels */',
-                [
+            'namespace declaration, multi-level'                                                          => [
+                'testMarker'     => '/* testNamespaceDeclarationWithLevels */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Vendor',
@@ -104,9 +104,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testUseStatement */',
-                [
+            'import use statement, class'                                                                 => [
+                'testMarker'     => '/* testUseStatement */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'ClassName',
@@ -117,9 +117,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testUseStatementWithLevels */',
-                [
+            'import use statement, class, multi-level'                                                    => [
+                'testMarker'     => '/* testUseStatementWithLevels */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Vendor',
@@ -146,9 +146,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionUseStatement */',
-                [
+            'import use statement, function'                                                              => [
+                'testMarker'     => '/* testFunctionUseStatement */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'function',
@@ -167,9 +167,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionUseStatementWithLevels */',
-                [
+            'import use statement, function, multi-level'                                                 => [
+                'testMarker'     => '/* testFunctionUseStatementWithLevels */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'function',
@@ -204,9 +204,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testConstantUseStatement */',
-                [
+            'import use statement, constant'                                                              => [
+                'testMarker'     => '/* testConstantUseStatement */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'const',
@@ -225,9 +225,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testConstantUseStatementWithLevels */',
-                [
+            'import use statement, constant, multi-level'                                                 => [
+                'testMarker'     => '/* testConstantUseStatementWithLevels */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'const',
@@ -262,9 +262,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiUseUnqualified */',
-                [
+            'import use statement, multi-statement, unqualified class'                                    => [
+                'testMarker'     => '/* testMultiUseUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'UnqualifiedClassName',
@@ -275,9 +275,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiUsePartiallyQualified */',
-                [
+            'import use statement, multi-statement, partially qualified class'                            => [
+                'testMarker'     => '/* testMultiUsePartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Sublevel',
@@ -296,9 +296,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testGroupUseStatement */',
-                [
+            'group use statement, multi-level prefix, mix inside group'                                   => [
+                'testMarker'     => '/* testGroupUseStatement */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Vendor',
@@ -492,9 +492,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testClassName */',
-                [
+            'class declaration'                                                                           => [
+                'testMarker'     => '/* testClassName */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'MyClass',
@@ -506,9 +506,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testExtendedFQN */',
-                [
+            'class declaration, extends fully qualified name'                                             => [
+                'testMarker'     => '/* testExtendedFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -540,9 +540,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testImplementsRelative */',
-                [
+            'class declaration, implements namespace relative name'                                       => [
+                'testMarker'     => '/* testImplementsRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -561,9 +561,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testImplementsFQN */',
-                [
+            'class declaration, implements fully qualified name'                                          => [
+                'testMarker'     => '/* testImplementsFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -586,9 +586,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testImplementsUnqualified */',
-                [
+            'class declaration, implements unqualified name'                                              => [
+                'testMarker'     => '/* testImplementsUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Unqualified',
@@ -599,9 +599,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testImplementsPartiallyQualified */',
-                [
+            'class declaration, implements partially qualified name'                                      => [
+                'testMarker'     => '/* testImplementsPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Sub',
@@ -629,9 +629,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionName */',
-                [
+            'method declaration'                                                                          => [
+                'testMarker'     => '/* testFunctionName */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'function_name',
@@ -642,9 +642,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testTypeDeclarationRelative */',
-                [
+            'param type declaration, namespace relative name'                                             => [
+                'testMarker'     => '/* testTypeDeclarationRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -667,9 +667,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testTypeDeclarationFQN */',
-                [
+            'param type declaration, fully qualified name'                                                => [
+                'testMarker'     => '/* testTypeDeclarationFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -700,9 +700,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testTypeDeclarationUnqualified */',
-                [
+            'param type declaration, unqualified name'                                                    => [
+                'testMarker'     => '/* testTypeDeclarationUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Unqualified',
@@ -717,9 +717,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testTypeDeclarationPartiallyQualified */',
-                [
+            'param type declaration, partially qualified name'                                            => [
+                'testMarker'     => '/* testTypeDeclarationPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NULLABLE',
                         'content' => '?',
@@ -742,9 +742,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testReturnTypeFQN */',
-                [
+            'return type declaration, fully qualified name'                                               => [
+                'testMarker'     => '/* testReturnTypeFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NULLABLE',
                         'content' => '?',
@@ -763,9 +763,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionCallRelative */',
-                [
+            'function call, namespace relative name'                                                      => [
+                'testMarker'     => '/* testFunctionCallRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'NameSpace',
@@ -784,9 +784,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionCallFQN */',
-                [
+            'function call, fully qualified name'                                                         => [
+                'testMarker'     => '/* testFunctionCallFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -817,9 +817,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionCallUnqualified */',
-                [
+            'function call, unqualified name'                                                             => [
+                'testMarker'     => '/* testFunctionCallUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'function_name',
@@ -830,9 +830,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testFunctionCallPartiallyQualified */',
-                [
+            'function call, partially qualified name'                                                     => [
+                'testMarker'     => '/* testFunctionCallPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Level',
@@ -851,9 +851,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCatchRelative */',
-                [
+            'catch, namespace relative name'                                                              => [
+                'testMarker'     => '/* testCatchRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -880,9 +880,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCatchFQN */',
-                [
+            'catch, fully qualified name'                                                                 => [
+                'testMarker'     => '/* testCatchFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -897,9 +897,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCatchUnqualified */',
-                [
+            'catch, unqualified name'                                                                     => [
+                'testMarker'     => '/* testCatchUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Exception',
@@ -910,9 +910,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCatchPartiallyQualified */',
-                [
+            'catch, partially qualified name'                                                             => [
+                'testMarker'     => '/* testCatchPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Level',
@@ -931,9 +931,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testNewRelative */',
-                [
+            'class instantiation, namespace relative name'                                                => [
+                'testMarker'     => '/* testNewRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -952,9 +952,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testNewFQN */',
-                [
+            'class instantiation, fully qualified name'                                                   => [
+                'testMarker'     => '/* testNewFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -977,9 +977,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testNewUnqualified */',
-                [
+            'class instantiation, unqualified name'                                                       => [
+                'testMarker'     => '/* testNewUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'ClassName',
@@ -990,9 +990,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testNewPartiallyQualified */',
-                [
+            'class instantiation, partially qualified name'                                               => [
+                'testMarker'     => '/* testNewPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Level',
@@ -1011,9 +1011,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testDoubleColonRelative */',
-                [
+            'double colon class access, namespace relative name'                                          => [
+                'testMarker'     => '/* testDoubleColonRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -1032,9 +1032,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testDoubleColonFQN */',
-                [
+            'double colon class access, fully qualified name'                                             => [
+                'testMarker'     => '/* testDoubleColonFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -1049,9 +1049,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testDoubleColonUnqualified */',
-                [
+            'double colon class access, unqualified name'                                                 => [
+                'testMarker'     => '/* testDoubleColonUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'ClassName',
@@ -1062,9 +1062,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testDoubleColonPartiallyQualified */',
-                [
+            'double colon class access, partially qualified name'                                         => [
+                'testMarker'     => '/* testDoubleColonPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Level',
@@ -1083,9 +1083,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInstanceOfRelative */',
-                [
+            'instanceof, namespace relative name'                                                         => [
+                'testMarker'     => '/* testInstanceOfRelative */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -1104,9 +1104,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInstanceOfFQN */',
-                [
+            'instanceof, fully qualified name'                                                            => [
+                'testMarker'     => '/* testInstanceOfFQN */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',
@@ -1129,9 +1129,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInstanceOfUnqualified */',
-                [
+            'instanceof, unqualified name'                                                                => [
+                'testMarker'     => '/* testInstanceOfUnqualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'ClassName',
@@ -1142,9 +1142,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInstanceOfPartiallyQualified */',
-                [
+            'instanceof, partially qualified name'                                                        => [
+                'testMarker'     => '/* testInstanceOfPartiallyQualified */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_STRING',
                         'content' => 'Partially',
@@ -1163,9 +1163,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalidInPHP8Whitespace */',
-                [
+            'function call, namespace relative, with whitespace (invalid in PHP 8)'                       => [
+                'testMarker'     => '/* testInvalidInPHP8Whitespace */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NAMESPACE',
                         'content' => 'namespace',
@@ -1213,9 +1213,9 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testInvalidInPHP8Comments */',
-                [
+            'double colon class access, fully qualified, with whitespace and comments (invalid in PHP 8)' => [
+                'testMarker'     => '/* testInvalidInPHP8Comments */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_NS_SEPARATOR',
                         'content' => '\\',


### PR DESCRIPTION
## Description

### Tests/UndoNamespacedNameSingleTokenTest: improve test markers

Make the test marker names more descriptive.

### Tests/UndoNamespacedNameSingleTokenTest: use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes making the data types in the docblocks more specific.

## Suggested changelog entry
_N/A_