### PR TITLE
PHP 8.3 | Generic/LowerCaseConstant: add support for typed constants

### DIFF
--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc
@@ -144,6 +144,14 @@ readonly class Properties {
     }
 }
 
+// PHP 8.3 introduces typed constants.
+class TypedConstants {
+    const MyClass|NULL|TRUE|FALSE MYCONST = FALSE;
+}
+
+// Global constants can not be typed.
+const MYCONST = TRUE;
+
 // Last coding/parse error.
 // This has to be the last test in the file.
 function UnclosedCurly (): FALSE {

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc.fixed
@@ -144,6 +144,14 @@ readonly class Properties {
     }
 }
 
+// PHP 8.3 introduces typed constants.
+class TypedConstants {
+    const MyClass|NULL|TRUE|FALSE MYCONST = false;
+}
+
+// Global constants can not be typed.
+const MYCONST = true;
+
 // Last coding/parse error.
 // This has to be the last test in the file.
 function UnclosedCurly (): FALSE {

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -64,6 +64,8 @@ final class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
                 121 => 1,
                 125 => 1,
                 129 => 1,
+                149 => 1,
+                153 => 1,
             ];
 
         case 'LowerCaseConstantUnitTest.js':


### PR DESCRIPTION

## Description
Type declarations are explicitly not checked by this sniff.

PHP 8.3 introduces typed constants. This means that the sniff now also needs to ensure that it doesn't flag non-lowercase `true`/`false`/`null` in the type declaration for a constant.

Fixed now. Includes tests.


## Suggested changelog entry
* Generic.PHP.LowerCaseConstant : support for typed class constants


## Related issues/external references

Related to #106


## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
