### PR TITLE
Soft deprecate all sniffs which are to be removed in PHPCS 4.0

### DIFF
--- a/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -5,6 +5,8 @@
  * @author    Roman Levishchenko <index.0h@gmail.com>
  * @copyright 2013-2014 Roman Levishchenko
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;

--- a/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
@@ -5,6 +5,8 @@
  * @author    Ryan McCue <ryan+gh@hmn.md>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -6,6 +6,8 @@
  * @author    Alexander Wei§ <aweisswa@gmx.de>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;

--- a/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
+++ b/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\CSS;

--- a/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;

--- a/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;

--- a/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;

--- a/src/Standards/MySource/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/MySource/Sniffs/Commenting/FunctionCommentSniff.php
@@ -7,6 +7,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Commenting;

--- a/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Debug;

--- a/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Debug;

--- a/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;

--- a/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;

--- a/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;

--- a/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
@@ -8,6 +8,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;

--- a/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;

--- a/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;

--- a/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;

--- a/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
+++ b/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Strings;

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;

--- a/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug;

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug;

--- a/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
@@ -5,6 +5,8 @@
  * @author    Sertan Danis <sdanis@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects;

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.3.0 Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
@@ -5,6 +5,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;


### PR DESCRIPTION
## Description

The deprecation of these sniffs was previously already announced in:
* CSS/JS specific sniffs: https://github.com/squizlabs/PHP_CodeSniffer/issues/2448
* MySource standard: https://github.com/squizlabs/PHP_CodeSniffer/issues/2471

This commit _soft_ deprecates these sniffs with a `@deprecated` annotation. This will get a mention in the changelog.

Hard deprecation will follow in a future 3.x minor as per #188.


## Suggested changelog entry

### Deprecated
- [#2448](https://github.com/squizlabs/PHP_CodeSniffer/issues/2448) Support for scanning JavaScript and CSS files.
    - This also means that all sniffs which are only aimed at JavaScript or CSS files are now deprecated.
    - The Javascript and CSS Tokenizers, all Javascript and CSS specific sniffs, and support for JS and CSS in select sniffs which support multiple file types, will be removed in version 4.0.0.
- [#2471](https://github.com/squizlabs/PHP_CodeSniffer/issues/2471) The MySource standard and all sniffs in it.
    - The MySource standard and all sniffs in it will be removed in version 4.0.0.
