### PR TITLE
Runner: allow the Performance report when running `phpcbf`

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -194,7 +194,15 @@ class Runner
             $this->config->showSources  = false;
             $this->config->recordErrors = false;
             $this->config->reportFile   = null;
-            $this->config->reports      = ['cbf' => null];
+
+            // Only use the "Cbf" report, but allow for the Performance report as well.
+            $originalReports = array_change_key_case($this->config->reports, CASE_LOWER);
+            $newReports      = ['cbf' => null];
+            if (array_key_exists('performance', $originalReports) === true) {
+                $newReports['performance'] = $originalReports['performance'];
+            }
+
+            $this->config->reports = $newReports;
 
             // If a standard tries to set command line arguments itself, some
             // may be blocked because PHPCBF is running, so stop the script


### PR DESCRIPTION
## Description
As things were, a `phpcbf` run overruled the `Config::$reports` setting / `--report=...` CLI arguments to always only show the `Cbf` report.

As running the Performance report can also be useful for `phpcbf` (to find particularly slow fixers), I'm proposing to change the logic which overrules the reports setting for `phpcbf` to allow for displaying the `Performance` report as well (if requested).


## Suggested changelog entry
* Performance report can now be used for a `phpcbf` run.

## Related issues/external references

Related to #60


## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
