### PR TITLE
Tests: data set keys should match parameter names

### DIFF
--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -244,7 +244,7 @@ final class ReportWidthTest extends TestCase
     /**
      * Test that the report width will be set correctly for various types of input.
      *
-     * @param mixed $input    Input value received.
+     * @param mixed $value    Input value received.
      * @param int   $expected Expected report width.
      *
      * @dataProvider dataReportWidthInputHandling
@@ -252,10 +252,10 @@ final class ReportWidthTest extends TestCase
      *
      * @return void
      */
-    public function testReportWidthInputHandling($input, $expected)
+    public function testReportWidthInputHandling($value, $expected)
     {
         $config = new Config();
-        $config->reportWidth = $input;
+        $config->reportWidth = $value;
 
         $this->assertSame($expected, $config->reportWidth);
 

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -730,9 +730,9 @@ EOD;
     {
         return [
             'no suppression'                                          => [
-                'before'         => '',
-                'after'          => '',
-                'expectedErrors' => 1,
+                'before'           => '',
+                'after'            => '',
+                'expectedWarnings' => 1,
             ],
 
             // Process with suppression.

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -36,16 +36,16 @@ final class IsReferenceTest extends AbstractMethodUnitTest
     /**
      * Test correctly identifying whether a "bitwise and" token is a reference or not.
      *
-     * @param string $identifier Comment which precedes the test case.
+     * @param string $testMarker Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
      *
      * @dataProvider dataIsReference
      *
      * @return void
      */
-    public function testIsReference($identifier, $expected)
+    public function testIsReference($testMarker, $expected)
     {
-        $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
+        $bitwiseAnd = $this->getTargetToken($testMarker, T_BITWISE_AND);
         $result     = self::$phpcsFile->isReference($bitwiseAnd);
         $this->assertSame($expected, $result);
 


### PR DESCRIPTION
## Description
Initially to prevent issues with a few PHPUnit versions which were around in the early days of PHP 8.0, where these would accidentally be seen as parameter names.

So, as a best practice, when using keys in data sets, the keys should match the parameter names of the receiving test method.

An ulterior reason to make this change is that PHPUnit 11 will always treat the keys as parameter names, so this can be seen as a preparation step for allowing for PHPUnit 11 support in PHPCS 4.0.


## Suggested changelog entry
_N/A_

## Related issues/external references

Loosely related to #25