### PR TITLE
PHP 8.3 | PSR12/ClassInstantiation: allow for readonly anonymous classes

### DIFF
--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -64,12 +64,14 @@ class ClassInstantiationSniff implements Sniff
                 continue;
             }
 
-            // Skip over potential attributes for anonymous classes.
+            // Bow out when this is an anonymous class.
+            // Anonymous classes are the only situation which would allow for an attribute
+            // or for the readonly keyword between "new" and the class "name".
             if ($tokens[$i]['code'] === T_ATTRIBUTE
-                && isset($tokens[$i]['attribute_closer']) === true
+                || $tokens[$i]['code'] === T_READONLY
+                || $tokens[$i]['code'] === T_ANON_CLASS
             ) {
-                $i = $tokens[$i]['attribute_closer'];
-                continue;
+                return;
             }
 
             if ($tokens[$i]['code'] === T_OPEN_SQUARE_BRACKET
@@ -84,11 +86,6 @@ class ClassInstantiationSniff implements Sniff
         }//end for
 
         if ($classNameEnd === null) {
-            return;
-        }
-
-        if ($tokens[$classNameEnd]['code'] === T_ANON_CLASS) {
-            // Ignore anon classes.
             return;
         }
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
@@ -45,3 +45,7 @@ $anonWithAttribute = new #[SomeAttribute('summary')] class {
 
 $foo = new parent();
 $foo = new parent;
+
+// PHP 8.3: safeguard that the sniff ignores anonymous classes, even when declared as readonly.
+$anon = new readonly class {};
+$anon = new #[MyAttribute] readonly class {};

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
@@ -45,3 +45,7 @@ $anonWithAttribute = new #[SomeAttribute('summary')] class {
 
 $foo = new parent();
 $foo = new parent();
+
+// PHP 8.3: safeguard that the sniff ignores anonymous classes, even when declared as readonly.
+$anon = new readonly class {};
+$anon = new #[MyAttribute] readonly class {};


### PR DESCRIPTION
## Description
The sniff is supposed to ignore anonymous class instantiations completely as otherwise it could create a conflict between this sniff and the PSR12 sniff checking anonymous class declarations.

As things were, however, the sniff would add parentheses after the `new` keyword or after an attribute if an anonymous class was declared as `readonly`, as allowed since PHP 8.3.

Fixed now.

Includes minor simplification - the sniff would previously _jump over_ attributes attached to anonymous classes to get to the `class` keyword only to bow out later for anonymous classes anyway. Now, the sniff will bow out straight away when either an attribute, the `readonly` keyword or the `class` keyword for an anonymous class declaration is encountered.

As `readonly` cannot be used as class name and attributes cannot be attached to (non-anonymous) class instantiations, this should maintain the previous behaviour, while also allowing for PHP 8.3 readonly anonymous classes and it should yield a very small performance benefit as well.

Includes unit tests.

## Suggested changelog entry
* Support for readonly anonymous classes has been added to the `PSR12.Classes.ClassInstantiation` sniff.


## Related issues/external references

Related to #106


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
