### PR TITLE
AbstractMethodUnitTest: move getTargetToken() logic to static method

### DIFF
--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core;
 
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -92,8 +93,28 @@ abstract class AbstractMethodUnitTest extends TestCase
      */
     public function getTargetToken($commentString, $tokenType, $tokenContent=null)
     {
-        $start   = (self::$phpcsFile->numTokens - 1);
-        $comment = self::$phpcsFile->findPrevious(
+        return self::getTargetTokenFromFile(self::$phpcsFile, $commentString, $tokenType, $tokenContent);
+
+    }//end getTargetToken()
+
+
+    /**
+     * Get the token pointer for a target token based on a specific comment found on the line before.
+     *
+     * Note: the test delimiter comment MUST start with "/* test" to allow this function to
+     * distinguish between comments used *in* a test and test delimiters.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file to find the token in.
+     * @param string                      $commentString The delimiter comment to look for.
+     * @param int|string|array            $tokenType     The type of token(s) to look for.
+     * @param string                      $tokenContent  Optional. The token content for the target token.
+     *
+     * @return int
+     */
+    public static function getTargetTokenFromFile(File $phpcsFile, $commentString, $tokenType, $tokenContent=null)
+    {
+        $start   = ($phpcsFile->numTokens - 1);
+        $comment = $phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -101,7 +122,7 @@ abstract class AbstractMethodUnitTest extends TestCase
             $commentString
         );
 
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $phpcsFile->getTokens();
         $end    = ($start + 1);
 
         // Limit the token finding to between this and the next delimiter comment.
@@ -116,7 +137,7 @@ abstract class AbstractMethodUnitTest extends TestCase
             }
         }
 
-        $target = self::$phpcsFile->findNext(
+        $target = $phpcsFile->findNext(
             $tokenType,
             ($comment + 1),
             $end,
@@ -130,12 +151,12 @@ abstract class AbstractMethodUnitTest extends TestCase
                 $msg .= ' With token content: '.$tokenContent;
             }
 
-            $this->assertFalse(true, $msg);
+            self::assertFalse(true, $msg);
         }
 
         return $target;
 
-    }//end getTargetToken()
+    }//end getTargetTokenFromFile()
 
 
     /**


### PR DESCRIPTION
## Description
The Core test suite is going to get at least one more test case and this new test case class will also need a `getTargetToken()` method.

To prevent having to duplicate the logic and needing to maintain it in multiple places, this commit introduces a `getTargetTokenFromFile()` method which takes a `$phpcsFile` parameter, which allows for the method to become `static`, which in turn allows for the method to be used by other test case classes.

The original `getTargetToken()` method still has the same functionality as before, it now just calls the `getTargetTokenFromFile()` method under the hood.

## Suggested changelog entry
_N/A_

