### PR TITLE
CS: add the RequireExplicitBooleanOperatorPrecedence sniff to PHPCS native ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -129,6 +129,9 @@
     <!-- Do not allow unreachable code. -->
     <rule ref="Squiz.PHP.NonExecutableCode"/>
 
+    <!-- Do not allow ambiguous conditions. -->
+    <rule ref="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence"/>
+
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
         <exclude-pattern>tests/bootstrap\.php</exclude-pattern>

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -60,10 +60,10 @@ class FunctionCommentSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $scopeModifier = $phpcsFile->getMethodProperties($stackPtr)['scope'];
-        if ($scopeModifier === 'protected'
-            && $this->minimumVisibility === 'public'
-            || $scopeModifier === 'private'
-            && ($this->minimumVisibility === 'public' || $this->minimumVisibility === 'protected')
+        if (($scopeModifier === 'protected'
+            && $this->minimumVisibility === 'public')
+            || ($scopeModifier === 'private'
+            && ($this->minimumVisibility === 'public' || $this->minimumVisibility === 'protected'))
         ) {
             return;
         }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -108,8 +108,8 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
                                     // Remove the newline after the docblock, and any entirely
                                     // empty lines before the member var.
-                                    if ($tokens[$i]['code'] === T_WHITESPACE
-                                        && $tokens[$i]['line'] === $tokens[$prev]['line']
+                                    if (($tokens[$i]['code'] === T_WHITESPACE
+                                        && $tokens[$i]['line'] === $tokens[$prev]['line'])
                                         || ($tokens[$i]['column'] === 1
                                         && $tokens[$i]['line'] !== $tokens[($i + 1)]['line'])
                                     ) {

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1727,7 +1727,7 @@ class PHP extends Tokenizer
                     || (stripos($newContent, '0b') === 0 && bindec(str_replace('_', '', $newContent)) > PHP_INT_MAX)
                     || (stripos($newContent, '0o') === 0 && octdec(str_replace('_', '', $newContent)) > PHP_INT_MAX)
                     || (stripos($newContent, '0x') !== 0
-                    && stripos($newContent, 'e') !== false || strpos($newContent, '.') !== false)
+                    && (stripos($newContent, 'e') !== false || strpos($newContent, '.') !== false))
                     || (strpos($newContent, '0') === 0 && stripos($newContent, '0x') !== 0
                     && stripos($newContent, '0b') !== 0 && octdec(str_replace('_', '', $newContent)) > PHP_INT_MAX)
                     || (strpos($newContent, '0') !== 0 && str_replace('_', '', $newContent) > PHP_INT_MAX))


### PR DESCRIPTION
## Description
This commit adds the new sniff as introduced in #197 by @TimWolla to the PHPCS native ruleset and fixes the few conditions which were ambiguous in this codebase.


## Suggested changelog entry
_N/A_


## Related issues/external references

Also see #197