### PR TITLE
Fix tokenizer bug - Heredoc in `if` condition broke scope mapping

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1073,6 +1073,13 @@ abstract class Tokenizer
                         continue;
                     }
 
+                    if ($tokenType === T_START_HEREDOC) {
+                        // Heredocs are special because they can be used as a value, including
+                        // inside a function call or as a default value for a parameter.
+                        // So if we find them nested inside another opener, just skip them.
+                        continue;
+                    }
+
                     if ($tokenType === T_FUNCTION
                         && $this->tokens[$stackPtr]['code'] !== T_FUNCTION
                     ) {

--- a/tests/Core/Tokenizers/PHP/ScopeOwnerTest.inc
+++ b/tests/Core/Tokenizers/PHP/ScopeOwnerTest.inc
@@ -1,0 +1,20 @@
+<?php
+
+/* testNormalIfCondition */
+if (true) {
+    return;
+}
+
+/* testFunctionCallInIfCondition */
+if (doThing(0)) {
+    return;
+}
+
+/* testHeredocInIfCondition */
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/149
+if (foo(<<<EOD
+foobar!
+EOD
+)) {
+    return;
+}

--- a/tests/Core/Tokenizers/PHP/ScopeOwnerTest.php
+++ b/tests/Core/Tokenizers/PHP/ScopeOwnerTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests that scope owner (scope_condition, conditions) is set correctly
+ *
+ * @author  Dan Wallis <dan@wallis.nz>
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+final class ScopeOwnerTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that a basic 'if' condition gets scope opener/closer set as expected.
+     *
+     * @param string $testMarker     The comment which prefaces the target token in the test file.
+     * @param int    $conditionWidth How many tokens wide the 'if' condition should be.
+     *
+     * @dataProvider dataIfCondition
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
+     *
+     * @return void
+     */
+    public function testIfCondition($testMarker, $conditionWidth)
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $targetIf = $this->getTargetToken($testMarker, T_IF);
+
+        $this->assertSame($targetIf, $tokens[$targetIf]['parenthesis_owner'], 'parenthesis owner is self for if');
+        $this->assertSame(($targetIf + 2), $tokens[$targetIf]['parenthesis_opener'], 'expected parenthesis opener');
+        $this->assertSame(($targetIf + 2 + $conditionWidth), $tokens[$targetIf]['parenthesis_closer'], 'expected parenthesis closer');
+        $this->assertSame($targetIf, $tokens[$targetIf]['scope_condition']);
+
+        $targetOpenCurly = $this->phpcsFile->findNext(T_OPEN_CURLY_BRACKET, $targetIf);
+        $this->assertSame($targetIf, $tokens[$targetOpenCurly]['scope_condition'], 'scope_condition set on open curly');
+
+        $targetCloseCurly = $tokens[$targetOpenCurly]['bracket_closer'];
+        $this->assertSame($targetIf, $tokens[$targetCloseCurly]['scope_condition'], 'scope_condition set on close curly');
+
+        $targetReturn = $this->phpcsFile->findNext(T_RETURN, $targetIf);
+        $this->assertSame([$targetIf => T_IF], $tokens[$targetReturn]['conditions'], 'conditions set on if statement body');
+
+    }//end testIfCondition()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testIfCondition()
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataIfCondition()
+    {
+        return [
+            'Basic if'                      => [
+                'testMarker'     => '/* testNormalIfCondition */',
+                'conditionWidth' => 2,
+            ],
+            'Function call in if condition' => [
+                'testMarker'     => '/* testFunctionCallInIfCondition */',
+                'conditionWidth' => 5,
+            ],
+            'Heredoc in if condition'       => [
+                'testMarker'     => '/* testHeredocInIfCondition */',
+                'conditionWidth' => 8,
+            ],
+        ];
+
+    }//end dataIfCondition()
+
+
+}//end class


### PR DESCRIPTION
## Description

I have been looking into #149. I started by creating a failing test which demonstrated the problem, and then worked on making that test pass. This pull request should fix the problem described in #149.

When the tokenizer creates its map of scopes, goes through each token in turn until it finds another scope opener. It then uses recursion to map each set of open/close parenthesises to the corresponding opener (eg, `if` statement). The case of a heredoc embedded within an open/close pair of parenthesises was not handled. There are already special cases for `use` and `namespace`. I have added to this list so that heredocs are also acceptable in this context.

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/c4251a1183dbfb2cc9ea4f39427dbda749d0b85e/src/Tokenizers/Tokenizer.php#L1128-L1144

If the scope opener isn't handled, the code assumes that a closer will never be found, and that there must be a parse error. This isn't the case with a heredoc. Adding support for heredocs seems to make sense in this context.
https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/c4251a1183dbfb2cc9ea4f39427dbda749d0b85e/src/Tokenizers/Tokenizer.php#L1194-L1195

The tests here could be much more robust / extensive. I've opted for a simple test here, and will leave writing very verbose tests for https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/146 for now. If it would be preferable to add more tests here, please let me know.

## Suggested changelog entry
- Fix bug in tokenizer where heredocs were not handled correctly within scope statements (like `if` conditions or `function` definitions).

## Related issues/external references

Fixes #149

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.