### PR TITLE
CS: always import all used classes [3]

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -16,6 +16,9 @@
 
 namespace PHP_CodeSniffer;
 
+use Composer\Autoload\ClassLoader;
+use Exception;
+
 if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
     class Autoload
     {
@@ -77,7 +80,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                     && @file_exists(__DIR__.'/../../autoload.php') === true
                 ) {
                     self::$composerAutoloader = include __DIR__.'/../../autoload.php';
-                    if (self::$composerAutoloader instanceof \Composer\Autoload\ClassLoader) {
+                    if (self::$composerAutoloader instanceof ClassLoader) {
                         self::$composerAutoloader->unregister();
                         self::$composerAutoloader->register();
                     } else {
@@ -282,7 +285,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
         public static function getLoadedClassName($path)
         {
             if (isset(self::$loadedClasses[$path]) === false) {
-                throw new \Exception("Cannot get class name for $path; file has not been included");
+                throw new Exception("Cannot get class name for $path; file has not been included");
             }
 
             return self::$loadedClasses[$path];
@@ -301,7 +304,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
         public static function getLoadedFileName($class)
         {
             if (isset(self::$loadedFiles[$class]) === false) {
-                throw new \Exception("Cannot get file name for $class; class has not been included");
+                throw new Exception("Cannot get file name for $class; class has not been included");
             }
 
             return self::$loadedFiles[$class];

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -107,8 +107,8 @@ foreach ($scripts as $script) {
     $srcDir    = realpath(__DIR__.'/../src');
     $srcDirLen = strlen($srcDir);
 
-    $rdi = new \RecursiveDirectoryIterator($srcDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
-    $di  = new \RecursiveIteratorIterator($rdi, 0, \RecursiveIteratorIterator::CATCH_GET_CHILD);
+    $rdi = new RecursiveDirectoryIterator($srcDir, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+    $di  = new RecursiveIteratorIterator($rdi, 0, RecursiveIteratorIterator::CATCH_GET_CHILD);
 
     $config    = new Config();
     $fileCount = 0;


### PR DESCRIPTION
## Description
... instead of using fully qualified global/PHP native classes inline.

And when there is no namespace, don't use fully qualified global class names.

Follow up on #347

## Suggested changelog entry
_N/A_