### PR TITLE
PSR2/UseDeclaration - refine testcase

### DIFF
--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.17.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.17.inc
@@ -1,3 +1,3 @@
 <?php
-use UnfinishedGroup\NotFixable {
+use UnfinishedGroup\NotFixable\ {
 	ClassT,


### PR DESCRIPTION
## Description

While this test-case was always intended to be a parse error, it wasn't intended to be _that_ parse error. The initial intention was that this particular case (unfinished group) not be fixable. That was the case when the code was initially written, but a later change enabled the auto-fixer and broke this.

I have opened <https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/333> to track the incorrect fixer changes being applied in the other parse error case.

This is related to #299

## Suggested changelog entry
This is probably not worth its own entry in the change-log.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
