### PR TITLE
Test-suite - Show warning when ".fixed" file not found

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -197,8 +197,10 @@ abstract class AbstractSniffUnitTest extends TestCase
                         $fixedFilename     = basename($fixedFile);
                         $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
                     }
+                } else {
+                    $this->addWarning("Unable to verify auto-fixer results. File not found: $fixedFile");
                 }
-            }
+            }//end if
 
             // Restore the config.
             $config->setSettings($oldConfig);

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -197,7 +197,7 @@ abstract class AbstractSniffUnitTest extends TestCase
                         $fixedFilename     = basename($fixedFile);
                         $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
                     }
-                } else {
+                } else if (is_callable([$this, 'addWarning']) === true) {
                     $this->addWarning("Unable to verify auto-fixer results. File not found: $fixedFile");
                 }
             }//end if

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -190,15 +190,15 @@ abstract class AbstractSniffUnitTest extends TestCase
 
                 // Check for a .fixed file to check for accuracy of fixes.
                 $fixedFile = $testFile.'.fixed';
+                $filename  = basename($testFile);
                 if (file_exists($fixedFile) === true) {
                     $diff = $phpcsFile->fixer->generateDiff($fixedFile);
                     if (trim($diff) !== '') {
-                        $filename          = basename($testFile);
                         $fixedFilename     = basename($fixedFile);
                         $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
                     }
                 } else if (is_callable([$this, 'addWarning']) === true) {
-                    $this->addWarning("Unable to verify auto-fixer results. File not found: $fixedFile");
+                    $this->addWarning("Missing fixed version of $filename to verify the accuracy of fixes, while the sniff is making fixes against the test case file");
                 }
             }//end if
 


### PR DESCRIPTION
## Description

This is one step closer to #300. The changes proposed in #300 are breaking as the test suite will start failing for cases where it currently does not. This pull request gives users of the test suite some information that there is a problem, before the breaking change gets introduced into 4.x.

## Suggested changelog entry
Test-suite - Show warning when ".fixed" file not found

## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.