### PR TITLE
Tests/Tokenizer/various: use named data sets

### DIFF
--- a/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
@@ -70,13 +70,17 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      * @see testAnonClassNoParentheses()
      * @see testAnonClassNoParenthesesNextOpenClose()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataAnonClassNoParentheses()
     {
         return [
-            ['/* testNoParentheses */'],
-            ['/* testNoParenthesesAndEmptyTokens */'],
+            'plain'                                              => [
+                'testMarker' => '/* testNoParentheses */',
+            ],
+            'declaration contains comments and extra whitespace' => [
+                'testMarker' => '/* testNoParenthesesAndEmptyTokens */',
+            ],
         ];
 
     }//end dataAnonClassNoParentheses()
@@ -129,13 +133,17 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      *
      * @see testAnonClassWithParentheses()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataAnonClassWithParentheses()
     {
         return [
-            ['/* testWithParentheses */'],
-            ['/* testWithParenthesesAndEmptyTokens */'],
+            'plain'                                              => [
+                'testMarker' => '/* testWithParentheses */',
+            ],
+            'declaration contains comments and extra whitespace' => [
+                'testMarker' => '/* testWithParenthesesAndEmptyTokens */',
+            ],
         ];
 
     }//end dataAnonClassWithParentheses()

--- a/tests/Core/Tokenizer/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizer/ArrayKeywordTest.php
@@ -49,19 +49,27 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @see testArrayKeyword()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataArrayKeyword()
     {
         return [
-            'empty array'                           => ['/* testEmptyArray */'],
-            'array with space before parenthesis'   => ['/* testArrayWithSpace */'],
-            'array with comment before parenthesis' => [
-                '/* testArrayWithComment */',
-                'Array',
+            'empty array'                           => [
+                'testMarker' => '/* testEmptyArray */',
             ],
-            'nested: outer array'                   => ['/* testNestingArray */'],
-            'nested: inner array'                   => ['/* testNestedArray */'],
+            'array with space before parenthesis'   => [
+                'testMarker' => '/* testArrayWithSpace */',
+            ],
+            'array with comment before parenthesis' => [
+                'testMarker'  => '/* testArrayWithComment */',
+                'testContent' => 'Array',
+            ],
+            'nested: outer array'                   => [
+                'testMarker' => '/* testNestingArray */',
+            ],
+            'nested: inner array'                   => [
+                'testMarker' => '/* testNestedArray */',
+            ],
         ];
 
     }//end dataArrayKeyword()
@@ -101,17 +109,21 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @see testArrayType()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataArrayType()
     {
         return [
             'closure return type'        => [
-                '/* testClosureReturnType */',
-                'Array',
+                'testMarker'  => '/* testClosureReturnType */',
+                'testContent' => 'Array',
             ],
-            'function param type'        => ['/* testFunctionDeclarationParamType */'],
-            'function union return type' => ['/* testFunctionDeclarationReturnType */'],
+            'function param type'        => [
+                'testMarker' => '/* testFunctionDeclarationParamType */',
+            ],
+            'function union return type' => [
+                'testMarker' => '/* testFunctionDeclarationReturnType */',
+            ],
         ];
 
     }//end dataArrayType()
@@ -152,16 +164,18 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      *
      * @see testNotArrayKeyword()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotArrayKeyword()
     {
         return [
             'class-constant-name' => [
-                '/* testClassConst */',
-                'ARRAY',
+                'testMarker'  => '/* testClassConst */',
+                'testContent' => 'ARRAY',
             ],
-            'class-method-name'   => ['/* testClassMethod */'],
+            'class-method-name'   => [
+                'testMarker' => '/* testClassMethod */',
+            ],
         ];
 
     }//end dataNotArrayKeyword()

--- a/tests/Core/Tokenizer/BackfillEnumTest.inc
+++ b/tests/Core/Tokenizer/BackfillEnumTest.inc
@@ -66,10 +66,6 @@ enum /* comment */ Name
     case SOME_CASE;
 }
 
-enum /* testEnumUsedAsEnumName */ Enum
-{
-}
-
 /* testEnumUsedAsNamespaceName */
 namespace Enum;
 /* testEnumUsedAsPartOfNamespaceName */

