### PR TITLE
show sniff codes in the docs

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -78,6 +78,22 @@ abstract class Generator
 
     }//end getTitle()
 
+    /**
+     * Retrieves the code of the sniff from the DOMNode supplied.
+     *
+     * @param \DOMNode $doc The DOMNode object for the sniff.
+     *                      It represents the "documentation" tag in the XML
+     *                      standard file.
+     *
+     * @return string
+     */
+    protected function getSniffCode(\DOMNode $doc)
+    {
+        $code = $doc->getAttribute('code');
+
+        return ! empty($code) ? $code : '';
+    }//end getSniffCode()
+
 
     /**
      * Generates the documentation for a standard.

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -111,6 +111,9 @@ abstract class Generator
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
+            if (empty($documentation->getAttribute('code'))) {
+                $documentation->setAttribute('code', $code);
+            }
             $this->processSniff($documentation);
         }
 

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -46,13 +46,13 @@ abstract class Generator
         $this->ruleset = $ruleset;
 
         foreach ($ruleset->sniffs as $className => $sniffClass) {
-            $file    = Autoload::getLoadedFileName($className);
-            $docFile = str_replace(
+            $file      = Autoload::getLoadedFileName($className);
+            $docFile   = str_replace(
                 DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR,
                 DIRECTORY_SEPARATOR.'Docs'.DIRECTORY_SEPARATOR,
                 $file
             );
-            $docFile = str_replace('Sniff.php', 'Standard.xml', $docFile);
+            $docFile   = str_replace('Sniff.php', 'Standard.xml', $docFile);
             $sniffCode = Util\Common::getSniffCode($className);
 
             if (is_file($docFile) === true) {
@@ -78,6 +78,7 @@ abstract class Generator
 
     }//end getTitle()
 
+
     /**
      * Retrieves the code of the sniff from the DOMNode supplied.
      *
@@ -91,7 +92,12 @@ abstract class Generator
     {
         $code = $doc->getAttribute('code');
 
-        return ! empty($code) ? $code : '';
+        if (empty($code) === true) {
+            return '';
+        }
+
+        return $code;
+
     }//end getSniffCode()
 
 
@@ -111,9 +117,11 @@ abstract class Generator
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            if (empty($documentation->getAttribute('code'))) {
+
+            if (empty($documentation->getAttribute('code')) === true) {
                 $documentation->setAttribute('code', $code);
             }
+
             $this->processSniff($documentation);
         }
 

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -14,6 +14,7 @@ namespace PHP_CodeSniffer\Generators;
 
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Autoload;
+use PHP_CodeSniffer\Util;
 
 abstract class Generator
 {
@@ -52,9 +53,10 @@ abstract class Generator
                 $file
             );
             $docFile = str_replace('Sniff.php', 'Standard.xml', $docFile);
+            $sniffCode = Util\Common::getSniffCode($className);
 
             if (is_file($docFile) === true) {
-                $this->docFiles[] = $docFile;
+                $this->docFiles[$sniffCode] = $docFile;
             }
         }
 
@@ -89,7 +91,7 @@ abstract class Generator
      */
     public function generate()
     {
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $code => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -31,10 +31,13 @@ class HTML extends Generator
         $this->printHeader();
         $this->printToc();
 
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $code => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
+            if (empty($documentation->getAttribute('code'))) {
+                $documentation->setAttribute('code', $code);
+            }
             $this->processSniff($documentation);
         }
 

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -197,6 +197,11 @@ class HTML extends Generator
         echo '  <a name="'.str_replace(' ', '-', $title).'" />'.PHP_EOL;
         echo "  <h2>$title</h2>".PHP_EOL;
 
