### PR TITLE
CS: clean up use statements

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,8 @@
 
 namespace PHP_CodeSniffer;
 
+use Exception;
+use Phar;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Common;
@@ -812,7 +814,7 @@ class Config
 
             try {
                 $this->setConfigData($key, $value);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 throw new DeepExitException($e->getMessage().PHP_EOL, 3);
             }
 
@@ -840,7 +842,7 @@ class Config
             } else {
                 try {
                     $this->setConfigData($key, null);
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     throw new DeepExitException($e->getMessage().PHP_EOL, 3);
                 }
 
@@ -1608,7 +1610,7 @@ class Config
         if ($temp === false) {
             $path = '';
             if (is_callable('\Phar::running') === true) {
-                $path = \Phar::running(false);
+                $path = Phar::running(false);
             }
 
             if ($path !== '') {
@@ -1679,7 +1681,7 @@ class Config
 
         $path = '';
         if (is_callable('\Phar::running') === true) {
-            $path = \Phar::running(false);
+            $path = Phar::running(false);
         }
 
         if ($path !== '') {

--- a/src/Config.php
+++ b/src/Config.php
@@ -17,6 +17,7 @@ use Phar;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Standards;
 
 /**
  * Stores the configuration used to run PHPCS and PHPCBF.
@@ -267,7 +268,7 @@ class Config
             $cleaned = [];
 
             // Check if the standard name is valid, or if the case is invalid.
-            $installedStandards = Util\Standards::getInstalledStandards();
+            $installedStandards = Standards::getInstalledStandards();
             foreach ($value as $standard) {
                 foreach ($installedStandards as $validStandard) {
                     if (strtolower($standard) === strtolower($validStandard)) {
@@ -422,7 +423,7 @@ class Config
 
         // Check for content on STDIN.
         if ($this->stdin === true
-            || (Util\Common::isStdinATTY() === false
+            || (Common::isStdinATTY() === false
             && feof($handle) === false)
         ) {
             $readStreams = [$handle];
@@ -651,7 +652,7 @@ class Config
             throw new DeepExitException($output, 0);
         case 'i' :
             ob_start();
-            Util\Standards::printInstalledStandards();
+            Standards::printInstalledStandards();
             $output = ob_get_contents();
             ob_end_clean();
             throw new DeepExitException($output, 0);
@@ -924,7 +925,7 @@ class Config
                 $this->cache = true;
                 self::$overriddenDefaults['cache'] = true;
 
-                $this->cacheFile = Util\Common::realpath(substr($arg, 6));
+                $this->cacheFile = Common::realpath(substr($arg, 6));
 
                 // It may not exist and return false instead.
                 if ($this->cacheFile === false) {
@@ -943,9 +944,9 @@ class Config
                     } else {
                         if ($dir[0] === '/') {
                             // An absolute path.
-                            $dir = Util\Common::realpath($dir);
+                            $dir = Common::realpath($dir);
                         } else {
-                            $dir = Util\Common::realpath(getcwd().'/'.$dir);
+                            $dir = Common::realpath(getcwd().'/'.$dir);
                         }
 
                         if ($dir !== false) {
@@ -966,7 +967,7 @@ class Config
                 $files     = explode(',', substr($arg, 10));
                 $bootstrap = [];
                 foreach ($files as $file) {
-                    $path = Util\Common::realpath($file);
+                    $path = Common::realpath($file);
                     if ($path === false) {
                         $error  = 'ERROR: The specified bootstrap file "'.$file.'" does not exist'.PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
@@ -980,7 +981,7 @@ class Config
                 self::$overriddenDefaults['bootstrap'] = true;
             } else if (substr($arg, 0, 10) === 'file-list=') {
                 $fileList = substr($arg, 10);
-                $path     = Util\Common::realpath($fileList);
+                $path     = Common::realpath($fileList);
                 if ($path === false) {
                     $error  = 'ERROR: The specified file list "'.$fileList.'" does not exist'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
@@ -1003,7 +1004,7 @@ class Config
                     break;
                 }
 
-                $this->stdinPath = Util\Common::realpath(substr($arg, 11));
+                $this->stdinPath = Common::realpath(substr($arg, 11));
 
                 // It may not exist and return false instead, so use whatever they gave us.
                 if ($this->stdinPath === false) {
@@ -1016,13 +1017,13 @@ class Config
                     break;
                 }
 
-                $this->reportFile = Util\Common::realpath(substr($arg, 12));
+                $this->reportFile = Common::realpath(substr($arg, 12));
 
                 // It may not exist and return false instead.
                 if ($this->reportFile === false) {
                     $this->reportFile = substr($arg, 12);
 
-                    $dir = Util\Common::realpath(dirname($this->reportFile));
+                    $dir = Common::realpath(dirname($this->reportFile));
                     if (is_dir($dir) === false) {
                         $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
@@ -1058,7 +1059,7 @@ class Config
                     break;
                 }
 
-                $this->basepath = Util\Common::realpath(substr($arg, 9));
+                $this->basepath = Common::realpath(substr($arg, 9));
 
                 // It may not exist and return false instead.
                 if ($this->basepath === false) {
@@ -1085,7 +1086,7 @@ class Config
                         if ($output === false) {
                             $output = null;
                         } else {
-                            $dir = Util\Common::realpath(dirname($output));
+                            $dir = Common::realpath(dirname($output));
                             if (is_dir($dir) === false) {
                                 $error  = 'ERROR: The specified '.$report.' report file path "'.$output.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                                 $error .= $this->printShortUsage(true);
@@ -1319,7 +1320,7 @@ class Config
             return;
         }
 
-        $file = Util\Common::realpath($path);
+        $file = Common::realpath($path);
         if (file_exists($file) === false) {
             if ($this->dieOnUnknownArg === false) {
                 return;
@@ -1655,7 +1656,7 @@ class Config
         // If the installed paths are being set, make sure all known
         // standards paths are added to the autoloader.
         if ($key === 'installed_paths') {
-            $installedStandards = Util\Standards::getInstalledStandardDetails();
+            $installedStandards = Standards::getInstalledStandardDetails();
             foreach ($installedStandards as $name => $details) {
                 Autoload::addSearchPath($details['path'], $details['namespace']);
             }

--- a/src/Exceptions/DeepExitException.php
+++ b/src/Exceptions/DeepExitException.php
@@ -12,7 +12,9 @@
 
 namespace PHP_CodeSniffer\Exceptions;
 
-class DeepExitException extends \Exception
+use Exception;
+
+class DeepExitException extends Exception
 {
 
 }//end class

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -9,7 +9,9 @@
 
 namespace PHP_CodeSniffer\Exceptions;
 
-class RuntimeException extends \RuntimeException
+use RuntimeException as PHPRuntimeException;
+
+class RuntimeException extends PHPRuntimeException
 {
 
 }//end class

--- a/src/Exceptions/TokenizerException.php
+++ b/src/Exceptions/TokenizerException.php
@@ -9,7 +9,9 @@
 
 namespace PHP_CodeSniffer\Exceptions;
 
-class TokenizerException extends \Exception
+use Exception;
+
+class TokenizerException extends Exception
 {
 
 }//end class

--- a/src/Files/DummyFile.php
+++ b/src/Files/DummyFile.php
@@ -14,8 +14,8 @@
 
 namespace PHP_CodeSniffer\Files;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
 
 class DummyFile extends File
 {

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -14,7 +14,8 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHP_CodeSniffer\Fixer;
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class File
 {
@@ -276,7 +277,7 @@ class File
         $this->tokens  = [];
 
         try {
-            $this->eolChar = Util\Common::detectLineEndings($content);
+            $this->eolChar = Common::detectLineEndings($content);
         } catch (RuntimeException $e) {
             $this->addWarningOnLine($e->getMessage(), 1, 'Internal.DetectLineEndings');
             return;
@@ -430,7 +431,7 @@ class File
 
             if (PHP_CODESNIFFER_VERBOSITY > 2) {
                 $type    = $token['type'];
-                $content = Util\Common::prepareForOutput($token['content']);
+                $content = Common::prepareForOutput($token['content']);
                 echo "\t\tProcess token $stackPtr: $type => $content".PHP_EOL;
             }
 
@@ -872,7 +873,7 @@ class File
         $parts = explode('.', $code);
         if ($parts[0] === 'Internal') {
             // An internal message.
-            $listenerCode = Util\Common::getSniffCode($this->activeListener);
+            $listenerCode = Common::getSniffCode($this->activeListener);
             $sniffCode    = $code;
             $checkCodes   = [$sniffCode];
         } else {
@@ -881,7 +882,7 @@ class File
                 $sniffCode    = $code;
                 $listenerCode = substr($sniffCode, 0, strrpos($sniffCode, '.'));
             } else {
-                $listenerCode = Util\Common::getSniffCode($this->activeListener);
+                $listenerCode = Common::getSniffCode($this->activeListener);
                 $sniffCode    = $listenerCode.'.'.$code;
                 $parts        = explode('.', $sniffCode);
             }
@@ -1615,7 +1616,7 @@ class File
                 $paramCount++;
                 break;
             case T_EQUAL:
-                $defaultStart = $this->findNext(Util\Tokens::$emptyTokens, ($i + 1), null, true);
+                $defaultStart = $this->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                 $equalToken   = $i;
                 break;
             }//end switch
@@ -1885,7 +1886,7 @@ class File
             T_READONLY  => T_READONLY,
         ];
 
-        $valid += Util\Tokens::$emptyTokens;
+        $valid += Tokens::$emptyTokens;
 
         $scope          = 'public';
         $scopeSpecified = false;
@@ -2073,7 +2074,7 @@ class File
         }
 
         $tokenBefore = $this->findPrevious(
-            Util\Tokens::$emptyTokens,
+            Tokens::$emptyTokens,
             ($stackPtr - 1),
             null,
             true
@@ -2097,14 +2098,14 @@ class File
             return true;
         }
 
-        if (isset(Util\Tokens::$assignmentTokens[$this->tokens[$tokenBefore]['code']]) === true) {
+        if (isset(Tokens::$assignmentTokens[$this->tokens[$tokenBefore]['code']]) === true) {
             // This is directly after an assignment. It's a reference. Even if
             // it is part of an operation, the other tests will handle it.
             return true;
         }
 
         $tokenAfter = $this->findNext(
-            Util\Tokens::$emptyTokens,
+            Tokens::$emptyTokens,
             ($stackPtr + 1),
             null,
             true
@@ -2155,7 +2156,7 @@ class File
             if ($this->tokens[$tokenAfter]['code'] === T_VARIABLE) {
                 return true;
             } else {
-                $skip   = Util\Tokens::$emptyTokens;
+                $skip   = Tokens::$emptyTokens;
                 $skip[] = T_NS_SEPARATOR;
                 $skip[] = T_SELF;
                 $skip[] = T_PARENT;
@@ -2382,7 +2383,7 @@ class File
      */
     public function findStartOfStatement($start, $ignore=null)
     {
-        $startTokens = Util\Tokens::$blockOpeners;
+        $startTokens = Tokens::$blockOpeners;
         $startTokens[T_OPEN_SHORT_ARRAY]   = true;
         $startTokens[T_OPEN_TAG]           = true;
         $startTokens[T_OPEN_TAG_WITH_ECHO] = true;
@@ -2436,7 +2437,7 @@ class File
 
             if ($prevMatch <= $this->tokens[$matchExpression]['scope_opener']) {
                 // We're before the arrow in the first case.
-                $next = $this->findNext(Util\Tokens::$emptyTokens, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
+                $next = $this->findNext(Tokens::$emptyTokens, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
                 if ($next === false) {
                     return $start;
                 }
@@ -2449,12 +2450,12 @@ class File
                 $prevMatchArrow = $this->findPrevious(T_MATCH_ARROW, ($prevMatch - 1), $this->tokens[$matchExpression]['scope_opener']);
                 if ($prevMatchArrow === false) {
                     // We're before the arrow in the first case.
-                    $next = $this->findNext(Util\Tokens::$emptyTokens, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
+                    $next = $this->findNext(Tokens::$emptyTokens, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
                     return $next;
                 }
 
                 $end  = $this->findEndOfStatement($prevMatchArrow);
-                $next = $this->findNext(Util\Tokens::$emptyTokens, ($end + 1), null, true);
+                $next = $this->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
                 return $next;
             }
         }//end if
@@ -2515,7 +2516,7 @@ class File
                 }
             }//end if
 
-            if (isset(Util\Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+            if (isset(Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
         }//end for
@@ -2610,7 +2611,7 @@ class File
                     continue;
                 }
 
-                if ($i === $start && isset(Util\Tokens::$scopeOpeners[$this->tokens[$i]['code']]) === true) {
+                if ($i === $start && isset(Tokens::$scopeOpeners[$this->tokens[$i]['code']]) === true) {
                     return $this->tokens[$i]['scope_closer'];
                 }
 
@@ -2630,7 +2631,7 @@ class File
                 }
             }//end if
 
-            if (isset(Util\Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+            if (isset(Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
         }//end for

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -9,12 +9,12 @@
 
 namespace PHP_CodeSniffer\Files;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Fixer;
-use PHP_CodeSniffer\Util;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Exceptions\TokenizerException;
+use PHP_CodeSniffer\Fixer;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util;
 
 class File
 {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -11,14 +11,20 @@
 
 namespace PHP_CodeSniffer\Files;
 
+use Countable;
+use FilesystemIterator;
+use Iterator;
 use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util;
+use RecursiveArrayIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReturnTypeWillChange;
 
-class FileList implements \Iterator, \Countable
+class FileList implements Iterator, Countable
 {
 
     /**
@@ -80,9 +86,9 @@ class FileList implements \Iterator, \Countable
 
                 $filterClass = $this->getFilterClass();
 
-                $di       = new \RecursiveDirectoryIterator($path, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS));
+                $di       = new RecursiveDirectoryIterator($path, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS));
                 $filter   = new $filterClass($di, $path, $config, $ruleset);
-                $iterator = new \RecursiveIteratorIterator($filter);
+                $iterator = new RecursiveIteratorIterator($filter);
 
                 foreach ($iterator as $file) {
                     $this->files[$file->getPathname()] = null;
@@ -121,9 +127,9 @@ class FileList implements \Iterator, \Countable
 
         $filterClass = $this->getFilterClass();
 
-        $di       = new \RecursiveArrayIterator([$path]);
+        $di       = new RecursiveArrayIterator([$path]);
         $filter   = new $filterClass($di, $path, $this->config, $this->ruleset);
-        $iterator = new \RecursiveIteratorIterator($filter);
+        $iterator = new RecursiveIteratorIterator($filter);
 
         foreach ($iterator as $path) {
             $this->files[$path] = $file;

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 use RecursiveArrayIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -78,7 +78,7 @@ class FileList implements Iterator, Countable
 
         $paths = $config->files;
         foreach ($paths as $path) {
-            $isPharFile = Util\Common::isPharFile($path);
+            $isPharFile = Common::isPharFile($path);
             if (is_dir($path) === true || $isPharFile === true) {
                 if ($isPharFile === true) {
                     $path = 'phar://'.$path;

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -12,10 +12,10 @@
 namespace PHP_CodeSniffer\Files;
 
 use PHP_CodeSniffer\Autoload;
-use PHP_CodeSniffer\Util;
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util;
 use ReturnTypeWillChange;
 
 class FileList implements \Iterator, \Countable

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Files;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util\Cache;
 use PHP_CodeSniffer\Util\Common;
 

--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -11,7 +11,7 @@
 
 namespace PHP_CodeSniffer\Filters;
 
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 
 abstract class ExactMatch extends Filter
 {
@@ -64,7 +64,7 @@ abstract class ExactMatch extends Filter
             }
         }
 
-        $filePath = Util\Common::realpath($this->current());
+        $filePath = Common::realpath($this->current());
 
         // If a file is both disallowed and allowed, the disallowed files list takes precedence.
         if (isset($this->disallowedFiles[$filePath]) === true) {

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -9,12 +9,15 @@
 
 namespace PHP_CodeSniffer\Filters;
 
+use FilesystemIterator;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util;
+use RecursiveDirectoryIterator;
+use RecursiveFilterIterator;
 use ReturnTypeWillChange;
 
-class Filter extends \RecursiveFilterIterator
+class Filter extends RecursiveFilterIterator
 {
 
     /**
@@ -137,7 +140,7 @@ class Filter extends \RecursiveFilterIterator
     {
         $filterClass = get_called_class();
         $children    = new $filterClass(
-            new \RecursiveDirectoryIterator($this->current(), (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)),
+            new RecursiveDirectoryIterator($this->current(), (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)),
             $this->basedir,
             $this->config,
             $this->ruleset

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -12,7 +12,7 @@ namespace PHP_CodeSniffer\Filters;
 use FilesystemIterator;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
 use ReturnTypeWillChange;
@@ -97,7 +97,7 @@ class Filter extends RecursiveFilterIterator
     public function accept()
     {
         $filePath = $this->current();
-        $realPath = Util\Common::realpath($filePath);
+        $realPath = Common::realpath($filePath);
 
         if ($realPath !== false) {
             // It's a real path somewhere, so record it

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Filters;
 
-use PHP_CodeSniffer\Util;
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util;
 use ReturnTypeWillChange;
 
 class Filter extends \RecursiveFilterIterator

--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Filters;
 
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 
 class GitModified extends ExactMatch
 {
@@ -65,7 +65,7 @@ class GitModified extends ExactMatch
         }
 
         foreach ($output as $path) {
-            $path = Util\Common::realpath($path);
+            $path = Common::realpath($path);
 
             if ($path === false) {
                 continue;

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -11,7 +11,7 @@
 
 namespace PHP_CodeSniffer\Filters;
 
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 
 class GitStaged extends ExactMatch
 {
@@ -67,7 +67,7 @@ class GitStaged extends ExactMatch
         }
 
         foreach ($output as $path) {
-            $path = Util\Common::realpath($path);
+            $path = Common::realpath($path);
             if ($path === false) {
                 // Skip deleted files.
                 continue;

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -362,7 +362,7 @@ class Fixer
             if ($bt[1]['class'] === __CLASS__) {
                 $sniff = 'Fixer';
             } else {
-                $sniff = Util\Common::getSniffCode($bt[1]['class']);
+                $sniff = Common::getSniffCode($bt[1]['class']);
             }
 
             $line = $bt[0]['line'];
@@ -447,7 +447,7 @@ class Fixer
                     $line  = $bt[0]['line'];
                 }
 
-                $sniff = Util\Common::getSniffCode($sniff);
+                $sniff = Common::getSniffCode($sniff);
 
                 $numChanges = count($this->changeset);
 
@@ -504,7 +504,7 @@ class Fixer
                 $line  = $bt[0]['line'];
             }
 
-            $sniff = Util\Common::getSniffCode($sniff);
+            $sniff = Common::getSniffCode($sniff);
 
             $tokens     = $this->currentFile->getTokens();
             $type       = $tokens[$stackPtr]['type'];
@@ -619,7 +619,7 @@ class Fixer
                 $line  = $bt[0]['line'];
             }
 
-            $sniff = Util\Common::getSniffCode($sniff);
+            $sniff = Common::getSniffCode($sniff);
 
             $tokens     = $this->currentFile->getTokens();
             $type       = $tokens[$stackPtr]['type'];

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -12,8 +12,8 @@
 
 namespace PHP_CodeSniffer\Generators;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Autoload;
+use PHP_CodeSniffer\Ruleset;
 
 abstract class Generator
 {

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -12,6 +12,8 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMDocument;
+use DOMNode;
 use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Ruleset;
 
@@ -70,7 +72,7 @@ abstract class Generator
      *
      * @return string
      */
-    protected function getTitle(\DOMNode $doc)
+    protected function getTitle(DOMNode $doc)
     {
         return $doc->getAttribute('title');
 
@@ -90,7 +92,7 @@ abstract class Generator
     public function generate()
     {
         foreach ($this->docFiles as $file) {
-            $doc = new \DOMDocument();
+            $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
             $this->processSniff($documentation);
@@ -111,7 +113,7 @@ abstract class Generator
      * @return void
      * @see    generate()
      */
-    abstract protected function processSniff(\DOMNode $doc);
+    abstract protected function processSniff(DOMNode $doc);
 
 
 }//end class

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -13,6 +13,8 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMDocument;
+use DOMNode;
 use PHP_CodeSniffer\Config;
 
 class HTML extends Generator
@@ -32,7 +34,7 @@ class HTML extends Generator
         $this->printToc();
 
         foreach ($this->docFiles as $file) {
-            $doc = new \DOMDocument();
+            $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
             $this->processSniff($documentation);
@@ -145,7 +147,7 @@ class HTML extends Generator
         echo '  <ul class="toc">'.PHP_EOL;
 
         foreach ($this->docFiles as $file) {
-            $doc = new \DOMDocument();
+            $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
             $title         = $this->getTitle($documentation);
@@ -188,7 +190,7 @@ class HTML extends Generator
      *
      * @return void
      */
-    public function processSniff(\DOMNode $doc)
+    public function processSniff(DOMNode $doc)
     {
         $title = $this->getTitle($doc);
         echo '  <a name="'.str_replace(' ', '-', $title).'" />'.PHP_EOL;
@@ -212,7 +214,7 @@ class HTML extends Generator
      *
      * @return void
      */
-    protected function printTextBlock(\DOMNode $node)
+    protected function printTextBlock(DOMNode $node)
     {
         $content = trim($node->nodeValue);
         $content = htmlspecialchars($content);
@@ -233,7 +235,7 @@ class HTML extends Generator
      *
      * @return void
      */
-    protected function printCodeComparisonBlock(\DOMNode $node)
+    protected function printCodeComparisonBlock(DOMNode $node)
     {
         $codeBlocks = $node->getElementsByTagName('code');
 

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -9,6 +9,8 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMDocument;
+use DOMNode;
 use PHP_CodeSniffer\Config;
 
 class Markdown extends Generator
@@ -27,7 +29,7 @@ class Markdown extends Generator
         $this->printHeader();
 
         foreach ($this->docFiles as $file) {
-            $doc = new \DOMDocument();
+            $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
             $this->processSniff($documentation);
@@ -81,7 +83,7 @@ class Markdown extends Generator
      *
      * @return void
      */
-    protected function processSniff(\DOMNode $doc)
+    protected function processSniff(DOMNode $doc)
     {
         $title = $this->getTitle($doc);
         echo PHP_EOL."## $title".PHP_EOL;
@@ -104,7 +106,7 @@ class Markdown extends Generator
      *
      * @return void
      */
-    protected function printTextBlock(\DOMNode $node)
+    protected function printTextBlock(DOMNode $node)
     {
         $content = trim($node->nodeValue);
         $content = htmlspecialchars($content);
@@ -124,7 +126,7 @@ class Markdown extends Generator
      *
      * @return void
      */
-    protected function printCodeComparisonBlock(\DOMNode $node)
+    protected function printCodeComparisonBlock(DOMNode $node)
     {
         $codeBlocks = $node->getElementsByTagName('code');
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -11,6 +11,8 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMNode;
+
 class Text extends Generator
 {
 
@@ -24,7 +26,7 @@ class Text extends Generator
      *
      * @return void
      */
-    public function processSniff(\DOMNode $doc)
+    public function processSniff(DOMNode $doc)
     {
         $this->printTitle($doc);
 
@@ -48,7 +50,7 @@ class Text extends Generator
      *
      * @return void
      */
-    protected function printTitle(\DOMNode $doc)
+    protected function printTitle(DOMNode $doc)
     {
         $title    = $this->getTitle($doc);
         $standard = $this->ruleset->name;
@@ -69,7 +71,7 @@ class Text extends Generator
      *
      * @return void
      */
-    protected function printTextBlock(\DOMNode $node)
+    protected function printTextBlock(DOMNode $node)
     {
         $text = trim($node->nodeValue);
         $text = str_replace('<em>', '*', $text);
@@ -123,7 +125,7 @@ class Text extends Generator
      *
      * @return void
      */
-    protected function printCodeComparisonBlock(\DOMNode $node)
+    protected function printCodeComparisonBlock(DOMNode $node)
     {
         $codeBlocks = $node->getElementsByTagName('code');
         $first      = trim($codeBlocks->item(0)->nodeValue);

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -15,7 +15,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Timing;
 
 class Cbf implements Report
 {
@@ -244,7 +244,7 @@ class Cbf implements Report
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
 
         if ($toScreen === true && $interactive === false) {
-            Util\Timing::printRunTime();
+            Timing::printRunTime();
         }
 
     }//end generate()

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use XMLWriter;
 
 class Checkstyle implements Report
 {
@@ -32,7 +33,7 @@ class Checkstyle implements Report
      */
     public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
     {
-        $out = new \XMLWriter;
+        $out = new XMLWriter;
         $out->openMemory();
         $out->setIndent(true);
 

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -11,7 +11,8 @@ namespace PHP_CodeSniffer\Reports;
 
 use Exception;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Timing;
 
 class Code implements Report
 {
@@ -236,7 +237,7 @@ class Code implements Report
                         $tokenContent = $token['content'];
                     }
 
-                    $tokenContent = Util\Common::prepareForOutput($tokenContent, ["\r", "\n", "\t"]);
+                    $tokenContent = Common::prepareForOutput($tokenContent, ["\r", "\n", "\t"]);
                     $tokenContent = str_replace("\000", ' ', $tokenContent);
 
                     $underline = false;
@@ -354,7 +355,7 @@ class Code implements Report
         echo $cachedData;
 
         if ($toScreen === true && $interactive === false) {
-            Util\Timing::printRunTime();
+            Timing::printRunTime();
         }
 
     }//end generate()

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Reports;
 
+use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util;
 
@@ -52,7 +53,7 @@ class Code implements Report
 
             try {
                 $phpcsFile->parse();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 // This is a second parse, so ignore exceptions.
                 // They would have been added to the file's error list already.
             }

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -10,7 +10,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Timing;
 
 class Full implements Report
 {
@@ -250,7 +250,7 @@ class Full implements Report
         echo $cachedData;
 
         if ($toScreen === true && $interactive === false) {
-            Util\Timing::printRunTime();
+            Timing::printRunTime();
         }
 
     }//end generate()

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -12,6 +12,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use XMLWriter;
 
 class Junit implements Report
 {
@@ -33,7 +34,7 @@ class Junit implements Report
      */
     public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
     {
-        $out = new \XMLWriter;
+        $out = new XMLWriter;
         $out->openMemory();
         $out->setIndent(true);
 

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -10,7 +10,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Timing;
 
 class Summary implements Report
 {
@@ -174,7 +174,7 @@ class Summary implements Report
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
 
         if ($toScreen === true && $interactive === false) {
-            Util\Timing::printRunTime();
+            Timing::printRunTime();
         }
 
     }//end generate()

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use XMLWriter;
 
 class Xml implements Report
 {
@@ -32,7 +33,7 @@ class Xml implements Report
      */
     public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
     {
-        $out = new \XMLWriter;
+        $out = new XMLWriter;
         $out->openMemory();
         $out->setIndent(true);
         $out->setIndentString('    ');

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -14,6 +14,9 @@ namespace PHP_CodeSniffer;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Util;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
 use stdClass;
 
 class Ruleset
@@ -779,8 +782,8 @@ class Ruleset
     {
         $sniffs = [];
 
-        $rdi = new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
-        $di  = new \RecursiveIteratorIterator($rdi, 0, \RecursiveIteratorIterator::CATCH_GET_CHILD);
+        $rdi = new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+        $di  = new RecursiveIteratorIterator($rdi, 0, RecursiveIteratorIterator::CATCH_GET_CHILD);
 
         $dirLen = strlen($directory);
 
@@ -1349,7 +1352,7 @@ class Ruleset
             }
 
             // Skip abstract classes.
-            $reflection = new \ReflectionClass($className);
+            $reflection = new ReflectionClass($className);
             if ($reflection->isAbstract() === true) {
                 continue;
             }

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -13,7 +13,8 @@ namespace PHP_CodeSniffer;
 
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Standards;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -148,13 +149,13 @@ class Ruleset
 
         $standardPaths = [];
         foreach ($config->standards as $standard) {
-            $installed = Util\Standards::getInstalledStandardPath($standard);
+            $installed = Standards::getInstalledStandardPath($standard);
             if ($installed === null) {
-                $standard = Util\Common::realpath($standard);
+                $standard = Common::realpath($standard);
                 if (is_dir($standard) === true
-                    && is_file(Util\Common::realpath($standard.DIRECTORY_SEPARATOR.'ruleset.xml')) === true
+                    && is_file(Common::realpath($standard.DIRECTORY_SEPARATOR.'ruleset.xml')) === true
                 ) {
-                    $standard = Util\Common::realpath($standard.DIRECTORY_SEPARATOR.'ruleset.xml');
+                    $standard = Common::realpath($standard.DIRECTORY_SEPARATOR.'ruleset.xml');
                 }
             } else {
                 $standard = $installed;
@@ -475,10 +476,10 @@ class Ruleset
      */
     public function processRuleset($rulesetPath, $depth=0)
     {
-        $rulesetPath = Util\Common::realpath($rulesetPath);
+        $rulesetPath = Common::realpath($rulesetPath);
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             echo str_repeat("\t", $depth);
-            echo 'Processing ruleset '.Util\Common::stripBasepath($rulesetPath, $this->config->basepath).PHP_EOL;
+            echo 'Processing ruleset '.Common::stripBasepath($rulesetPath, $this->config->basepath).PHP_EOL;
         }
 
         libxml_use_internal_errors(true);
@@ -508,7 +509,7 @@ class Ruleset
         if (is_dir($sniffDir) === true) {
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 echo str_repeat("\t", $depth);
-                echo "\tAdding sniff files from ".Util\Common::stripBasepath($sniffDir, $this->config->basepath).' directory'.PHP_EOL;
+                echo "\tAdding sniff files from ".Common::stripBasepath($sniffDir, $this->config->basepath).' directory'.PHP_EOL;
             }
 
             $ownSniffs = $this->expandSniffDirectory($sniffDir, $depth);
@@ -523,7 +524,7 @@ class Ruleset
             $autoloadPath = (string) $autoload;
 
             // Try relative autoload paths first.
-            $relativePath = Util\Common::realPath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
+            $relativePath = Common::realPath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
 
             if ($relativePath !== false && is_file($relativePath) === true) {
                 $autoloadPath = $relativePath;
@@ -713,7 +714,7 @@ class Ruleset
             // Change the directory so all relative paths are worked
             // out based on the location of the ruleset instead of
             // the location of the user.
-            $inPhar = Util\Common::isPharFile($rulesetDir);
+            $inPhar = Common::isPharFile($rulesetDir);
             if ($inPhar === false) {
                 $currentDir = getcwd();
                 chdir($rulesetDir);
@@ -760,7 +761,7 @@ class Ruleset
             if (in_array($sniff, $excludedSniffs, true) === true) {
                 continue;
             } else {
-                $files[] = Util\Common::realpath($sniff);
+                $files[] = Common::realpath($sniff);
             }
         }
 
@@ -818,7 +819,7 @@ class Ruleset
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 echo str_repeat("\t", $depth);
-                echo "\t\t=> ".Util\Common::stripBasepath($path, $this->config->basepath).PHP_EOL;
+                echo "\t\t=> ".Common::stripBasepath($path, $this->config->basepath).PHP_EOL;
             }
 
             $sniffs[] = $path;
@@ -859,12 +860,12 @@ class Ruleset
         // to absolute paths. If this fails, let the reference run through
         // the normal checks and have it fail as normal.
         if (substr($ref, 0, 1) === '.') {
-            $realpath = Util\Common::realpath($rulesetDir.'/'.$ref);
+            $realpath = Common::realpath($rulesetDir.'/'.$ref);
             if ($realpath !== false) {
                 $ref = $realpath;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     echo str_repeat("\t", $depth);
-                    echo "\t\t=> ".Util\Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
+                    echo "\t\t=> ".Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
                 }
             }
         }
@@ -872,12 +873,12 @@ class Ruleset
         // As sniffs can't begin with a tilde, assume references in
         // this format are relative to the user's home directory.
         if (substr($ref, 0, 2) === '~/') {
-            $realpath = Util\Common::realpath($ref);
+            $realpath = Common::realpath($ref);
             if ($realpath !== false) {
                 $ref = $realpath;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     echo str_repeat("\t", $depth);
-                    echo "\t\t=> ".Util\Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
+                    echo "\t\t=> ".Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
                 }
             }
         }
@@ -890,8 +891,8 @@ class Ruleset
             }
         } else {
             // See if this is a whole standard being referenced.
-            $path = Util\Standards::getInstalledStandardPath($ref);
-            if ($path !== null && Util\Common::isPharFile($path) === true && strpos($path, 'ruleset.xml') === false) {
+            $path = Standards::getInstalledStandardPath($ref);
+            if ($path !== null && Common::isPharFile($path) === true && strpos($path, 'ruleset.xml') === false) {
                 // If the ruleset exists inside the phar file, use it.
                 if (file_exists($path.DIRECTORY_SEPARATOR.'ruleset.xml') === true) {
                     $path .= DIRECTORY_SEPARATOR.'ruleset.xml';
@@ -904,7 +905,7 @@ class Ruleset
                 $ref = $path;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     echo str_repeat("\t", $depth);
-                    echo "\t\t=> ".Util\Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
+                    echo "\t\t=> ".Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
                 }
             } else if (is_dir($ref) === false) {
                 // Work out the sniff path.
@@ -928,16 +929,16 @@ class Ruleset
                 }
 
                 $newRef  = false;
-                $stdPath = Util\Standards::getInstalledStandardPath($stdName);
+                $stdPath = Standards::getInstalledStandardPath($stdName);
                 if ($stdPath !== null && $path !== '') {
-                    if (Util\Common::isPharFile($stdPath) === true
+                    if (Common::isPharFile($stdPath) === true
                         && strpos($stdPath, 'ruleset.xml') === false
                     ) {
                         // Phar files can only return the directory,
                         // since ruleset can be omitted if building one standard.
-                        $newRef = Util\Common::realpath($stdPath.$path);
+                        $newRef = Common::realpath($stdPath.$path);
                     } else {
-                        $newRef = Util\Common::realpath(dirname($stdPath).$path);
+                        $newRef = Common::realpath(dirname($stdPath).$path);
                     }
                 }
 
@@ -952,7 +953,7 @@ class Ruleset
                             continue;
                         }
 
-                        $newRef = Util\Common::realpath($dir.$path);
+                        $newRef = Common::realpath($dir.$path);
 
                         if ($newRef !== false) {
                             $ref = $newRef;
@@ -964,7 +965,7 @@ class Ruleset
 
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     echo str_repeat("\t", $depth);
-                    echo "\t\t=> ".Util\Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
+                    echo "\t\t=> ".Common::stripBasepath($ref, $this->config->basepath).PHP_EOL;
                 }
             }//end if
         }//end if
@@ -1333,7 +1334,7 @@ class Ruleset
             }
 
             $className   = Autoload::loadFile($file);
-            $compareName = Util\Common::cleanSniffClass($className);
+            $compareName = Common::cleanSniffClass($className);
 
             // If they have specified a list of sniffs to restrict to, check
             // to see if this sniff is allowed.
@@ -1384,7 +1385,7 @@ class Ruleset
             $this->sniffs[$sniffClass] = null;
             $this->sniffs[$sniffClass] = new $sniffClass();
 
-            $sniffCode = Util\Common::getSniffCode($sniffClass);
+            $sniffCode = Common::getSniffCode($sniffClass);
             $this->sniffCodes[$sniffCode] = $sniffClass;
 
             if ($this->sniffs[$sniffClass] instanceof DeprecatedSniff) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer\Files\FileList;
 use PHP_CodeSniffer\Util\Cache;
 use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\Standards;
+use PHP_CodeSniffer\Util\Timing;
+use PHP_CodeSniffer\Util\Tokens;
 
 class Runner
 {
@@ -57,7 +59,7 @@ class Runner
         $this->registerOutOfMemoryShutdownMessage('phpcs');
 
         try {
-            Util\Timing::startTiming();
+            Timing::startTiming();
             Runner::checkRequirements();
 
             if (defined('PHP_CODESNIFFER_CBF') === false) {
@@ -128,7 +130,7 @@ class Runner
                 && ($toScreen === false
                 || (($this->reporter->totalErrors + $this->reporter->totalWarnings) === 0 && $this->config->showProgress === true))
             ) {
-                Util\Timing::printRunTime();
+                Timing::printRunTime();
             }
         } catch (DeepExitException $e) {
             echo $e->getMessage();
@@ -163,7 +165,7 @@ class Runner
         }
 
         try {
-            Util\Timing::startTiming();
+            Timing::startTiming();
             Runner::checkRequirements();
 
             // Creating the Config object populates it with all required settings
@@ -214,7 +216,7 @@ class Runner
             $this->reporter->printReports();
 
             echo PHP_EOL;
-            Util\Timing::printRunTime();
+            Timing::printRunTime();
         } catch (DeepExitException $e) {
             echo $e->getMessage();
             return $e->getCode();
@@ -311,12 +313,12 @@ class Runner
 
         // Check that the standards are valid.
         foreach ($this->config->standards as $standard) {
-            if (Util\Standards::isInstalledStandard($standard) === false) {
+            if (Standards::isInstalledStandard($standard) === false) {
                 // They didn't select a valid coding standard, so help them
                 // out by letting them know which standards are installed.
                 $error = 'ERROR: the "'.$standard.'" coding standard is not installed. ';
                 ob_start();
-                Util\Standards::printInstalledStandards();
+                Standards::printInstalledStandards();
                 $error .= ob_get_contents();
                 ob_end_clean();
                 throw new DeepExitException($error, 3);
@@ -331,7 +333,7 @@ class Runner
 
         // Create this class so it is autoloaded and sets up a bunch
         // of PHP_CodeSniffer-specific token type constants.
-        $tokens = new Util\Tokens();
+        $tokens = new Tokens();
 
         // Allow autoloading of custom files inside installed standards.
         $installedStandards = Standards::getInstalledStandardDetails();

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -12,6 +12,7 @@
 
 namespace PHP_CodeSniffer;
 
+use Exception;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\DummyFile;
@@ -662,7 +663,7 @@ class Runner
                     echo " ($errors errors, $warnings warnings)".PHP_EOL;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $error = 'An error occurred during processing; checking has been aborted. The error message was: '.$e->getMessage();
 
             // Determine which sniff caused the error.

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -9,10 +9,10 @@
 
 namespace PHP_CodeSniffer\Sniffs;
 
-use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
-use PHP_CodeSniffer\Tokenizers\PHP;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Tokenizers\PHP;
+use PHP_CodeSniffer\Util\Tokens;
 
 abstract class AbstractPatternSniff implements Sniff
 {

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -26,8 +26,8 @@
 
 namespace PHP_CodeSniffer\Sniffs;
 
-use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
 
 abstract class AbstractScopeSniff implements Sniff
 {

--- a/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -10,6 +10,8 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;
 
+use ReflectionFunction;
+
 class DeprecatedFunctionsSniff extends ForbiddenFunctionsSniff
 {
 
@@ -34,7 +36,7 @@ class DeprecatedFunctionsSniff extends ForbiddenFunctionsSniff
         $functions = get_defined_functions();
 
         foreach ($functions['internal'] as $functionName) {
-            $function = new \ReflectionFunction($functionName);
+            $function = new ReflectionFunction($functionName);
 
             if ($function->isDeprecated() === true) {
                 $this->forbiddenFunctions[$functionName] = null;

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes;
 
+use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Tokens;
@@ -66,7 +67,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
             if (empty($propertyInfo) === true) {
                 return;
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Turns out not to be a property after all.
             return;
         }

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Standards\Zend\Sniffs\Files;
 
-use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 class ClosingTagSniff implements Sniff

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions;
 
+use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Common;
-use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
 class ValidVariableNameSniff extends AbstractVariableSniff

--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Tokenizers;
 
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
 
 class Comment
 {
@@ -56,7 +56,7 @@ class Comment
         $stackPtr++;
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            $content = Util\Common::prepareForOutput($openTag);
+            $content = Common::prepareForOutput($openTag);
             echo "\t\tCreate comment token: T_DOC_COMMENT_OPEN_TAG => $content".PHP_EOL;
         }
 
@@ -99,7 +99,7 @@ class Comment
                 $tokens[$stackPtr] = $space;
                 $stackPtr++;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    $content = Util\Common::prepareForOutput($space['content']);
+                    $content = Common::prepareForOutput($space['content']);
                     echo "\t\tCreate comment token: T_DOC_COMMENT_WHITESPACE => $content".PHP_EOL;
                 }
 
@@ -134,7 +134,7 @@ class Comment
             foreach ($lineTokens as $lineToken) {
                 $tokens[$stackPtr] = $lineToken;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    $content = Util\Common::prepareForOutput($lineToken['content']);
+                    $content = Common::prepareForOutput($lineToken['content']);
                     $type    = $lineToken['type'];
                     echo "\t\tCreate comment token: $type => $content".PHP_EOL;
                 }
@@ -150,7 +150,7 @@ class Comment
         $tokens[$stackPtr] = $closeTag;
         $tokens[$openPtr]['comment_closer'] = $stackPtr;
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            $content = Util\Common::prepareForOutput($closeTag['content']);
+            $content = Common::prepareForOutput($closeTag['content']);
             echo "\t\tCreate comment token: T_DOC_COMMENT_CLOSE_TAG => $content".PHP_EOL;
         }
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -9,7 +9,8 @@
 
 namespace PHP_CodeSniffer\Tokenizers;
 
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class PHP extends Tokenizer
 {
@@ -543,12 +544,12 @@ class PHP extends Tokenizer
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 if ($tokenIsArray === true) {
-                    $type    = Util\Tokens::tokenName($token[0]);
-                    $content = Util\Common::prepareForOutput($token[1]);
+                    $type    = Tokens::tokenName($token[0]);
+                    $content = Common::prepareForOutput($token[1]);
                 } else {
                     $newToken = self::resolveSimpleToken($token[0]);
                     $type     = $newToken['type'];
-                    $content  = Util\Common::prepareForOutput($token[0]);
+                    $content  = Common::prepareForOutput($token[0]);
                 }
 
                 echo "\tProcess token ";
@@ -562,7 +563,7 @@ class PHP extends Tokenizer
             }//end if
 
             if ($newStackPtr > 0
-                && isset(Util\Tokens::$emptyTokens[$finalTokens[($newStackPtr - 1)]['code']]) === false
+                && isset(Tokens::$emptyTokens[$finalTokens[($newStackPtr - 1)]['code']]) === false
             ) {
                 $lastNotEmptyToken = ($newStackPtr - 1);
             }
@@ -607,7 +608,7 @@ class PHP extends Tokenizer
             */
 
             if ($tokenIsArray === true
-                && isset(Util\Tokens::$contextSensitiveKeywords[$token[0]]) === true
+                && isset(Tokens::$contextSensitiveKeywords[$token[0]]) === true
                 && (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
                 || $finalTokens[$lastNotEmptyToken]['content'] === '&'
                 || $insideConstDeclaration === true)
@@ -629,7 +630,7 @@ class PHP extends Tokenizer
                     ) {
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === false
-                                || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                                || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                             ) {
                                 break;
                             }
@@ -654,7 +655,7 @@ class PHP extends Tokenizer
                                 break;
                             }
 
-                            if (isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true) {
+                            if (isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true) {
                                 continue;
                             }
 
@@ -677,7 +678,7 @@ class PHP extends Tokenizer
                     // Find the next non-empty token.
                     for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                         if (is_array($tokens[$i]) === true
-                            && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                            && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
                         ) {
                             continue;
                         }
@@ -695,7 +696,7 @@ class PHP extends Tokenizer
                     $preserveKeyword = true;
 
                     for ($i = ($lastNotEmptyToken - 1); $i >= 0; $i--) {
-                        if (isset(Util\Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
+                        if (isset(Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
                             continue;
                         }
 
@@ -709,7 +710,7 @@ class PHP extends Tokenizer
 
                 if ($preserveKeyword === false) {
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                        $type = Util\Tokens::tokenName($token[0]);
+                        $type = Tokens::tokenName($token[0]);
                         echo "\t\t* token $stackPtr changed from $type to T_STRING".PHP_EOL;
                     }
 
@@ -754,7 +755,7 @@ class PHP extends Tokenizer
             ) {
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === true
-                        && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                        && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
                     ) {
                         continue;
                     }
@@ -1109,7 +1110,7 @@ class PHP extends Tokenizer
                 // Get the next non-empty token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1263,8 +1264,8 @@ class PHP extends Tokenizer
                 }
 
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    $type    = Util\Tokens::tokenName($token[0]);
-                    $content = Util\Common::prepareForOutput($token[1]);
+                    $type    = Tokens::tokenName($token[0]);
+                    $content = Common::prepareForOutput($token[1]);
                     echo "\t\t* token $stackPtr split into individual tokens; was: $type => $content".PHP_EOL;
                 }
 
@@ -1327,7 +1328,7 @@ class PHP extends Tokenizer
                 // Get the next non-empty token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1340,7 +1341,7 @@ class PHP extends Tokenizer
                     // Get the previous non-empty token.
                     for ($j = ($stackPtr - 1); $j > 0; $j--) {
                         if (is_array($tokens[$j]) === false
-                            || isset(Util\Tokens::$emptyTokens[$tokens[$j][0]]) === false
+                            || isset(Tokens::$emptyTokens[$tokens[$j][0]]) === false
                         ) {
                             break;
                         }
@@ -1363,7 +1364,7 @@ class PHP extends Tokenizer
                         $tokens[$stackPtr][0] = T_PARAM_NAME;
 
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                            $type = Util\Tokens::tokenName($token[0]);
+                            $type = Tokens::tokenName($token[0]);
                             echo "\t\t* token $stackPtr changed from $type to T_PARAM_NAME".PHP_EOL;
                         }
 
@@ -1384,7 +1385,7 @@ class PHP extends Tokenizer
                 // Get the next non-whitespace token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1414,7 +1415,7 @@ class PHP extends Tokenizer
                             $tokenType = $tokens[$i];
                         }
 
-                        if (isset(Util\Tokens::$emptyTokens[$tokenType]) === true) {
+                        if (isset(Tokens::$emptyTokens[$tokenType]) === true) {
                             continue;
                         }
 
@@ -1508,8 +1509,8 @@ class PHP extends Tokenizer
 
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     for ($i = ($stackPtr + 1); $i <= ($stackPtr + 2); $i++) {
-                        $type    = Util\Tokens::tokenName($tokens[$i][0]);
-                        $content = Util\Common::prepareForOutput($tokens[$i][1]);
+                        $type    = Tokens::tokenName($tokens[$i][0]);
+                        $content = Common::prepareForOutput($tokens[$i][1]);
                         echo "\t\t* token $i merged into T_YIELD_FROM; was: $type => $content".PHP_EOL;
                     }
                 }
@@ -1543,8 +1544,8 @@ class PHP extends Tokenizer
 
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         for ($i = ($stackPtr + 1); $i <= ($stackPtr + 2); $i++) {
-                            $type    = Util\Tokens::tokenName($tokens[$i][0]);
-                            $content = Util\Common::prepareForOutput($tokens[$i][1]);
+                            $type    = Tokens::tokenName($tokens[$i][0]);
+                            $content = Common::prepareForOutput($tokens[$i][1]);
                             echo "\t\t* token $i merged into T_YIELD_FROM; was: $type => $content".PHP_EOL;
                         }
                     }
@@ -1783,7 +1784,7 @@ class PHP extends Tokenizer
 
                 $newToken            = [];
                 $newToken['code']    = $newType;
-                $newToken['type']    = Util\Tokens::tokenName($newType);
+                $newToken['type']    = Tokens::tokenName($newType);
                 $newToken['content'] = $newContent;
                 $finalTokens[$newStackPtr] = $newToken;
 
@@ -1807,7 +1808,7 @@ class PHP extends Tokenizer
             ) {
                 $isMatch = false;
                 for ($x = ($stackPtr + 1); $x < $numTokens; $x++) {
-                    if (isset($tokens[$x][0], Util\Tokens::$emptyTokens[$tokens[$x][0]]) === true) {
+                    if (isset($tokens[$x][0], Tokens::$emptyTokens[$tokens[$x][0]]) === true) {
                         continue;
                     }
 
@@ -1872,7 +1873,7 @@ class PHP extends Tokenizer
                     }
 
                     if (is_array($tokens[$x]) === false
-                        || isset(Util\Tokens::$emptyTokens[$tokens[$x][0]]) === false
+                        || isset(Tokens::$emptyTokens[$tokens[$x][0]]) === false
                     ) {
                         // Non-empty, non-comma content.
                         break;
@@ -1945,7 +1946,7 @@ class PHP extends Tokenizer
                         $tokenType = $tokens[$i];
                     }
 
-                    if (isset(Util\Tokens::$emptyTokens[$tokenType]) === true) {
+                    if (isset(Tokens::$emptyTokens[$tokenType]) === true) {
                         continue;
                     }
 
@@ -2014,7 +2015,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($prevNonEmpty === null
-                        && isset(Util\Tokens::$emptyTokens[$tokenType]) === false
+                        && isset(Tokens::$emptyTokens[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
                         if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
@@ -2033,7 +2034,7 @@ class PHP extends Tokenizer
 
                     if ($tokenType === T_FUNCTION
                         || $tokenType === T_FN
-                        || isset(Util\Tokens::$methodPrefixes[$tokenType]) === true
+                        || isset(Tokens::$methodPrefixes[$tokenType]) === true
                         || $tokenType === T_VAR
                     ) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -2055,7 +2056,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset(Util\Tokens::$emptyTokens[$tokenType]) === false) {
+                    if (isset(Tokens::$emptyTokens[$tokenType]) === false) {
                         $lastSeenNonEmpty = $tokenType;
                     }
                 }//end for
@@ -2078,7 +2079,7 @@ class PHP extends Tokenizer
                 && $token[0] !== T_STRING
                 && $token[0] !== T_VARIABLE
                 && $token[0] !== T_DOLLAR
-                && isset(Util\Tokens::$emptyTokens[$token[0]]) === false
+                && isset(Tokens::$emptyTokens[$token[0]]) === false
             ) {
                 $newToken            = [];
                 $newToken['code']    = T_STRING;
@@ -2138,7 +2139,7 @@ class PHP extends Tokenizer
                 if ($parenthesisCloser !== false) {
                     for ($x = ($parenthesisCloser + 1); $x < $numTokens; $x++) {
                         if (is_array($tokens[$x]) === false
-                            || isset(Util\Tokens::$emptyTokens[$tokens[$x][0]]) === false
+                            || isset(Tokens::$emptyTokens[$tokens[$x][0]]) === false
                         ) {
                             // Non-empty content.
                             if (is_array($tokens[$x]) === true && $tokens[$x][0] === T_USE) {
@@ -2161,7 +2162,7 @@ class PHP extends Tokenizer
                         // Find the start of the return type.
                         for ($x += 1; $x < $numTokens; $x++) {
                             if (is_array($tokens[$x]) === true
-                                && isset(Util\Tokens::$emptyTokens[$tokens[$x][0]]) === true
+                                && isset(Tokens::$emptyTokens[$tokens[$x][0]]) === true
                             ) {
                                 // Whitespace or comments before the return type.
                                 continue;
@@ -2273,7 +2274,7 @@ class PHP extends Tokenizer
                 $tokenLines = explode($this->eolChar, $token[1]);
                 $numLines   = count($tokenLines);
                 $newToken   = [
-                    'type'    => Util\Tokens::tokenName($token[0]),
+                    'type'    => Tokens::tokenName($token[0]),
                     'code'    => $token[0],
                     'content' => '',
                 ];
@@ -2305,7 +2306,7 @@ class PHP extends Tokenizer
                         // Find the next non-empty token.
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === true
-                                && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                                && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
                             ) {
                                 continue;
                             }
@@ -2333,7 +2334,7 @@ class PHP extends Tokenizer
                     } else if ($finalTokens[$lastNotEmptyToken]['content'] === '&') {
                         // Function names for functions declared to return by reference.
                         for ($i = ($lastNotEmptyToken - 1); $i >= 0; $i--) {
-                            if (isset(Util\Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
+                            if (isset(Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
                                 continue;
                             }
 
@@ -2347,7 +2348,7 @@ class PHP extends Tokenizer
                         // Keywords with special PHPCS token when used as a function call.
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === true
-                                && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                                && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
                             ) {
                                 continue;
                             }
@@ -2404,7 +2405,7 @@ class PHP extends Tokenizer
                     // Get the previous non-empty token.
                     for ($i = ($stackPtr - 1); $i > 0; $i--) {
                         if (is_array($tokens[$i]) === false
-                            || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                            || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                         ) {
                             break;
                         }
@@ -2511,7 +2512,7 @@ class PHP extends Tokenizer
                 if ($newToken['code'] === T_ARRAY) {
                     for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                         if (is_array($tokens[$i]) === false
-                            || isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                            || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
                         ) {
                             // Non-empty content.
                             break;
@@ -2613,7 +2614,7 @@ class PHP extends Tokenizer
 
                 if (isset($this->tokens[$i]['scope_opener']) === true) {
                     for ($x = ($i + 1); $x < $numTokens; $x++) {
-                        if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
+                        if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
                             && $this->tokens[$x]['code'] !== T_BITWISE_AND
                         ) {
                             break;
@@ -2649,7 +2650,7 @@ class PHP extends Tokenizer
                 */
 
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
                         break;
                     }
                 }
@@ -2700,7 +2701,7 @@ class PHP extends Tokenizer
             } else if ($this->tokens[$i]['code'] === T_FN && isset($this->tokens[($i + 1)]) === true) {
                 // Possible arrow function.
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
                         && $this->tokens[$x]['code'] !== T_BITWISE_AND
                     ) {
                         // Non-whitespace content.
@@ -2709,7 +2710,7 @@ class PHP extends Tokenizer
                 }
 
                 if (isset($this->tokens[$x]) === true && $this->tokens[$x]['code'] === T_OPEN_PARENTHESIS) {
-                    $ignore  = Util\Tokens::$emptyTokens;
+                    $ignore  = Tokens::$emptyTokens;
                     $ignore += [
                         T_ARRAY             => T_ARRAY,
                         T_CALLABLE          => T_CALLABLE,
@@ -2768,7 +2769,7 @@ class PHP extends Tokenizer
                                 }
 
                                 for ($lastNonEmpty = ($scopeCloser - 1); $lastNonEmpty > $arrow; $lastNonEmpty--) {
-                                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
+                                    if (isset(Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
                                         $scopeCloser = $lastNonEmpty;
                                         break 2;
                                     }
@@ -2783,7 +2784,7 @@ class PHP extends Tokenizer
                                     && $this->tokens[$scopeCloser]['bracket_opener'] < $arrow))
                                 ) {
                                     for ($lastNonEmpty = ($scopeCloser - 1); $lastNonEmpty > $arrow; $lastNonEmpty--) {
-                                        if (isset(Util\Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
+                                        if (isset(Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
                                             $scopeCloser = $lastNonEmpty;
                                             break;
                                         }
@@ -2912,7 +2913,7 @@ class PHP extends Tokenizer
                     T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
                     T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
                 ];
-                $allowed     += Util\Tokens::$magicConstants;
+                $allowed     += Tokens::$magicConstants;
 
                 for ($x = ($i - 1); $x >= 0; $x--) {
                     // If we hit a scope opener, the statement has ended
@@ -2923,11 +2924,11 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
                         // Allow for control structures without braces.
                         if (($this->tokens[$x]['code'] === T_CLOSE_PARENTHESIS
                             && isset($this->tokens[$x]['parenthesis_owner']) === true
-                            && isset(Util\Tokens::$scopeOpeners[$this->tokens[$this->tokens[$x]['parenthesis_owner']]['code']]) === true)
+                            && isset(Tokens::$scopeOpeners[$this->tokens[$this->tokens[$x]['parenthesis_owner']]['code']]) === true)
                             || isset($allowed[$this->tokens[$x]['code']]) === false
                         ) {
                             $isShortArray = true;
@@ -2989,7 +2990,7 @@ class PHP extends Tokenizer
                         T_OPEN_SHORT_ARRAY    => T_OPEN_SHORT_ARRAY,
                         T_DOUBLE_ARROW        => T_DOUBLE_ARROW,
                     ];
-                    $searchFor += Util\Tokens::$scopeOpeners;
+                    $searchFor += Tokens::$scopeOpeners;
 
                     for ($x = ($this->tokens[$i]['scope_opener'] + 1); $x < $this->tokens[$i]['scope_closer']; $x++) {
                         if (isset($searchFor[$this->tokens[$x]['code']]) === false) {
@@ -3049,7 +3050,7 @@ class PHP extends Tokenizer
                 $typeTokenCount = 0;
 
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
                         continue;
                     }
 
@@ -3114,7 +3115,7 @@ class PHP extends Tokenizer
                 $confirmed      = false;
 
                 for ($x = ($i - 1); $x >= 0; $x--) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
                         continue;
                     }
 
@@ -3144,7 +3145,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($suspectedType === 'property or parameter'
-                        && (isset(Util\Tokens::$scopeModifiers[$this->tokens[$x]['code']]) === true
+                        && (isset(Tokens::$scopeModifiers[$this->tokens[$x]['code']]) === true
                         || $this->tokens[$x]['code'] === T_VAR
                         || $this->tokens[$x]['code'] === T_STATIC
                         || $this->tokens[$x]['code'] === T_READONLY)
@@ -3172,7 +3173,7 @@ class PHP extends Tokenizer
                         // had additional processing done.
                         if (isset($this->tokens[$last]['parenthesis_opener']) === true) {
                             for ($x = ($this->tokens[$last]['parenthesis_opener'] - 1); $x >= 0; $x--) {
-                                if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                                if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
                                     continue;
                                 }
 
@@ -3181,7 +3182,7 @@ class PHP extends Tokenizer
 
                             if ($this->tokens[$x]['code'] === T_FN) {
                                 for (--$x; $x >= 0; $x--) {
-                                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true
+                                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true
                                         || $this->tokens[$x]['code'] === T_BITWISE_AND
                                     ) {
                                         continue;
@@ -3228,7 +3229,7 @@ class PHP extends Tokenizer
                 continue;
             } else if ($this->tokens[$i]['code'] === T_STATIC) {
                 for ($x = ($i - 1); $x > 0; $x--) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
                         break;
                     }
                 }
@@ -3249,7 +3250,7 @@ class PHP extends Tokenizer
                 || $this->tokens[$i]['code'] === T_NULL
             ) {
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
                         // Non-whitespace content.
                         break;
                     }
@@ -3285,7 +3286,7 @@ class PHP extends Tokenizer
             // opening this case statement and the opener and closer are
             // probably set incorrectly.
             for ($x = ($scopeOpener + 1); $x < $numTokens; $x++) {
-                if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
                     // Non-whitespace content.
                     break;
                 }
@@ -3389,14 +3390,14 @@ class PHP extends Tokenizer
                             $type     = $this->tokens[$x]['type'];
                             $oldConds = '';
                             foreach ($oldConditions as $condition) {
-                                $oldConds .= Util\Tokens::tokenName($condition).',';
+                                $oldConds .= Tokens::tokenName($condition).',';
                             }
 
                             $oldConds = rtrim($oldConds, ',');
 
                             $newConds = '';
                             foreach ($this->tokens[$x]['conditions'] as $condition) {
-                                $newConds .= Util\Tokens::tokenName($condition).',';
+                                $newConds .= Tokens::tokenName($condition).',';
                             }
 
                             $newConds = rtrim($newConds, ',');
@@ -3484,7 +3485,7 @@ class PHP extends Tokenizer
         } else {
             $newToken = [
                 'code' => $token[0],
-                'type' => Util\Tokens::tokenName($token[0]),
+                'type' => Tokens::tokenName($token[0]),
             ];
 
             self::$resolveTokenCache[$token[0]] = $newToken;

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -10,7 +10,8 @@
 namespace PHP_CodeSniffer\Tokenizers;
 
 use PHP_CodeSniffer\Exceptions\TokenizerException;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 abstract class Tokenizer
 {
@@ -680,7 +681,7 @@ abstract class Tokenizer
                 Parenthesis mapping.
             */
 
-            if (isset(Util\Tokens::$parenthesisOpeners[$this->tokens[$i]['code']]) === true) {
+            if (isset(Tokens::$parenthesisOpeners[$this->tokens[$i]['code']]) === true) {
                 $this->tokens[$i]['parenthesis_opener'] = null;
                 $this->tokens[$i]['parenthesis_closer'] = null;
                 $this->tokens[$i]['parenthesis_owner']  = $i;
@@ -896,7 +897,7 @@ abstract class Tokenizer
             if (isset($this->scopeOpeners[$this->tokens[$i]['code']]) === true) {
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     $type    = $this->tokens[$i]['type'];
-                    $content = Util\Common::prepareForOutput($this->tokens[$i]['content']);
+                    $content = Common::prepareForOutput($this->tokens[$i]['content']);
                     echo "\tStart scope map at $i:$type => $content".PHP_EOL;
                 }
 
@@ -958,7 +959,7 @@ abstract class Tokenizer
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 $type    = $this->tokens[$i]['type'];
                 $line    = $this->tokens[$i]['line'];
-                $content = Util\Common::prepareForOutput($this->tokens[$i]['content']);
+                $content = Common::prepareForOutput($this->tokens[$i]['content']);
 
                 echo str_repeat("\t", $depth);
                 echo "Process token $i on line $line [";
@@ -1314,13 +1315,13 @@ abstract class Tokenizer
                         // Make sure this is actually an opener and not a
                         // string offset (e.g., $var{0}).
                         for ($x = ($i - 1); $x > 0; $x--) {
-                            if (isset(Util\Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                            if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
                                 continue;
                             } else {
                                 // If the first non-whitespace/comment token looks like this
                                 // brace is a string offset, or this brace is mid-way through
                                 // a new statement, it isn't a scope opener.
-                                $disallowed  = Util\Tokens::$assignmentTokens;
+                                $disallowed  = Tokens::$assignmentTokens;
                                 $disallowed += [
                                     T_DOLLAR                   => true,
                                     T_VARIABLE                 => true,
@@ -1388,7 +1389,7 @@ abstract class Tokenizer
             } else if ($tokenType === T_OPEN_PARENTHESIS) {
                 if (isset($this->tokens[$i]['parenthesis_owner']) === true) {
                     $owner = $this->tokens[$i]['parenthesis_owner'];
-                    if (isset(Util\Tokens::$scopeOpeners[$this->tokens[$owner]['code']]) === true
+                    if (isset(Tokens::$scopeOpeners[$this->tokens[$owner]['code']]) === true
                         && isset($this->tokens[$i]['parenthesis_closer']) === true
                     ) {
                         // If we get into here, then we opened a parenthesis for
@@ -1427,7 +1428,7 @@ abstract class Tokenizer
                 // token was empty (in which case we'll just confirm there is
                 // more code in this file and not just a big comment).
                 if ($this->tokens[$i]['line'] >= ($startLine + 30)
-                    && isset(Util\Tokens::$emptyTokens[$this->tokens[($i - 1)]['code']]) === false
+                    && isset(Tokens::$emptyTokens[$this->tokens[($i - 1)]['code']]) === false
                 ) {
                     if ($this->scopeOpeners[$currType]['strict'] === true) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -1516,14 +1517,14 @@ abstract class Tokenizer
                 $len  = $this->tokens[$i]['length'];
                 $col  = $this->tokens[$i]['column'];
 
-                $content = Util\Common::prepareForOutput($this->tokens[$i]['content']);
+                $content = Common::prepareForOutput($this->tokens[$i]['content']);
 
                 echo str_repeat("\t", ($level + 1));
                 echo "Process token $i on line $line [col:$col;len:$len;lvl:$level;";
                 if (empty($conditions) !== true) {
                     $conditionString = 'conds;';
                     foreach ($conditions as $condition) {
-                        $conditionString .= Util\Tokens::tokenName($condition).',';
+                        $conditionString .= Tokens::tokenName($condition).',';
                     }
 
                     echo rtrim($conditionString, ',').';';
@@ -1584,14 +1585,14 @@ abstract class Tokenizer
                                     $type     = $this->tokens[$x]['type'];
                                     $oldConds = '';
                                     foreach ($oldConditions as $condition) {
-                                        $oldConds .= Util\Tokens::tokenName($condition).',';
+                                        $oldConds .= Tokens::tokenName($condition).',';
                                     }
 
                                     $oldConds = rtrim($oldConds, ',');
 
                                     $newConds = '';
                                     foreach ($this->tokens[$x]['conditions'] as $condition) {
-                                        $newConds .= Util\Tokens::tokenName($condition).',';
+                                        $newConds .= Tokens::tokenName($condition).',';
                                     }
 
                                     $newConds = rtrim($newConds, ',');
@@ -1660,7 +1661,7 @@ abstract class Tokenizer
                             $oldCondition = array_pop($conditions);
                             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                                 echo str_repeat("\t", ($level + 1));
-                                echo '* token '.Util\Tokens::tokenName($oldCondition).' removed from conditions array *'.PHP_EOL;
+                                echo '* token '.Tokens::tokenName($oldCondition).' removed from conditions array *'.PHP_EOL;
                             }
 
                             // Make sure this closer actually belongs to us.
@@ -1672,7 +1673,7 @@ abstract class Tokenizer
                                     $badToken = $this->tokens[$oldOpener]['scope_condition'];
 
                                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                                        $type = Util\Tokens::tokenName($oldCondition);
+                                        $type = Tokens::tokenName($oldCondition);
                                         echo str_repeat("\t", ($level + 1));
                                         echo "* scope closer was bad, cleaning up $badToken:$type *".PHP_EOL;
                                     }
@@ -1686,14 +1687,14 @@ abstract class Tokenizer
                                             $type     = $this->tokens[$x]['type'];
                                             $oldConds = '';
                                             foreach ($oldConditions as $condition) {
-                                                $oldConds .= Util\Tokens::tokenName($condition).',';
+                                                $oldConds .= Tokens::tokenName($condition).',';
                                             }
 
                                             $oldConds = rtrim($oldConds, ',');
 
                                             $newConds = '';
                                             foreach ($this->tokens[$x]['conditions'] as $condition) {
-                                                $newConds .= Util\Tokens::tokenName($condition).',';
+                                                $newConds .= Tokens::tokenName($condition).',';
                                             }
 
                                             $newConds = rtrim($newConds, ',');

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -9,9 +9,13 @@
 
 namespace PHP_CodeSniffer\Util;
 
+use FilesystemIterator;
 use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 class Cache
 {
@@ -95,11 +99,11 @@ class Cache
         // hash. This ensures that core PHPCS changes will also invalidate the cache.
         // Note that we ignore sniffs here, and any files that don't affect
         // the outcome of the run.
-        $di     = new \RecursiveDirectoryIterator(
+        $di     = new RecursiveDirectoryIterator(
             $installDir,
-            (\FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS)
+            (FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS)
         );
-        $filter = new \RecursiveCallbackFilterIterator(
+        $filter = new RecursiveCallbackFilterIterator(
             $di,
             function ($file, $key, $iterator) {
                 // Skip non-php files.
@@ -126,7 +130,7 @@ class Cache
             }
         );
 
-        $iterator = new \RecursiveIteratorIterator($filter);
+        $iterator = new RecursiveIteratorIterator($filter);
         foreach ($iterator as $file) {
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 echo "\t\t=> core file: $file".PHP_EOL;

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -9,6 +9,8 @@
 
 namespace PHP_CodeSniffer\Util;
 
+use Phar;
+
 class Common
 {
 
@@ -112,7 +114,7 @@ class Common
             return $path;
         }
 
-        $phar  = \Phar::running(false);
+        $phar  = Phar::running(false);
         $extra = str_replace('phar://'.$phar, '', $path);
         $path  = realpath($phar);
         if ($path === false) {

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Util;
 
+use DirectoryIterator;
 use PHP_CodeSniffer\Config;
 
 class Standards
@@ -99,7 +100,7 @@ class Standards
                 continue;
             }
 
-            $di = new \DirectoryIterator($standardsDir);
+            $di = new DirectoryIterator($standardsDir);
             foreach ($di as $file) {
                 if ($file->isDir() === true && $file->isDot() === false) {
                     $filename = $file->getFilename();
@@ -190,7 +191,7 @@ class Standards
                 continue;
             }
 
-            $di = new \DirectoryIterator($standardsDir);
+            $di = new DirectoryIterator($standardsDir);
             $standardsInDir = [];
             foreach ($di as $file) {
                 if ($file->isDir() === true && $file->isDot() === false) {

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -9,9 +9,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -11,8 +11,8 @@
 namespace PHP_CodeSniffer\Tests\Core;
 
 use PHP_CodeSniffer\Tests\FileList;
-use PHPUnit\TextUI\TestRunner;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\TextUI\TestRunner;
 
 class AllTests
 {

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
@@ -12,8 +12,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 use PHPUnit\Framework\TestCase;

--- a/tests/FileList.php
+++ b/tests/FileList.php
@@ -9,6 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests;
 
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+
 class FileList
 {
 
@@ -52,21 +56,21 @@ class FileList
     {
         $this->rootPath = $rootPath;
 
-        $directory = new \RecursiveDirectoryIterator(
+        $directory = new RecursiveDirectoryIterator(
             $directory,
-            \RecursiveDirectoryIterator::UNIX_PATHS
+            RecursiveDirectoryIterator::UNIX_PATHS
         );
-        $flattened = new \RecursiveIteratorIterator(
+        $flattened = new RecursiveIteratorIterator(
             $directory,
-            \RecursiveIteratorIterator::LEAVES_ONLY,
-            \RecursiveIteratorIterator::CATCH_GET_CHILD
+            RecursiveIteratorIterator::LEAVES_ONLY,
+            RecursiveIteratorIterator::CATCH_GET_CHILD
         );
 
         if ($filter === '') {
             $filter = sprintf($this->baseRegex, preg_quote($this->rootPath));
         }
 
-        $this->fileIterator = new \RegexIterator($flattened, $filter);
+        $this->fileIterator = new RegexIterator($flattened, $filter);
 
         return $this;
 

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -14,8 +14,8 @@
 namespace PHP_CodeSniffer\Tests\Standards;
 
 use PHP_CodeSniffer\Exceptions\RuntimeException;
-use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -13,6 +13,7 @@
 
 namespace PHP_CodeSniffer\Tests\Standards;
 
+use DirectoryIterator;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
@@ -78,7 +79,7 @@ abstract class AbstractSniffUnitTest extends TestCase
         $testFiles = [];
 
         $dir = substr($testFileBase, 0, strrpos($testFileBase, DIRECTORY_SEPARATOR));
-        $di  = new \DirectoryIterator($dir);
+        $di  = new DirectoryIterator($dir);
 
         foreach ($di as $file) {
             $path = $file->getPathname();

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -9,10 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Standards;
 
-use PHP_CodeSniffer\Util\Standards;
 use PHP_CodeSniffer\Autoload;
-use PHPUnit\TextUI\TestRunner;
+use PHP_CodeSniffer\Util\Standards;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\TextUI\TestRunner;
 
 class AllSniffs
 {

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Util\Standards;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\TextUI\TestRunner;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 class AllSniffs
 {
@@ -71,7 +73,7 @@ class AllSniffs
                 continue;
             }
 
-            $di = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($testsDir));
+            $di = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($testsDir));
 
             foreach ($di as $file) {
                 // Skip hidden files.

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-use PHPUnit\Framework\TestSuite as PHPUnit_TestSuite;
 use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite as PHPUnit_TestSuite;
 
 class TestSuite extends PHPUnit_TestSuite
 {

--- a/tests/TestSuite7.php
+++ b/tests/TestSuite7.php
@@ -9,8 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-use PHPUnit\Framework\TestSuite as PHPUnit_TestSuite;
 use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite as PHPUnit_TestSuite;
 
 class TestSuite extends PHPUnit_TestSuite
 {


### PR DESCRIPTION
## Description

### CS: alphabetically order import use statements

Follow up on squizlabs/PHP_CodeSniffer#2714

Note: sniffs which have been removed in 4.0 have been excluded from this commit.

### CS: always import all used classes [1]

... instead of using fully qualified global/PHP native classes inline.

### CS: always import all used classes [2]

.... instead of importing the namespace and using partially qualified names.

Previously, this was not consistently applied, which led to near-miss bugs/code which only worked by accident, not by design, like in the `Config`, `Fixer` and `Runner` classes, where certain code only worked by the grace of the namespace of the class itself being the top-level `PHP_CodeSniffer` namespace.

Note: the JS/CSS tokenizers and a sniff which has been removed in 4.0 have been excluded from this commit.

## Suggested changelog entry
_N/A_
