### PR TITLE
PSR2/ClassDeclaration: bug fix - space before class keyword is not checked correctly

### DIFF
--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -257,3 +257,28 @@ if (!class_exists('IndentedDeclaration')) {
 
     }
 }
+
+// Space between modifier and class keyword would not be flagged nor fixed if newline + indentation.
+final
+    class FinalClassWithIndentation
+    {
+    }
+
+readonly
+    class ReadonlyClassWithIndentation
+    {
+    }
+
+// And would also not be flagged if there was a comment between (not auto-fixable).
+final/*comment*/class FinalClassWithComment
+{
+}
+abstract /*comment*/  class AbstractClassWithComment
+{
+}
+
+readonly
+    // comment
+    class ReadonlyClassWithComment
+    {
+    }

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -247,3 +247,26 @@ if (!class_exists('IndentedDeclaration')) {
         function foo() {}
     }
 }
+
+// Space between modifier and class keyword would not be flagged nor fixed if newline + indentation.
+final class FinalClassWithIndentation
+{
+    }
+
+readonly class ReadonlyClassWithIndentation
+{
+    }
+
+// And would also not be flagged if there was a comment between (not auto-fixable).
+final/*comment*/class FinalClassWithComment
+{
+}
+abstract /*comment*/  class AbstractClassWithComment
+{
+}
+
+readonly
+    // comment
+    class ReadonlyClassWithComment
+    {
+    }

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -71,6 +71,11 @@ final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             244 => 1,
             248 => 1,
             258 => 1,
+            263 => 1,
+            268 => 1,
+            273 => 1,
+            276 => 1,
+            282 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description

* If there would be a newline + indentation between a modifier keyword and the "class" keyword, the space between them would not be flagged as incorrect (should be one space).
* Along the same lines, if there would be a comment between the modifier keyword and the "class" keyword, the space between them would not be checked, let alone flagged.

Fixed now.

Includes additional tests.

## Suggested changelog entry
* PSR2.Classes.ClassDeclaration : incorrect space between the last class modifier and the `class` keyword was not always flagged.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
