### PR TITLE
Tests/Tokenizer: split `ContextSensitiveKeywordsTest`

### DIFF
--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
@@ -53,7 +53,6 @@ class ContextSensitiveKeywords
     const /* testMatch */ MATCH = 'MATCH';
     const /* testNamespace */ NAMESPACE = 'NAMESPACE';
     const /* testNew */ NEW = 'NEW';
-    const /* testParent */ PARENT = 'PARENT';
     const /* testPrint */ PRINT = 'PRINT';
     const /* testPrivate */ PRIVATE = 'PRIVATE';
     const /* testProtected */ PROTECTED = 'PROTECTED';
@@ -62,7 +61,6 @@ class ContextSensitiveKeywords
     const /* testRequire */ REQUIRE = 'REQUIRE';
     const /* testRequireOnce */ REQUIRE_ONCE = 'REQUIRE_ONCE';
     const /* testReturn */ RETURN = 'RETURN';
-    const /* testSelf */ SELF = 'SELF';
     const /* testStatic */ STATIC = 'STATIC';
     const /* testSwitch */ SWITCH = 'SWITCH';
     const /* testThrows */ THROW = 'THROW';
@@ -78,10 +76,6 @@ class ContextSensitiveKeywords
     const /* testAnd */ AND = 'LOGICAL_AND';
     const /* testOr */ OR = 'LOGICAL_OR';
     const /* testXor */ XOR = 'LOGICAL_XOR';
-
-    const /* testFalse */ FALSE = 'FALSE',
-    const /* testTrue */ TRUE = 'TRUE',
-    const /* testNull */ NULL = 'NULL',
 }
 
 namespace /* testKeywordAfterNamespaceShouldBeString */ class;
@@ -110,10 +104,6 @@ namespace /* testNamespaceNameIsString1 */ my\ /* testNamespaceNameIsString2 */ 
     /* testFinalIsKeyword */ final /* testFunctionIsKeyword */ function someFunction(
         /* testCallableIsKeyword */
         callable $callable,
-        /* testSelfIsKeyword */
-        self $self,
-        /* testParentIsKeyword */
-        parent $parent
     ) {
         /* testReturnIsKeyword */
         return $this;
@@ -220,9 +210,7 @@ $anonymousClass = new /* testAnonymousClassIsKeyword */ class {};
 $anonymousClass2 = new class /* testExtendsInAnonymousClassIsKeyword */ extends SomeParent {};
 $anonymousClass3 = new class /* testImplementsInAnonymousClassIsKeyword */ implements SomeInterface {};
 
-$instantiated1 = new /* testClassInstantiationParentIsKeyword */ parent();
-$instantiated2 = new /* testClassInstantiationSelfIsKeyword */ SELF;
-$instantiated3 = new /* testClassInstantiationStaticIsKeyword */ static($param);
+$instantiated = new /* testClassInstantiationStaticIsKeyword */ static($param);
 
 class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 {}
@@ -230,35 +218,10 @@ class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 function /* testKeywordAfterFunctionShouldBeString */ eval() {}
 function /* testKeywordAfterFunctionByRefShouldBeString */ &switch() {}
 
-function /* testKeywordSelfAfterFunctionByRefShouldBeString */ &self() {}
 function /* testKeywordStaticAfterFunctionByRefShouldBeString */ &static() {}
-function /* testKeywordParentAfterFunctionByRefShouldBeString */ &parent() {}
-function /* testKeywordFalseAfterFunctionByRefShouldBeString */ &false() {}
-function /* testKeywordTrueAfterFunctionByRefShouldBeString */ & true () {}
-function /* testKeywordNullAfterFunctionByRefShouldBeString */ &NULL() {}
 
-/* testKeywordAsFunctionCallNameShouldBeStringSelf */ self();
 /* testKeywordAsFunctionCallNameShouldBeStringStatic */ static();
 $obj-> /* testKeywordAsMethodCallNameShouldBeStringStatic */ static();
-/* testKeywordAsFunctionCallNameShouldBeStringParent */ parent();
-/* testKeywordAsFunctionCallNameShouldBeStringFalse */ false();
-/* testKeywordAsFunctionCallNameShouldBeStringTrue */ True ();
-/* testKeywordAsFunctionCallNameShouldBeStringNull */ null /*comment*/ ();
-
-$instantiated4 = new /* testClassInstantiationFalseIsString */ False();
-$instantiated5 = new /* testClassInstantiationTrueIsString */ true ();
-$instantiated6 = new /* testClassInstantiationNullIsString */ null();
 
 $function = /* testStaticIsKeywordBeforeClosure */ static function(/* testStaticIsKeywordWhenParamType */ static $param) {};
 $arrow = /* testStaticIsKeywordBeforeArrow */ static fn(): /* testStaticIsKeywordWhenReturnType */ static => 10;
-
-function standAloneFalseTrueNullTypesAndMore(
-    /* testFalseIsKeywordAsParamType */ false $paramA,
-    /* testTrueIsKeywordAsParamType */ true $paramB,
-    /* testNullIsKeywordAsParamType */ null $paramC,
-) /* testFalseIsKeywordAsReturnType */ false | /* testTrueIsKeywordAsReturnType */ true | /* testNullIsKeywordAsReturnType */ null {
-    if ($a === /* testFalseIsKeywordInComparison */ false
-    || $a === /* testTrueIsKeywordInComparison */ true
-    || $a === /* testNullIsKeywordInComparison */ null
-    ) {}
-}

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the conversion of context sensitive keywords to T_STRING.
+ * Tests the conversion of PHP native context sensitive keywords to T_STRING.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
  * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -28,7 +28,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public function testStrings($testMarker)
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]));
+        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING]));
         $tokenArray = $tokens[$target];
 
         $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
