### PR TITLE
Fix some links in the 3.7.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,15 +344,15 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 
 [#3616]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3616
 [#3618]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3618
-[#3632]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3632
-[#3639]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3639
-[#3640]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3640
-[#3645]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3645
-[#3653]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3653
+[#3632]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3632
+[#3639]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3639
+[#3640]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3640
+[#3645]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3645
+[#3653]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3653
 [#3666]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3666
 [#3668]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3668
 [#3672]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3672
-[#3694]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3694
+[#3694]: https://github.com/squizlabs/PHP_CodeSniffer/pull/3694 
 
 ## [3.7.1] - 2022-06-18
 ### Fixed


### PR DESCRIPTION
## Description

Per https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/279#issuecomment-1894500366, this PR fixes some GitHub links that were using `issues` when they are actually PRs. The links were working due to a redirect, but it is preferable to use the canonical URLs.


## Related issues/external references

Issue raised in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/279#issuecomment-1894500366


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.