### PR TITLE
Tests: fix recording code coverage for Tokenizer tests

### DIFF
--- a/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Base class to use when testing parts of the tokenizer.
+ *
+ * This is a near duplicate of the AbstractMethodUnitTest class, with the
+ * difference being that it allows for recording code coverage for tokenizer tests.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2018-2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTokenizerTestCase extends TestCase
+{
+
+    /**
+     * The file extension of the test case file (without leading dot).
+     *
+     * This allows child classes to overrule the default `inc` with, for instance,
+     * `js` or `css` when applicable.
+     *
+     * @var string
+     */
+    protected $fileExtension = 'inc';
+
+    /**
+     * The tab width setting to use when tokenizing the file.
+     *
+     * This allows for test case files to use a different tab width than the default.
+     *
+     * @var integer
+     */
+    protected $tabWidth = 4;
+
+    /**
+     * The \PHP_CodeSniffer\Files\File object containing the parsed contents of the test case file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    protected $phpcsFile;
+
+
+    /**
+     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
+     *
+     * The test case file for a unit test class has to be in the same directory
+     * directory and use the same file name as the test class, using the .inc extension.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function initializeFile()
+    {
+        if (isset($this->phpcsFile) === false) {
+            $config = new ConfigDouble();
+            // Also set a tab-width to enable testing tab-replaced vs `orig_content`.
+            $config->tabWidth = $this->tabWidth;
+
+            $ruleset = new Ruleset($config);
+
+            // Default to a file with the same name as the test class. Extension is property based.
+            $relativeCN     = str_replace(__NAMESPACE__, '', get_called_class());
+            $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
+            $pathToTestFile = realpath(__DIR__).$relativePath.'.'.$this->fileExtension;
+
+            // Make sure the file gets parsed correctly based on the file type.
+            $contents  = 'phpcs_input_file: '.$pathToTestFile.PHP_EOL;
+            $contents .= file_get_contents($pathToTestFile);
+
+            $this->phpcsFile = new DummyFile($contents, $ruleset, $config);
+            $this->phpcsFile->process();
+        }
+
+    }//end initializeFile()
+
+
+    /**
+     * Get the token pointer for a target token based on a specific comment found on the line before.
+     *
+     * Note: the test delimiter comment MUST start with "/* test" to allow this function to
+     * distinguish between comments used *in* a test and test delimiters.
+     *
+     * @param string           $commentString The delimiter comment to look for.
+     * @param int|string|array $tokenType     The type of token(s) to look for.
+     * @param string           $tokenContent  Optional. The token content for the target token.
+     *
+     * @return int
+     */
+    protected function getTargetToken($commentString, $tokenType, $tokenContent=null)
+    {
+        return AbstractMethodUnitTest::getTargetTokenFromFile($this->phpcsFile, $commentString, $tokenType, $tokenContent);
+
+    }//end getTargetToken()
+
+
+}//end class

