### PR TITLE
GH Actions: re-attempt upgrade actions/[upload|download]-artifact from 3 to 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: php scripts/build-phar.php
 
       - name: Upload the PHPCS phar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: phpcs-phar
           path: ./phpcs.phar
@@ -48,7 +48,7 @@ jobs:
           retention-days: 28
 
       - name: Upload the PHPCBF phar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: phpcbf-phar
           path: ./phpcbf.phar
@@ -165,7 +165,7 @@ jobs:
 
       - name: Download the PHPCS phar
         if: ${{ matrix.custom_ini == false }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: phpcs-phar
 


### PR DESCRIPTION
## Description
The upstream issue appears to have been fixed. Let's try this again.

Re-does PR #172+ #173 and reverts PR #204.


## Suggested changelog entry
_N/A_

## Related issues/external references

Ref: actions/download-artifact#249

Fixes #208