@@ -47,107 +47,88 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public static function dataStrings()
     {
         return [
-            'constant declaration: abstract'                                    => ['/* testAbstract */'],
-            'constant declaration: array'                                       => ['/* testArray */'],
-            'constant declaration: as'                                          => ['/* testAs */'],
-            'constant declaration: break'                                       => ['/* testBreak */'],
-            'constant declaration: callable'                                    => ['/* testCallable */'],
-            'constant declaration: case'                                        => ['/* testCase */'],
-            'constant declaration: catch'                                       => ['/* testCatch */'],
-            'constant declaration: class'                                       => ['/* testClass */'],
-            'constant declaration: clone'                                       => ['/* testClone */'],
-            'constant declaration: const'                                       => ['/* testConst */'],
-            'constant declaration: continue'                                    => ['/* testContinue */'],
-            'constant declaration: declare'                                     => ['/* testDeclare */'],
-            'constant declaration: default'                                     => ['/* testDefault */'],
-            'constant declaration: do'                                          => ['/* testDo */'],
-            'constant declaration: echo'                                        => ['/* testEcho */'],
-            'constant declaration: else'                                        => ['/* testElse */'],
-            'constant declaration: elseif'                                      => ['/* testElseIf */'],
-            'constant declaration: empty'                                       => ['/* testEmpty */'],
-            'constant declaration: enddeclare'                                  => ['/* testEndDeclare */'],
-            'constant declaration: endfor'                                      => ['/* testEndFor */'],
-            'constant declaration: endforeach'                                  => ['/* testEndForeach */'],
-            'constant declaration: endif'                                       => ['/* testEndIf */'],
-            'constant declaration: endswitch'                                   => ['/* testEndSwitch */'],
-            'constant declaration: endwhile'                                    => ['/* testEndWhile */'],
-            'constant declaration: enum'                                        => ['/* testEnum */'],
-            'constant declaration: eval'                                        => ['/* testEval */'],
-            'constant declaration: exit'                                        => ['/* testExit */'],
-            'constant declaration: extends'                                     => ['/* testExtends */'],
-            'constant declaration: final'                                       => ['/* testFinal */'],
-            'constant declaration: finally'                                     => ['/* testFinally */'],
-            'constant declaration: fn'                                          => ['/* testFn */'],
-            'constant declaration: for'                                         => ['/* testFor */'],
-            'constant declaration: foreach'                                     => ['/* testForeach */'],
-            'constant declaration: function'                                    => ['/* testFunction */'],
-            'constant declaration: global'                                      => ['/* testGlobal */'],
-            'constant declaration: goto'                                        => ['/* testGoto */'],
-            'constant declaration: if'                                          => ['/* testIf */'],
-            'constant declaration: implements'                                  => ['/* testImplements */'],
-            'constant declaration: include'                                     => ['/* testInclude */'],
-            'constant declaration: include_once'                                => ['/* testIncludeOnce */'],
-            'constant declaration: instanceof'                                  => ['/* testInstanceOf */'],
-            'constant declaration: insteadof'                                   => ['/* testInsteadOf */'],
-            'constant declaration: interface'                                   => ['/* testInterface */'],
-            'constant declaration: isset'                                       => ['/* testIsset */'],
-            'constant declaration: list'                                        => ['/* testList */'],
-            'constant declaration: match'                                       => ['/* testMatch */'],
-            'constant declaration: namespace'                                   => ['/* testNamespace */'],
-            'constant declaration: new'                                         => ['/* testNew */'],
-            'constant declaration: parent'                                      => ['/* testParent */'],
-            'constant declaration: print'                                       => ['/* testPrint */'],
-            'constant declaration: private'                                     => ['/* testPrivate */'],
-            'constant declaration: protected'                                   => ['/* testProtected */'],
-            'constant declaration: public'                                      => ['/* testPublic */'],
-            'constant declaration: readonly'                                    => ['/* testReadonly */'],
-            'constant declaration: require'                                     => ['/* testRequire */'],
-            'constant declaration: require_once'                                => ['/* testRequireOnce */'],
-            'constant declaration: return'                                      => ['/* testReturn */'],
-            'constant declaration: self'                                        => ['/* testSelf */'],
-            'constant declaration: static'                                      => ['/* testStatic */'],
-            'constant declaration: switch'                                      => ['/* testSwitch */'],
-            'constant declaration: throws'                                      => ['/* testThrows */'],
-            'constant declaration: trait'                                       => ['/* testTrait */'],
-            'constant declaration: try'                                         => ['/* testTry */'],
-            'constant declaration: unset'                                       => ['/* testUnset */'],
-            'constant declaration: use'                                         => ['/* testUse */'],
-            'constant declaration: var'                                         => ['/* testVar */'],
-            'constant declaration: while'                                       => ['/* testWhile */'],
-            'constant declaration: yield'                                       => ['/* testYield */'],
-            'constant declaration: yield_from'                                  => ['/* testYieldFrom */'],
-            'constant declaration: and'                                         => ['/* testAnd */'],
-            'constant declaration: or'                                          => ['/* testOr */'],
-            'constant declaration: xor'                                         => ['/* testXor */'],
-            'constant declaration: false'                                       => ['/* testFalse */'],
-            'constant declaration: true'                                        => ['/* testTrue */'],
-            'constant declaration: null'                                        => ['/* testNull */'],
+            'constant declaration: abstract'                  => ['/* testAbstract */'],
+            'constant declaration: array'                     => ['/* testArray */'],
+            'constant declaration: as'                        => ['/* testAs */'],
+            'constant declaration: break'                     => ['/* testBreak */'],
+            'constant declaration: callable'                  => ['/* testCallable */'],
+            'constant declaration: case'                      => ['/* testCase */'],
+            'constant declaration: catch'                     => ['/* testCatch */'],
+            'constant declaration: class'                     => ['/* testClass */'],
+            'constant declaration: clone'                     => ['/* testClone */'],
+            'constant declaration: const'                     => ['/* testConst */'],
+            'constant declaration: continue'                  => ['/* testContinue */'],
+            'constant declaration: declare'                   => ['/* testDeclare */'],
+            'constant declaration: default'                   => ['/* testDefault */'],
+            'constant declaration: do'                        => ['/* testDo */'],
+            'constant declaration: echo'                      => ['/* testEcho */'],
+            'constant declaration: else'                      => ['/* testElse */'],
+            'constant declaration: elseif'                    => ['/* testElseIf */'],
+            'constant declaration: empty'                     => ['/* testEmpty */'],
+            'constant declaration: enddeclare'                => ['/* testEndDeclare */'],
+            'constant declaration: endfor'                    => ['/* testEndFor */'],
+            'constant declaration: endforeach'                => ['/* testEndForeach */'],
+            'constant declaration: endif'                     => ['/* testEndIf */'],
+            'constant declaration: endswitch'                 => ['/* testEndSwitch */'],
+            'constant declaration: endwhile'                  => ['/* testEndWhile */'],
+            'constant declaration: enum'                      => ['/* testEnum */'],
+            'constant declaration: eval'                      => ['/* testEval */'],
+            'constant declaration: exit'                      => ['/* testExit */'],
+            'constant declaration: extends'                   => ['/* testExtends */'],
+            'constant declaration: final'                     => ['/* testFinal */'],
+            'constant declaration: finally'                   => ['/* testFinally */'],
+            'constant declaration: fn'                        => ['/* testFn */'],
+            'constant declaration: for'                       => ['/* testFor */'],
+            'constant declaration: foreach'                   => ['/* testForeach */'],
+            'constant declaration: function'                  => ['/* testFunction */'],
+            'constant declaration: global'                    => ['/* testGlobal */'],
+            'constant declaration: goto'                      => ['/* testGoto */'],
+            'constant declaration: if'                        => ['/* testIf */'],
+            'constant declaration: implements'                => ['/* testImplements */'],
+            'constant declaration: include'                   => ['/* testInclude */'],
+            'constant declaration: include_once'              => ['/* testIncludeOnce */'],
+            'constant declaration: instanceof'                => ['/* testInstanceOf */'],
+            'constant declaration: insteadof'                 => ['/* testInsteadOf */'],
+            'constant declaration: interface'                 => ['/* testInterface */'],
+            'constant declaration: isset'                     => ['/* testIsset */'],
+            'constant declaration: list'                      => ['/* testList */'],
+            'constant declaration: match'                     => ['/* testMatch */'],
+            'constant declaration: namespace'                 => ['/* testNamespace */'],
+            'constant declaration: new'                       => ['/* testNew */'],
+            'constant declaration: print'                     => ['/* testPrint */'],
+            'constant declaration: private'                   => ['/* testPrivate */'],
+            'constant declaration: protected'                 => ['/* testProtected */'],
+            'constant declaration: public'                    => ['/* testPublic */'],
+            'constant declaration: readonly'                  => ['/* testReadonly */'],
+            'constant declaration: require'                   => ['/* testRequire */'],
+            'constant declaration: require_once'              => ['/* testRequireOnce */'],
+            'constant declaration: return'                    => ['/* testReturn */'],
+            'constant declaration: static'                    => ['/* testStatic */'],
+            'constant declaration: switch'                    => ['/* testSwitch */'],
+            'constant declaration: throws'                    => ['/* testThrows */'],
+            'constant declaration: trait'                     => ['/* testTrait */'],
+            'constant declaration: try'                       => ['/* testTry */'],
+            'constant declaration: unset'                     => ['/* testUnset */'],
+            'constant declaration: use'                       => ['/* testUse */'],
+            'constant declaration: var'                       => ['/* testVar */'],
+            'constant declaration: while'                     => ['/* testWhile */'],
+            'constant declaration: yield'                     => ['/* testYield */'],
+            'constant declaration: yield_from'                => ['/* testYieldFrom */'],
+            'constant declaration: and'                       => ['/* testAnd */'],
+            'constant declaration: or'                        => ['/* testOr */'],
+            'constant declaration: xor'                       => ['/* testXor */'],
 
-            'namespace declaration: class'                                      => ['/* testKeywordAfterNamespaceShouldBeString */'],
-            'namespace declaration (partial): my'                               => ['/* testNamespaceNameIsString1 */'],
-            'namespace declaration (partial): class'                            => ['/* testNamespaceNameIsString2 */'],
-            'namespace declaration (partial): foreach'                          => ['/* testNamespaceNameIsString3 */'],
+            'namespace declaration: class'                    => ['/* testKeywordAfterNamespaceShouldBeString */'],
+            'namespace declaration (partial): my'             => ['/* testNamespaceNameIsString1 */'],
+            'namespace declaration (partial): class'          => ['/* testNamespaceNameIsString2 */'],
+            'namespace declaration (partial): foreach'        => ['/* testNamespaceNameIsString3 */'],
 
-            'function declaration: eval'                                        => ['/* testKeywordAfterFunctionShouldBeString */'],
-            'function declaration with return by ref: switch'                   => ['/* testKeywordAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: self'                     => ['/* testKeywordSelfAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: static'                   => ['/* testKeywordStaticAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: parent'                   => ['/* testKeywordParentAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: false'                    => ['/* testKeywordFalseAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: true'                     => ['/* testKeywordTrueAfterFunctionByRefShouldBeString */'],
-            'function declaration with return by ref: null'                     => ['/* testKeywordNullAfterFunctionByRefShouldBeString */'],
+            'function declaration: eval'                      => ['/* testKeywordAfterFunctionShouldBeString */'],
+            'function declaration with return by ref: switch' => ['/* testKeywordAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: static' => ['/* testKeywordStaticAfterFunctionByRefShouldBeString */'],
 
-            'function call: self'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringSelf */'],
-            'function call: static'                                             => ['/* testKeywordAsFunctionCallNameShouldBeStringStatic */'],
-            'method call: static'                                               => ['/* testKeywordAsMethodCallNameShouldBeStringStatic */'],
-            'function call: parent'                                             => ['/* testKeywordAsFunctionCallNameShouldBeStringParent */'],
-            'function call: false'                                              => ['/* testKeywordAsFunctionCallNameShouldBeStringFalse */'],
-            'function call: true'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringTrue */'],
-            'function call: null; with comment between keyword and parentheses' => ['/* testKeywordAsFunctionCallNameShouldBeStringNull */'],
-
-            'class instantiation: false'                                        => ['/* testClassInstantiationFalseIsString */'],
-            'class instantiation: true'                                         => ['/* testClassInstantiationTrueIsString */'],
-            'class instantiation: null'                                         => ['/* testClassInstantiationNullIsString */'],
+            'function call: static'                           => ['/* testKeywordAsFunctionCallNameShouldBeStringStatic */'],
+            'method call: static'                             => ['/* testKeywordAsMethodCallNameShouldBeStringStatic */'],
         ];
 
     }//end dataStrings()
@@ -167,10 +148,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public function testKeywords($testMarker, $expectedTokenType)
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken(
-            $testMarker,
-            (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_PARENT, T_SELF, T_STRING, T_NULL, T_FALSE, T_TRUE])
-        );
+        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_STRING]));
         $tokenArray = $tokens[$target];
 
         $this->assertSame(
@@ -197,394 +175,341 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public static function dataKeywords()
     {
         return [
-            'namespace: declaration'                  => [
+            'namespace: declaration'                 => [
                 'testMarker'        => '/* testNamespaceIsKeyword */',
                 'expectedTokenType' => 'T_NAMESPACE',
             ],
-            'abstract: class declaration'             => [
+            'abstract: class declaration'            => [
                 'testMarker'        => '/* testAbstractIsKeyword */',
                 'expectedTokenType' => 'T_ABSTRACT',
             ],
-            'class: declaration'                      => [
+            'class: declaration'                     => [
                 'testMarker'        => '/* testClassIsKeyword */',
                 'expectedTokenType' => 'T_CLASS',
             ],
-            'extends: in class declaration'           => [
+            'extends: in class declaration'          => [
                 'testMarker'        => '/* testExtendsIsKeyword */',
                 'expectedTokenType' => 'T_EXTENDS',
             ],
-            'implements: in class declaration'        => [
+            'implements: in class declaration'       => [
                 'testMarker'        => '/* testImplementsIsKeyword */',
                 'expectedTokenType' => 'T_IMPLEMENTS',
             ],
-            'use: in trait import'                    => [
+            'use: in trait import'                   => [
                 'testMarker'        => '/* testUseIsKeyword */',
                 'expectedTokenType' => 'T_USE',
             ],
-            'insteadof: in trait import'              => [
+            'insteadof: in trait import'             => [
                 'testMarker'        => '/* testInsteadOfIsKeyword */',
                 'expectedTokenType' => 'T_INSTEADOF',
             ],
-            'as: in trait import'                     => [
+            'as: in trait import'                    => [
                 'testMarker'        => '/* testAsIsKeyword */',
                 'expectedTokenType' => 'T_AS',
             ],
-            'const: declaration'                      => [
+            'const: declaration'                     => [
                 'testMarker'        => '/* testConstIsKeyword */',
                 'expectedTokenType' => 'T_CONST',
             ],
-            'private: property declaration'           => [
+            'private: property declaration'          => [
                 'testMarker'        => '/* testPrivateIsKeyword */',
                 'expectedTokenType' => 'T_PRIVATE',
             ],
-            'protected: property declaration'         => [
+            'protected: property declaration'        => [
                 'testMarker'        => '/* testProtectedIsKeyword */',
                 'expectedTokenType' => 'T_PROTECTED',
             ],
-            'public: property declaration'            => [
+            'public: property declaration'           => [
                 'testMarker'        => '/* testPublicIsKeyword */',
                 'expectedTokenType' => 'T_PUBLIC',
             ],
-            'var: property declaration'               => [
+            'var: property declaration'              => [
                 'testMarker'        => '/* testVarIsKeyword */',
                 'expectedTokenType' => 'T_VAR',
             ],
-            'static: property declaration'            => [
+            'static: property declaration'           => [
                 'testMarker'        => '/* testStaticIsKeyword */',
                 'expectedTokenType' => 'T_STATIC',
             ],
-            'readonly: property declaration'          => [
+            'readonly: property declaration'         => [
                 'testMarker'        => '/* testReadonlyIsKeyword */',
                 'expectedTokenType' => 'T_READONLY',
             ],
-            'final: function declaration'             => [
+            'final: function declaration'            => [
                 'testMarker'        => '/* testFinalIsKeyword */',
                 'expectedTokenType' => 'T_FINAL',
             ],
-            'function: declaration'                   => [
+            'function: declaration'                  => [
                 'testMarker'        => '/* testFunctionIsKeyword */',
                 'expectedTokenType' => 'T_FUNCTION',
             ],
-            'callable: param type declaration'        => [
+            'callable: param type declaration'       => [
                 'testMarker'        => '/* testCallableIsKeyword */',
                 'expectedTokenType' => 'T_CALLABLE',
             ],
-            'self: param type declaration'            => [
-                'testMarker'        => '/* testSelfIsKeyword */',
-                'expectedTokenType' => 'T_SELF',
-            ],
-            'parent: param type declaration'          => [
-                'testMarker'        => '/* testParentIsKeyword */',
-                'expectedTokenType' => 'T_PARENT',
-            ],
-            'return: statement'                       => [
+            'return: statement'                      => [
                 'testMarker'        => '/* testReturnIsKeyword */',
                 'expectedTokenType' => 'T_RETURN',
             ],
 
-            'interface: declaration'                  => [
+            'interface: declaration'                 => [
                 'testMarker'        => '/* testInterfaceIsKeyword */',
                 'expectedTokenType' => 'T_INTERFACE',
             ],
-            'trait: declaration'                      => [
+            'trait: declaration'                     => [
                 'testMarker'        => '/* testTraitIsKeyword */',
                 'expectedTokenType' => 'T_TRAIT',
             ],
-            'enum: declaration'                       => [
+            'enum: declaration'                      => [
                 'testMarker'        => '/* testEnumIsKeyword */',
                 'expectedTokenType' => 'T_ENUM',
             ],
 
-            'new: named instantiation'                => [
+            'new: named instantiation'               => [
                 'testMarker'        => '/* testNewIsKeyword */',
                 'expectedTokenType' => 'T_NEW',
             ],
-            'instanceof: comparison'                  => [
+            'instanceof: comparison'                 => [
                 'testMarker'        => '/* testInstanceOfIsKeyword */',
                 'expectedTokenType' => 'T_INSTANCEOF',
             ],
-            'clone'                                   => [
+            'clone'                                  => [
                 'testMarker'        => '/* testCloneIsKeyword */',
                 'expectedTokenType' => 'T_CLONE',
             ],
 
-            'if'                                      => [
+            'if'                                     => [
                 'testMarker'        => '/* testIfIsKeyword */',
                 'expectedTokenType' => 'T_IF',
             ],
-            'empty'                                   => [
+            'empty'                                  => [
                 'testMarker'        => '/* testEmptyIsKeyword */',
                 'expectedTokenType' => 'T_EMPTY',
             ],
-            'elseif'                                  => [
+            'elseif'                                 => [
                 'testMarker'        => '/* testElseIfIsKeyword */',
                 'expectedTokenType' => 'T_ELSEIF',
             ],
-            'else'                                    => [
+            'else'                                   => [
                 'testMarker'        => '/* testElseIsKeyword */',
                 'expectedTokenType' => 'T_ELSE',
             ],
-            'endif'                                   => [
+            'endif'                                  => [
                 'testMarker'        => '/* testEndIfIsKeyword */',
                 'expectedTokenType' => 'T_ENDIF',
             ],
 
-            'for'                                     => [
+            'for'                                    => [
                 'testMarker'        => '/* testForIsKeyword */',
                 'expectedTokenType' => 'T_FOR',
             ],
-            'endfor'                                  => [
+            'endfor'                                 => [
                 'testMarker'        => '/* testEndForIsKeyword */',
                 'expectedTokenType' => 'T_ENDFOR',
             ],
 
-            'foreach'                                 => [
+            'foreach'                                => [
                 'testMarker'        => '/* testForeachIsKeyword */',
                 'expectedTokenType' => 'T_FOREACH',
             ],
-            'endforeach'                              => [
+            'endforeach'                             => [
                 'testMarker'        => '/* testEndForeachIsKeyword */',
                 'expectedTokenType' => 'T_ENDFOREACH',
             ],
 
-            'switch'                                  => [
+            'switch'                                 => [
                 'testMarker'        => '/* testSwitchIsKeyword */',
                 'expectedTokenType' => 'T_SWITCH',
             ],
-            'case: in switch'                         => [
+            'case: in switch'                        => [
                 'testMarker'        => '/* testCaseIsKeyword */',
                 'expectedTokenType' => 'T_CASE',
             ],
-            'default: in switch'                      => [
+            'default: in switch'                     => [
                 'testMarker'        => '/* testDefaultIsKeyword */',
                 'expectedTokenType' => 'T_DEFAULT',
             ],
-            'endswitch'                               => [
+            'endswitch'                              => [
                 'testMarker'        => '/* testEndSwitchIsKeyword */',
                 'expectedTokenType' => 'T_ENDSWITCH',
             ],
-            'break: in switch'                        => [
+            'break: in switch'                       => [
                 'testMarker'        => '/* testBreakIsKeyword */',
                 'expectedTokenType' => 'T_BREAK',
             ],
-            'continue: in switch'                     => [
+            'continue: in switch'                    => [
                 'testMarker'        => '/* testContinueIsKeyword */',
                 'expectedTokenType' => 'T_CONTINUE',
             ],
 
-            'do'                                      => [
+            'do'                                     => [
                 'testMarker'        => '/* testDoIsKeyword */',
                 'expectedTokenType' => 'T_DO',
             ],
-            'while'                                   => [
+            'while'                                  => [
                 'testMarker'        => '/* testWhileIsKeyword */',
                 'expectedTokenType' => 'T_WHILE',
             ],
-            'endwhile'                                => [
+            'endwhile'                               => [
                 'testMarker'        => '/* testEndWhileIsKeyword */',
                 'expectedTokenType' => 'T_ENDWHILE',
             ],
 
-            'try'                                     => [
+            'try'                                    => [
                 'testMarker'        => '/* testTryIsKeyword */',
                 'expectedTokenType' => 'T_TRY',
             ],
-            'throw: statement'                        => [
+            'throw: statement'                       => [
                 'testMarker'        => '/* testThrowIsKeyword */',
                 'expectedTokenType' => 'T_THROW',
             ],
-            'catch'                                   => [
+            'catch'                                  => [
                 'testMarker'        => '/* testCatchIsKeyword */',
                 'expectedTokenType' => 'T_CATCH',
             ],
-            'finally'                                 => [
+            'finally'                                => [
                 'testMarker'        => '/* testFinallyIsKeyword */',
                 'expectedTokenType' => 'T_FINALLY',
             ],
 
-            'global'                                  => [
+            'global'                                 => [
                 'testMarker'        => '/* testGlobalIsKeyword */',
                 'expectedTokenType' => 'T_GLOBAL',
             ],
-            'echo'                                    => [
+            'echo'                                   => [
                 'testMarker'        => '/* testEchoIsKeyword */',
                 'expectedTokenType' => 'T_ECHO',
             ],
-            'print: statement'                        => [
+            'print: statement'                       => [
                 'testMarker'        => '/* testPrintIsKeyword */',
                 'expectedTokenType' => 'T_PRINT',
             ],
-            'die: statement'                          => [
+            'die: statement'                         => [
                 'testMarker'        => '/* testDieIsKeyword */',
                 'expectedTokenType' => 'T_EXIT',
             ],
-            'eval'                                    => [
+            'eval'                                   => [
                 'testMarker'        => '/* testEvalIsKeyword */',
                 'expectedTokenType' => 'T_EVAL',
             ],
-            'exit: statement'                         => [
+            'exit: statement'                        => [
                 'testMarker'        => '/* testExitIsKeyword */',
                 'expectedTokenType' => 'T_EXIT',
             ],
-            'isset'                                   => [
+            'isset'                                  => [
                 'testMarker'        => '/* testIssetIsKeyword */',
                 'expectedTokenType' => 'T_ISSET',
             ],
-            'unset'                                   => [
+            'unset'                                  => [
                 'testMarker'        => '/* testUnsetIsKeyword */',
                 'expectedTokenType' => 'T_UNSET',
             ],
 
-            'include'                                 => [
+            'include'                                => [
                 'testMarker'        => '/* testIncludeIsKeyword */',
                 'expectedTokenType' => 'T_INCLUDE',
             ],
-            'include_once'                            => [
+            'include_once'                           => [
                 'testMarker'        => '/* testIncludeOnceIsKeyword */',
                 'expectedTokenType' => 'T_INCLUDE_ONCE',
             ],
-            'require'                                 => [
+            'require'                                => [
                 'testMarker'        => '/* testRequireIsKeyword */',
                 'expectedTokenType' => 'T_REQUIRE',
             ],
-            'require_once'                            => [
+            'require_once'                           => [
                 'testMarker'        => '/* testRequireOnceIsKeyword */',
                 'expectedTokenType' => 'T_REQUIRE_ONCE',
             ],
 
-            'list'                                    => [
+            'list'                                   => [
                 'testMarker'        => '/* testListIsKeyword */',
                 'expectedTokenType' => 'T_LIST',
             ],
-            'goto'                                    => [
+            'goto'                                   => [
                 'testMarker'        => '/* testGotoIsKeyword */',
                 'expectedTokenType' => 'T_GOTO',
             ],
-            'match'                                   => [
+            'match'                                  => [
                 'testMarker'        => '/* testMatchIsKeyword */',
                 'expectedTokenType' => 'T_MATCH',
             ],
-            'default: in match expression'            => [
+            'default: in match expression'           => [
                 'testMarker'        => '/* testMatchDefaultIsKeyword */',
                 'expectedTokenType' => 'T_MATCH_DEFAULT',
             ],
-            'fn'                                      => [
+            'fn'                                     => [
                 'testMarker'        => '/* testFnIsKeyword */',
                 'expectedTokenType' => 'T_FN',
             ],
 
-            'yield'                                   => [
+            'yield'                                  => [
                 'testMarker'        => '/* testYieldIsKeyword */',
                 'expectedTokenType' => 'T_YIELD',
             ],
-            'yield from'                              => [
+            'yield from'                             => [
                 'testMarker'        => '/* testYieldFromIsKeyword */',
                 'expectedTokenType' => 'T_YIELD_FROM',
             ],
 
-            'declare'                                 => [
+            'declare'                                => [
                 'testMarker'        => '/* testDeclareIsKeyword */',
                 'expectedTokenType' => 'T_DECLARE',
             ],
-            'enddeclare'                              => [
+            'enddeclare'                             => [
                 'testMarker'        => '/* testEndDeclareIsKeyword */',
                 'expectedTokenType' => 'T_ENDDECLARE',
             ],
 
-            'and: in if'                              => [
+            'and: in if'                             => [
                 'testMarker'        => '/* testAndIsKeyword */',
                 'expectedTokenType' => 'T_LOGICAL_AND',
             ],
-            'or: in if'                               => [
+            'or: in if'                              => [
                 'testMarker'        => '/* testOrIsKeyword */',
                 'expectedTokenType' => 'T_LOGICAL_OR',
             ],
-            'xor: in if'                              => [
+            'xor: in if'                             => [
                 'testMarker'        => '/* testXorIsKeyword */',
                 'expectedTokenType' => 'T_LOGICAL_XOR',
             ],
 
-            'class: anon class declaration'           => [
+            'class: anon class declaration'          => [
                 'testMarker'        => '/* testAnonymousClassIsKeyword */',
                 'expectedTokenType' => 'T_ANON_CLASS',
             ],
-            'extends: anon class declaration'         => [
+            'extends: anon class declaration'        => [
                 'testMarker'        => '/* testExtendsInAnonymousClassIsKeyword */',
                 'expectedTokenType' => 'T_EXTENDS',
             ],
-            'implements: anon class declaration'      => [
+            'implements: anon class declaration'     => [
                 'testMarker'        => '/* testImplementsInAnonymousClassIsKeyword */',
                 'expectedTokenType' => 'T_IMPLEMENTS',
             ],
-            'parent: class instantiation'             => [
-                'testMarker'        => '/* testClassInstantiationParentIsKeyword */',
-                'expectedTokenType' => 'T_PARENT',
-            ],
-            'self: class instantiation'               => [
-                'testMarker'        => '/* testClassInstantiationSelfIsKeyword */',
-                'expectedTokenType' => 'T_SELF',
-            ],
-            'static: class instantiation'             => [
+            'static: class instantiation'            => [
                 'testMarker'        => '/* testClassInstantiationStaticIsKeyword */',
                 'expectedTokenType' => 'T_STATIC',
             ],
-            'namespace: operator'                     => [
+            'namespace: operator'                    => [
                 'testMarker'        => '/* testNamespaceInNameIsKeyword */',
                 'expectedTokenType' => 'T_NAMESPACE',
             ],
 
-            'static: closure declaration'             => [
+            'static: closure declaration'            => [
                 'testMarker'        => '/* testStaticIsKeywordBeforeClosure */',
                 'expectedTokenType' => 'T_STATIC',
             ],
-            'static: parameter type (illegal)'        => [
+            'static: parameter type (illegal)'       => [
                 'testMarker'        => '/* testStaticIsKeywordWhenParamType */',
                 'expectedTokenType' => 'T_STATIC',
             ],
-            'static: arrow function declaration'      => [
+            'static: arrow function declaration'     => [
                 'testMarker'        => '/* testStaticIsKeywordBeforeArrow */',
                 'expectedTokenType' => 'T_STATIC',
             ],
-            'static: return type for arrow function'  => [
+            'static: return type for arrow function' => [
                 'testMarker'        => '/* testStaticIsKeywordWhenReturnType */',
                 'expectedTokenType' => 'T_STATIC',
-            ],
-
-            'false: param type declaration'           => [
-                'testMarker'        => '/* testFalseIsKeywordAsParamType */',
-                'expectedTokenType' => 'T_FALSE',
-            ],
-            'true: param type declaration'            => [
-                'testMarker'        => '/* testTrueIsKeywordAsParamType */',
-                'expectedTokenType' => 'T_TRUE',
-            ],
-            'null: param type declaration'            => [
-                'testMarker'        => '/* testNullIsKeywordAsParamType */',
-                'expectedTokenType' => 'T_NULL',
-            ],
-            'false: return type declaration in union' => [
-                'testMarker'        => '/* testFalseIsKeywordAsReturnType */',
-                'expectedTokenType' => 'T_FALSE',
-            ],
-            'true: return type declaration in union'  => [
-                'testMarker'        => '/* testTrueIsKeywordAsReturnType */',
-                'expectedTokenType' => 'T_TRUE',
-            ],
-            'null: return type declaration in union'  => [
-                'testMarker'        => '/* testNullIsKeywordAsReturnType */',
-                'expectedTokenType' => 'T_NULL',
-            ],
-            'false: in comparison'                    => [
-                'testMarker'        => '/* testFalseIsKeywordInComparison */',
-                'expectedTokenType' => 'T_FALSE',
-            ],
-            'true: in comparison'                     => [
-                'testMarker'        => '/* testTrueIsKeywordInComparison */',
-                'expectedTokenType' => 'T_TRUE',
-            ],
-            'null: in comparison'                     => [
-                'testMarker'        => '/* testNullIsKeywordInComparison */',
-                'expectedTokenType' => 'T_NULL',
             ],
         ];
 

--- a/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+class OtherContextSensitiveKeywords
+{
+    const /* testParent */ PARENT = 'PARENT';
+    const /* testSelf */ SELF = 'SELF';
+
+    const /* testFalse */ FALSE = 'FALSE',
+    const /* testTrue */ TRUE = 'TRUE',
+    const /* testNull */ NULL = 'NULL',
+}
+
+abstract class SomeClass
+{
+    final function someFunction(
+        /* testSelfIsKeyword */
+        self $self,
+        /* testParentIsKeyword */
+        parent $parent
+    ) {
+        return $this;
+    }
+}
+
+$instantiated1 = new /* testClassInstantiationParentIsKeyword */ parent();
+$instantiated2 = new /* testClassInstantiationSelfIsKeyword */ SELF;
+
+function /* testKeywordSelfAfterFunctionByRefShouldBeString */ &self() {}
+function /* testKeywordParentAfterFunctionByRefShouldBeString */ &parent() {}
+function /* testKeywordFalseAfterFunctionByRefShouldBeString */ &false() {}
+function /* testKeywordTrueAfterFunctionByRefShouldBeString */ & true () {}
+function /* testKeywordNullAfterFunctionByRefShouldBeString */ &NULL() {}
+
+/* testKeywordAsFunctionCallNameShouldBeStringSelf */ self();
+/* testKeywordAsFunctionCallNameShouldBeStringParent */ parent();
+/* testKeywordAsFunctionCallNameShouldBeStringFalse */ false();
+/* testKeywordAsFunctionCallNameShouldBeStringTrue */ True ();
+/* testKeywordAsFunctionCallNameShouldBeStringNull */ null /*comment*/ ();
+
+$instantiated4 = new /* testClassInstantiationFalseIsString */ False();
+$instantiated5 = new /* testClassInstantiationTrueIsString */ true ();
+$instantiated6 = new /* testClassInstantiationNullIsString */ null();
+
+function standAloneFalseTrueNullTypesAndMore(
+    /* testFalseIsKeywordAsParamType */ false $paramA,
+    /* testTrueIsKeywordAsParamType */ true $paramB,
+    /* testNullIsKeywordAsParamType */ null $paramC,
+) /* testFalseIsKeywordAsReturnType */ false | /* testTrueIsKeywordAsReturnType */ true | /* testNullIsKeywordAsReturnType */ null {
+    if ($a === /* testFalseIsKeywordInComparison */ false
+    || $a === /* testTrueIsKeywordInComparison */ true
+    || $a === /* testNullIsKeywordInComparison */ null
+    ) {}
+}

--- a/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests the conversion of PHPCS native context sensitive keyword tokens to T_STRING.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+/**
+ * Tests the conversion of PHPCS native context sensitive keyword tokens to T_STRING.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::standardiseToken
+ */
+final class OtherContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Clear the "resolved tokens" cache before running this test as otherwise the code
+     * under test may not be run during the test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function clearTokenCache()
+    {
+        parent::clearResolvedTokensCache();
+
+    }//end clearTokenCache()
+
+
+    /**
+     * Test that context sensitive keyword is tokenized as string when it should be string.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataStrings
+     *
+     * @return void
+     */
+    public function testStrings($testMarker)
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
+
+    }//end testStrings()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testStrings()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataStrings()
+    {
+        return [
+            'constant declaration: parent'                                      => ['/* testParent */'],
+            'constant declaration: self'                                        => ['/* testSelf */'],
+            'constant declaration: false'                                       => ['/* testFalse */'],
+            'constant declaration: true'                                        => ['/* testTrue */'],
+            'constant declaration: null'                                        => ['/* testNull */'],
+
+            'function declaration with return by ref: self'                     => ['/* testKeywordSelfAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: parent'                   => ['/* testKeywordParentAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: false'                    => ['/* testKeywordFalseAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: true'                     => ['/* testKeywordTrueAfterFunctionByRefShouldBeString */'],
+            'function declaration with return by ref: null'                     => ['/* testKeywordNullAfterFunctionByRefShouldBeString */'],
+
+            'function call: self'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringSelf */'],
+            'function call: parent'                                             => ['/* testKeywordAsFunctionCallNameShouldBeStringParent */'],
+            'function call: false'                                              => ['/* testKeywordAsFunctionCallNameShouldBeStringFalse */'],
+            'function call: true'                                               => ['/* testKeywordAsFunctionCallNameShouldBeStringTrue */'],
+            'function call: null; with comment between keyword and parentheses' => ['/* testKeywordAsFunctionCallNameShouldBeStringNull */'],
+
+            'class instantiation: false'                                        => ['/* testClassInstantiationFalseIsString */'],
+            'class instantiation: true'                                         => ['/* testClassInstantiationTrueIsString */'],
+            'class instantiation: null'                                         => ['/* testClassInstantiationNullIsString */'],
+        ];
+
+    }//end dataStrings()
+
+
+    /**
+     * Test that context sensitive keyword is tokenized as keyword when it should be keyword.
+     *
+     * @param string $testMarker        The comment which prefaces the target token in the test file.
+     * @param string $expectedTokenType The expected token type.
+     *
+     * @dataProvider dataKeywords
+     *
+     * @return void
+     */
+    public function testKeywords($testMarker, $expectedTokenType)
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(
+            constant($expectedTokenType),
+            $tokenArray['code'],
+            'Token tokenized as '.$tokenArray['type'].', not '.$expectedTokenType.' (code)'
+        );
+        $this->assertSame(
+            $expectedTokenType,
+            $tokenArray['type'],
+            'Token tokenized as '.$tokenArray['type'].', not '.$expectedTokenType.' (type)'
+        );
+
+    }//end testKeywords()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testKeywords()
+     *
+     * @return array
+     */
+    public static function dataKeywords()
+    {
+        return [
+            'self: param type declaration'            => [
+                'testMarker'        => '/* testSelfIsKeyword */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: param type declaration'          => [
+                'testMarker'        => '/* testParentIsKeyword */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'parent: class instantiation'             => [
+                'testMarker'        => '/* testClassInstantiationParentIsKeyword */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: class instantiation'               => [
+                'testMarker'        => '/* testClassInstantiationSelfIsKeyword */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+
+            'false: param type declaration'           => [
+                'testMarker'        => '/* testFalseIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: param type declaration'            => [
+                'testMarker'        => '/* testTrueIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: param type declaration'            => [
+                'testMarker'        => '/* testNullIsKeywordAsParamType */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'false: return type declaration in union' => [
+                'testMarker'        => '/* testFalseIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: return type declaration in union'  => [
+                'testMarker'        => '/* testTrueIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: return type declaration in union'  => [
+                'testMarker'        => '/* testNullIsKeywordAsReturnType */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'false: in comparison'                    => [
+                'testMarker'        => '/* testFalseIsKeywordInComparison */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: in comparison'                     => [
+                'testMarker'        => '/* testTrueIsKeywordInComparison */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: in comparison'                     => [
+                'testMarker'        => '/* testNullIsKeywordInComparison */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+        ];
+
+    }//end dataKeywords()
+
+
+}//end class


### PR DESCRIPTION
## Description
Split `ContextSensitiveKeywordsTest` as one part of these tests is about the PHP native context sensitive keywords and the other part is about PHPCS native tokens for certain keyword.

These things are handled in different parts of the `Tokenizer\PHP` class and, in part, need different `@covers` tags.


## Suggested changelog entry
_N/A_


## Related issues/external references

Related to #146
