### PR TITLE
PHP 8.3 | Generic/UpperCaseConstantName: add support for typed constants

### DIFF
--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
@@ -31,3 +31,13 @@ class ClassConstBowOutTest {
 }
 
 $foo->getBar()?->define('foo');
+
+// PHP 8.3 introduces typed constants.
+class TypedConstants {
+    const MISSING_VALUE; // Parse error.
+    const MyClass MYCONST = new MyClass;
+    const int VALID_NAME = 0;
+    const INT invalid_name = 0;
+    const FALSE false = false; // Yes, false can be used as a constant name, don't ask.
+    const array ARRAY = array(); // Same goes for array.
+}

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -38,6 +38,8 @@ final class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
             19 => 1,
             28 => 1,
             30 => 1,
+            40 => 1,
+            41 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description
This sniff is specifically targeted at constant names.

PHP 8.3 introduces typed constants. This means that the sniff now needs to jump over a potentially declared constant type to get at the constant name.

Fixed now.

Includes tests.

## Suggested changelog entry
* Generic.NamingConventions.UpperCaseConstantName : support for typed class constants


## Related issues/external references

Related to #106
Fixes squizlabs/PHP_CodeSniffer#3927
Closes squizlabs/PHP_CodeSniffer#3936



## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
