### PR TITLE
Remove more remnants of PEAR installation support

### DIFF
--- a/bin/phpcbf
+++ b/bin/phpcbf
@@ -8,11 +8,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (is_file(__DIR__.'/../autoload.php') === true) {
-    include_once __DIR__.'/../autoload.php';
-} else {
-    include_once 'PHP/CodeSniffer/autoload.php';
-}
+require_once __DIR__.'/../autoload.php';
 
 $runner   = new PHP_CodeSniffer\Runner();
 $exitCode = $runner->runPHPCBF();

--- a/bin/phpcs
+++ b/bin/phpcs
@@ -8,11 +8,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-if (is_file(__DIR__.'/../autoload.php') === true) {
-    include_once __DIR__.'/../autoload.php';
-} else {
-    include_once 'PHP/CodeSniffer/autoload.php';
-}
+require_once __DIR__.'/../autoload.php';
 
 $runner   = new PHP_CodeSniffer\Runner();
 $exitCode = $runner->runPHPCS();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,11 +19,7 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-if (is_file(__DIR__.'/../autoload.php') === true) {
-    include_once __DIR__.'/../autoload.php';
-} else {
-    include_once 'PHP/CodeSniffer/autoload.php';
-}
+require_once __DIR__.'/../autoload.php';
 
 $tokens = new \PHP_CodeSniffer\Util\Tokens();
 


### PR DESCRIPTION
## Description
Follow up after #4 and #39

The alternative path referred to in the bin scripts and the test bootstrap was specific for running via a PEAR install. This should no longer be needed (nor will this work).


## Suggested changelog entry
_N/A_