--- a/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
+final class AnonClassParenthesisOwnerTest extends AbstractTokenizerTestCase
 {
 
 
@@ -27,7 +25,7 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      */
     public function testAnonClassNoParentheses($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $anonClass = $this->getTargetToken($testMarker, T_ANON_CLASS);
         $this->assertFalse(array_key_exists('parenthesis_owner', $tokens[$anonClass]));
@@ -50,7 +48,7 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      */
     public function testAnonClassNoParenthesesNextOpenClose($testMarker)
     {
-        $tokens   = self::$phpcsFile->getTokens();
+        $tokens   = $this->phpcsFile->getTokens();
         $function = $this->getTargetToken($testMarker, T_FUNCTION);
 
         $opener = $this->getTargetToken($testMarker, T_OPEN_PARENTHESIS);
@@ -99,7 +97,7 @@ final class AnonClassParenthesisOwnerTest extends AbstractMethodUnitTest
      */
     public function testAnonClassWithParentheses($testMarker)
     {
-        $tokens    = self::$phpcsFile->getTokens();
+        $tokens    = $this->phpcsFile->getTokens();
         $anonClass = $this->getTargetToken($testMarker, T_ANON_CLASS);
         $opener    = $this->getTargetToken($testMarker, T_OPEN_PARENTHESIS);
         $closer    = $this->getTargetToken($testMarker, T_CLOSE_PARENTHESIS);

--- a/tests/Core/Tokenizer/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizer/ArrayKeywordTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class ArrayKeywordTest extends AbstractMethodUnitTest
+final class ArrayKeywordTest extends AbstractTokenizerTestCase
 {
 
 
@@ -29,7 +27,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      */
     public function testArrayKeyword($testMarker, $testContent='array')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_ARRAY, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
@@ -89,7 +87,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      */
     public function testArrayType($testMarker, $testContent='array')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_ARRAY, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
@@ -144,7 +142,7 @@ final class ArrayKeywordTest extends AbstractMethodUnitTest
      */
     public function testNotArrayKeyword($testMarker, $testContent='array')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_ARRAY, T_STRING], $testContent);
         $tokenArray = $tokens[$token];

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class AttributesTest extends AbstractMethodUnitTest
+final class AttributesTest extends AbstractTokenizerTestCase
 {
 
 
@@ -31,7 +29,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testAttribute($testMarker, $length, $tokenCodes)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $attribute = $this->getTargetToken($testMarker, T_ATTRIBUTE);
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
@@ -294,7 +292,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testTwoAttributesOnTheSameLine()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $attribute = $this->getTargetToken('/* testTwoAttributeOnTheSameLine */', T_ATTRIBUTE);
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
@@ -318,7 +316,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testAttributeAndLineComment()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $attribute = $this->getTargetToken('/* testAttributeAndCommentOnTheSameLine */', T_ATTRIBUTE);
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
@@ -348,7 +346,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testAttributeOnParameters($testMarker, $position, $length, array $tokenCodes)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $function  = $this->getTargetToken($testMarker, T_FUNCTION);
         $attribute = ($function + $position);
@@ -455,7 +453,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testAttributeContainingTextLookingLikeCloseTag($testMarker, $length, array $expectedTokensAttribute, array $expectedTokensAfter)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $attribute = $this->getTargetToken($testMarker, T_ATTRIBUTE);
 
@@ -601,7 +599,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testInvalidAttribute()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
 
@@ -622,7 +620,7 @@ final class AttributesTest extends AbstractMethodUnitTest
      */
     public function testNestedAttributes()
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $tokenCodes = [
             T_STRING,
             T_NS_SEPARATOR,

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -615,6 +615,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
      * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
      * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
      * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::createAttributesNestingMap
      *
      * @return void
      */

--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class BackfillEnumTest extends AbstractMethodUnitTest
+final class BackfillEnumTest extends AbstractTokenizerTestCase
 {
 
 
@@ -30,7 +28,7 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      */
     public function testEnums($testMarker, $testContent, $openerOffset, $closerOffset)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $enum       = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
         $tokenArray = $tokens[$enum];
 
@@ -138,7 +136,7 @@ final class BackfillEnumTest extends AbstractMethodUnitTest
      */
     public function testNotEnums($testMarker, $testContent)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_ENUM, T_STRING], $testContent);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
+final class BackfillExplicitOctalNotationTest extends AbstractTokenizerTestCase
 {
 
 
@@ -30,7 +28,7 @@ final class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
      */
     public function testExplicitOctalNotation($marker, $value, $nextToken, $nextContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $number = $this->getTargetToken($marker, [T_LNUMBER]);
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class BackfillFnTokenTest extends AbstractMethodUnitTest
+final class BackfillFnTokenTest extends AbstractTokenizerTestCase
 {
 
 
@@ -106,7 +104,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testNestedInner()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token = $this->getTargetToken('/* testNestedInner */', T_FN);
         $this->backfillHelper($token, true);
@@ -137,7 +135,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testNestedSharedCloser()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token = $this->getTargetToken('/* testNestedSharedCloserOuter */', T_FN);
         $this->backfillHelper($token);
@@ -380,7 +378,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testKeywordReturnTypes()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $testMarkers = [
             'Self',
@@ -453,7 +451,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testTernary()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token = $this->getTargetToken('/* testTernary */', T_FN);
         $this->backfillHelper($token);
@@ -505,7 +503,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testTernaryWithTypes()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token = $this->getTargetToken('/* testTernaryWithTypes */', T_FN);
         $this->backfillHelper($token);
@@ -563,7 +561,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testInMatchValue($testMarker, $openerOffset, $closerOffset, $expectedCloserType, $expectedCloserFriendlyName)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token = $this->getTargetToken($testMarker, T_FN);
         $this->backfillHelper($token);
@@ -647,7 +645,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     public function testNotAnArrowFunction($testMarker, $testContent='fn')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_STRING, T_FN], $testContent);
         $tokenArray = $tokens[$token];
@@ -745,7 +743,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     private function backfillHelper($token, $skipScopeCloserCheck=false)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $this->assertTrue(array_key_exists('scope_condition', $tokens[$token]), 'Scope condition is not set');
         $this->assertTrue(array_key_exists('scope_opener', $tokens[$token]), 'Scope opener is not set');
@@ -797,7 +795,7 @@ final class BackfillFnTokenTest extends AbstractMethodUnitTest
      */
     private function scopePositionTestHelper($token, $openerOffset, $closerOffset, $expectedCloserType='semicolon')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
         $expectedScopeOpener = ($token + $openerOffset);
         $expectedScopeCloser = ($token + $closerOffset);
 

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.php
@@ -10,10 +10,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class BackfillMatchTokenTest extends AbstractMethodUnitTest
+final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
 {
 
 
@@ -32,7 +31,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      */
     public function testMatchExpression($testMarker, $openerOffset, $closerOffset, $testContent='match')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_STRING, T_MATCH], $testContent);
         $tokenArray = $tokens[$token];
@@ -213,7 +212,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      */
     public function testNotAMatchStructure($testMarker, $testContent='match')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_STRING, T_MATCH], $testContent);
         $tokenArray = $tokens[$token];
@@ -228,7 +227,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
         $this->assertArrayNotHasKey('parenthesis_opener', $tokenArray, 'Parenthesis opener is set');
         $this->assertArrayNotHasKey('parenthesis_closer', $tokenArray, 'Parenthesis closer is set');
 
-        $next = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($token + 1), null, true);
+        $next = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($token + 1), null, true);
         if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             $this->assertArrayNotHasKey('parenthesis_owner', $tokenArray, 'Parenthesis owner is set for opener after');
         }
