### PR TITLE
Zend.Debug.CodeAnalyzer: soft deprecate the sniff

### DIFF
--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -6,6 +6,8 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.9.0
  */
 
 namespace PHP_CodeSniffer\Standards\Zend\Sniffs\Debug;


### PR DESCRIPTION
## Description

See #58.

This commit _soft_ deprecates the sniffs with a `@deprecated` annotation. This will get a mention in the changelog.

Hard deprecation will follow in a future 3.x minor as per #188.


## Suggested changelog entry

### Deprecated
* The `Zend.Debug.CodeAnalyzer` sniff. The sniff will be removed in PHP_CodeSniffer 4.0.