--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -73,52 +73,52 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      *
      * @see testEnums()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataEnums()
     {
         return [
-            [
-                '/* testPureEnum */',
-                'enum',
-                4,
-                12,
+            'enum - pure'                                                                   => [
+                'testMarker'   => '/* testPureEnum */',
+                'testContent'  => 'enum',
+                'openerOffset' => 4,
+                'closerOffset' => 12,
             ],
-            [
-                '/* testBackedIntEnum */',
-                'enum',
-                7,
-                29,
+            'enum - backed int'                                                             => [
+                'testMarker'   => '/* testBackedIntEnum */',
+                'testContent'  => 'enum',
+                'openerOffset' => 7,
+                'closerOffset' => 29,
             ],
-            [
-                '/* testBackedStringEnum */',
-                'enum',
-                8,
-                30,
+            'enum - backed string'                                                          => [
+                'testMarker'   => '/* testBackedStringEnum */',
+                'testContent'  => 'enum',
+                'openerOffset' => 8,
+                'closerOffset' => 30,
             ],
-            [
-                '/* testComplexEnum */',
-                'enum',
-                11,
-                72,
+            'enum - backed int + implements'                                                => [
+                'testMarker'   => '/* testComplexEnum */',
+                'testContent'  => 'enum',
+                'openerOffset' => 11,
+                'closerOffset' => 72,
             ],
-            [
-                '/* testEnumWithEnumAsClassName */',
-                'enum',
-                6,
-                7,
+            'enum keyword when "enum" is the name for the construct (yes, this is allowed)' => [
+                'testMarker'   => '/* testEnumWithEnumAsClassName */',
+                'testContent'  => 'enum',
+                'openerOffset' => 6,
+                'closerOffset' => 7,
             ],
-            [
-                '/* testEnumIsCaseInsensitive */',
-                'EnUm',
-                4,
-                5,
+            'enum - keyword is case insensitive'                                            => [
+                'testMarker'   => '/* testEnumIsCaseInsensitive */',
+                'testContent'  => 'EnUm',
+                'openerOffset' => 4,
+                'closerOffset' => 5,
             ],
-            [
-                '/* testDeclarationContainingComment */',
-                'enum',
-                6,
-                14,
+            'enum - declaration containing comment'                                         => [
+                'testMarker'   => '/* testDeclarationContainingComment */',
+                'testContent'  => 'enum',
+                'openerOffset' => 6,
+                'closerOffset' => 14,
             ],
         ];
 
@@ -152,74 +152,70 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      *
      * @see testNotEnums()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotEnums()
     {
         return [
-            [
-                '/* testEnumAsClassNameAfterEnumKeyword */',
-                'Enum',
+            'not enum - construct named enum'                            => [
+                'testMarker'  => '/* testEnumAsClassNameAfterEnumKeyword */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testEnumUsedAsClassName */',
-                'Enum',
+            'not enum - class named enum'                                => [
+                'testMarker'  => '/* testEnumUsedAsClassName */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testEnumUsedAsClassConstantName */',
-                'ENUM',
+            'not enum - class constant named enum'                       => [
+                'testMarker'  => '/* testEnumUsedAsClassConstantName */',
+                'testContent' => 'ENUM',
             ],
-            [
-                '/* testEnumUsedAsMethodName */',
-                'enum',
+            'not enum - method named enum'                               => [
+                'testMarker'  => '/* testEnumUsedAsMethodName */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testEnumUsedAsPropertyName */',
-                'enum',
+            'not enum - class property named enum'                       => [
+                'testMarker'  => '/* testEnumUsedAsPropertyName */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testEnumUsedAsFunctionName */',
-                'enum',
+            'not enum - global function named enum'                      => [
+                'testMarker'  => '/* testEnumUsedAsFunctionName */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testEnumUsedAsEnumName */',
-                'Enum',
+            'not enum - namespace named enum'                            => [
+                'testMarker'  => '/* testEnumUsedAsNamespaceName */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testEnumUsedAsNamespaceName */',
-                'Enum',
+            'not enum - part of namespace named enum'                    => [
+                'testMarker'  => '/* testEnumUsedAsPartOfNamespaceName */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testEnumUsedAsPartOfNamespaceName */',
-                'Enum',
+            'not enum - class instantiation for class enum'              => [
+                'testMarker'  => '/* testEnumUsedInObjectInitialization */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testEnumUsedInObjectInitialization */',
-                'Enum',
+            'not enum - function call'                                   => [
+                'testMarker'  => '/* testEnumAsFunctionCall */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testEnumAsFunctionCall */',
-                'enum',
+            'not enum - namespace relative function call'                => [
+                'testMarker'  => '/* testEnumAsFunctionCallWithNamespace */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testEnumAsFunctionCallWithNamespace */',
-                'enum',
+            'not enum - class constant fetch with enum as class name'    => [
+                'testMarker'  => '/* testClassConstantFetchWithEnumAsClassName */',
+                'testContent' => 'Enum',
             ],
-            [
-                '/* testClassConstantFetchWithEnumAsClassName */',
-                'Enum',
+            'not enum - class constant fetch with enum as constant name' => [
+                'testMarker'  => '/* testClassConstantFetchWithEnumAsConstantName */',
+                'testContent' => 'ENUM',
             ],
-            [
-                '/* testClassConstantFetchWithEnumAsConstantName */',
-                'ENUM',
+            'parse error, not enum - enum declaration without name'      => [
+                'testMarker'  => '/* testParseErrorMissingName */',
+                'testContent' => 'enum',
             ],
-            [
-                '/* testParseErrorMissingName */',
-                'enum',
-            ],
-            [
-                '/* testParseErrorLiveCoding */',
-                'enum',
+            'parse error, not enum - enum declaration with curlies'      => [
+                'testMarker'  => '/* testParseErrorLiveCoding */',
+                'testContent' => 'enum',
             ],
         ];
 

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -47,66 +47,66 @@ final class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
      *
      * @see testExplicitOctalNotation()
      *
-     * @return array
+     * @return array<string, array<string, int|string>>
      */
     public static function dataExplicitOctalNotation()
     {
         return [
-            [
+            'Explicit octal'                                                                                       => [
                 'marker'      => '/* testExplicitOctal */',
                 'value'       => '0o137041',
                 'nextToken'   => T_SEMICOLON,
                 'nextContent' => ';',
             ],
-            [
+            'Explicit octal - capitalized O'                                                                       => [
                 'marker'      => '/* testExplicitOctalCapitalised */',
                 'value'       => '0O137041',
                 'nextToken'   => T_SEMICOLON,
                 'nextContent' => ';',
             ],
-            [
+            'Explicit octal - with numeric literal separator'                                                      => [
                 'marker'      => '/* testExplicitOctalWithNumericSeparator */',
                 'value'       => '0o137_041',
                 'nextToken'   => T_SEMICOLON,
                 'nextContent' => ';',
             ],
-            [
+            'Invalid explicit octal - numeric literal separator directly after "0o"'                               => [
                 'marker'      => '/* testInvalid1 */',
                 'value'       => '0',
                 'nextToken'   => T_STRING,
                 'nextContent' => 'o_137',
             ],
-            [
+            'Invalid explicit octal - numeric literal separator directly after "0O" (capitalized O)'               => [
                 'marker'      => '/* testInvalid2 */',
                 'value'       => '0',
                 'nextToken'   => T_STRING,
                 'nextContent' => 'O_41',
             ],
-            [
+            'Invalid explicit octal - number out of octal range'                                                   => [
                 'marker'      => '/* testInvalid3 */',
                 'value'       => '0',
                 'nextToken'   => T_STRING,
                 'nextContent' => 'o91',
             ],
-            [
+            'Invalid explicit octal - part of the number out of octal range'                                       => [
                 'marker'      => '/* testInvalid4 */',
                 'value'       => '0O2',
                 'nextToken'   => T_LNUMBER,
                 'nextContent' => '82',
             ],
-            [
+            'Invalid explicit octal - part of the number out of octal range with numeric literal separator after'  => [
                 'marker'      => '/* testInvalid5 */',
                 'value'       => '0o2',
                 'nextToken'   => T_LNUMBER,
                 'nextContent' => '8_2',
             ],
-            [
+            'Invalid explicit octal - part of the number out of octal range with numeric literal separator before' => [
                 'marker'      => '/* testInvalid6 */',
                 'value'       => '0o2',
                 'nextToken'   => T_STRING,
                 'nextContent' => '_82',
             ],
-            [
+            'Invalid explicit octal - explicit notation without number'                                            => [
                 'marker'      => '/* testInvalid7 */',
                 'value'       => '0',
                 'nextToken'   => T_STRING,

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -579,38 +579,38 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      *
      * @see testInMatchValue()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataInMatchValue()
     {
         return [
             'not_last_value'                      => [
-                '/* testInMatchNotLastValue */',
-                5,
-                11,
-                'T_COMMA',
-                'comma',
+                'testMarker'                 => '/* testInMatchNotLastValue */',
+                'openerOffset'               => 5,
+                'closerOffset'               => 11,
+                'expectedCloserType'         => 'T_COMMA',
+                'expectedCloserFriendlyName' => 'comma',
             ],
             'last_value_with_trailing_comma'      => [
-                '/* testInMatchLastValueWithTrailingComma */',
-                5,
-                11,
-                'T_COMMA',
-                'comma',
+                'testMarker'                 => '/* testInMatchLastValueWithTrailingComma */',
+                'openerOffset'               => 5,
+                'closerOffset'               => 11,
+                'expectedCloserType'         => 'T_COMMA',
+                'expectedCloserFriendlyName' => 'comma',
             ],
             'last_value_without_trailing_comma_1' => [
-                '/* testInMatchLastValueNoTrailingComma1 */',
-                5,
-                10,
-                'T_CLOSE_PARENTHESIS',
-                'close parenthesis',
+                'testMarker'                 => '/* testInMatchLastValueNoTrailingComma1 */',
+                'openerOffset'               => 5,
+                'closerOffset'               => 10,
+                'expectedCloserType'         => 'T_CLOSE_PARENTHESIS',
+                'expectedCloserFriendlyName' => 'close parenthesis',
             ],
             'last_value_without_trailing_comma_2' => [
-                '/* testInMatchLastValueNoTrailingComma2 */',
-                5,
-                11,
-                'T_VARIABLE',
-                '$y variable',
+                'testMarker'                 => '/* testInMatchLastValueNoTrailingComma2 */',
+                'openerOffset'               => 5,
+                'closerOffset'               => 11,
+                'expectedCloserType'         => 'T_VARIABLE',
+                'expectedCloserFriendlyName' => '$y variable',
             ],
         ];
 
@@ -669,47 +669,63 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      *
      * @see testNotAnArrowFunction()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotAnArrowFunction()
     {
         return [
-            ['/* testFunctionName */'],
-            [
-                '/* testConstantDeclaration */',
-                'FN',
+            'name of a function, context: declaration'                                       => [
+                'testMarker' => '/* testFunctionName */',
             ],
-            [
-                '/* testConstantDeclarationLower */',
-                'fn',
+            'name of a constant, context: declaration using "const" keyword - uppercase'     => [
+                'testMarker'  => '/* testConstantDeclaration */',
+                'testContent' => 'FN',
             ],
-            ['/* testStaticMethodName */'],
-            ['/* testPropertyAssignment */'],
-            [
-                '/* testAnonClassMethodName */',
-                'fN',
+            'name of a constant, context: declaration using "const" keyword - lowercase'     => [
+                'testMarker'  => '/* testConstantDeclarationLower */',
+                'testContent' => 'fn',
             ],
-            ['/* testNonArrowStaticMethodCall */'],
-            [
-                '/* testNonArrowConstantAccess */',
-                'FN',
+            'name of a (static) method, context: declaration'                                => [
+                'testMarker' => '/* testStaticMethodName */',
             ],
-            [
-                '/* testNonArrowConstantAccessMixed */',
-                'Fn',
+            'name of a property, context: property access'                                   => [
+                'testMarker' => '/* testPropertyAssignment */',
             ],
-            ['/* testNonArrowObjectMethodCall */'],
-            [
-                '/* testNonArrowObjectMethodCallUpper */',
-                'FN',
+            'name of a method, context: declaration in an anon class - mixed case'           => [
+                'testMarker'  => '/* testAnonClassMethodName */',
+                'testContent' => 'fN',
             ],
-            [
-                '/* testNonArrowNamespacedFunctionCall */',
-                'Fn',
+            'name of a method, context: static method call'                                  => [
+                'testMarker' => '/* testNonArrowStaticMethodCall */',
             ],
-            ['/* testNonArrowNamespaceOperatorFunctionCall */'],
-            ['/* testNonArrowFunctionNameWithUnionTypes */'],
-            ['/* testLiveCoding */'],
+            'name of a constant, context: constant access - uppercase'                       => [
+                'testMarker'  => '/* testNonArrowConstantAccess */',
+                'testContent' => 'FN',
+            ],
+            'name of a constant, context: constant access - mixed case'                      => [
+                'testMarker'  => '/* testNonArrowConstantAccessMixed */',
+                'testContent' => 'Fn',
+            ],
+            'name of a method, context: method call on object - lowercase'                   => [
+                'testMarker' => '/* testNonArrowObjectMethodCall */',
+            ],
+            'name of a method, context: method call on object - uppercase'                   => [
+                'testMarker'  => '/* testNonArrowObjectMethodCallUpper */',
+                'testContent' => 'FN',
+            ],
+            'name of a (namespaced) function, context: partially qualified function call'    => [
+                'testMarker'  => '/* testNonArrowNamespacedFunctionCall */',
+                'testContent' => 'Fn',
+            ],
+            'name of a (namespaced) function, context: namespace relative function call'     => [
+                'testMarker' => '/* testNonArrowNamespaceOperatorFunctionCall */',
+            ],
+            'name of a function, context: declaration with union types for param and return' => [
+                'testMarker' => '/* testNonArrowFunctionNameWithUnionTypes */',
+            ],
+            'unknown - live coding/parse error'                                              => [
+                'testMarker' => '/* testLiveCoding */',
+            ],
         ];
 
     }//end dataNotAnArrowFunction()

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.php
@@ -51,147 +51,147 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @see testMatchExpression()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataMatchExpression()
     {
         return [
             'simple_match'                              => [
-                '/* testMatchSimple */',
-                6,
-                33,
+                'testMarker'   => '/* testMatchSimple */',
+                'openerOffset' => 6,
+                'closerOffset' => 33,
             ],
             'no_trailing_comma'                         => [
-                '/* testMatchNoTrailingComma */',
-                6,
-                24,
+                'testMarker'   => '/* testMatchNoTrailingComma */',
+                'openerOffset' => 6,
+                'closerOffset' => 24,
             ],
             'with_default_case'                         => [
-                '/* testMatchWithDefault */',
-                6,
-                33,
+                'testMarker'   => '/* testMatchWithDefault */',
+                'openerOffset' => 6,
+                'closerOffset' => 33,
             ],
             'expression_in_condition'                   => [
-                '/* testMatchExpressionInCondition */',
-                6,
-                77,
+                'testMarker'   => '/* testMatchExpressionInCondition */',
+                'openerOffset' => 6,
+                'closerOffset' => 77,
             ],
             'multicase'                                 => [
-                '/* testMatchMultiCase */',
-                6,
-                40,
+                'testMarker'   => '/* testMatchMultiCase */',
+                'openerOffset' => 6,
+                'closerOffset' => 40,
             ],
             'multicase_trailing_comma_in_case'          => [
-                '/* testMatchMultiCaseTrailingCommaInCase */',
-                6,
-                47,
+                'testMarker'   => '/* testMatchMultiCaseTrailingCommaInCase */',
+                'openerOffset' => 6,
+                'closerOffset' => 47,
             ],
             'in_closure_not_lowercase'                  => [
-                '/* testMatchInClosureNotLowercase */',
-                6,
-                36,
-                'Match',
+                'testMarker'   => '/* testMatchInClosureNotLowercase */',
+                'openerOffset' => 6,
+                'closerOffset' => 36,
+                'testContent'  => 'Match',
             ],
             'in_arrow_function'                         => [
-                '/* testMatchInArrowFunction */',
-                5,
-                36,
+                'testMarker'   => '/* testMatchInArrowFunction */',
+                'openerOffset' => 5,
+                'closerOffset' => 36,
             ],
             'arrow_function_in_match_no_trailing_comma' => [
-                '/* testArrowFunctionInMatchNoTrailingComma */',
-                6,
-                44,
+                'testMarker'   => '/* testArrowFunctionInMatchNoTrailingComma */',
+                'openerOffset' => 6,
+                'closerOffset' => 44,
             ],
             'in_function_call_param_not_lowercase'      => [
-                '/* testMatchInFunctionCallParamNotLowercase */',
-                8,
-                32,
-                'MATCH',
+                'testMarker'   => '/* testMatchInFunctionCallParamNotLowercase */',
+                'openerOffset' => 8,
+                'closerOffset' => 32,
+                'testContent'  => 'MATCH',
             ],
             'in_method_call_param'                      => [
-                '/* testMatchInMethodCallParam */',
-                5,
-                13,
+                'testMarker'   => '/* testMatchInMethodCallParam */',
+                'openerOffset' => 5,
+                'closerOffset' => 13,
             ],
             'discard_result'                            => [
-                '/* testMatchDiscardResult */',
-                6,
-                18,
+                'testMarker'   => '/* testMatchDiscardResult */',
+                'openerOffset' => 6,
+                'closerOffset' => 18,
             ],
             'duplicate_conditions_and_comments'         => [
-                '/* testMatchWithDuplicateConditionsWithComments */',
-                12,
-                59,
+                'testMarker'   => '/* testMatchWithDuplicateConditionsWithComments */',
+                'openerOffset' => 12,
+                'closerOffset' => 59,
             ],
             'nested_match_outer'                        => [
-                '/* testNestedMatchOuter */',
-                6,
-                33,
+                'testMarker'   => '/* testNestedMatchOuter */',
+                'openerOffset' => 6,
+                'closerOffset' => 33,
             ],
             'nested_match_inner'                        => [
-                '/* testNestedMatchInner */',
-                6,
-                14,
+                'testMarker'   => '/* testNestedMatchInner */',
+                'openerOffset' => 6,
+                'closerOffset' => 14,
             ],
             'ternary_condition'                         => [
-                '/* testMatchInTernaryCondition */',
-                6,
-                21,
+                'testMarker'   => '/* testMatchInTernaryCondition */',
+                'openerOffset' => 6,
+                'closerOffset' => 21,
             ],
             'ternary_then'                              => [
-                '/* testMatchInTernaryThen */',
-                6,
-                21,
+                'testMarker'   => '/* testMatchInTernaryThen */',
+                'openerOffset' => 6,
+                'closerOffset' => 21,
             ],
             'ternary_else'                              => [
-                '/* testMatchInTernaryElse */',
-                6,
-                21,
+                'testMarker'   => '/* testMatchInTernaryElse */',
+                'openerOffset' => 6,
+                'closerOffset' => 21,
             ],
             'array_value'                               => [
-                '/* testMatchInArrayValue */',
-                6,
-                21,
+                'testMarker'   => '/* testMatchInArrayValue */',
+                'openerOffset' => 6,
+                'closerOffset' => 21,
             ],
             'array_key'                                 => [
-                '/* testMatchInArrayKey */',
-                6,
-                21,
+                'testMarker'   => '/* testMatchInArrayKey */',
+                'openerOffset' => 6,
+                'closerOffset' => 21,
             ],
             'returning_array'                           => [
-                '/* testMatchreturningArray */',
-                6,
-                125,
+                'testMarker'   => '/* testMatchreturningArray */',
+                'openerOffset' => 6,
+                'closerOffset' => 125,
             ],
             'nested_in_switch_case_1'                   => [
-                '/* testMatchWithDefaultNestedInSwitchCase1 */',
-                6,
-                25,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchCase1 */',
+                'openerOffset' => 6,
+                'closerOffset' => 25,
             ],
             'nested_in_switch_case_2'                   => [
-                '/* testMatchWithDefaultNestedInSwitchCase2 */',
-                6,
-                25,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchCase2 */',
+                'openerOffset' => 6,
+                'closerOffset' => 25,
             ],
             'nested_in_switch_default'                  => [
-                '/* testMatchWithDefaultNestedInSwitchDefault */',
-                6,
-                25,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchDefault */',
+                'openerOffset' => 6,
+                'closerOffset' => 25,
             ],
             'match_with_nested_switch'                  => [
-                '/* testMatchContainingSwitch */',
-                6,
-                180,
+                'testMarker'   => '/* testMatchContainingSwitch */',
+                'openerOffset' => 6,
+                'closerOffset' => 180,
             ],
             'no_cases'                                  => [
-                '/* testMatchNoCases */',
-                6,
-                7,
+                'testMarker'   => '/* testMatchNoCases */',
+                'openerOffset' => 6,
+                'closerOffset' => 7,
             ],
             'multi_default'                             => [
-                '/* testMatchMultiDefault */',
-                6,
-                40,
+                'testMarker'   => '/* testMatchMultiDefault */',
+                'openerOffset' => 6,
+                'closerOffset' => 40,
             ],
         ];
 
@@ -241,76 +241,102 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @see testNotAMatchStructure()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotAMatchStructure()
     {
         return [
-            'static_method_call'                   => ['/* testNoMatchStaticMethodCall */'],
+            'static_method_call'                   => [
+                'testMarker' => '/* testNoMatchStaticMethodCall */',
+            ],
             'class_constant_access'                => [
-                '/* testNoMatchClassConstantAccess */',
-                'MATCH',
+                'testMarker'  => '/* testNoMatchClassConstantAccess */',
+                'testContent' => 'MATCH',
             ],
             'class_constant_array_access'          => [
-                '/* testNoMatchClassConstantArrayAccessMixedCase */',
-                'Match',
+                'testMarker'  => '/* testNoMatchClassConstantArrayAccessMixedCase */',
+                'testContent' => 'Match',
             ],
-            'method_call'                          => ['/* testNoMatchMethodCall */'],
+            'method_call'                          => [
+                'testMarker' => '/* testNoMatchMethodCall */',
+            ],
             'method_call_uppercase'                => [
-                '/* testNoMatchMethodCallUpper */',
-                'MATCH',
+                'testMarker'  => '/* testNoMatchMethodCallUpper */',
+                'testContent' => 'MATCH',
             ],
-            'property_access'                      => ['/* testNoMatchPropertyAccess */'],
-            'namespaced_function_call'             => ['/* testNoMatchNamespacedFunctionCall */'],
-            'namespace_operator_function_call'     => ['/* testNoMatchNamespaceOperatorFunctionCall */'],
-            'interface_method_declaration'         => ['/* testNoMatchInterfaceMethodDeclaration */'],
-            'class_constant_declaration'           => ['/* testNoMatchClassConstantDeclarationLower */'],
-            'class_method_declaration'             => ['/* testNoMatchClassMethodDeclaration */'],
-            'property_assigment'                   => ['/* testNoMatchPropertyAssignment */'],
+            'property_access'                      => [
+                'testMarker' => '/* testNoMatchPropertyAccess */',
+            ],
+            'namespaced_function_call'             => [
+                'testMarker' => '/* testNoMatchNamespacedFunctionCall */',
+            ],
+            'namespace_operator_function_call'     => [
+                'testMarker' => '/* testNoMatchNamespaceOperatorFunctionCall */',
+            ],
+            'interface_method_declaration'         => [
+                'testMarker' => '/* testNoMatchInterfaceMethodDeclaration */',
+            ],
+            'class_constant_declaration'           => [
+                'testMarker' => '/* testNoMatchClassConstantDeclarationLower */',
+            ],
+            'class_method_declaration'             => [
+                'testMarker' => '/* testNoMatchClassMethodDeclaration */',
+            ],
+            'property_assigment'                   => [
+                'testMarker' => '/* testNoMatchPropertyAssignment */',
+            ],
             'class_instantiation'                  => [
-                '/* testNoMatchClassInstantiation */',
-                'Match',
+                'testMarker'  => '/* testNoMatchClassInstantiation */',
+                'testContent' => 'Match',
             ],
             'anon_class_method_declaration'        => [
-                '/* testNoMatchAnonClassMethodDeclaration */',
-                'maTCH',
+                'testMarker'  => '/* testNoMatchAnonClassMethodDeclaration */',
+                'testContent' => 'maTCH',
             ],
             'class_declaration'                    => [
-                '/* testNoMatchClassDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchClassDeclaration */',
+                'testContent' => 'Match',
             ],
             'interface_declaration'                => [
-                '/* testNoMatchInterfaceDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchInterfaceDeclaration */',
+                'testContent' => 'Match',
             ],
             'trait_declaration'                    => [
-                '/* testNoMatchTraitDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchTraitDeclaration */',
+                'testContent' => 'Match',
             ],
             'constant_declaration'                 => [
-                '/* testNoMatchConstantDeclaration */',
-                'MATCH',
+                'testMarker'  => '/* testNoMatchConstantDeclaration */',
+                'testContent' => 'MATCH',
             ],
-            'function_declaration'                 => ['/* testNoMatchFunctionDeclaration */'],
+            'function_declaration'                 => [
+                'testMarker' => '/* testNoMatchFunctionDeclaration */',
+            ],
             'namespace_declaration'                => [
-                '/* testNoMatchNamespaceDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchNamespaceDeclaration */',
+                'testContent' => 'Match',
             ],
             'class_extends_declaration'            => [
-                '/* testNoMatchExtendedClassDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchExtendedClassDeclaration */',
+                'testContent' => 'Match',
             ],
             'class_implements_declaration'         => [
-                '/* testNoMatchImplementedClassDeclaration */',
-                'Match',
+                'testMarker'  => '/* testNoMatchImplementedClassDeclaration */',
+                'testContent' => 'Match',
             ],
             'use_statement'                        => [
-                '/* testNoMatchInUseStatement */',
-                'Match',
+                'testMarker'  => '/* testNoMatchInUseStatement */',
+                'testContent' => 'Match',
             ],
-            'unsupported_inline_control_structure' => ['/* testNoMatchMissingCurlies */'],
-            'unsupported_alternative_syntax'       => ['/* testNoMatchAlternativeSyntax */'],
-            'live_coding'                          => ['/* testLiveCoding */'],
+            'unsupported_inline_control_structure' => [
+                'testMarker' => '/* testNoMatchMissingCurlies */',
+            ],
+            'unsupported_alternative_syntax'       => [
+                'testMarker' => '/* testNoMatchAlternativeSyntax */',
+            ],
+            'live_coding'                          => [
+                'testMarker' => '/* testLiveCoding */',
+            ],
         ];
 
     }//end dataNotAMatchStructure()
@@ -344,25 +370,25 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @see testSwitchExpression()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSwitchExpression()
     {
         return [
             'switch_containing_match'   => [
-                '/* testSwitchContainingMatch */',
-                6,
-                174,
+                'testMarker'   => '/* testSwitchContainingMatch */',
+                'openerOffset' => 6,
+                'closerOffset' => 174,
             ],
             'match_containing_switch_1' => [
-                '/* testSwitchNestedInMatch1 */',
-                5,
-                63,
+                'testMarker'   => '/* testSwitchNestedInMatch1 */',
+                'openerOffset' => 5,
+                'closerOffset' => 63,
             ],
             'match_containing_switch_2' => [
-                '/* testSwitchNestedInMatch2 */',
-                5,
-                63,
+                'testMarker'   => '/* testSwitchNestedInMatch2 */',
+                'openerOffset' => 5,
+                'closerOffset' => 63,
             ],
         ];
 
@@ -397,35 +423,35 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      *
      * @see testSwitchCaseVersusMatch()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSwitchCaseVersusMatch()
     {
         return [
             'switch_with_nested_match_case_1'       => [
-                '/* testMatchWithDefaultNestedInSwitchCase1 */',
-                3,
-                55,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchCase1 */',
+                'openerOffset' => 3,
+                'closerOffset' => 55,
             ],
             'switch_with_nested_match_case_2'       => [
-                '/* testMatchWithDefaultNestedInSwitchCase2 */',
-                4,
-                21,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchCase2 */',
+                'openerOffset' => 4,
+                'closerOffset' => 21,
             ],
             'switch_with_nested_match_default_case' => [
-                '/* testMatchWithDefaultNestedInSwitchDefault */',
-                1,
-                38,
+                'testMarker'   => '/* testMatchWithDefaultNestedInSwitchDefault */',
+                'openerOffset' => 1,
+                'closerOffset' => 38,
             ],
             'match_with_nested_switch_case'         => [
-                '/* testSwitchDefaultNestedInMatchCase */',
-                1,
-                18,
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchCase */',
+                'openerOffset' => 1,
+                'closerOffset' => 18,
             ],
             'match_with_nested_switch_default_case' => [
-                '/* testSwitchDefaultNestedInMatchDefault */',
-                1,
-                20,
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchDefault */',
+                'openerOffset' => 1,
+                'closerOffset' => 20,
             ],
         ];
 

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -43,112 +43,112 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      *
      * @see testStrings()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataStrings()
     {
         return [
-            ['/* testAbstract */'],
-            ['/* testArray */'],
-            ['/* testAs */'],
-            ['/* testBreak */'],
-            ['/* testCallable */'],
-            ['/* testCase */'],
-            ['/* testCatch */'],
-            ['/* testClass */'],
-            ['/* testClone */'],
-            ['/* testConst */'],
-            ['/* testContinue */'],
-            ['/* testDeclare */'],
-            ['/* testDefault */'],
-            ['/* testDo */'],
-            ['/* testEcho */'],
-            ['/* testElse */'],
-            ['/* testElseIf */'],
-            ['/* testEmpty */'],
-            ['/* testEndDeclare */'],
-            ['/* testEndFor */'],
-            ['/* testEndForeach */'],
-            ['/* testEndIf */'],
-            ['/* testEndSwitch */'],
-            ['/* testEndWhile */'],
-            ['/* testEnum */'],
-            ['/* testEval */'],
-            ['/* testExit */'],
-            ['/* testExtends */'],
-            ['/* testFinal */'],
-            ['/* testFinally */'],
-            ['/* testFn */'],
-            ['/* testFor */'],
-            ['/* testForeach */'],
-            ['/* testFunction */'],
-            ['/* testGlobal */'],
-            ['/* testGoto */'],
-            ['/* testIf */'],
-            ['/* testImplements */'],
-            ['/* testInclude */'],
-            ['/* testIncludeOnce */'],
-            ['/* testInstanceOf */'],
-            ['/* testInsteadOf */'],
-            ['/* testInterface */'],
-            ['/* testIsset */'],
-            ['/* testList */'],
-            ['/* testMatch */'],
-            ['/* testNamespace */'],
-            ['/* testNew */'],
-            ['/* testParent */'],
-            ['/* testPrint */'],
-            ['/* testPrivate */'],
-            ['/* testProtected */'],
-            ['/* testPublic */'],
-            ['/* testReadonly */'],
-            ['/* testRequire */'],
-            ['/* testRequireOnce */'],
-            ['/* testReturn */'],
-            ['/* testSelf */'],
-            ['/* testStatic */'],
-            ['/* testSwitch */'],
-            ['/* testThrows */'],
-            ['/* testTrait */'],
-            ['/* testTry */'],
-            ['/* testUnset */'],
-            ['/* testUse */'],
-            ['/* testVar */'],
-            ['/* testWhile */'],
-            ['/* testYield */'],
-            ['/* testYieldFrom */'],
-            ['/* testAnd */'],
-            ['/* testOr */'],
-            ['/* testXor */'],
-            ['/* testFalse */'],
-            ['/* testTrue */'],
-            ['/* testNull */'],
+            'constant declaration: abstract'                                    => ['/* testAbstract */'],
+            'constant declaration: array'                                       => ['/* testArray */'],
+            'constant declaration: as'                                          => ['/* testAs */'],
+            'constant declaration: break'                                       => ['/* testBreak */'],
+            'constant declaration: callable'                                    => ['/* testCallable */'],
+            'constant declaration: case'                                        => ['/* testCase */'],
+            'constant declaration: catch'                                       => ['/* testCatch */'],
+            'constant declaration: class'                                       => ['/* testClass */'],
+            'constant declaration: clone'                                       => ['/* testClone */'],
+            'constant declaration: const'                                       => ['/* testConst */'],
+            'constant declaration: continue'                                    => ['/* testContinue */'],
+            'constant declaration: declare'                                     => ['/* testDeclare */'],
+            'constant declaration: default'                                     => ['/* testDefault */'],
+            'constant declaration: do'                                          => ['/* testDo */'],
+            'constant declaration: echo'                                        => ['/* testEcho */'],
+            'constant declaration: else'                                        => ['/* testElse */'],
+            'constant declaration: elseif'                                      => ['/* testElseIf */'],
+            'constant declaration: empty'                                       => ['/* testEmpty */'],
+            'constant declaration: enddeclare'                                  => ['/* testEndDeclare */'],
+            'constant declaration: endfor'                                      => ['/* testEndFor */'],
+            'constant declaration: endforeach'                                  => ['/* testEndForeach */'],
+            'constant declaration: endif'                                       => ['/* testEndIf */'],
+            'constant declaration: endswitch'                                   => ['/* testEndSwitch */'],
+            'constant declaration: endwhile'                                    => ['/* testEndWhile */'],
+            'constant declaration: enum'                                        => ['/* testEnum */'],
+            'constant declaration: eval'                                        => ['/* testEval */'],
+            'constant declaration: exit'                                        => ['/* testExit */'],
+            'constant declaration: extends'                                     => ['/* testExtends */'],
+            'constant declaration: final'                                       => ['/* testFinal */'],
+            'constant declaration: finally'                                     => ['/* testFinally */'],
+            'constant declaration: fn'                                          => ['/* testFn */'],
+            'constant declaration: for'                                         => ['/* testFor */'],
+            'constant declaration: foreach'                                     => ['/* testForeach */'],
+            'constant declaration: function'                                    => ['/* testFunction */'],
+            'constant declaration: global'                                      => ['/* testGlobal */'],
+            'constant declaration: goto'                                        => ['/* testGoto */'],
+            'constant declaration: if'                                          => ['/* testIf */'],
+            'constant declaration: implements'                                  => ['/* testImplements */'],
+            'constant declaration: include'                                     => ['/* testInclude */'],
+            'constant declaration: include_once'                                => ['/* testIncludeOnce */'],
+            'constant declaration: instanceof'                                  => ['/* testInstanceOf */'],
+            'constant declaration: insteadof'                                   => ['/* testInsteadOf */'],
+            'constant declaration: interface'                                   => ['/* testInterface */'],
+            'constant declaration: isset'                                       => ['/* testIsset */'],
+            'constant declaration: list'                                        => ['/* testList */'],
+            'constant declaration: match'                                       => ['/* testMatch */'],
+            'constant declaration: namespace'                                   => ['/* testNamespace */'],
+            'constant declaration: new'                                         => ['/* testNew */'],
+            'constant declaration: parent'                                      => ['/* testParent */'],
+            'constant declaration: print'                                       => ['/* testPrint */'],
+            'constant declaration: private'                                     => ['/* testPrivate */'],
+            'constant declaration: protected'                                   => ['/* testProtected */'],
+            'constant declaration: public'                                      => ['/* testPublic */'],
+            'constant declaration: readonly'                                    => ['/* testReadonly */'],
+            'constant declaration: require'                                     => ['/* testRequire */'],
+            'constant declaration: require_once'                                => ['/* testRequireOnce */'],
+            'constant declaration: return'                                      => ['/* testReturn */'],
+            'constant declaration: self'                                        => ['/* testSelf */'],
+            'constant declaration: static'                                      => ['/* testStatic */'],
+            'constant declaration: switch'                                      => ['/* testSwitch */'],
+            'constant declaration: throws'                                      => ['/* testThrows */'],
+            'constant declaration: trait'                                       => ['/* testTrait */'],
+            'constant declaration: try'                                         => ['/* testTry */'],
+            'constant declaration: unset'                                       => ['/* testUnset */'],
+            'constant declaration: use'                                         => ['/* testUse */'],
+            'constant declaration: var'                                         => ['/* testVar */'],
+            'constant declaration: while'                                       => ['/* testWhile */'],
+            'constant declaration: yield'                                       => ['/* testYield */'],
+            'constant declaration: yield_from'                                  => ['/* testYieldFrom */'],
+            'constant declaration: and'                                         => ['/* testAnd */'],
+            'constant declaration: or'                                          => ['/* testOr */'],
+            'constant declaration: xor'                                         => ['/* testXor */'],
+            'constant declaration: false'                                       => ['/* testFalse */'],
+            'constant declaration: true'                                        => ['/* testTrue */'],
+            'constant declaration: null'                                        => ['/* testNull */'],
 
-            ['/* testKeywordAfterNamespaceShouldBeString */'],
-            ['/* testNamespaceNameIsString1 */'],
-            ['/* testNamespaceNameIsString2 */'],
-            ['/* testNamespaceNameIsString3 */'],
+            'namespace declaration: class'                                      => ['/* testKeywordAfterNamespaceShouldBeString */'],
+            'namespace declaration (partial): my'                               => ['/* testNamespaceNameIsString1 */'],
+            'namespace declaration (partial): class'                            => ['/* testNamespaceNameIsString2 */'],
+            'namespace declaration (partial): foreach'                          => ['/* testNamespaceNameIsString3 */'],
 
-            ['/* testKeywordAfterFunctionShouldBeString */'],
-            ['/* testKeywordAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordSelfAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordStaticAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordParentAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordFalseAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordTrueAfterFunctionByRefShouldBeString */'],
-            ['/* testKeywordNullAfterFunctionByRefShouldBeString */'],
+            'function declaration: eval'                                        => ['/* testKeywordAfterFunctionShouldBeString */'],
+            'function declaration with return by ref: switch'                   => ['/* testKeywordAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: self'                     => ['/* testKeywordSelfAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: static'                   => ['/* testKeywordStaticAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: parent'                   => ['/* testKeywordParentAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: false'                    => ['/* testKeywordFalseAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: true'                     => ['/* testKeywordTrueAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: null'                     => ['/* testKeywordNullAfterFunctionByRefShouldBeString */'],
 
-            ['/* testKeywordAsFunctionCallNameShouldBeStringSelf */'],
-            ['/* testKeywordAsFunctionCallNameShouldBeStringStatic */'],
-            ['/* testKeywordAsMethodCallNameShouldBeStringStatic */'],
-            ['/* testKeywordAsFunctionCallNameShouldBeStringParent */'],
-            ['/* testKeywordAsFunctionCallNameShouldBeStringFalse */'],
-            ['/* testKeywordAsFunctionCallNameShouldBeStringTrue */'],
-            ['/* testKeywordAsFunctionCallNameShouldBeStringNull */'],
+            'function call: self'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringSelf */'],
+            'function call: static'                                             => ['/* testKeywordAsFunctionCallNameShouldBeStringStatic */'],
+            'method call: static'                                               => ['/* testKeywordAsMethodCallNameShouldBeStringStatic */'],
+            'function call: parent'                                             => ['/* testKeywordAsFunctionCallNameShouldBeStringParent */'],
+            'function call: false'                                              => ['/* testKeywordAsFunctionCallNameShouldBeStringFalse */'],
+            'function call: true'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringTrue */'],
+            'function call: null; with comment between keyword and parentheses' => ['/* testKeywordAsFunctionCallNameShouldBeStringNull */'],
 
-            ['/* testClassInstantiationFalseIsString */'],
-            ['/* testClassInstantiationTrueIsString */'],
-            ['/* testClassInstantiationNullIsString */'],
+            'class instantiation: false'                                        => ['/* testClassInstantiationFalseIsString */'],
+            'class instantiation: true'                                         => ['/* testClassInstantiationTrueIsString */'],
+            'class instantiation: null'                                         => ['/* testClassInstantiationNullIsString */'],
         ];
 
     }//end dataStrings()
@@ -190,394 +190,394 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
     public static function dataKeywords()
     {
         return [
-            [
-                '/* testNamespaceIsKeyword */',
-                'T_NAMESPACE',
+            'namespace: declaration'                  => [
+                'testMarker'        => '/* testNamespaceIsKeyword */',
+                'expectedTokenType' => 'T_NAMESPACE',
             ],
-            [
-                '/* testAbstractIsKeyword */',
-                'T_ABSTRACT',
+            'abstract: class declaration'             => [
+                'testMarker'        => '/* testAbstractIsKeyword */',
+                'expectedTokenType' => 'T_ABSTRACT',
             ],
-            [
-                '/* testClassIsKeyword */',
-                'T_CLASS',
+            'class: declaration'                      => [
+                'testMarker'        => '/* testClassIsKeyword */',
+                'expectedTokenType' => 'T_CLASS',
             ],
-            [
-                '/* testExtendsIsKeyword */',
-                'T_EXTENDS',
+            'extends: in class declaration'           => [
+                'testMarker'        => '/* testExtendsIsKeyword */',
+                'expectedTokenType' => 'T_EXTENDS',
             ],
-            [
-                '/* testImplementsIsKeyword */',
-                'T_IMPLEMENTS',
+            'implements: in class declaration'        => [
+                'testMarker'        => '/* testImplementsIsKeyword */',
+                'expectedTokenType' => 'T_IMPLEMENTS',
             ],
-            [
-                '/* testUseIsKeyword */',
-                'T_USE',
+            'use: in trait import'                    => [
+                'testMarker'        => '/* testUseIsKeyword */',
+                'expectedTokenType' => 'T_USE',
             ],
-            [
-                '/* testInsteadOfIsKeyword */',
-                'T_INSTEADOF',
+            'insteadof: in trait import'              => [
+                'testMarker'        => '/* testInsteadOfIsKeyword */',
+                'expectedTokenType' => 'T_INSTEADOF',
             ],
-            [
-                '/* testAsIsKeyword */',
-                'T_AS',
+            'as: in trait import'                     => [
+                'testMarker'        => '/* testAsIsKeyword */',
+                'expectedTokenType' => 'T_AS',
             ],
-            [
-                '/* testConstIsKeyword */',
-                'T_CONST',
+            'const: declaration'                      => [
+                'testMarker'        => '/* testConstIsKeyword */',
+                'expectedTokenType' => 'T_CONST',
             ],
-            [
-                '/* testPrivateIsKeyword */',
-                'T_PRIVATE',
+            'private: property declaration'           => [
+                'testMarker'        => '/* testPrivateIsKeyword */',
+                'expectedTokenType' => 'T_PRIVATE',
             ],
-            [
-                '/* testProtectedIsKeyword */',
-                'T_PROTECTED',
+            'protected: property declaration'         => [
+                'testMarker'        => '/* testProtectedIsKeyword */',
+                'expectedTokenType' => 'T_PROTECTED',
             ],
-            [
-                '/* testPublicIsKeyword */',
-                'T_PUBLIC',
+            'public: property declaration'            => [
+                'testMarker'        => '/* testPublicIsKeyword */',
+                'expectedTokenType' => 'T_PUBLIC',
             ],
-            [
-                '/* testVarIsKeyword */',
-                'T_VAR',
+            'var: property declaration'               => [
+                'testMarker'        => '/* testVarIsKeyword */',
+                'expectedTokenType' => 'T_VAR',
             ],
-            [
-                '/* testStaticIsKeyword */',
-                'T_STATIC',
+            'static: property declaration'            => [
+                'testMarker'        => '/* testStaticIsKeyword */',
+                'expectedTokenType' => 'T_STATIC',
             ],
-            [
-                '/* testReadonlyIsKeyword */',
-                'T_READONLY',
+            'readonly: property declaration'          => [
+                'testMarker'        => '/* testReadonlyIsKeyword */',
+                'expectedTokenType' => 'T_READONLY',
             ],
-            [
-                '/* testFinalIsKeyword */',
-                'T_FINAL',
+            'final: function declaration'             => [
+                'testMarker'        => '/* testFinalIsKeyword */',
+                'expectedTokenType' => 'T_FINAL',
             ],
-            [
-                '/* testFunctionIsKeyword */',
-                'T_FUNCTION',
+            'function: declaration'                   => [
+                'testMarker'        => '/* testFunctionIsKeyword */',
+                'expectedTokenType' => 'T_FUNCTION',
             ],
-            [
-                '/* testCallableIsKeyword */',
-                'T_CALLABLE',
+            'callable: param type declaration'        => [
+                'testMarker'        => '/* testCallableIsKeyword */',
+                'expectedTokenType' => 'T_CALLABLE',
             ],
-            [
-                '/* testSelfIsKeyword */',
-                'T_SELF',
+            'self: param type declaration'            => [
+                'testMarker'        => '/* testSelfIsKeyword */',
+                'expectedTokenType' => 'T_SELF',
             ],
-            [
-                '/* testParentIsKeyword */',
-                'T_PARENT',
+            'parent: param type declaration'          => [
+                'testMarker'        => '/* testParentIsKeyword */',
+                'expectedTokenType' => 'T_PARENT',
             ],
-            [
-                '/* testReturnIsKeyword */',
-                'T_RETURN',
-            ],
-
-            [
-                '/* testInterfaceIsKeyword */',
-                'T_INTERFACE',
-            ],
-            [
-                '/* testTraitIsKeyword */',
-                'T_TRAIT',
-            ],
-            [
-                '/* testEnumIsKeyword */',
-                'T_ENUM',
+            'return: statement'                       => [
+                'testMarker'        => '/* testReturnIsKeyword */',
+                'expectedTokenType' => 'T_RETURN',
             ],
 
-            [
-                '/* testNewIsKeyword */',
-                'T_NEW',
+            'interface: declaration'                  => [
+                'testMarker'        => '/* testInterfaceIsKeyword */',
+                'expectedTokenType' => 'T_INTERFACE',
             ],
-            [
-                '/* testInstanceOfIsKeyword */',
-                'T_INSTANCEOF',
+            'trait: declaration'                      => [
+                'testMarker'        => '/* testTraitIsKeyword */',
+                'expectedTokenType' => 'T_TRAIT',
             ],
-            [
-                '/* testCloneIsKeyword */',
-                'T_CLONE',
-            ],
-
-            [
-                '/* testIfIsKeyword */',
-                'T_IF',
-            ],
-            [
-                '/* testEmptyIsKeyword */',
-                'T_EMPTY',
-            ],
-            [
-                '/* testElseIfIsKeyword */',
-                'T_ELSEIF',
-            ],
-            [
-                '/* testElseIsKeyword */',
-                'T_ELSE',
-            ],
-            [
-                '/* testEndIfIsKeyword */',
-                'T_ENDIF',
+            'enum: declaration'                       => [
+                'testMarker'        => '/* testEnumIsKeyword */',
+                'expectedTokenType' => 'T_ENUM',
             ],
 
-            [
-                '/* testForIsKeyword */',
-                'T_FOR',
+            'new: named instantiation'                => [
+                'testMarker'        => '/* testNewIsKeyword */',
+                'expectedTokenType' => 'T_NEW',
             ],
-            [
-                '/* testEndForIsKeyword */',
-                'T_ENDFOR',
+            'instanceof: comparison'                  => [
+                'testMarker'        => '/* testInstanceOfIsKeyword */',
+                'expectedTokenType' => 'T_INSTANCEOF',
             ],
-
-            [
-                '/* testForeachIsKeyword */',
-                'T_FOREACH',
-            ],
-            [
-                '/* testEndForeachIsKeyword */',
-                'T_ENDFOREACH',
+            'clone'                                   => [
+                'testMarker'        => '/* testCloneIsKeyword */',
+                'expectedTokenType' => 'T_CLONE',
             ],
 
-            [
-                '/* testSwitchIsKeyword */',
-                'T_SWITCH',
+            'if'                                      => [
+                'testMarker'        => '/* testIfIsKeyword */',
+                'expectedTokenType' => 'T_IF',
             ],
-            [
-                '/* testCaseIsKeyword */',
-                'T_CASE',
+            'empty'                                   => [
+                'testMarker'        => '/* testEmptyIsKeyword */',
+                'expectedTokenType' => 'T_EMPTY',
             ],
-            [
-                '/* testDefaultIsKeyword */',
-                'T_DEFAULT',
+            'elseif'                                  => [
+                'testMarker'        => '/* testElseIfIsKeyword */',
+                'expectedTokenType' => 'T_ELSEIF',
             ],
-            [
-                '/* testEndSwitchIsKeyword */',
-                'T_ENDSWITCH',
+            'else'                                    => [
+                'testMarker'        => '/* testElseIsKeyword */',
+                'expectedTokenType' => 'T_ELSE',
             ],
-            [
-                '/* testBreakIsKeyword */',
-                'T_BREAK',
-            ],
-            [
-                '/* testContinueIsKeyword */',
-                'T_CONTINUE',
+            'endif'                                   => [
+                'testMarker'        => '/* testEndIfIsKeyword */',
+                'expectedTokenType' => 'T_ENDIF',
             ],
 
-            [
-                '/* testDoIsKeyword */',
-                'T_DO',
+            'for'                                     => [
+                'testMarker'        => '/* testForIsKeyword */',
+                'expectedTokenType' => 'T_FOR',
             ],
-            [
-                '/* testWhileIsKeyword */',
-                'T_WHILE',
-            ],
-            [
-                '/* testEndWhileIsKeyword */',
-                'T_ENDWHILE',
+            'endfor'                                  => [
+                'testMarker'        => '/* testEndForIsKeyword */',
+                'expectedTokenType' => 'T_ENDFOR',
             ],
 
-            [
-                '/* testTryIsKeyword */',
-                'T_TRY',
+            'foreach'                                 => [
+                'testMarker'        => '/* testForeachIsKeyword */',
+                'expectedTokenType' => 'T_FOREACH',
             ],
-            [
-                '/* testThrowIsKeyword */',
-                'T_THROW',
-            ],
-            [
-                '/* testCatchIsKeyword */',
-                'T_CATCH',
-            ],
-            [
-                '/* testFinallyIsKeyword */',
-                'T_FINALLY',
+            'endforeach'                              => [
+                'testMarker'        => '/* testEndForeachIsKeyword */',
+                'expectedTokenType' => 'T_ENDFOREACH',
             ],
 
-            [
-                '/* testGlobalIsKeyword */',
-                'T_GLOBAL',
+            'switch'                                  => [
+                'testMarker'        => '/* testSwitchIsKeyword */',
+                'expectedTokenType' => 'T_SWITCH',
             ],
-            [
-                '/* testEchoIsKeyword */',
-                'T_ECHO',
+            'case: in switch'                         => [
+                'testMarker'        => '/* testCaseIsKeyword */',
+                'expectedTokenType' => 'T_CASE',
             ],
-            [
-                '/* testPrintIsKeyword */',
-                'T_PRINT',
+            'default: in switch'                      => [
+                'testMarker'        => '/* testDefaultIsKeyword */',
+                'expectedTokenType' => 'T_DEFAULT',
             ],
-            [
-                '/* testDieIsKeyword */',
-                'T_EXIT',
+            'endswitch'                               => [
+                'testMarker'        => '/* testEndSwitchIsKeyword */',
+                'expectedTokenType' => 'T_ENDSWITCH',
             ],
-            [
-                '/* testEvalIsKeyword */',
-                'T_EVAL',
+            'break: in switch'                        => [
+                'testMarker'        => '/* testBreakIsKeyword */',
+                'expectedTokenType' => 'T_BREAK',
             ],
-            [
-                '/* testExitIsKeyword */',
-                'T_EXIT',
-            ],
-            [
-                '/* testIssetIsKeyword */',
-                'T_ISSET',
-            ],
-            [
-                '/* testUnsetIsKeyword */',
-                'T_UNSET',
+            'continue: in switch'                     => [
+                'testMarker'        => '/* testContinueIsKeyword */',
+                'expectedTokenType' => 'T_CONTINUE',
             ],
 
-            [
-                '/* testIncludeIsKeyword */',
-                'T_INCLUDE',
+            'do'                                      => [
+                'testMarker'        => '/* testDoIsKeyword */',
+                'expectedTokenType' => 'T_DO',
             ],
-            [
-                '/* testIncludeOnceIsKeyword */',
-                'T_INCLUDE_ONCE',
+            'while'                                   => [
+                'testMarker'        => '/* testWhileIsKeyword */',
+                'expectedTokenType' => 'T_WHILE',
             ],
-            [
-                '/* testRequireIsKeyword */',
-                'T_REQUIRE',
-            ],
-            [
-                '/* testRequireOnceIsKeyword */',
-                'T_REQUIRE_ONCE',
+            'endwhile'                                => [
+                'testMarker'        => '/* testEndWhileIsKeyword */',
+                'expectedTokenType' => 'T_ENDWHILE',
             ],
 
-            [
-                '/* testListIsKeyword */',
-                'T_LIST',
+            'try'                                     => [
+                'testMarker'        => '/* testTryIsKeyword */',
+                'expectedTokenType' => 'T_TRY',
             ],
-            [
-                '/* testGotoIsKeyword */',
-                'T_GOTO',
+            'throw: statement'                        => [
+                'testMarker'        => '/* testThrowIsKeyword */',
+                'expectedTokenType' => 'T_THROW',
             ],
-            [
-                '/* testMatchIsKeyword */',
-                'T_MATCH',
+            'catch'                                   => [
+                'testMarker'        => '/* testCatchIsKeyword */',
+                'expectedTokenType' => 'T_CATCH',
             ],
-            [
-                '/* testMatchDefaultIsKeyword */',
-                'T_MATCH_DEFAULT',
-            ],
-            [
-                '/* testFnIsKeyword */',
-                'T_FN',
+            'finally'                                 => [
+                'testMarker'        => '/* testFinallyIsKeyword */',
+                'expectedTokenType' => 'T_FINALLY',
             ],
 
-            [
-                '/* testYieldIsKeyword */',
-                'T_YIELD',
+            'global'                                  => [
+                'testMarker'        => '/* testGlobalIsKeyword */',
+                'expectedTokenType' => 'T_GLOBAL',
             ],
-            [
-                '/* testYieldFromIsKeyword */',
-                'T_YIELD_FROM',
+            'echo'                                    => [
+                'testMarker'        => '/* testEchoIsKeyword */',
+                'expectedTokenType' => 'T_ECHO',
             ],
-
-            [
-                '/* testDeclareIsKeyword */',
-                'T_DECLARE',
+            'print: statement'                        => [
+                'testMarker'        => '/* testPrintIsKeyword */',
+                'expectedTokenType' => 'T_PRINT',
             ],
-            [
-                '/* testEndDeclareIsKeyword */',
-                'T_ENDDECLARE',
+            'die: statement'                          => [
+                'testMarker'        => '/* testDieIsKeyword */',
+                'expectedTokenType' => 'T_EXIT',
             ],
-
-            [
-                '/* testAndIsKeyword */',
-                'T_LOGICAL_AND',
+            'eval'                                    => [
+                'testMarker'        => '/* testEvalIsKeyword */',
+                'expectedTokenType' => 'T_EVAL',
             ],
-            [
-                '/* testOrIsKeyword */',
-                'T_LOGICAL_OR',
+            'exit: statement'                         => [
+                'testMarker'        => '/* testExitIsKeyword */',
+                'expectedTokenType' => 'T_EXIT',
             ],
-            [
-                '/* testXorIsKeyword */',
-                'T_LOGICAL_XOR',
+            'isset'                                   => [
+                'testMarker'        => '/* testIssetIsKeyword */',
+                'expectedTokenType' => 'T_ISSET',
             ],
-
-            [
-                '/* testAnonymousClassIsKeyword */',
-                'T_ANON_CLASS',
-            ],
-            [
-                '/* testExtendsInAnonymousClassIsKeyword */',
-                'T_EXTENDS',
-            ],
-            [
-                '/* testImplementsInAnonymousClassIsKeyword */',
-                'T_IMPLEMENTS',
-            ],
-            [
-                '/* testClassInstantiationParentIsKeyword */',
-                'T_PARENT',
-            ],
-            [
-                '/* testClassInstantiationSelfIsKeyword */',
-                'T_SELF',
-            ],
-            [
-                '/* testClassInstantiationStaticIsKeyword */',
-                'T_STATIC',
-            ],
-            [
-                '/* testNamespaceInNameIsKeyword */',
-                'T_NAMESPACE',
+            'unset'                                   => [
+                'testMarker'        => '/* testUnsetIsKeyword */',
+                'expectedTokenType' => 'T_UNSET',
             ],
 
-            [
-                '/* testStaticIsKeywordBeforeClosure */',
-                'T_STATIC',
+            'include'                                 => [
+                'testMarker'        => '/* testIncludeIsKeyword */',
+                'expectedTokenType' => 'T_INCLUDE',
             ],
-            [
-                '/* testStaticIsKeywordWhenParamType */',
-                'T_STATIC',
+            'include_once'                            => [
+                'testMarker'        => '/* testIncludeOnceIsKeyword */',
+                'expectedTokenType' => 'T_INCLUDE_ONCE',
             ],
-            [
-                '/* testStaticIsKeywordBeforeArrow */',
-                'T_STATIC',
+            'require'                                 => [
+                'testMarker'        => '/* testRequireIsKeyword */',
+                'expectedTokenType' => 'T_REQUIRE',
             ],
-            [
-                '/* testStaticIsKeywordWhenReturnType */',
-                'T_STATIC',
+            'require_once'                            => [
+                'testMarker'        => '/* testRequireOnceIsKeyword */',
+                'expectedTokenType' => 'T_REQUIRE_ONCE',
             ],
 
-            [
-                '/* testFalseIsKeywordAsParamType */',
-                'T_FALSE',
+            'list'                                    => [
+                'testMarker'        => '/* testListIsKeyword */',
+                'expectedTokenType' => 'T_LIST',
             ],
-            [
-                '/* testTrueIsKeywordAsParamType */',
-                'T_TRUE',
+            'goto'                                    => [
+                'testMarker'        => '/* testGotoIsKeyword */',
+                'expectedTokenType' => 'T_GOTO',
             ],
-            [
-                '/* testNullIsKeywordAsParamType */',
-                'T_NULL',
+            'match'                                   => [
+                'testMarker'        => '/* testMatchIsKeyword */',
+                'expectedTokenType' => 'T_MATCH',
             ],
-            [
-                '/* testFalseIsKeywordAsReturnType */',
-                'T_FALSE',
+            'default: in match expression'            => [
+                'testMarker'        => '/* testMatchDefaultIsKeyword */',
+                'expectedTokenType' => 'T_MATCH_DEFAULT',
             ],
-            [
-                '/* testTrueIsKeywordAsReturnType */',
-                'T_TRUE',
+            'fn'                                      => [
+                'testMarker'        => '/* testFnIsKeyword */',
+                'expectedTokenType' => 'T_FN',
             ],
-            [
-                '/* testNullIsKeywordAsReturnType */',
-                'T_NULL',
+
+            'yield'                                   => [
+                'testMarker'        => '/* testYieldIsKeyword */',
+                'expectedTokenType' => 'T_YIELD',
             ],
-            [
-                '/* testFalseIsKeywordInComparison */',
-                'T_FALSE',
+            'yield from'                              => [
+                'testMarker'        => '/* testYieldFromIsKeyword */',
+                'expectedTokenType' => 'T_YIELD_FROM',
             ],
-            [
-                '/* testTrueIsKeywordInComparison */',
-                'T_TRUE',
+
+            'declare'                                 => [
+                'testMarker'        => '/* testDeclareIsKeyword */',
+                'expectedTokenType' => 'T_DECLARE',
             ],
-            [
-                '/* testNullIsKeywordInComparison */',
-                'T_NULL',
+            'enddeclare'                              => [
+                'testMarker'        => '/* testEndDeclareIsKeyword */',
+                'expectedTokenType' => 'T_ENDDECLARE',
+            ],
+
+            'and: in if'                              => [
+                'testMarker'        => '/* testAndIsKeyword */',
+                'expectedTokenType' => 'T_LOGICAL_AND',
+            ],
+            'or: in if'                               => [
+                'testMarker'        => '/* testOrIsKeyword */',
+                'expectedTokenType' => 'T_LOGICAL_OR',
+            ],
+            'xor: in if'                              => [
+                'testMarker'        => '/* testXorIsKeyword */',
+                'expectedTokenType' => 'T_LOGICAL_XOR',
+            ],
+
+            'class: anon class declaration'           => [
+                'testMarker'        => '/* testAnonymousClassIsKeyword */',
+                'expectedTokenType' => 'T_ANON_CLASS',
+            ],
+            'extends: anon class declaration'         => [
+                'testMarker'        => '/* testExtendsInAnonymousClassIsKeyword */',
+                'expectedTokenType' => 'T_EXTENDS',
+            ],
+            'implements: anon class declaration'      => [
+                'testMarker'        => '/* testImplementsInAnonymousClassIsKeyword */',
+                'expectedTokenType' => 'T_IMPLEMENTS',
+            ],
+            'parent: class instantiation'             => [
+                'testMarker'        => '/* testClassInstantiationParentIsKeyword */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: class instantiation'               => [
+                'testMarker'        => '/* testClassInstantiationSelfIsKeyword */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'static: class instantiation'             => [
+                'testMarker'        => '/* testClassInstantiationStaticIsKeyword */',
+                'expectedTokenType' => 'T_STATIC',
+            ],
+            'namespace: operator'                     => [
+                'testMarker'        => '/* testNamespaceInNameIsKeyword */',
+                'expectedTokenType' => 'T_NAMESPACE',
+            ],
+
+            'static: closure declaration'             => [
+                'testMarker'        => '/* testStaticIsKeywordBeforeClosure */',
+                'expectedTokenType' => 'T_STATIC',
+            ],
+            'static: parameter type (illegal)'        => [
+                'testMarker'        => '/* testStaticIsKeywordWhenParamType */',
+                'expectedTokenType' => 'T_STATIC',
+            ],
+            'static: arrow function declaration'      => [
+                'testMarker'        => '/* testStaticIsKeywordBeforeArrow */',
+                'expectedTokenType' => 'T_STATIC',
+            ],
+            'static: return type for arrow function'  => [
+                'testMarker'        => '/* testStaticIsKeywordWhenReturnType */',
+                'expectedTokenType' => 'T_STATIC',
+            ],
+
+            'false: param type declaration'           => [
+                'testMarker'        => '/* testFalseIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: param type declaration'            => [
+                'testMarker'        => '/* testTrueIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: param type declaration'            => [
+                'testMarker'        => '/* testNullIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'false: return type declaration in union' => [
+                'testMarker'        => '/* testFalseIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: return type declaration in union'  => [
+                'testMarker'        => '/* testTrueIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: return type declaration in union'  => [
+                'testMarker'        => '/* testNullIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'false: in comparison'                    => [
+                'testMarker'        => '/* testFalseIsKeywordInComparison */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: in comparison'                     => [
+                'testMarker'        => '/* testTrueIsKeywordInComparison */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: in comparison'                     => [
+                'testMarker'        => '/* testNullIsKeywordInComparison */',
+                'expectedTokenType' => 'T_NULL',
             ],
         ];
 

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -53,40 +53,50 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @see testMatchDefault()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataMatchDefault()
     {
         return [
-            'simple_match_default'                                    => ['/* testSimpleMatchDefault */'],
-            'match_default_in_switch_case_1'                          => ['/* testMatchDefaultNestedInSwitchCase1 */'],
-            'match_default_in_switch_case_2'                          => ['/* testMatchDefaultNestedInSwitchCase2 */'],
-            'match_default_in_switch_default'                         => ['/* testMatchDefaultNestedInSwitchDefault */'],
-            'match_default_containing_switch'                         => ['/* testMatchDefault */'],
+            'simple_match_default'                                    => [
+                'testMarker' => '/* testSimpleMatchDefault */',
+            ],
+            'match_default_in_switch_case_1'                          => [
+                'testMarker' => '/* testMatchDefaultNestedInSwitchCase1 */',
+            ],
+            'match_default_in_switch_case_2'                          => [
+                'testMarker' => '/* testMatchDefaultNestedInSwitchCase2 */',
+            ],
+            'match_default_in_switch_default'                         => [
+                'testMarker' => '/* testMatchDefaultNestedInSwitchDefault */',
+            ],
+            'match_default_containing_switch'                         => [
+                'testMarker' => '/* testMatchDefault */',
+            ],
 
             'match_default_with_nested_long_array_and_default_key'    => [
-                '/* testMatchDefaultWithNestedLongArrayWithClassConstantKey */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultWithNestedLongArrayWithClassConstantKey */',
+                'testContent' => 'DEFAULT',
             ],
             'match_default_with_nested_long_array_and_default_key_2'  => [
-                '/* testMatchDefaultWithNestedLongArrayWithClassConstantKeyLevelDown */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultWithNestedLongArrayWithClassConstantKeyLevelDown */',
+                'testContent' => 'DEFAULT',
             ],
             'match_default_with_nested_short_array_and_default_key'   => [
-                '/* testMatchDefaultWithNestedShortArrayWithClassConstantKey */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultWithNestedShortArrayWithClassConstantKey */',
+                'testContent' => 'DEFAULT',
             ],
             'match_default_with_nested_short_array_and_default_key_2' => [
-                '/* testMatchDefaultWithNestedShortArrayWithClassConstantKeyLevelDown */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultWithNestedShortArrayWithClassConstantKeyLevelDown */',
+                'testContent' => 'DEFAULT',
             ],
             'match_default_in_long_array'                             => [
-                '/* testMatchDefaultNestedInLongArray */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultNestedInLongArray */',
+                'testContent' => 'DEFAULT',
             ],
             'match_default_in_short_array'                            => [
-                '/* testMatchDefaultNestedInShortArray */',
-                'DEFAULT',
+                'testMarker'  => '/* testMatchDefaultNestedInShortArray */',
+                'testContent' => 'DEFAULT',
             ],
         ];
 
@@ -169,40 +179,40 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @see testSwitchDefault()
      *
-     * @return array
+     * @return array<string, array<string, string|int>>
      */
     public static function dataSwitchDefault()
     {
         return [
             'simple_switch_default'                  => [
-                '/* testSimpleSwitchDefault */',
-                1,
-                4,
+                'testMarker'   => '/* testSimpleSwitchDefault */',
+                'openerOffset' => 1,
+                'closerOffset' => 4,
             ],
             'simple_switch_default_with_curlies'     => [
                 // For a default structure with curly braces, the scope opener
                 // will be the open curly and the closer the close curly.
                 // However, scope conditions will not be set for open to close,
                 // but only for the open token up to the "break/return/continue" etc.
-                '/* testSimpleSwitchDefaultWithCurlies */',
-                3,
-                12,
-                6,
+                'testMarker'    => '/* testSimpleSwitchDefaultWithCurlies */',
+                'openerOffset'  => 3,
+                'closerOffset'  => 12,
+                'conditionStop' => 6,
             ],
             'switch_default_toplevel'                => [
-                '/* testSwitchDefault */',
-                1,
-                43,
+                'testMarker'   => '/* testSwitchDefault */',
+                'openerOffset' => 1,
+                'closerOffset' => 43,
             ],
             'switch_default_nested_in_match_case'    => [
-                '/* testSwitchDefaultNestedInMatchCase */',
-                1,
-                20,
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchCase */',
+                'openerOffset' => 1,
+                'closerOffset' => 20,
             ],
             'switch_default_nested_in_match_default' => [
-                '/* testSwitchDefaultNestedInMatchDefault */',
-                1,
-                18,
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchDefault */',
+                'openerOffset' => 1,
+                'closerOffset' => 18,
             ],
         ];
 
@@ -244,34 +254,68 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      *
      * @see testNotDefaultKeyword()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotDefaultKeyword()
     {
         return [
-            'class-constant-as-short-array-key'                   => ['/* testClassConstantAsShortArrayKey */'],
-            'class-property-as-short-array-key'                   => ['/* testClassPropertyAsShortArrayKey */'],
-            'namespaced-constant-as-short-array-key'              => ['/* testNamespacedConstantAsShortArrayKey */'],
-            'fqn-global-constant-as-short-array-key'              => ['/* testFQNGlobalConstantAsShortArrayKey */'],
-            'class-constant-as-long-array-key'                    => ['/* testClassConstantAsLongArrayKey */'],
-            'class-constant-as-yield-key'                         => ['/* testClassConstantAsYieldKey */'],
+            'class-constant-as-short-array-key'                   => [
+                'testMarker' => '/* testClassConstantAsShortArrayKey */',
+            ],
+            'class-property-as-short-array-key'                   => [
+                'testMarker' => '/* testClassPropertyAsShortArrayKey */',
+            ],
+            'namespaced-constant-as-short-array-key'              => [
+                'testMarker' => '/* testNamespacedConstantAsShortArrayKey */',
+            ],
+            'fqn-global-constant-as-short-array-key'              => [
+                'testMarker' => '/* testFQNGlobalConstantAsShortArrayKey */',
+            ],
+            'class-constant-as-long-array-key'                    => [
+                'testMarker' => '/* testClassConstantAsLongArrayKey */',
+            ],
+            'class-constant-as-yield-key'                         => [
+                'testMarker' => '/* testClassConstantAsYieldKey */',
+            ],
 
-            'class-constant-as-long-array-key-nested-in-match'    => ['/* testClassConstantAsLongArrayKeyNestedInMatch */'],
-            'class-constant-as-long-array-key-nested-in-match-2'  => ['/* testClassConstantAsLongArrayKeyNestedInMatchLevelDown */'],
-            'class-constant-as-short-array-key-nested-in-match'   => ['/* testClassConstantAsShortArrayKeyNestedInMatch */'],
-            'class-constant-as-short-array-key-nested-in-match-2' => ['/* testClassConstantAsShortArrayKeyNestedInMatchLevelDown */'],
-            'class-constant-as-long-array-key-with-nested-match'  => ['/* testClassConstantAsLongArrayKeyWithNestedMatch */'],
-            'class-constant-as-short-array-key-with-nested-match' => ['/* testClassConstantAsShortArrayKeyWithNestedMatch */'],
+            'class-constant-as-long-array-key-nested-in-match'    => [
+                'testMarker' => '/* testClassConstantAsLongArrayKeyNestedInMatch */',
+            ],
+            'class-constant-as-long-array-key-nested-in-match-2'  => [
+                'testMarker' => '/* testClassConstantAsLongArrayKeyNestedInMatchLevelDown */',
+            ],
+            'class-constant-as-short-array-key-nested-in-match'   => [
+                'testMarker' => '/* testClassConstantAsShortArrayKeyNestedInMatch */',
+            ],
+            'class-constant-as-short-array-key-nested-in-match-2' => [
+                'testMarker' => '/* testClassConstantAsShortArrayKeyNestedInMatchLevelDown */',
+            ],
+            'class-constant-as-long-array-key-with-nested-match'  => [
+                'testMarker' => '/* testClassConstantAsLongArrayKeyWithNestedMatch */',
+            ],
+            'class-constant-as-short-array-key-with-nested-match' => [
+                'testMarker' => '/* testClassConstantAsShortArrayKeyWithNestedMatch */',
+            ],
 
-            'class-constant-in-switch-case'                       => ['/* testClassConstantInSwitchCase */'],
-            'class-property-in-switch-case'                       => ['/* testClassPropertyInSwitchCase */'],
-            'namespaced-constant-in-switch-case'                  => ['/* testNamespacedConstantInSwitchCase */'],
-            'namespace-relative-constant-in-switch-case'          => ['/* testNamespaceRelativeConstantInSwitchCase */'],
+            'class-constant-in-switch-case'                       => [
+                'testMarker' => '/* testClassConstantInSwitchCase */',
+            ],
+            'class-property-in-switch-case'                       => [
+                'testMarker' => '/* testClassPropertyInSwitchCase */',
+            ],
+            'namespaced-constant-in-switch-case'                  => [
+                'testMarker' => '/* testNamespacedConstantInSwitchCase */',
+            ],
+            'namespace-relative-constant-in-switch-case'          => [
+                'testMarker' => '/* testNamespaceRelativeConstantInSwitchCase */',
+            ],
 
-            'class-constant-declaration'                          => ['/* testClassConstant */'],
+            'class-constant-declaration'                          => [
+                'testMarker' => '/* testClassConstant */',
+            ],
             'class-method-declaration'                            => [
-                '/* testMethodDeclaration */',
-                'default',
+                'testMarker'  => '/* testMethodDeclaration */',
+                'testContent' => 'default',
             ],
         ];
 

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -40,90 +40,98 @@ final class DoubleQuotedStringTest extends AbstractMethodUnitTest
     /**
      * Data provider.
      *
+     * Type reference:
+     * 1. Directly embedded variables.
+     * 2. Braces outside the variable.
+     * 3. Braces after the dollar sign.
+     * 4. Variable variables and expressions.
+     *
+     * @link https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
+     *
      * @see testDoubleQuotedString()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataDoubleQuotedString()
     {
         return [
-            [
+            'Type 1: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple1 */',
                 'expectedContent' => '"$foo"',
             ],
-            [
+            'Type 2: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple2 */',
                 'expectedContent' => '"{$foo}"',
             ],
-            [
+            'Type 3: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple3 */',
                 'expectedContent' => '"${foo}"',
             ],
-            [
+            'Type 1: array offset'                                                     => [
                 'testMarker'      => '/* testDIM1 */',
                 'expectedContent' => '"$foo[bar]"',
             ],
-            [
+            'Type 2: array offset'                                                     => [
                 'testMarker'      => '/* testDIM2 */',
                 'expectedContent' => '"{$foo[\'bar\']}"',
             ],
-            [
+            'Type 3: array offset'                                                     => [
                 'testMarker'      => '/* testDIM3 */',
                 'expectedContent' => '"${foo[\'bar\']}"',
             ],
-            [
+            'Type 1: object property'                                                  => [
                 'testMarker'      => '/* testProperty1 */',
                 'expectedContent' => '"$foo->bar"',
             ],
-            [
+            'Type 2: object property'                                                  => [
                 'testMarker'      => '/* testProperty2 */',
                 'expectedContent' => '"{$foo->bar}"',
             ],
-            [
+            'Type 2: object method call'                                               => [
                 'testMarker'      => '/* testMethod1 */',
                 'expectedContent' => '"{$foo->bar()}"',
             ],
-            [
+            'Type 2: closure function call'                                            => [
                 'testMarker'      => '/* testClosure1 */',
                 'expectedContent' => '"{$foo()}"',
             ],
-            [
+            'Type 2: chaining various syntaxes'                                        => [
                 'testMarker'      => '/* testChain1 */',
                 'expectedContent' => '"{$foo[\'bar\']->baz()()}"',
             ],
-            [
+            'Type 4: variable variables'                                               => [
                 'testMarker'      => '/* testVariableVar1 */',
                 'expectedContent' => '"${$bar}"',
             ],
-            [
+            'Type 4: variable constants'                                               => [
                 'testMarker'      => '/* testVariableVar2 */',
                 'expectedContent' => '"${(foo)}"',
             ],
-            [
+            'Type 4: object property'                                                  => [
                 'testMarker'      => '/* testVariableVar3 */',
                 'expectedContent' => '"${foo->bar}"',
             ],
-            [
+            'Type 4: variable variable nested in array offset'                         => [
                 'testMarker'      => '/* testNested1 */',
                 'expectedContent' => '"${foo["${bar}"]}"',
             ],
-            [
+            'Type 4: variable array offset nested in array offset'                     => [
                 'testMarker'      => '/* testNested2 */',
                 'expectedContent' => '"${foo["${bar[\'baz\']}"]}"',
             ],
-            [
+            'Type 4: variable object property'                                         => [
                 'testMarker'      => '/* testNested3 */',
                 'expectedContent' => '"${foo->{$baz}}"',
             ],
-            [
+            'Type 4: variable object property - complex with single quotes'            => [
                 'testMarker'      => '/* testNested4 */',
                 'expectedContent' => '"${foo->{${\'a\'}}}"',
             ],
-            [
+            'Type 4: variable object property - complex with single and double quotes' => [
                 'testMarker'      => '/* testNested5 */',
                 'expectedContent' => '"${foo->{"${\'a\'}"}}"',
             ],
-            [
+            'Type 4: live coding/parse error'                                          => [
                 'testMarker'      => '/* testParseError */',
                 'expectedContent' => '"${foo["${bar
 ',

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -41,14 +41,14 @@ final class FinallyTest extends AbstractMethodUnitTest
      *
      * @see testFinallyKeyword()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataFinallyKeyword()
     {
         return [
-            ['/* testTryCatchFinally */'],
-            ['/* testTryFinallyCatch */'],
-            ['/* testTryFinally */'],
+            'finally after try and catch'   => ['/* testTryCatchFinally */'],
+            'finally between try and catch' => ['/* testTryFinallyCatch */'],
+            'finally after try, no catch'   => ['/* testTryFinally */'],
         ];
 
     }//end dataFinallyKeyword()
@@ -80,14 +80,14 @@ final class FinallyTest extends AbstractMethodUnitTest
      *
      * @see testFinallyNonKeyword()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataFinallyNonKeyword()
     {
         return [
-            ['/* testFinallyUsedAsClassConstantName */'],
-            ['/* testFinallyUsedAsMethodName */'],
-            ['/* testFinallyUsedAsPropertyName */'],
+            'finally used as class constant name' => ['/* testFinallyUsedAsClassConstantName */'],
+            'finally used as method name'         => ['/* testFinallyUsedAsMethodName */'],
+            'finally used as property name'       => ['/* testFinallyUsedAsPropertyName */'],
         ];
 
     }//end dataFinallyNonKeyword()

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -43,18 +43,18 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @see testGotoStatement()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataGotoStatement()
     {
         return [
-            [
-                '/* testGotoStatement */',
-                'marker',
+            'label for goto statement'                              => [
+                'testMarker'  => '/* testGotoStatement */',
+                'testContent' => 'marker',
             ],
-            [
-                '/* testGotoStatementInLoop */',
-                'end',
+            'label for goto statement in loop, keyword capitalized' => [
+                'testMarker'  => '/* testGotoStatementInLoop */',
+                'testContent' => 'end',
             ],
         ];
 
@@ -89,18 +89,18 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @see testGotoDeclaration()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataGotoDeclaration()
     {
         return [
-            [
-                '/* testGotoDeclaration */',
-                'marker:',
+            'label in goto declaration - marker' => [
+                'testMarker'  => '/* testGotoDeclaration */',
+                'testContent' => 'marker:',
             ],
-            [
-                '/* testGotoDeclarationOutsideLoop */',
-                'end:',
+            'label in goto declaration - end'    => [
+                'testMarker'  => '/* testGotoDeclarationOutsideLoop */',
+                'testContent' => 'end:',
             ],
         ];
 
@@ -134,38 +134,38 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      *
      * @see testNotAGotoDeclaration()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataNotAGotoDeclaration()
     {
         return [
-            [
-                '/* testNotGotoDeclarationGlobalConstant */',
-                'CONSTANT',
+            'not goto label - global constant followed by switch-case colon'     => [
+                'testMarker'  => '/* testNotGotoDeclarationGlobalConstant */',
+                'testContent' => 'CONSTANT',
             ],
-            [
-                '/* testNotGotoDeclarationNamespacedConstant */',
-                'CONSTANT',
+            'not goto label - namespaced constant followed by switch-case colon' => [
+                'testMarker'  => '/* testNotGotoDeclarationNamespacedConstant */',
+                'testContent' => 'CONSTANT',
             ],
-            [
-                '/* testNotGotoDeclarationClassConstant */',
-                'CONSTANT',
+            'not goto label - class constant followed by switch-case colon'      => [
+                'testMarker'  => '/* testNotGotoDeclarationClassConstant */',
+                'testContent' => 'CONSTANT',
             ],
-            [
-                '/* testNotGotoDeclarationClassProperty */',
-                'property',
+            'not goto label - class property use followed by switch-case colon'  => [
+                'testMarker'  => '/* testNotGotoDeclarationClassProperty */',
+                'testContent' => 'property',
             ],
-            [
-                '/* testNotGotoDeclarationGlobalConstantInTernary */',
-                'CONST_A',
+            'not goto label - global constant followed by ternary else'          => [
+                'testMarker'  => '/* testNotGotoDeclarationGlobalConstantInTernary */',
+                'testContent' => 'CONST_A',
             ],
-            [
-                '/* testNotGotoDeclarationGlobalConstantInTernary */',
-                'CONST_B',
+            'not goto label - global constant after ternary else'                => [
+                'testMarker'  => '/* testNotGotoDeclarationGlobalConstantInTernary */',
+                'testContent' => 'CONST_B',
             ],
-            [
-                '/* testNotGotoDeclarationEnumWithType */',
-                'Suit',
+            'not goto label - name of backed enum'                               => [
+                'testMarker'  => '/* testNotGotoDeclarationEnumWithType */',
+                'testContent' => 'Suit',
             ],
         ];
 

--- a/tests/Core/Tokenizer/HeredocStringTest.php
+++ b/tests/Core/Tokenizer/HeredocStringTest.php
@@ -62,86 +62,94 @@ final class HeredocStringTest extends AbstractMethodUnitTest
     /**
      * Data provider.
      *
+     * Type reference:
+     * 1. Directly embedded variables.
+     * 2. Braces outside the variable.
+     * 3. Braces after the dollar sign.
+     * 4. Variable variables and expressions.
+     *
+     * @link https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
+     *
      * @see testHeredocString()
      *
-     * @return array
+     * @return array<string, array<string, string>>
      */
     public static function dataHeredocString()
     {
         return [
-            [
+            'Type 1: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple1 */',
                 'expectedContent' => '$foo',
             ],
-            [
+            'Type 2: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple2 */',
                 'expectedContent' => '{$foo}',
             ],
-            [
+            'Type 3: simple variable'                                                  => [
                 'testMarker'      => '/* testSimple3 */',
                 'expectedContent' => '${foo}',
             ],
-            [
+            'Type 1: array offset'                                                     => [
                 'testMarker'      => '/* testDIM1 */',
                 'expectedContent' => '$foo[bar]',
             ],
-            [
+            'Type 2: array offset'                                                     => [
                 'testMarker'      => '/* testDIM2 */',
                 'expectedContent' => '{$foo[\'bar\']}',
             ],
-            [
+            'Type 3: array offset'                                                     => [
                 'testMarker'      => '/* testDIM3 */',
                 'expectedContent' => '${foo[\'bar\']}',
             ],
-            [
+            'Type 1: object property'                                                  => [
                 'testMarker'      => '/* testProperty1 */',
                 'expectedContent' => '$foo->bar',
             ],
-            [
+            'Type 2: object property'                                                  => [
                 'testMarker'      => '/* testProperty2 */',
                 'expectedContent' => '{$foo->bar}',
             ],
-            [
+            'Type 2: object method call'                                               => [
                 'testMarker'      => '/* testMethod1 */',
                 'expectedContent' => '{$foo->bar()}',
             ],
-            [
+            'Type 2: closure function call'                                            => [
                 'testMarker'      => '/* testClosure1 */',
                 'expectedContent' => '{$foo()}',
             ],
-            [
+            'Type 2: chaining various syntaxes'                                        => [
                 'testMarker'      => '/* testChain1 */',
                 'expectedContent' => '{$foo[\'bar\']->baz()()}',
             ],
-            [
+            'Type 4: variable variables'                                               => [
                 'testMarker'      => '/* testVariableVar1 */',
                 'expectedContent' => '${$bar}',
             ],
-            [
+            'Type 4: variable constants'                                               => [
                 'testMarker'      => '/* testVariableVar2 */',
                 'expectedContent' => '${(foo)}',
             ],
-            [
+            'Type 4: object property'                                                  => [
                 'testMarker'      => '/* testVariableVar3 */',
                 'expectedContent' => '${foo->bar}',
             ],
-            [
+            'Type 4: variable variable nested in array offset'                         => [
                 'testMarker'      => '/* testNested1 */',
                 'expectedContent' => '${foo["${bar}"]}',
             ],
-            [
+            'Type 4: variable array offset nested in array offset'                     => [
                 'testMarker'      => '/* testNested2 */',
                 'expectedContent' => '${foo["${bar[\'baz\']}"]}',
             ],
-            [
+            'Type 4: variable object property'                                         => [
                 'testMarker'      => '/* testNested3 */',
                 'expectedContent' => '${foo->{$baz}}',
             ],
-            [
+            'Type 4: variable object property - complex with single quotes'            => [
                 'testMarker'      => '/* testNested4 */',
                 'expectedContent' => '${foo->{${\'a\'}}}',
             ],
-            [
+            'Type 4: variable object property - complex with single and double quotes' => [
                 'testMarker'      => '/* testNested5 */',
                 'expectedContent' => '${foo->{"${\'a\'}"}}',
             ],

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
@@ -18,7 +18,7 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
     /**
      * Tokens to search for.
      *
-     * @var array
+     * @var array<int|string>
      */
     protected $find = [
         T_NULLSAFE_OBJECT_OPERATOR,
@@ -71,13 +71,13 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      *
      * @see testNullsafeObjectOperator()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataNullsafeObjectOperator()
     {
         return [
-            ['/* testNullsafeObjectOperator */'],
-            ['/* testNullsafeObjectOperatorWriteContext */'],
+            'nullsafe operator'                         => ['/* testNullsafeObjectOperator */'],
+            'illegal nullsafe operator (write context)' => ['/* testNullsafeObjectOperatorWriteContext */'],
         ];
 
     }//end dataNullsafeObjectOperator()
@@ -117,21 +117,25 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      *
      * @see testTernaryThen()
      *
-     * @return array
+     * @return array<string, array<string, string|bool>>
      */
     public static function dataTernaryThen()
     {
         return [
-            ['/* testTernaryThen */'],
-            [
-                '/* testParseErrorWhitespaceNotAllowed */',
-                true,
+            'ternary then'                                         => [
+                'testMarker' => '/* testTernaryThen */',
             ],
-            [
-                '/* testParseErrorCommentNotAllowed */',
-                true,
+            'whitespace between question mark and object operator' => [
+                'testMarker'         => '/* testParseErrorWhitespaceNotAllowed */',
+                'testObjectOperator' => true,
             ],
-            ['/* testLiveCoding */'],
+            'comment between question mark and object operator'    => [
+                'testMarker'         => '/* testParseErrorCommentNotAllowed */',
+                'testObjectOperator' => true,
+            ],
+            'parse error/live coding'                              => [
+                'testMarker' => '/* testLiveCoding */',
+            ],
         ];
 
     }//end dataTernaryThen()

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the adding of the "bracket_opener/closer" keys to use group tokens.
+ * Tests the scope opener/closers are set correctly when the namespace keyword is used as an operator.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -18,10 +18,10 @@ final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
     /**
      * Test that the scope opener/closers are set correctly when the namespace keyword is encountered as an operator.
      *
-     * @param string       $testMarker The comment which prefaces the target tokens in the test file.
-     * @param int|string[] $tokenTypes The token type to search for.
-     * @param int|string[] $open       Optional. The token type for the scope opener.
-     * @param int|string[] $close      Optional. The token type for the scope closer.
+     * @param string            $testMarker The comment which prefaces the target tokens in the test file.
+     * @param array<int|string> $tokenTypes The token type to search for.
+     * @param array<int|string> $open       Optional. The token type for the scope opener.
+     * @param array<int|string> $close      Optional. The token type for the scope closer.
      *
      * @dataProvider dataScopeSetting
      * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
@@ -59,36 +59,36 @@ final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
      *
      * @see testScopeSetting()
      *
-     * @return array
+     * @return array<string, array<string, string|array<int|string>>>
      */
     public static function dataScopeSetting()
     {
         return [
-            [
-                '/* testClassExtends */',
-                [T_CLASS],
+            'class which extends namespace relative name'           => [
+                'testMarker' => '/* testClassExtends */',
+                'tokenTypes' => [T_CLASS],
             ],
-            [
-                '/* testClassImplements */',
-                [T_ANON_CLASS],
+            'class which implements namespace relative name'        => [
+                'testMarker' => '/* testClassImplements */',
+                'tokenTypes' => [T_ANON_CLASS],
             ],
-            [
-                '/* testInterfaceExtends */',
-                [T_INTERFACE],
+            'interface which extend namespace relative name'        => [
+                'testMarker' => '/* testInterfaceExtends */',
+                'tokenTypes' => [T_INTERFACE],
             ],
-            [
-                '/* testFunctionReturnType */',
-                [T_FUNCTION],
+            'namespace relative name in function return type'       => [
+                'testMarker' => '/* testFunctionReturnType */',
+                'tokenTypes' => [T_FUNCTION],
             ],
-            [
-                '/* testClosureReturnType */',
-                [T_CLOSURE],
+            'namespace relative name in closure return type'        => [
+                'testMarker' => '/* testClosureReturnType */',
+                'tokenTypes' => [T_CLOSURE],
             ],
-            [
-                '/* testArrowFunctionReturnType */',
-                [T_FN],
-                [T_FN_ARROW],
-                [T_SEMICOLON],
+            'namespace relative name in arrow function return type' => [
+                'testMarker' => '/* testArrowFunctionReturnType */',
+                'tokenTypes' => [T_FN],
+                'open'       => [T_FN_ARROW],
+                'close'      => [T_SEMICOLON],
             ],
         ];
 

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -25,8 +25,8 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
     /**
      * Test that comment tokenization with new lines at the end of the comment is stable.
      *
-     * @param string $testMarker     The comment prefacing the test.
-     * @param array  $expectedTokens The tokenization expected.
+     * @param string                       $testMarker     The comment prefacing the test.
+     * @param array<array<string, string>> $expectedTokens The tokenization expected.
      *
      * @dataProvider dataCommentTokenization
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -54,14 +54,14 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
      *
      * @see testCommentTokenization()
      *
-     * @return array
+     * @return array<string, array<string, string|array<array<string, string>>>>
      */
     public static function dataCommentTokenization()
     {
         return [
-            [
-                '/* testSingleLineSlashComment */',
-                [
+            'slash comment, single line'                                  => [
+                'testMarker'     => '/* testSingleLineSlashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment
@@ -74,9 +74,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashCommentTrailing */',
-                [
+            'slash comment, single line, trailing'                        => [
+                'testMarker'     => '/* testSingleLineSlashCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment
@@ -89,9 +89,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashAnnotation */',
-                [
+            'slash ignore annotation, single line'                        => [
+                'testMarker'     => '/* testSingleLineSlashAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_DISABLE',
                         'content' => '// phpcs:disable Stnd.Cat
@@ -104,9 +104,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashComment */',
-                [
+            'slash comment, multi-line'                                   => [
+                'testMarker'     => '/* testMultiLineSlashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -129,9 +129,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithIndent */',
-                [
+            'slash comment, multi-line, indented'                         => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -162,9 +162,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationStart */',
-                [
+            'slash comment, multi-line, ignore annotation as first line'  => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationStart */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_IGNORE',
                         'content' => '// phpcs:ignore Stnd.Cat
@@ -187,9 +187,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationMiddle */',
-                [
+            'slash comment, multi-line, ignore annotation as middle line' => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationMiddle */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -212,9 +212,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationEnd */',
-                [
+            'slash comment, multi-line, ignore annotation as last line'   => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -237,9 +237,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineStarComment */',
-                [
+            'star comment, single line'                                   => [
+                'testMarker'     => '/* testSingleLineStarComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Single line star comment */',
@@ -251,9 +251,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineStarCommentTrailing */',
-                [
+            'star comment, single line, trailing'                         => [
+                'testMarker'     => '/* testSingleLineStarCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment */',
@@ -265,9 +265,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineStarAnnotation */',
-                [
+            'star ignore annotation, single line'                         => [
+                'testMarker'     => '/* testSingleLineStarAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_IGNORE',
                         'content' => '/* phpcs:ignore Stnd.Cat */',
@@ -279,9 +279,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineStarComment */',
-                [
+            'star comment, multi-line'                                    => [
+                'testMarker'     => '/* testMultiLineStarComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment1
@@ -303,9 +303,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineStarCommentWithIndent */',
-                [
+            'star comment, multi-line, indented'                          => [
+                'testMarker'     => '/* testMultiLineStarCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment1
@@ -327,9 +327,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineStarCommentWithAnnotationStart */',
-                [
+            'star comment, multi-line, ignore annotation as first line'   => [
+                'testMarker'     => '/* testMultiLineStarCommentWithAnnotationStart */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_IGNORE',
                         'content' => '/* @phpcs:ignore Stnd.Cat
@@ -351,9 +351,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineStarCommentWithAnnotationMiddle */',
-                [
+            'star comment, multi-line, ignore annotation as middle line'  => [
+                'testMarker'     => '/* testMultiLineStarCommentWithAnnotationMiddle */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment1
@@ -375,9 +375,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineStarCommentWithAnnotationEnd */',
-                [
+            'star comment, multi-line, ignore annotation as last line'    => [
+                'testMarker'     => '/* testMultiLineStarCommentWithAnnotationEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment1
@@ -400,9 +400,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                 ],
             ],
 
-            [
-                '/* testSingleLineDocblockComment */',
-                [
+            'docblock comment, single line'                               => [
+                'testMarker'     => '/* testSingleLineDocblockComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -426,9 +426,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineDocblockCommentTrailing */',
-                [
+            'docblock comment, single line, trailing'                     => [
+                'testMarker'     => '/* testSingleLineDocblockCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -452,9 +452,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineDocblockAnnotation */',
-                [
+            'docblock ignore annotation, single line'                     => [
+                'testMarker'     => '/* testSingleLineDocblockAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -479,9 +479,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                 ],
             ],
 
-            [
-                '/* testMultiLineDocblockComment */',
-                [
+            'docblock comment, multi-line'                                => [
+                'testMarker'     => '/* testMultiLineDocblockComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -590,9 +590,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineDocblockCommentWithIndent */',
-                [
+            'docblock comment, multi-line, indented'                      => [
+                'testMarker'     => '/* testMultiLineDocblockCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -701,9 +701,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineDocblockCommentWithAnnotation */',
-                [
+            'docblock comment, multi-line, ignore annotation'             => [
+                'testMarker'     => '/* testMultiLineDocblockCommentWithAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -812,9 +812,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineDocblockCommentWithTagAnnotation */',
-                [
+            'docblock comment, multi-line, ignore annotation as tag'      => [
+                'testMarker'     => '/* testMultiLineDocblockCommentWithTagAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_DOC_COMMENT_OPEN_TAG',
                         'content' => '/**',
@@ -923,9 +923,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashComment */',
-                [
+            'hash comment, single line'                                   => [
+                'testMarker'     => '/* testSingleLineHashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment
@@ -938,9 +938,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashCommentTrailing */',
-                [
+            'hash comment, single line, trailing'                         => [
+                'testMarker'     => '/* testSingleLineHashCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment
@@ -953,9 +953,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineHashComment */',
-                [
+            'hash comment, multi-line'                                    => [
+                'testMarker'     => '/* testMultiLineHashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment1
@@ -978,9 +978,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineHashCommentWithIndent */',
-                [
+            'hash comment, multi-line, indented'                          => [
+                'testMarker'     => '/* testMultiLineHashCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment1
@@ -1011,9 +1011,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashCommentNoNewLineAtEnd */',
-                [
+            'slash comment, single line, without new line at end'         => [
+                'testMarker'     => '/* testSingleLineSlashCommentNoNewLineAtEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Slash ',
@@ -1025,9 +1025,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashCommentNoNewLineAtEnd */',
-                [
+            'hash comment, single line, without new line at end'          => [
+                'testMarker'     => '/* testSingleLineHashCommentNoNewLineAtEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Hash ',
@@ -1039,9 +1039,9 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCommentAtEndOfFile */',
-                [
+            'unclosed star comment at end of file'                        => [
+                'testMarker'     => '/* testCommentAtEndOfFile */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment',

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -22,8 +22,8 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
     /**
      * Test that comment tokenization with new lines at the end of the comment is stable.
      *
-     * @param string $testMarker     The comment prefacing the test.
-     * @param array  $expectedTokens The tokenization expected.
+     * @param string                       $testMarker     The comment prefacing the test.
+     * @param array<array<string, string>> $expectedTokens The tokenization expected.
      *
      * @dataProvider dataCommentTokenization
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -51,14 +51,14 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
      *
      * @see testCommentTokenization()
      *
-     * @return array
+     * @return array<string, array<string, string|array<array<string, string>>>>
      */
     public static function dataCommentTokenization()
     {
         return [
-            [
-                '/* testSingleLineSlashComment */',
-                [
+            'slash comment, single line'                                  => [
+                'testMarker'     => '/* testSingleLineSlashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment
@@ -71,9 +71,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashCommentTrailing */',
-                [
+            'slash comment, single line, trailing'                        => [
+                'testMarker'     => '/* testSingleLineSlashCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment
@@ -86,9 +86,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashAnnotation */',
-                [
+            'slash ignore annotation, single line'                        => [
+                'testMarker'     => '/* testSingleLineSlashAnnotation */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_DISABLE',
                         'content' => '// phpcs:disable Stnd.Cat
@@ -101,9 +101,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashComment */',
-                [
+            'slash comment, multi-line'                                   => [
+                'testMarker'     => '/* testMultiLineSlashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -126,9 +126,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithIndent */',
-                [
+            'slash comment, multi-line, indented'                         => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -159,9 +159,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationStart */',
-                [
+            'slash comment, multi-line, ignore annotation as first line'  => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationStart */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_PHPCS_IGNORE',
                         'content' => '// phpcs:ignore Stnd.Cat
@@ -184,9 +184,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationMiddle */',
-                [
+            'slash comment, multi-line, ignore annotation as middle line' => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationMiddle */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -209,9 +209,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineSlashCommentWithAnnotationEnd */',
-                [
+            'slash comment, multi-line, ignore annotation as last line'   => [
+                'testMarker'     => '/* testMultiLineSlashCommentWithAnnotationEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Comment1
@@ -234,9 +234,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineSlashCommentNoNewLineAtEnd */',
-                [
+            'slash comment, single line, without new line at end'         => [
+                'testMarker'     => '/* testSingleLineSlashCommentNoNewLineAtEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Slash ',
@@ -248,9 +248,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashComment */',
-                [
+            'hash comment, single line'                                   => [
+                'testMarker'     => '/* testSingleLineHashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment
@@ -263,9 +263,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashCommentTrailing */',
-                [
+            'hash comment, single line, trailing'                         => [
+                'testMarker'     => '/* testSingleLineHashCommentTrailing */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment
@@ -278,9 +278,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineHashComment */',
-                [
+            'hash comment, multi-line'                                    => [
+                'testMarker'     => '/* testMultiLineHashComment */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment1
@@ -303,9 +303,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testMultiLineHashCommentWithIndent */',
-                [
+            'hash comment, multi-line, indented'                          => [
+                'testMarker'     => '/* testMultiLineHashCommentWithIndent */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Comment1
@@ -336,9 +336,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testSingleLineHashCommentNoNewLineAtEnd */',
-                [
+            'hash comment, single line, without new line at end'          => [
+                'testMarker'     => '/* testSingleLineHashCommentNoNewLineAtEnd */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '# Hash ',
@@ -350,9 +350,9 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                     ],
                 ],
             ],
-            [
-                '/* testCommentAtEndOfFile */',
-                [
+            'unclosed star comment at end of file'                        => [
+                'testMarker'     => '/* testCommentAtEndOfFile */',
+                'expectedTokens' => [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '/* Comment',


### PR DESCRIPTION
## Description

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.
Using named data sets also documents what exactly each data set is testing.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes making the data types in the docblocks more specific.

## Suggested changelog entry
_N/A_