### PR TITLE
Tests: stabelize tests using the `Config` class

### DIFF
--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Config class for use in the tests.
+ *
+ * The Config class contains a number of static properties.
+ * As the value of these static properties will be retained between instantiations of the class,
+ * config values set in one test can influence the results for another test, which makes tests unstable.
+ *
+ * This class is a "double" of the Config class which prevents this from happening.
+ * In _most_ cases, tests should be using this class instead of the "normal" Config,
+ * with the exception of select tests for the Config class itself.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests;
+
+use PHP_CodeSniffer\Config;
+use ReflectionProperty;
+
+final class ConfigDouble extends Config
+{
+
+    /**
+     * Whether or not the setting of a standard should be skipped.
+     *
+     * @var boolean
+     */
+    private $skipSettingStandard = false;
+
+
+    /**
+     * Creates a clean Config object and populates it with command line values.
+     *
+     * @param array<string> $cliArgs                An array of values gathered from CLI args.
+     * @param bool          $skipSettingStandard    Whether to skip setting a standard to prevent
+     *                                              the Config class trying to auto-discover a ruleset file.
+     *                                              Should only be set to `true` for tests which actually test
+     *                                              the ruleset auto-discovery.
+     *                                              Note: there is no need to set this to `true` when a standard
+     *                                              is being passed via the `$cliArgs`. Those settings will always
+     *                                              respected.
+     *                                              Defaults to `false`. Will result in the standard being set
+     *                                              to "PSR1" if not provided via `$cliArgs`.
+     * @param bool          $skipSettingReportWidth Whether to skip setting a report-width to prevent
+     *                                              the Config class trying to auto-discover the screen width.
+     *                                              Should only be set to `true` for tests which actually test
+     *                                              the screen width auto-discovery.
+     *                                              Note: there is no need to set this to `true` when a report-width
+     *                                              is being passed via the `$cliArgs`. Those settings will always
+     *                                              respected.
+     *                                              Defaults to `false`. Will result in the reportWidth being set
+     *                                              to "80" if not provided via `$cliArgs`.
+     *
+     * @return void
+     */
+    public function __construct(array $cliArgs=[], $skipSettingStandard=false, $skipSettingReportWidth=false)
+    {
+        $this->skipSettingStandard = $skipSettingStandard;
+
+        $this->resetSelectProperties();
+        $this->preventReadingCodeSnifferConfFile();
+
+        parent::__construct($cliArgs);
+
+        if ($skipSettingReportWidth !== true) {
+            $this->preventAutoDiscoveryScreenWidth();
+        }
+
+    }//end __construct()
+
+
+    /**
+     * Sets the command line values and optionally prevents a file system search for a custom ruleset.
+     *
+     * @param array<string> $args An array of command line arguments to set.
+     *
+     * @return void
+     */
+    public function setCommandLineValues($args)
+    {
+        parent::setCommandLineValues($args);
+
+        if ($this->skipSettingStandard !== true) {
+            $this->preventSearchingForRuleset();
+        }
+
+    }//end setCommandLineValues()
+
+
+    /**
+     * Reset a few properties on the Config class to their default values.
+     *
+     * @return void
+     */
+    private function resetSelectProperties()
+    {
+        $this->setStaticConfigProperty('overriddenDefaults', []);
+        $this->setStaticConfigProperty('executablePaths', []);
+
+    }//end resetSelectProperties()
+
+
+    /**
+     * Prevent the values in a potentially available user-specific `CodeSniffer.conf` file
+     * from influencing the tests.
+     *
+     * This also prevents some file system calls which can influence the test runtime.
+     *
+     * @return void
+     */
+    private function preventReadingCodeSnifferConfFile()
+    {
+        $this->setStaticConfigProperty('configData', []);
+        $this->setStaticConfigProperty('configDataFile', '');
+
+    }//end preventReadingCodeSnifferConfFile()
+
+
+    /**
+     * Prevent searching for a custom ruleset by setting a standard, but only if the test
+     * being run doesn't set a standard itself.
+     *
+     * This also prevents some file system calls which can influence the test runtime.
+     *
+     * The standard being set is the smallest one available so the ruleset initialization
+     * will be the fastest possible.
+     *
+     * @return void
+     */
+    private function preventSearchingForRuleset()
+    {
+        $overriddenDefaults = $this->getStaticConfigProperty('overriddenDefaults');
+        if (isset($overriddenDefaults['standards']) === false) {
+            $this->standards = ['PSR1'];
+            $overriddenDefaults['standards'] = true;
+        }
+
+        self::setStaticConfigProperty('overriddenDefaults', $overriddenDefaults);
+
+    }//end preventSearchingForRuleset()
+
+
+    /**
+     * Prevent a call to stty to figure out the screen width, but only if the test being run
+     * doesn't set a report width itself.
+     *
+     * @return void
+     */
+    private function preventAutoDiscoveryScreenWidth()
+    {
+        $settings = $this->getSettings();
+        if ($settings['reportWidth'] === 'auto') {
+            $this->reportWidth = self::DEFAULT_REPORT_WIDTH;
+        }
+
+    }//end preventAutoDiscoveryScreenWidth()
+
+
+    /**
+     * Helper function to retrieve the value of a private static property on the Config class.
+     *
+     * @param string $name The name of the property to retrieve.
+     *
+     * @return mixed
+     */
+    private function getStaticConfigProperty($name)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        return $property->getValue();
+
+    }//end getStaticConfigProperty()
+
+
+    /**
+     * Helper function to set the value of a private static property on the Config class.
+     *
+     * @param string $name  The name of the property to set.
+     * @param mixed  $value The value to set the property to.
+     *
+     * @return void
+     */
+    private function setStaticConfigProperty($name, $value)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+        $property->setAccessible(false);
+
+    }//end setStaticConfigProperty()
+
+
+}//end class

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -57,22 +57,7 @@ abstract class AbstractMethodUnitTest extends TestCase
      */
     public static function initializeFile()
     {
-        /*
-         * Set the static properties in the Config class to specific values for performance
-         * and to clear out values from other tests.
-         */
-
-        self::setStaticConfigProperty('executablePaths', []);
-
-        // Set to a usable value to circumvent Config trying to find a phpcs.xml config file.
-        self::setStaticConfigProperty('overriddenDefaults', ['standards' => ['PSR1']]);
-
-        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
-        // from being read and influencing the tests. Also prevent an `exec()` call to stty.
-        self::setStaticConfigProperty('configData', ['report_width' => 80]);
-        self::setStaticConfigProperty('configDataFile', '');
-
-        $config = new Config();
+        $config = new ConfigDouble();
         // Also set a tab-width to enable testing tab-replaced vs `orig_content`.
         $config->tabWidth = static::$tabWidth;
 
@@ -91,44 +76,6 @@ abstract class AbstractMethodUnitTest extends TestCase
         self::$phpcsFile->process();
 
     }//end initializeFile()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @afterClass