+        $code = $this->getSniffCode($doc);
+        if (! empty($code)) {
+            echo "  <code>$code</code>".PHP_EOL;
+        }
+
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {
                 $this->printTextBlock($node);

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -35,9 +35,11 @@ class HTML extends Generator
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            if (empty($documentation->getAttribute('code'))) {
+
+            if (empty($documentation->getAttribute('code')) === true) {
                 $documentation->setAttribute('code', $code);
             }
+
             $this->processSniff($documentation);
         }
 
@@ -198,7 +200,7 @@ class HTML extends Generator
         echo "  <h2>$title</h2>".PHP_EOL;
 
         $code = $this->getSniffCode($doc);
-        if (! empty($code)) {
+        if (empty($code) === false) {
             echo "  <code>$code</code>".PHP_EOL;
         }
 

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -26,10 +26,13 @@ class Markdown extends Generator
         ob_start();
         $this->printHeader();
 
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $code => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
+            if (empty($documentation->getAttribute('code'))) {
+                $documentation->setAttribute('code', $code);
+            }
             $this->processSniff($documentation);
         }
 

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -89,6 +89,11 @@ class Markdown extends Generator
         $title = $this->getTitle($doc);
         echo PHP_EOL."## $title".PHP_EOL;
 
+        $code = $this->getSniffCode($doc);
+        if (! empty($code)) {
+            echo PHP_EOL."`$code`".PHP_EOL.PHP_EOL;
+        }
+
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {
                 $this->printTextBlock($node);

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -30,9 +30,11 @@ class Markdown extends Generator
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            if (empty($documentation->getAttribute('code'))) {
+
+            if (empty($documentation->getAttribute('code')) === true) {
                 $documentation->setAttribute('code', $code);
             }
+
             $this->processSniff($documentation);
         }
 
@@ -90,7 +92,7 @@ class Markdown extends Generator
         echo PHP_EOL."## $title".PHP_EOL;
 
         $code = $this->getSniffCode($doc);
-        if (! empty($code)) {
+        if (empty($code) === false) {
             echo PHP_EOL."`$code`".PHP_EOL.PHP_EOL;
         }
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -29,7 +29,7 @@ class Text extends Generator
         $this->printTitle($doc);
 
         $code = $this->getSniffCode($doc);
-        if (! empty($code)) {
+        if (empty($code) === false) {
             echo "$code".PHP_EOL.PHP_EOL;
         }
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -28,6 +28,11 @@ class Text extends Generator
     {
         $this->printTitle($doc);
 
+        $code = $this->getSniffCode($doc);
+        if (! empty($code)) {
+            echo "$code".PHP_EOL.PHP_EOL;
+        }
+
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {
                 $this->printTextBlock($node);


### PR DESCRIPTION
This PR adds sniff codes to the documentation created with `--generate` attribute.

## Description

Searching for proper sniff explanations was always a complicated thing when using `phpcs`, at least for me. Since I don't know the `phpcs` codebase well yet (that's my second contribution try), I still have problems with finding sniff codes that I could use to build my ruleset. Or maybe I'm just dumb and can't find something crucial in the docs 😆

We can list all the sniffs in the specific coding standard by adding the `-e` attribute, but we need to iterate through all the available standards and check the results manually. It also doesn't provide explanations. We can show more docs by using the `--generator=text` attribute but the sniff code is not available there, and navigating/searching through this data is hard.

So finally, I mostly had to use reverse engineering to find a proper sniff code to include/exclude in the custom rulesets, or at least find the problem explanation. I've noticed that it would be much easier and faster if I'd have the sniff code in the documentation generated with `--generate` attribute. I know that not all the sniffs are documented, but including such simple things as sniff code in those reports made the searching process much easier.

I've decided to give it a try and I've managed to show them there. The changes here:
- Display sniff code in the documentation created with `--generate` tag.
- The sniff code can be set in the `code` attribute of the `documentation` XML tag (optional).
- When the sniff code is not set in the mentioned tag, it is automatically detected by phpcs engine and displayed.

Thanks to this I'm able to:
- Review the available docs and find the sniff codes to include/exclude them in the ruleset much faster.
- Find more information about errors much easier by searching info by sniff code.

## Screenshots

<img width="762" alt="HTML" src="https://github.com/PHPCSStandards/PHP_CodeSniffer/assets/13350922/276f5970-52f9-4401-910c-9351f0008d2c">
<img width="890" alt="Text" src="https://github.com/PHPCSStandards/PHP_CodeSniffer/assets/13350922/c6fb326a-f563-49c8-8968-c14b7d207340">
<img width="1005" alt="markdown" src="https://github.com/PHPCSStandards/PHP_CodeSniffer/assets/13350922/f7789cde-3a8b-4031-a355-3e8fee01fd27">

## Suggested changelog entry

Added: Sniff codes in the generated documentation.

## Related issues/external references

- https://github.com/squizlabs/PHP_CodeSniffer/issues/1926
- https://github.com/squizlabs/PHP_CodeSniffer/issues/1752#issuecomment-750927206
- https://github.com/squizlabs/PHP_CodeSniffer/issues/2213

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [ ] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
