### PR TITLE
Generic/ArbitraryParenthesesSpacing: improve handling of switch-case scope closers

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -103,7 +103,8 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
         $preOpener = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
         if ($preOpener !== false
             && isset($this->ignoreTokens[$tokens[$preOpener]['code']]) === true
-            && isset($tokens[$preOpener]['scope_condition']) === false
+            && ($tokens[$preOpener]['code'] !== T_CLOSE_CURLY_BRACKET
+            || isset($tokens[$preOpener]['scope_condition']) === false )
         ) {
             // Function or language construct call.
             return;

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.1.inc
@@ -180,3 +180,13 @@ class NonArbitraryParenthesesWithKeywords {
 $b = match (  $a  ) {
     1 => true,
 };
+
+// Parentheses after die/exit in a switch case should be ignored.
+switch ( $type ) {
+    case A:
+        exit(    1    );
+    case B:
+        die();
+    default:
+        break;
+}

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.1.inc.fixed
@@ -168,3 +168,13 @@ class NonArbitraryParenthesesWithKeywords {
 $b = match (  $a  ) {
     1 => true,
 };
+
+// Parentheses after die/exit in a switch case should be ignored.
+switch ( $type ) {
+    case A:
+        exit(    1    );
+    case B:
+        die();
+    default:
+        break;
+}


### PR DESCRIPTION
## Description
Follow up on squizlabs/PHP_CodeSniffer#2826 which was fixed via squizlabs/PHP_CodeSniffer#2876.

The sniff explicitly only intends to handle _arbitrary_ parentheses and tries to avoid clashes with sniffs handling the parentheses spacing of function calls and language construct invocations.

This is done by the sniff bowing out early when the token before the open parenthesis is a token which can be used in a (variable) function call or one of a select list of reserved keywords.

The previous PR tweaked the "bowing out" to allow the sniff to operate on arbitrary parentheses which directly follow the close curly brace of a a previous scope.

The additional condition added was, however, not limited to `T_CLOSE_CURLY_BRACKET` tokens.

This has led to a new false positive: When a `die()`/`exit()` is used within a `switch-case` statement, the `die`/`exit` keyword will be regarded as a scope closer for the `case` statement, in which case, the parentheses for the `die`/`exit` would now be treated as arbitrary instead of as belonging to the `die`/`exit` keyword.

This commit fixes this by limiting the previously introduced check for a scope closer to curly braces only.

Includes tests proving the bug and safeguarding the fix.


## Suggested changelog entry
- Generic/ArbitraryParenthesesSpacing : false positive for non-arbitrary parentheses when these follow the scope closer of a `switch` `case`.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
