### PR TITLE
Squiz/IncrementDecrementUsage: various bug fixes - whitespace/comment tolerance

### DIFF
--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -145,8 +145,8 @@ class IncrementDecrementUsageSniff implements Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === T_EQUAL) {
-            $nextVar          = ($stackPtr + 1);
-            $previousVariable = ($stackPtr + 1);
+            $nextVar          = $stackPtr;
+            $previousVariable = $stackPtr;
             $variableCount    = 0;
             while (($nextVar = $phpcsFile->findNext(T_VARIABLE, ($nextVar + 1), $statementEnd)) !== false) {
                 $previousVariable = $nextVar;

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -129,8 +129,14 @@ class IncrementDecrementUsageSniff implements Sniff
         $statementEnd = $phpcsFile->findNext([T_SEMICOLON, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET, T_CLOSE_CURLY_BRACKET], $stackPtr);
 
         // If there is anything other than variables, numbers, spaces or operators we need to return.
-        $noiseTokens = $phpcsFile->findNext([T_LNUMBER, T_VARIABLE, T_WHITESPACE, T_PLUS, T_MINUS, T_OPEN_PARENTHESIS], ($stackPtr + 1), $statementEnd, true);
+        $find   = Tokens::$emptyTokens;
+        $find[] = T_LNUMBER;
+        $find[] = T_VARIABLE;
+        $find[] = T_PLUS;
+        $find[] = T_MINUS;
+        $find[] = T_OPEN_PARENTHESIS;
 
+        $noiseTokens = $phpcsFile->findNext($find, ($stackPtr + 1), $statementEnd, true);
         if ($noiseTokens !== false) {
             return;
         }

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -165,8 +165,8 @@ class IncrementDecrementUsageSniff implements Sniff
 
         // We have only one variable, and it's the same as what is being assigned,
         // so we need to check what is being added or subtracted.
-        $nextNumber     = ($stackPtr + 1);
-        $previousNumber = ($stackPtr + 1);
+        $nextNumber     = $stackPtr;
+        $previousNumber = $stackPtr;
         $numberCount    = 0;
         while (($nextNumber = $phpcsFile->findNext([T_LNUMBER], ($nextNumber + 1), $statementEnd, false)) !== false) {
             $previousNumber = $nextNumber;

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -120,7 +120,7 @@ class IncrementDecrementUsageSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $assignedVar = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $assignedVar = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         // Not an assignment, return.
         if ($tokens[$assignedVar]['code'] !== T_VARIABLE) {
             return;

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
@@ -40,3 +40,6 @@ $expected[($i + 1)]['sort_order'] = ($i + 1);
 $id = $id.($obj->i++).$id;
 $id = $obj?->i++.$id;
 $id = $obj?->i++*10;
+
+$var+=1;
+$var-=1;

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
@@ -51,3 +51,6 @@ $var /*comment*/ +=1;
 $var
     // phpcs:ignore Something
     -=1;
+
+$var += /*comment*/ 1;
+$var = ( $var /*comment*/ - 1 /*comment*/);

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
@@ -46,3 +46,8 @@ $var-=1;
 
 $var=$var+1;
 $var=$var-1;
+
+$var /*comment*/ +=1;
+$var
+    // phpcs:ignore Something
+    -=1;

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
@@ -43,3 +43,6 @@ $id = $obj?->i++*10;
 
 $var+=1;
 $var-=1;
+
+$var=$var+1;
+$var=$var-1;

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -48,6 +48,8 @@ final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
             48 => 1,
             50 => 1,
             53 => 1,
+            55 => 1,
+            56 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -44,6 +44,8 @@ final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
             42 => 1,
             44 => 1,
             45 => 1,
+            47 => 1,
+            48 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -46,6 +46,8 @@ final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
             45 => 1,
             47 => 1,
             48 => 1,
+            50 => 1,
+            53 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -42,6 +42,8 @@ final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
             31 => 1,
             41 => 1,
             42 => 1,
+            44 => 1,
+            45 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description

As the Squiz/IncrementDecrementUsage sniff is looking for certain functional code patterns, the sniff should disregard whitespace and comments when looking for the relevant tokens to determine whether the code under scan contains the code pattern the sniff is looking for.

The sniff, however, does not do this correctly (in multiple places).

### Squiz/IncrementDecrementUsage: bug fix - code without whitespace [1]

This commit fixes just one of these issues, as reported in #325.

For this particular issue, the `$startPtr` for the `findNext()` is incremented for each `while` loop, but the initial `$startPtr` was also incremented, which meant that if there was no whitespace after an equals sign, the first relevant token was being skipped over.

Fixed now.

Includes tests.

### Squiz/IncrementDecrementUsage: bug fix - code without whitespace [2]

This commit fixes the same issue as fixed in the previous commit, but now specifically for the part in the code where it is checking that a `$var = $var + 1;` like statement only has one variable in the code comprising the value being assigned.

Same as before, the `$startPtr` for the `findNext()` is incremented for each `while` loop, but the initial `$startPtr` was also incremented, which meant that if there was no whitespace after an equals sign, the first relevant token was being skipped over.

Fixed now.

Includes tests.

### Squiz/IncrementDecrementUsage: bug fix - comments between variable and equal sign

This commit fixes another one of these issues.

In this case, if there was a comment between the `$var` and the subsequent equal sign, the sniff would incorrectly disregard the assignment as one which should be examined.

Fixed now.

Includes tests.

### Squiz/IncrementDecrementUsage: bug fix - comments in value being assigned

This commit fixes one more of these issues.

In this case, if there was a comment anywhere in the value being assigned, the sniff would incorrectly disregard the assignment as one which should be examined.

Fixed now.

Includes tests.


## Suggested changelog entry
* Squiz.Operators.IncrementDecrementUsage : the sniff was underreporting when there was (no) whitespace and/or comments in unexpected places


## Related issues/external references

Fixes #325


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