-     *
-     * @return void
-     */
-    public static function resetFile()
-    {
-        self::$phpcsFile = null;
-
-        // Reset the static properties in the Config class to their defaults to prevent tests influencing each other.
-        self::setStaticConfigProperty('overriddenDefaults', []);
-        self::setStaticConfigProperty('executablePaths', []);
-        self::setStaticConfigProperty('configData', null);
-        self::setStaticConfigProperty('configDataFile', null);
-
-    }//end resetFile()
-
-
-    /**
-     * Helper function to set the value of a private static property on the Config class.
-     *
-     * @param string $name  The name of the property to set.
-     * @param mixed  $value The value to set the property to.
-     *
-     * @return void
-     */
-    public static function setStaticConfigProperty($name, $value)
-    {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
-        $property->setValue(null, $value);
-        $property->setAccessible(false);
-
-    }//end setStaticConfigProperty()
 
 
     /**

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,7 +41,7 @@ final class ErrorSuppressionTest extends TestCase
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
@@ -173,7 +173,7 @@ final class ErrorSuppressionTest extends TestCase
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
@@ -265,7 +265,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.Commenting.Todo'];
 
@@ -349,7 +349,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
@@ -445,7 +445,7 @@ EOD;
      */
     public function testSuppressLineMidLine()
     {
-        $config            = new Config();
+        $config            = new ConfigDouble();
         $config->standards = ['Generic'];
         $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
@@ -468,7 +468,7 @@ EOD;
      */
     public function testSuppressLineWithinDocblock()
     {
-        $config            = new Config();
+        $config            = new ConfigDouble();
         $config->standards = ['Generic'];
         $config->sniffs    = ['Generic.Files.LineLength'];
 
@@ -508,7 +508,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
@@ -598,7 +598,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['PEAR'];
             $config->sniffs    = ['PEAR.Functions.FunctionDeclaration'];
 
@@ -695,7 +695,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = ['Generic.Commenting.Todo'];
 
@@ -809,7 +809,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = [
                 'Generic.PHP.LowerCaseConstant',
@@ -926,7 +926,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = [
                 'Generic.PHP.LowerCaseConstant',
@@ -1100,7 +1100,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = [
                 'Generic.PHP.LowerCaseConstant',
@@ -1191,7 +1191,7 @@ EOD;
         static $config, $ruleset;
 
         if (isset($config, $ruleset) === false) {
-            $config            = new Config();
+            $config            = new ConfigDouble();
             $config->standards = ['Generic'];
             $config->sniffs    = [
                 'Generic.PHP.LowerCaseConstant',

--- a/tests/Core/Filters/AbstractFilterTestCase.php
+++ b/tests/Core/Filters/AbstractFilterTestCase.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Filters;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Filters\Filter;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use RecursiveIteratorIterator;
 
@@ -45,7 +45,7 @@ abstract class AbstractFilterTestCase extends TestCase
      */
     public static function initializeConfigAndRuleset()
     {
-        self::$config  = new Config(['--standard=PSR1', '--extensions=php,inc/php,js,css', '--report-width=80']);
+        self::$config  = new ConfigDouble(['--extensions=php,inc/php,js,css']);
         self::$ruleset = new Ruleset(self::$config);
 
     }//end initializeConfigAndRuleset()

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -13,6 +13,7 @@ namespace PHP_CodeSniffer\Tests\Core\Filters\Filter;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Filters\Filter;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Filters\AbstractFilterTestCase;
 use RecursiveArrayIterator;
 
@@ -35,7 +36,7 @@ final class AcceptTest extends AbstractFilterTestCase
     public static function initializeConfigAndRuleset()
     {
         $standard      = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
-        self::$config  = new Config(["--standard=$standard", '--ignore=*/somethingelse/*', '--report-width=80']);
+        self::$config  = new ConfigDouble(["--standard=$standard", '--ignore=*/somethingelse/*']);
         self::$ruleset = new Ruleset(self::$config);
 
     }//end initializeConfigAndRuleset()

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,7 +31,7 @@ final class ExplainTest extends TestCase
     public function testExplain()
     {
         // Set up the ruleset.
-        $config  = new Config(['--standard=PSR1', '-e', '--report-width=80']);
+        $config  = new ConfigDouble(['--standard=PSR1', '-e']);
         $ruleset = new Ruleset($config);
 
         $expected  = PHP_EOL;
@@ -66,7 +66,7 @@ final class ExplainTest extends TestCase
     public function testExplainAlwaysDisplaysCompleteSniffName()
     {
         // Set up the ruleset.
-        $config  = new Config(['--standard=PSR1', '-e', '--report-width=30']);
+        $config  = new ConfigDouble(['--standard=PSR1', '-e', '--report-width=30']);
         $ruleset = new Ruleset($config);
 
         $expected  = PHP_EOL;
@@ -104,7 +104,7 @@ final class ExplainTest extends TestCase
     {
         // Set up the ruleset.
         $standard = __DIR__.'/ExplainSingleSniffTest.xml';
-        $config   = new Config(["--standard=$standard", '-e', '--report-width=80']);
+        $config   = new ConfigDouble(["--standard=$standard", '-e']);
         $ruleset  = new Ruleset($config);
 
         $expected  = PHP_EOL;
@@ -135,7 +135,7 @@ final class ExplainTest extends TestCase
     {
         // Set up the ruleset.
         $standard = __DIR__.'/ExplainCustomRulesetTest.xml';
-        $config   = new Config(["--standard=$standard", '-e', '--report-width=80']);
+        $config   = new ConfigDouble(["--standard=$standard", '-e']);
         $ruleset  = new Ruleset($config);
 
         $expected  = PHP_EOL;

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -71,7 +71,7 @@ final class RuleInclusionAbsoluteLinuxTest extends TestCase
         }
 
         // Initialize the config and ruleset objects for the test.
-        $config        = new Config(["--standard={$this->standard}"]);
+        $config        = new ConfigDouble(["--standard={$this->standard}"]);
         $this->ruleset = new Ruleset($config);
 
     }//end initializeConfigAndRuleset()

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -70,7 +70,7 @@ final class RuleInclusionAbsoluteWindowsTest extends TestCase
         }
 
         // Initialize the config and ruleset objects for the test.
-        $config        = new Config(["--standard={$this->standard}"]);
+        $config        = new ConfigDouble(["--standard={$this->standard}"]);
         $this->ruleset = new Ruleset($config);
 
     }//end initializeConfigAndRuleset()

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
@@ -74,7 +74,7 @@ final class RuleInclusionTest extends TestCase
             self::markTestSkipped('On the fly ruleset adjustment failed');
         }
 
-        $config        = new Config(["--standard=$standard"]);
+        $config        = new ConfigDouble(["--standard=$standard"]);
         self::$ruleset = new Ruleset($config);
 
     }//end initializeConfigAndRuleset()

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
@@ -46,7 +46,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
         // Verify that the sniff has been registered.
@@ -102,7 +102,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml';
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
         // Test that the two sniffs which support the property have received the value.
@@ -147,7 +147,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyThrowsErrorOnInvalidPropertyTest.xml';
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
     }//end testSetPropertyThrowsErrorOnInvalidProperty()
@@ -174,7 +174,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyNotAllowedViaAttributeTest.xml';
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
     }//end testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
@@ -192,7 +192,7 @@ final class SetSniffPropertyTest extends TestCase
     {
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml';
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
     }//end testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandard()
@@ -210,7 +210,7 @@ final class SetSniffPropertyTest extends TestCase
     {
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml';
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
     }//end testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategory()
@@ -230,7 +230,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
         $propertyName  = 'arbitrarystring';
@@ -281,7 +281,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
         $propertyName = 'arbitrarystring';
@@ -388,7 +388,7 @@ final class SetSniffPropertyTest extends TestCase
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
-        $config   = new Config(["--standard=$standard"]);
+        $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
         $propertyName = 'arbitrarystring';

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -13,10 +13,10 @@
 
 namespace PHP_CodeSniffer\Tests\Standards;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 
@@ -134,7 +134,7 @@ abstract class AbstractSniffUnitTest extends TestCase
         if (isset($GLOBALS['PHP_CODESNIFFER_CONFIG']) === true) {
             $config = $GLOBALS['PHP_CODESNIFFER_CONFIG'];
         } else {
-            $config        = new Config();
+            $config        = new ConfigDouble();
             $config->cache = false;
             $GLOBALS['PHP_CODESNIFFER_CONFIG'] = $config;
         }


### PR DESCRIPTION
## Context

Nearly every time I work on expanding the Core test suite or adding tests to the Core test suite for a new feature , I run into issues related to the static properties from `Config` bleeding through between tests and causing problems.

While it can be considered a known issue, it is still annoying and having to work around it each time (and remembering to do so), has lost me enough time by now.

Additionally, there are performance issues with the `Config` class, due to the use of shell commands, like `stty`/`which`/where` and file system access. This is not necessarily a problem during a "normal" PHPCS run which only instantiates the `Config` class once, but can have an impact on the test suite where the `Config` class gets instantiated numerous times.
These performance issues can be circumvented, but again, doing so is something which needs to be remembered for each test instantiating the `Config` class.

The test double I'm now introducing will hopefully prevent/circumvent the majority of these issues for future tests.

Note: there is still an issue with `--sniffs` and `--exclude` CLI arguments not being respected by the `Ruleset` class when the referenced sniffs are test fixtures, but that's something to be solved another time.

## Description

### Tests: new ConfigDouble test helper class

The PHP_CodeSniffer native `Config` class contains a number of static properties.
As the value of these static properties will be retained between instantiations of the class, config values set in one test can influence the results for another test, which makes tests unstable.

This commit introduces a test "double" of the `Config` class which prevents this from happening.
In _most_ cases, tests should be using this class instead of the "normal" Config, with the exception of select tests for the Config class itself.

### Tests: implement use of the new ConfigDouble class

Note: for the `AbstractSniffUnitTest` class, this change has little to no effect, other than protecting the sniff tests from changes made to the static properties in the `Config` class by the `Core` tests.
This is due to the `Config` being cached to a global variable. Fixing that is outside the scope of this PR.

Related issues: squizlabs/PHP_CodeSniffer#2899 and #25.

## Suggested changelog entry
_N/A_


## Related issues/external references

Loosely related to #146

Previous related issues around the performance issues with `Config` in the tests: squizlabs/PHP_CodeSniffer#3831 / #61