### PR TITLE
Generic/IncrementDecrementSpacing: fix post-decrement error message

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -135,7 +135,7 @@ class IncrementDecrementSpacingSniff implements Sniff
                 $fixable = false;
                 $spaces  = 'comment';
             } else {
-                if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
+                if ($tokens[$stackPtr]['line'] !== $tokens[$prevNonEmpty]['line']) {
                     $spaces = 'newline';
                 } else {
                     $spaces = $tokens[($stackPtr - 1)]['length'];

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
@@ -38,3 +38,6 @@ $obj->prop['key'] ++;
 
 getObject()->count
 ++;
+getObject()->count++;
+++ getObject()->count;
+++getObject()->count;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
@@ -35,3 +35,6 @@ $obj->prop['key'] ++;
 
 --ClassName::$prop;
 -- ClassName::$prop;
+
+getObject()->count
+++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
@@ -34,3 +34,5 @@ $obj->prop['key']++;
 
 --ClassName::$prop;
 --ClassName::$prop;
+
+getObject()->count++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
@@ -36,3 +36,6 @@ $obj->prop['key']++;
 --ClassName::$prop;
 
 getObject()->count++;
+getObject()->count++;
+++getObject()->count;
+++getObject()->count;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -54,6 +54,7 @@ final class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
             $errors[34] = 1;
             $errors[37] = 1;
             $errors[40] = 1;
+            $errors[42] = 1;
 
             return $errors;
 

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -53,6 +53,7 @@ final class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
             $errors[31] = 1;
             $errors[34] = 1;
             $errors[37] = 1;
+            $errors[40] = 1;
 
             return $errors;
 


### PR DESCRIPTION
## Description

This PR fixes the post-decrement error message when there is one or more newlines between the variable and the post-decrement operator.

The wrong variable was used to check whether the post-decrement and the variable were not on the same line, resulting in an incorrect error message. The error message should explicitly say that a newline was found.

Before this commit, the error message was:

```
Expected no spaces between $i and the decrement operator; 0 found
```

Now it is:

```
Expected no spaces between the decrement operator and $i; newline found
```

(`newline` instead of `0`)

## Suggested changelog entry

Generic/IncrementDecrementSpacing: fix error message when one or more newlines are found between the variable and the post-decrement operator


## Related issues/external references

Fixes #288 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
