### PR TITLE
Tests/Tokenizer: make failure messages more descriptive

### DIFF
--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -30,21 +30,21 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      */
     public function testEnums($testMarker, $testContent, $openerOffset, $closerOffset)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $enum       = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
+        $tokenArray = $tokens[$enum];
 
-        $enum = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
+        $this->assertSame(T_ENUM, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_ENUM (code)');
+        $this->assertSame('T_ENUM', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_ENUM (type)');
 
-        $this->assertSame(T_ENUM, $tokens[$enum]['code']);
-        $this->assertSame('T_ENUM', $tokens[$enum]['type']);
+        $this->assertArrayHasKey('scope_condition', $tokenArray);
+        $this->assertArrayHasKey('scope_opener', $tokenArray);
+        $this->assertArrayHasKey('scope_closer', $tokenArray);
 
-        $this->assertArrayHasKey('scope_condition', $tokens[$enum]);
-        $this->assertArrayHasKey('scope_opener', $tokens[$enum]);
-        $this->assertArrayHasKey('scope_closer', $tokens[$enum]);
+        $this->assertSame($enum, $tokenArray['scope_condition']);
 
-        $this->assertSame($enum, $tokens[$enum]['scope_condition']);
-
-        $scopeOpener = $tokens[$enum]['scope_opener'];
-        $scopeCloser = $tokens[$enum]['scope_closer'];
+        $scopeOpener = $tokenArray['scope_opener'];
+        $scopeCloser = $tokenArray['scope_closer'];
 
         $expectedScopeOpener = ($enum + $openerOffset);
         $expectedScopeCloser = ($enum + $closerOffset);
@@ -138,11 +138,12 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      */
     public function testNotEnums($testMarker, $testContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
+        $tokenArray = $tokens[$target];
 
-        $target = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
-        $this->assertSame(T_STRING, $tokens[$target]['code']);
-        $this->assertSame('T_STRING', $tokens[$target]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testNotEnums()
 

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
 
 final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 {
@@ -29,12 +30,13 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      */
     public function testBackfill($marker, $type, $value)
     {
-        $tokens = self::$phpcsFile->getTokens();
-        $number = $this->getTargetToken($marker, [T_LNUMBER, T_DNUMBER]);
+        $tokens     = self::$phpcsFile->getTokens();
+        $number     = $this->getTargetToken($marker, [T_LNUMBER, T_DNUMBER]);
+        $tokenArray = $tokens[$number];
 
-        $this->assertSame(constant($type), $tokens[$number]['code']);
-        $this->assertSame($type, $tokens[$number]['type']);
-        $this->assertSame($value, $tokens[$number]['content']);
+        $this->assertSame(constant($type), $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not '.$type.' (code)');
+        $this->assertSame($type, $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not '.$type.' (type)');
+        $this->assertSame($value, $tokenArray['content']);
 
     }//end testBackfill()
 
@@ -153,7 +155,11 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 
         foreach ($expectedTokens as $key => $expectedToken) {
             $i = ($number + $key);
-            $this->assertSame($expectedToken['code'], $tokens[$i]['code']);
+            $this->assertSame(
+                $expectedToken['code'],
+                $tokens[$i]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$i]['code']).', not '.Tokens::tokenName($expectedToken['code'])
+            );
             $this->assertSame($expectedToken['content'], $tokens[$i]['content']);
         }
 

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -29,11 +29,12 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      */
     public function testReadonly($testMarker, $testContent='readonly')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
+        $tokenArray = $tokens[$target];
 
-        $target = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
-        $this->assertSame(T_READONLY, $tokens[$target]['code']);
-        $this->assertSame('T_READONLY', $tokens[$target]['type']);
+        $this->assertSame(T_READONLY, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_READONLY (code)');
+        $this->assertSame('T_READONLY', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_READONLY (type)');
 
     }//end testReadonly()
 
@@ -174,11 +175,12 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      */
     public function testNotReadonly($testMarker, $testContent='readonly')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
+        $tokenArray = $tokens[$target];
 
-        $target = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
-        $this->assertSame(T_STRING, $tokens[$target]['code']);
-        $this->assertSame('T_STRING', $tokens[$target]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testNotReadonly()
 

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -27,11 +27,12 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      */
     public function testBitwiseOr($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
+        $tokenArray = $tokens[$target];
 
-        $opener = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
-        $this->assertSame(T_BITWISE_OR, $tokens[$opener]['code']);
-        $this->assertSame('T_BITWISE_OR', $tokens[$opener]['type']);
+        $this->assertSame(T_BITWISE_OR, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_BITWISE_OR (code)');
+        $this->assertSame('T_BITWISE_OR', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_BITWISE_OR (type)');
 
     }//end testBitwiseOr()
 
@@ -78,11 +79,12 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      */
     public function testTypeUnion($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
+        $tokenArray = $tokens[$target];
 
-        $opener = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
-        $this->assertSame(T_TYPE_UNION, $tokens[$opener]['code']);
-        $this->assertSame('T_TYPE_UNION', $tokens[$opener]['type']);
+        $this->assertSame(T_TYPE_UNION, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_TYPE_UNION (code)');
+        $this->assertSame('T_TYPE_UNION', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_TYPE_UNION (type)');
 
     }//end testTypeUnion()
 

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -28,12 +28,12 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      */
     public function testStrings($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]));
+        $tokenArray = $tokens[$target];
 
-        $token = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]));
-
-        $this->assertSame(T_STRING, $tokens[$token]['code']);
-        $this->assertSame('T_STRING', $tokens[$token]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testStrings()
 
@@ -167,15 +167,23 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      */
     public function testKeywords($testMarker, $expectedTokenType)
     {
-        $tokens = self::$phpcsFile->getTokens();
-
-        $token = $this->getTargetToken(
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken(
             $testMarker,
             (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_PARENT, T_SELF, T_STRING, T_NULL, T_FALSE, T_TRUE])
         );
+        $tokenArray = $tokens[$target];
 
-        $this->assertSame(constant($expectedTokenType), $tokens[$token]['code']);
-        $this->assertSame($expectedTokenType, $tokens[$token]['type']);
+        $this->assertSame(
+            constant($expectedTokenType),
+            $tokenArray['code'],
+            'Token tokenized as '.$tokenArray['type'].', not '.$expectedTokenType.' (code)'
+        );
+        $this->assertSame(
+            $expectedTokenType,
+            $tokenArray['type'],
+            'Token tokenized as '.$tokenArray['type'].', not '.$expectedTokenType.' (type)'
+        );
 
     }//end testKeywords()
 

--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -28,16 +28,16 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testEnumCases($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $enumCase   = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
+        $tokenArray = $tokens[$enumCase];
 
-        $enumCase = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
+        $this->assertSame(T_ENUM_CASE, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_ENUM_CASE (code)');
+        $this->assertSame('T_ENUM_CASE', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_ENUM_CASE (type)');
 
-        $this->assertSame(T_ENUM_CASE, $tokens[$enumCase]['code']);
-        $this->assertSame('T_ENUM_CASE', $tokens[$enumCase]['type']);
-
-        $this->assertArrayNotHasKey('scope_condition', $tokens[$enumCase], 'Scope condition is set');
-        $this->assertArrayNotHasKey('scope_opener', $tokens[$enumCase], 'Scope opener is set');
-        $this->assertArrayNotHasKey('scope_closer', $tokens[$enumCase], 'Scope closer is set');
+        $this->assertArrayNotHasKey('scope_condition', $tokenArray, 'Scope condition is set');
+        $this->assertArrayNotHasKey('scope_opener', $tokenArray, 'Scope opener is set');
+        $this->assertArrayNotHasKey('scope_closer', $tokenArray, 'Scope closer is set');
 
     }//end testEnumCases()
 
@@ -77,16 +77,16 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testNotEnumCases($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $case       = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
+        $tokenArray = $tokens[$case];
 
-        $case = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
+        $this->assertSame(T_CASE, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_CASE (code)');
+        $this->assertSame('T_CASE', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_CASE (type)');
 
-        $this->assertSame(T_CASE, $tokens[$case]['code']);
-        $this->assertSame('T_CASE', $tokens[$case]['type']);
-
-        $this->assertArrayHasKey('scope_condition', $tokens[$case], 'Scope condition is not set');
-        $this->assertArrayHasKey('scope_opener', $tokens[$case], 'Scope opener is not set');
-        $this->assertArrayHasKey('scope_closer', $tokens[$case], 'Scope closer is not set');
+        $this->assertArrayHasKey('scope_condition', $tokenArray, 'Scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokenArray, 'Scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokenArray, 'Scope closer is not set');
 
     }//end testNotEnumCases()
 
@@ -125,12 +125,12 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testKeywordAsEnumCaseNameShouldBeString($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
-
+        $tokens       = self::$phpcsFile->getTokens();
         $enumCaseName = $this->getTargetToken($testMarker, [T_STRING, T_INTERFACE, T_TRAIT, T_ENUM, T_FUNCTION, T_FALSE, T_DEFAULT, T_ARRAY]);
+        $tokenArray   = $tokens[$enumCaseName];
 
-        $this->assertSame(T_STRING, $tokens[$enumCaseName]['code']);
-        $this->assertSame('T_STRING', $tokens[$enumCaseName]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testKeywordAsEnumCaseNameShouldBeString()
 

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -27,11 +27,12 @@ final class FinallyTest extends AbstractMethodUnitTest
      */
     public function testFinallyKeyword($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
+        $tokenArray = $tokens[$target];
 
-        $target = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
-        $this->assertSame(T_FINALLY, $tokens[$target]['code']);
-        $this->assertSame('T_FINALLY', $tokens[$target]['type']);
+        $this->assertSame(T_FINALLY, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_FINALLY (code)');
+        $this->assertSame('T_FINALLY', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_FINALLY (type)');
 
     }//end testFinallyKeyword()
 
@@ -66,11 +67,12 @@ final class FinallyTest extends AbstractMethodUnitTest
      */
     public function testFinallyNonKeyword($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
+        $tokenArray = $tokens[$target];
 
-        $target = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
-        $this->assertSame(T_STRING, $tokens[$target]['code']);
-        $this->assertSame('T_STRING', $tokens[$target]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testFinallyNonKeyword()
 

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -120,11 +120,12 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      */
     public function testNotAGotoDeclaration($testMarker, $testContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
-        $target = $this->getTargetToken($testMarker, [T_GOTO_LABEL, T_STRING], $testContent);
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_GOTO_LABEL, T_STRING], $testContent);
+        $tokenArray = $tokens[$target];
 
-        $this->assertSame(T_STRING, $tokens[$target]['code']);
-        $this->assertSame('T_STRING', $tokens[$target]['type']);
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
 
     }//end testNotAGotoDeclaration()
 

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -27,16 +27,19 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      */
     public function testSquareBrackets($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $opener     = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
+        $tokenArray = $tokens[$opener];
 
-        $opener = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
-        $this->assertSame(T_OPEN_SQUARE_BRACKET, $tokens[$opener]['code']);
-        $this->assertSame('T_OPEN_SQUARE_BRACKET', $tokens[$opener]['type']);
+        $this->assertSame(T_OPEN_SQUARE_BRACKET, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_OPEN_SQUARE_BRACKET (code)');
+        $this->assertSame('T_OPEN_SQUARE_BRACKET', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_OPEN_SQUARE_BRACKET (type)');
 
         if (isset($tokens[$opener]['bracket_closer']) === true) {
-            $closer = $tokens[$opener]['bracket_closer'];
-            $this->assertSame(T_CLOSE_SQUARE_BRACKET, $tokens[$closer]['code']);
-            $this->assertSame('T_CLOSE_SQUARE_BRACKET', $tokens[$closer]['type']);
+            $closer     = $tokens[$opener]['bracket_closer'];
+            $tokenArray = $tokens[$closer];
+
+            $this->assertSame(T_CLOSE_SQUARE_BRACKET, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_CLOSE_SQUARE_BRACKET (code)');
+            $this->assertSame('T_CLOSE_SQUARE_BRACKET', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_CLOSE_SQUARE_BRACKET (type)');
         }
 
     }//end testSquareBrackets()
@@ -92,16 +95,19 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      */
     public function testShortArrays($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $opener     = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
+        $tokenArray = $tokens[$opener];
 
-        $opener = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
-        $this->assertSame(T_OPEN_SHORT_ARRAY, $tokens[$opener]['code']);
-        $this->assertSame('T_OPEN_SHORT_ARRAY', $tokens[$opener]['type']);
+        $this->assertSame(T_OPEN_SHORT_ARRAY, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_OPEN_SHORT_ARRAY (code)');
+        $this->assertSame('T_OPEN_SHORT_ARRAY', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_OPEN_SHORT_ARRAY (type)');
 
         if (isset($tokens[$opener]['bracket_closer']) === true) {
-            $closer = $tokens[$opener]['bracket_closer'];
-            $this->assertSame(T_CLOSE_SHORT_ARRAY, $tokens[$closer]['code']);
-            $this->assertSame('T_CLOSE_SHORT_ARRAY', $tokens[$closer]['type']);
+            $closer     = $tokens[$opener]['bracket_closer'];
+            $tokenArray = $tokens[$closer];
+
+            $this->assertSame(T_CLOSE_SHORT_ARRAY, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_CLOSE_SHORT_ARRAY (code)');
+            $this->assertSame('T_CLOSE_SHORT_ARRAY', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_CLOSE_SHORT_ARRAY (type)');
         }
 
     }//end testShortArrays()

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -39,8 +39,16 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
         $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
 
         foreach ($expectedTokens as $key => $tokenInfo) {
-            $this->assertSame(constant($tokenInfo['type']), $tokens[$comment]['code']);
-            $this->assertSame($tokenInfo['type'], $tokens[$comment]['type']);
+            $this->assertSame(
+                constant($tokenInfo['type']),
+                $tokens[$comment]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$comment]['code']).', not '.$tokenInfo['type'].' (code)'
+            );
+            $this->assertSame(
+                $tokenInfo['type'],
+                $tokens[$comment]['type'],
+                'Token tokenized as '.$tokens[$comment]['type'].', not '.$tokenInfo['type'].' (type)'
+            );
             $this->assertSame($tokenInfo['content'], $tokens[$comment]['content']);
 
             ++$comment;

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -36,8 +36,16 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
         $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
 
         foreach ($expectedTokens as $key => $tokenInfo) {
-            $this->assertSame(constant($tokenInfo['type']), $tokens[$comment]['code']);
-            $this->assertSame($tokenInfo['type'], $tokens[$comment]['type']);
+            $this->assertSame(
+                constant($tokenInfo['type']),
+                $tokens[$comment]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$comment]['code']).', not '.$tokenInfo['type'].' (code)'
+            );
+            $this->assertSame(
+                $tokenInfo['type'],
+                $tokens[$comment]['type'],
+                'Token tokenized as '.$tokens[$comment]['type'].', not '.$tokenInfo['type'].' (type)'
+            );
             $this->assertSame($tokenInfo['content'], $tokens[$comment]['content']);
 
             ++$comment;

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -28,11 +28,12 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      */
     public function testBitwiseAnd($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
+        $tokenArray = $tokens[$target];
 
-        $opener = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
-        $this->assertSame(T_BITWISE_AND, $tokens[$opener]['code']);
-        $this->assertSame('T_BITWISE_AND', $tokens[$opener]['type']);
+        $this->assertSame(T_BITWISE_AND, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_BITWISE_AND (code)');
+        $this->assertSame('T_BITWISE_AND', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_BITWISE_AND (type)');
 
     }//end testBitwiseAnd()
 
@@ -81,11 +82,12 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      */
     public function testTypeIntersection($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens     = self::$phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
+        $tokenArray = $tokens[$target];
 
-        $opener = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
-        $this->assertSame(T_TYPE_INTERSECTION, $tokens[$opener]['code']);
-        $this->assertSame('T_TYPE_INTERSECTION', $tokens[$opener]['type']);
+        $this->assertSame(T_TYPE_INTERSECTION, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_TYPE_INTERSECTION (code)');
+        $this->assertSame('T_TYPE_INTERSECTION', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_TYPE_INTERSECTION (type)');
 
     }//end testTypeIntersection()
 

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -20,6 +20,7 @@
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
 
 final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
 {
@@ -42,8 +43,16 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
         $identifier = $this->getTargetToken($testMarker, constant($expectedTokens[0]['type']));
 
         foreach ($expectedTokens as $key => $tokenInfo) {
-            $this->assertSame(constant($tokenInfo['type']), $tokens[$identifier]['code']);
-            $this->assertSame($tokenInfo['type'], $tokens[$identifier]['type']);
+            $this->assertSame(
+                constant($tokenInfo['type']),
+                $tokens[$identifier]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$identifier]['code']).', not '.$tokenInfo['type'].' (code)'
+            );
+            $this->assertSame(
+                $tokenInfo['type'],
+                $tokens[$identifier]['type'],
+                'Token tokenized as '.$tokens[$identifier]['type'].', not '.$tokenInfo['type'].' (type)'
+            );
             $this->assertSame($tokenInfo['content'], $tokens[$identifier]['content']);
 
             ++$identifier;


### PR DESCRIPTION
## Description
Most Tokenizer tests first assert that the token `'code'` is correct and after that, that the token `'type'` is correct. When the first assertion fails, an error message like this will be displayed:
`Failed asserting that 357 is identical to 313.`

That's because the PHP native token constants are integers. And even if someone would memorize all token constant integers, the integer values are different depending on the PHP version being used. All in all, that makes error messages like the above hard to decipher.

To mitigate this, a number of the Tokenizer tests already used the `$msg` parameter for the `assertSame()` call.

This commit adds this `$msg` parameter to more assertions to make the failure messages actually useful.

Includes introducing an interim `$tokenArray` variable in a lot of these tests to keep the line length in check.


## Suggested changelog entry
_N/A_