@@ -477,7 +476,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      */
     private function scopeTestHelper($token, $openerOffset, $closerOffset, $skipScopeCloserCheck=false)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $tokenArray = $tokens[$token];
         $tokenType  = $tokenArray['type'];
         $expectedScopeOpener = ($token + $openerOffset);
@@ -532,7 +531,7 @@ final class BackfillMatchTokenTest extends AbstractMethodUnitTest
      */
     private function parenthesisTestHelper($token)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $tokenArray = $tokens[$token];
         $tokenType  = $tokenArray['type'];
 

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -9,10 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
+final class BackfillNumericSeparatorTest extends AbstractTokenizerTestCase
 {
 
 
@@ -30,7 +29,7 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      */
     public function testBackfill($marker, $type, $value)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $number     = $this->getTargetToken($marker, [T_LNUMBER, T_DNUMBER]);
         $tokenArray = $tokens[$number];
 
@@ -150,7 +149,7 @@ final class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
      */
     public function testNoBackfill($testMarker, $expectedTokens)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
         $number = $this->getTargetToken($testMarker, [T_LNUMBER, T_DNUMBER]);
 
         foreach ($expectedTokens as $key => $expectedToken) {

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class BackfillReadonlyTest extends AbstractMethodUnitTest
+final class BackfillReadonlyTest extends AbstractTokenizerTestCase
 {
 
 
@@ -29,7 +27,7 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      */
     public function testReadonly($testMarker, $testContent='readonly')
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
         $tokenArray = $tokens[$target];
 
@@ -175,7 +173,7 @@ final class BackfillReadonlyTest extends AbstractMethodUnitTest
      */
     public function testNotReadonly($testMarker, $testContent='readonly')
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class BitwiseOrTest extends AbstractMethodUnitTest
+final class BitwiseOrTest extends AbstractTokenizerTestCase
 {
 
 
@@ -27,7 +25,7 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      */
     public function testBitwiseOr($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
         $tokenArray = $tokens[$target];
 
@@ -79,7 +77,7 @@ final class BitwiseOrTest extends AbstractMethodUnitTest
      */
     public function testTypeUnion($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION]);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -9,10 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
+final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
 {
 
 
@@ -28,7 +27,7 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      */
     public function testStrings($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]));
         $tokenArray = $tokens[$target];
 
@@ -167,7 +166,7 @@ final class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
      */
     public function testKeywords($testMarker, $expectedTokenType)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken(
             $testMarker,
             (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_PARENT, T_SELF, T_STRING, T_NULL, T_FALSE, T_TRUE])

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -10,9 +10,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class DefaultKeywordTest extends AbstractMethodUnitTest
+final class DefaultKeywordTest extends AbstractTokenizerTestCase
 {
 
 
@@ -33,7 +31,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      */
     public function testMatchDefault($testMarker, $testContent='default')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
@@ -123,7 +121,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      */
     public function testSwitchDefault($testMarker, $openerOffset, $closerOffset, $conditionStop=null, $testContent='default')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
@@ -234,7 +232,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      */
     public function testNotDefaultKeyword($testMarker, $testContent='DEFAULT')
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
@@ -334,7 +332,7 @@ final class DefaultKeywordTest extends AbstractMethodUnitTest
      */
     public function testIssue3326()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken('/* testClassConstant */', [T_SEMICOLON]);
         $tokenArray = $tokens[$token];

--- a/tests/Core/Tokenizer/DoubleArrowTest.php
+++ b/tests/Core/Tokenizer/DoubleArrowTest.php
@@ -11,9 +11,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class DoubleArrowTest extends AbstractMethodUnitTest
+final class DoubleArrowTest extends AbstractTokenizerTestCase
 {
 
 
@@ -29,7 +27,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      */
     public function testDoubleArrow($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
         $tokenArray = $tokens[$token];
@@ -114,7 +112,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      */
     public function testMatchArrow($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
         $tokenArray = $tokens[$token];
@@ -201,7 +199,7 @@ final class DoubleArrowTest extends AbstractMethodUnitTest
      */
     public function testFnArrow($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
         $tokenArray = $tokens[$token];

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -10,9 +10,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class DoubleQuotedStringTest extends AbstractMethodUnitTest
+final class DoubleQuotedStringTest extends AbstractTokenizerTestCase
 {
 
 
@@ -29,7 +27,7 @@ final class DoubleQuotedStringTest extends AbstractMethodUnitTest
      */
     public function testDoubleQuotedString($testMarker, $expectedContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $target = $this->getTargetToken($testMarker, T_DOUBLE_QUOTED_STRING);
         $this->assertSame($expectedContent, $tokens[$target]['content']);

--- a/tests/Core/Tokenizer/EnumCaseTest.php
+++ b/tests/Core/Tokenizer/EnumCaseTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class EnumCaseTest extends AbstractMethodUnitTest
+final class EnumCaseTest extends AbstractTokenizerTestCase
 {
 
 
@@ -28,7 +26,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testEnumCases($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $enumCase   = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
         $tokenArray = $tokens[$enumCase];
 
@@ -77,7 +75,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testNotEnumCases($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $case       = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);
         $tokenArray = $tokens[$case];
 
@@ -125,7 +123,7 @@ final class EnumCaseTest extends AbstractMethodUnitTest
      */
     public function testKeywordAsEnumCaseNameShouldBeString($testMarker)
     {
-        $tokens       = self::$phpcsFile->getTokens();
+        $tokens       = $this->phpcsFile->getTokens();
         $enumCaseName = $this->getTargetToken($testMarker, [T_STRING, T_INTERFACE, T_TRAIT, T_ENUM, T_FUNCTION, T_FALSE, T_DEFAULT, T_ARRAY]);
         $tokenArray   = $tokens[$enumCaseName];
 

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class FinallyTest extends AbstractMethodUnitTest
+final class FinallyTest extends AbstractTokenizerTestCase
 {
 
 
@@ -27,7 +25,7 @@ final class FinallyTest extends AbstractMethodUnitTest
      */
     public function testFinallyKeyword($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
         $tokenArray = $tokens[$target];
 
@@ -67,7 +65,7 @@ final class FinallyTest extends AbstractMethodUnitTest
      */
     public function testFinallyNonKeyword($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class GotoLabelTest extends AbstractMethodUnitTest
+final class GotoLabelTest extends AbstractTokenizerTestCase
 {
 
 
@@ -28,7 +26,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      */
     public function testGotoStatement($testMarker, $testContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $label = $this->getTargetToken($testMarker, T_STRING);
 
@@ -74,7 +72,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      */
     public function testGotoDeclaration($testMarker, $testContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $label = $this->getTargetToken($testMarker, T_GOTO_LABEL);
 
@@ -120,7 +118,7 @@ final class GotoLabelTest extends AbstractMethodUnitTest
      */
     public function testNotAGotoDeclaration($testMarker, $testContent)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_GOTO_LABEL, T_STRING], $testContent);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizer/HeredocNowdocCloserTest.php
@@ -9,14 +9,12 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
 /**
  * Heredoc/nowdoc closer token test.
  *
  * @requires PHP 7.3
  */
-final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
+final class HeredocNowdocCloserTest extends AbstractTokenizerTestCase
 {
 
 
@@ -33,7 +31,7 @@ final class HeredocNowdocCloserTest extends AbstractMethodUnitTest
      */
     public function testHeredocNowdocCloserTabReplacement($testMarker, $expected)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $closer = $this->getTargetToken($testMarker, [T_END_HEREDOC, T_END_NOWDOC]);
 

--- a/tests/Core/Tokenizer/HeredocStringTest.php
+++ b/tests/Core/Tokenizer/HeredocStringTest.php
@@ -10,9 +10,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class HeredocStringTest extends AbstractMethodUnitTest
+final class HeredocStringTest extends AbstractTokenizerTestCase
 {
 
 
@@ -29,7 +27,7 @@ final class HeredocStringTest extends AbstractMethodUnitTest
      */
     public function testHeredocString($testMarker, $expectedContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $target = $this->getTargetToken($testMarker, T_HEREDOC);
         $this->assertSame($expectedContent."\n", $tokens[$target]['content']);
@@ -50,7 +48,7 @@ final class HeredocStringTest extends AbstractMethodUnitTest
      */
     public function testHeredocStringWrapped($testMarker, $expectedContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $testMarker = substr($testMarker, 0, -3).'Wrapped */';
         $target     = $this->getTargetToken($testMarker, T_HEREDOC);

--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
@@ -9,10 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
+final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
 {
 
 
@@ -30,7 +29,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testNamedFunctionCallArguments($testMarker, $parameters)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         foreach ($parameters as $content) {
             $label = $this->getTargetToken($testMarker, [T_STRING, T_PARAM_NAME], $content);
@@ -47,7 +46,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
             );
 
             // Get the next non-empty token.
-            $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+            $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
             $this->assertSame(
                 ':',
@@ -295,7 +294,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testOtherTstringInFunctionCall($testMarker, $content)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $label = $this->getTargetToken($testMarker, [T_STRING, T_PARAM_NAME], $content);
 
@@ -354,12 +353,12 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testMixedPositionalAndNamedArgsWithTernary()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $true = $this->getTargetToken('/* testMixedPositionalAndNamedArgsWithTernary */', T_TRUE);
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -375,7 +374,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testMixedPositionalAndNamedArgsWithTernary */', T_PARAM_NAME, 'name');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -406,7 +405,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testNamedArgWithTernary()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         /*
          * First argument.
@@ -415,7 +414,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testNamedArgWithTernary */', T_PARAM_NAME, 'label');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -436,7 +435,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $true = $this->getTargetToken('/* testNamedArgWithTernary */', T_TRUE);
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -456,7 +455,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testNamedArgWithTernary */', T_PARAM_NAME, 'more');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -477,7 +476,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $true = $this->getTargetToken('/* testNamedArgWithTernary */', T_STRING, 'CONSTANT_A');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -503,7 +502,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testTernaryWithFunctionCallsInThenElse()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         /*
          * Then.
@@ -512,7 +511,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_PARAM_NAME, 'label');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -533,7 +532,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $closeParens = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_CLOSE_PARENTHESIS);
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($closeParens + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($closeParens + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -553,7 +552,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_PARAM_NAME, 'more');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -583,12 +582,12 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testTernaryWithConstantsInThenElse()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $constant = $this->getTargetToken('/* testTernaryWithConstantsInThenElse */', T_STRING, 'CONSTANT_NAME');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($constant + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($constant + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -613,12 +612,12 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testSwitchStatement()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $label = $this->getTargetToken('/* testSwitchCaseWithConstant */', T_STRING, 'MY_CONSTANT');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -634,7 +633,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $label = $this->getTargetToken('/* testSwitchCaseWithClassProperty */', T_STRING, 'property');
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -650,7 +649,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $default = $this->getTargetToken('/* testSwitchDefault */', T_DEFAULT);
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($default + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($default + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -675,7 +674,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testParseErrorVariableLabel()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $label = $this->getTargetToken('/* testParseErrorDynamicName */', [T_VARIABLE, T_PARAM_NAME], '$variableStoringParamName');
 
@@ -691,7 +690,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         );
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -725,7 +724,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testOtherColonsInTernary($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $startOfStatement = $this->getTargetToken($testMarker, T_VARIABLE);
 
@@ -792,7 +791,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
      */
     public function testReservedKeywordsAsName($testMarker, $tokenTypes, $tokenContent)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
         $label  = $this->getTargetToken($testMarker, $tokenTypes, $tokenContent);
 
         $this->assertSame(
@@ -807,7 +806,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         );
 
         // Get the next non-empty token.
-        $colon = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
 
         $this->assertSame(
             ':',

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
@@ -9,10 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
+final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
 {
 
     /**
@@ -36,7 +35,7 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      */
     public function testObjectOperator()
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $operator = $this->getTargetToken('/* testObjectOperator */', $this->find);
         $this->assertSame(T_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is object operator');
@@ -57,7 +56,7 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      */
     public function testNullsafeObjectOperator($testMarker)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $operator = $this->getTargetToken($testMarker, $this->find);
         $this->assertSame(T_NULLSAFE_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is nullsafe object operator');
@@ -97,14 +96,14 @@ final class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
      */
     public function testTernaryThen($testMarker, $testObjectOperator=false)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $operator = $this->getTargetToken($testMarker, $this->find);
         $this->assertSame(T_INLINE_THEN, $tokens[$operator]['code'], 'Failed asserting code is inline then');
         $this->assertSame('T_INLINE_THEN', $tokens[$operator]['type'], 'Failed asserting type is inline then');
 
         if ($testObjectOperator === true) {
-            $next = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($operator + 1), null, true);
+            $next = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($operator + 1), null, true);
             $this->assertSame(T_OBJECT_OPERATOR, $tokens[$next]['code'], 'Failed asserting code is object operator');
             $this->assertSame('T_OBJECT_OPERATOR', $tokens[$next]['type'], 'Failed asserting type is object operator');
         }

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
+final class ScopeSettingWithNamespaceOperatorTest extends AbstractTokenizerTestCase
 {
 
 
@@ -30,7 +28,7 @@ final class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
      */
     public function testScopeSetting($testMarker, $tokenTypes, $open=T_OPEN_CURLY_BRACKET, $close=T_CLOSE_CURLY_BRACKET)
     {
-        $tokens = self::$phpcsFile->getTokens();
+        $tokens = $this->phpcsFile->getTokens();
 
         $target = $this->getTargetToken($testMarker, $tokenTypes);
         $opener = $this->getTargetToken($testMarker, $open);

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -9,9 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class ShortArrayTest extends AbstractMethodUnitTest
+final class ShortArrayTest extends AbstractTokenizerTestCase
 {
 
 
@@ -27,7 +25,7 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      */
     public function testSquareBrackets($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $opener     = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
         $tokenArray = $tokens[$opener];
 
@@ -95,7 +93,7 @@ final class ShortArrayTest extends AbstractMethodUnitTest
      */
     public function testShortArrays($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $opener     = $this->getTargetToken($testMarker, [T_OPEN_SQUARE_BRACKET, T_OPEN_SHORT_ARRAY]);
         $tokenArray = $tokens[$opener];
 

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -15,10 +15,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
+final class StableCommentWhitespaceTest extends AbstractTokenizerTestCase
 {
 
 
@@ -35,7 +34,7 @@ final class StableCommentWhitespaceTest extends AbstractMethodUnitTest
      */
     public function testCommentTokenization($testMarker, $expectedTokens)
     {
-        $tokens  = self::$phpcsFile->getTokens();
+        $tokens  = $this->phpcsFile->getTokens();
         $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
 
         foreach ($expectedTokens as $key => $tokenInfo) {

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -12,10 +12,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
+final class StableCommentWhitespaceWinTest extends AbstractTokenizerTestCase
 {
 
 
@@ -32,7 +31,7 @@ final class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
      */
     public function testCommentTokenization($testMarker, $expectedTokens)
     {
-        $tokens  = self::$phpcsFile->getTokens();
+        $tokens  = $this->phpcsFile->getTokens();
         $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
 
         foreach ($expectedTokens as $key => $tokenInfo) {

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -10,9 +10,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-
-final class TypeIntersectionTest extends AbstractMethodUnitTest
+final class TypeIntersectionTest extends AbstractTokenizerTestCase
 {
 
 
@@ -28,7 +26,7 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      */
     public function testBitwiseAnd($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
         $tokenArray = $tokens[$target];
 
@@ -82,7 +80,7 @@ final class TypeIntersectionTest extends AbstractMethodUnitTest
      */
     public function testTypeIntersection($testMarker)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION]);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -19,10 +19,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHP_CodeSniffer\Util\Tokens;
 
-final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
+final class UndoNamespacedNameSingleTokenTest extends AbstractTokenizerTestCase
 {
 
 
@@ -39,7 +38,7 @@ final class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
      */
     public function testIdentifierTokenization($testMarker, $expectedTokens)
     {
-        $tokens     = self::$phpcsFile->getTokens();
+        $tokens     = $this->phpcsFile->getTokens();
         $identifier = $this->getTargetToken($testMarker, constant($expectedTokens[0]['type']));
 
         foreach ($expectedTokens as $key => $tokenInfo) {


### PR DESCRIPTION
## Description

### Tests: new AbstractTokenizerTestCase class

Until now, code coverage was not being recorded for the Tokenizer tests due to the way the tests were set up.

This new `AbstractTokenizerTestCase` class is intended to fix this.

**Background info:**
* Code run in a `setUpBeforeClass()` method does not cause code coverage to be recorded.
* Code run in a `setUp()` method _does_ cause code coverage to be recorded.

Now, the `AbstractMethodUnitTest` test case class was originally set up to allow for testing the utility methods in the `File` class.
To do so in the most efficient way and to allow the tests to be fast, the file containing the code being used in the tests, is only tokenized once in a `setUpBeforeClass()` method.

Over time, when Tokenizer tests were being introduced, the `AbstractMethodUnitTest` class also started to be used by these, which was fine as code coverage wasn't being measured or recorded anyway.

However, this last part has been changed recently via PR #144, so now it is time to ensure that the Tokenizer related tests record code coverage too.

This new test case class allows for that by moving the tokenization of the code used in the tests from `setUpBeforeClass()` to a `setUp()` method.
As the tokenized file won't change during the test run, this is still only done once, but as that "once" is now in the `setUp()` method, it should allow for code coverage to be recorded.

Note: while code coverage can now be measured and recorded for Tokenizer related tests, it will still not be very precise as the `Tokenizer\PHP` class contains "monster methods", which means that the `@covers` tags in the Tokenizer related tests cannot be set up to target only a small, specific part of that class, as targeted by the test. But that's a problem for another time.


### Implement use of the new AbstractTokenizerTestCase class

### AttributesTest: add missing `@covers` tag 


## Suggested changelog entry
_N/A_


## Related issues/external references

Loosely related to #146
