### PR TITLE
Generic/LowerCaseType: bug fix in intersection type ignore code

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -135,7 +135,7 @@ class LowerCaseTypeSniff implements Sniff
                     $error     = 'PHP property type declarations must be lowercase; expected "%s" but found "%s"';
                     $errorCode = 'PropertyTypeFound';
 
-                    if ($props['type_token'] === T_TYPE_INTERSECTION) {
+                    if (strpos($type, '&') !== false) {
                         // Intersection types don't support simple types.
                     } else if (strpos($type, '|') !== false) {
                         $this->processUnionType(
@@ -167,7 +167,7 @@ class LowerCaseTypeSniff implements Sniff
             $error     = 'PHP return type declarations must be lowercase; expected "%s" but found "%s"';
             $errorCode = 'ReturnTypeFound';
 
-            if ($props['return_type_token'] === T_TYPE_INTERSECTION) {
+            if (strpos($returnType, '&') !== false) {
                 // Intersection types don't support simple types.
             } else if (strpos($returnType, '|') !== false) {
                 $this->processUnionType(
@@ -199,7 +199,7 @@ class LowerCaseTypeSniff implements Sniff
                 $error     = 'PHP parameter type declarations must be lowercase; expected "%s" but found "%s"';
                 $errorCode = 'ParamTypeFound';
 
-                if ($param['type_hint_token'] === T_TYPE_INTERSECTION) {
+                if (strpos($typeHint, '&') !== false) {
                     // Intersection types don't support simple types.
                 } else if (strpos($typeHint, '|') !== false) {
                     $this->processUnionType(


### PR DESCRIPTION
## Description
PR squizlabs/PHP_CodeSniffer#3581 introduced support for PHP 8.1 intersection types.
_Note: the sniff, or PHPCS itself for that matter, currently does not (yet) support PHP 8.2 DNF types. Once support for DNF types has been added, this sniff will need a further update/fix._

For now, for the purpose of this sniff, intersection types should be skipped as they cannot contain the simple types for which the case is being checked by this sniff.

However, the check for whether a type is an intersection type or not was wrong. The `'*type_token'` key for each of these checks contains the stack pointer to the _first_ token in the type declaration, so the comparison with `T_TYPE_INTERSECTION` will always yield `false`.

This did not lead to false positives due to how the type is handled after that, but is still a bug which should be fixed.

## Suggested changelog entry
_N/A_ (as the bug didn't lead to false positives)

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
