### PR TITLE
PHP 8.3 | Add tests with readonly anonymous classes to various sniffs

### DIFF
--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc
@@ -88,3 +88,9 @@ $instance = new class() extends SomeClass implements
     SomeInterface{
     public function __construct() {}
 };
+
+// PHP 8.3 readonly anonymous classes.
+$anon = new readonly class {};
+$anon = new readonly    class {};
+$anon = new readonly
+        class {};

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc.fixed
@@ -91,3 +91,8 @@ $instance = new class () extends SomeClass implements
 {
     public function __construct() {}
 };
+
+// PHP 8.3 readonly anonymous classes.
+$anon = new readonly class {};
+$anon = new readonly class {};
+$anon = new readonly class {};

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -55,6 +55,8 @@ final class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
             75 => 1,
             87 => 1,
             88 => 1,
+            94 => 1,
+            96 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -12,3 +12,5 @@ ReadOnly class MyClass
 }
 
 $a = new CLASS() {};
+
+$anon = new ReadOnly class() {};

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -12,3 +12,5 @@ readonly class MyClass
 }
 
 $a = new class() {};
+
+$anon = new readonly class() {};

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -40,6 +40,7 @@ final class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             10 => 1,
             11 => 1,
             14 => 1,
+            16 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -139,3 +139,11 @@ class ReadonlyTest {
 
     public function __construct(readonly  protected  float|int $x, public readonly?string &$y = 'test') {}
 }
+
+// PHP 8.2 readonly classes.
+readonly class ReadonlyClassTest {}
+readonly    class ReadonlyClassTest {}
+
+// PHP 8.3 readonly anonymous classes.
+$anon = new readonly class {};
+$anon = new readonly    class {};

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -133,3 +133,11 @@ class ReadonlyTest {
 
     public function __construct(readonly protected float|int $x, public readonly ?string &$y = 'test') {}
 }
+
+// PHP 8.2 readonly classes.
+readonly class ReadonlyClassTest {}
+readonly class ReadonlyClassTest {}
+
+// PHP 8.3 readonly anonymous classes.
+$anon = new readonly class {};
+$anon = new readonly class {};

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -56,6 +56,8 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
                 134 => 2,
                 138 => 2,
                 140 => 3,
+                145 => 1,
+                149 => 1,
             ];
 
         case 'ScopeKeywordSpacingUnitTest.3.inc':


### PR DESCRIPTION
## Description

### PHP 8.3 | Squiz/LowercaseClassKeywords: add tests with readonly anonymous classes

Sniff already handles this and handles it correctly.

### PHP 8.2/8.3 | Squiz/ScopeKeywordSpacing: add tests with readonly classes

Adds test for both plain readonly classes (PHP 8.2) as well as anonymous readonly classes (PHP 8.3).

Sniff already handles this and handles it correctly.

### PHP 8.3 | PSR12/AnonClassDeclaration: add tests with readonly anonymous classes

The underlying `PSR2.Classes.ClassDeclaration` sniff, which does the actual checking of the space between a potential modifier keyword and the `class` keyword, already handles this correctly (after squizlabs/PHP_CodeSniffer#3826 and #307).

Note: tests were only added to the PSR12 sniffs as that sniffs registers the `T_ANON_CLASS` token.
The `PEAR.Classes.ClassDeclaration` sniff and the `PSR2` and `Squiz` versions, which both extend the `PEAR` class, don't need tests as none of those listen for the `T_ANON_CLASS` token.


## Suggested changelog entry
_N/A_


## Related issues/external references

Related to #106

