### PR TITLE
`Squiz.Commenting.ClosingDeclarationComment` - add missing `.fixed` file for test-suite, and fix a bug found during

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -110,7 +110,7 @@ class ClosingDeclarationCommentSniff implements Sniff
             } else {
                 $fix = $phpcsFile->addFixableError('Expected %s', $closingBracket, 'Missing', $data);
                 if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken($closingBracket, '}'.$comment.$phpcsFile->eolChar);
+                    $phpcsFile->fixer->replaceToken($closingBracket, '}'.$comment);
                 }
             }
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc.fixed
@@ -58,16 +58,13 @@ class TestClass
 {
 }//end class
 
-
 abstract class TestClass
 {
 }//end class
 
-
 interface TestClass
 {
 }//end interface
-
 
 class MyClass
 {
@@ -83,7 +80,6 @@ class TestClass
 
 enum MissingClosingComment {
 }//end enum
-
 
 enum HasClosingComment {
 }//end enum

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc.fixed
@@ -1,0 +1,89 @@
+<?php
+
+function __construct()
+{
+}//end __construct()
+
+function myFunction()
+{
+}//end myFunction()
+
+function ourFunction()
+{
+}//end ourFunction()
+
+function yourFunction()
+{
+}//end yourFunction()
+
+class TestClass
+{
+    function __construct()
+    {
+    }//end __construct()
+
+    function myFunction()
+    {
+    }//end myFunction()
+
+    function yourFunction()
+    {
+    }//end yourFunction()
+
+}//end class
+
+abstract class TestClass
+{
+    abstract function myFunction();
+
+    function ourFunction()
+    {
+    }//end ourFunction()
+
+    function yourFunction()
+    {
+    }//end yourFunction()
+
+}//end class
+
+interface TestClass
+{
+    function myFunction();
+    function ourFunction();
+    function yourFunction();
+
+}//end interface
+
+class TestClass
+{
+}//end class
+
+
+abstract class TestClass
+{
+}//end class
+
+
+interface TestClass
+{
+}//end interface
+
+
+class MyClass
+{
+    public function myFunction();
+}//end class
+
+// Closures don't need end comments.
+echo preg_replace_callback('~-([a-z])~', function ($match) { return strtoupper($match[1]); }, 'hello-world');
+
+class TestClass
+{
+}//end class
+
+enum MissingClosingComment {
+}//end enum
+
+
+enum HasClosingComment {
+}//end enum


### PR DESCRIPTION
## Description
This pull request adds a missing `.fixed` file for an existing test for `Squiz.Commenting.ClosingDeclarationComment`.

While I was reviewing the automatically-created ".fixed" file (from `phpcbf`), I noticed a bug. I'm fixing that bug in this same pull request, but am happy to move that elsewhere if desired.

## Suggested changelog entry
- `Squiz.Commenting.ClosingDeclarationComment` - no longer add extra newline when adding a missing comment

## Related issues/external references

Related to #299

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.