### PR TITLE
Tests: improve performance of the sniff tests

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -193,10 +193,13 @@ abstract class AbstractSniffUnitTest extends TestCase
                 $fixedFile = $testFile.'.fixed';
                 $filename  = basename($testFile);
                 if (file_exists($fixedFile) === true) {
-                    $diff = $phpcsFile->fixer->generateDiff($fixedFile);
-                    if (trim($diff) !== '') {
-                        $fixedFilename     = basename($fixedFile);
-                        $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
+                    if ($phpcsFile->fixer->getContents() !== file_get_contents($fixedFile)) {
+                        // Only generate the (expensive) diff if a difference is expected.
+                        $diff = $phpcsFile->fixer->generateDiff($fixedFile);
+                        if (trim($diff) !== '') {
+                            $fixedFilename     = basename($fixedFile);
+                            $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
+                        }
                     }
                 } else if (is_callable([$this, 'addWarning']) === true) {
                     $this->addWarning("Missing fixed version of $filename to verify the accuracy of fixes, while the sniff is making fixes against the test case file");


### PR DESCRIPTION
## Description
The `Fixer::generateDiff()` method uses `shell_exec()` with the `diff` command to generate a file diff.

Using this command is slow, in particular on Windows.

This commit introduces a preliminary check in the test logic to see if a diff is even needed and skips generating the diff if no differences are expected.

I don't know whether and if so, how much this will make a difference for *nix users, but on Windows, it makes a significant difference when running the sniff tests.

A run of just the sniff tests (`vendor/bin/phpunit tests/AllTests.php --filter Standards --no-coverage`) for PHPCS without this fix takes > 1 minute (~01.03.701 last time I ran it).
With this fix, the run time of the sniff tests is brought down to ~8 seconds.

So let's call this a quality of life improvement for all devs which regularly need to run sniff tests for either PHPCS itself or for external standards which base their test suite on the PHPCS native test framework.

### 👉🏻 Request for testing:
Based on the test runs in CI, this change should make no significant different on *nix systems, but I'd love to have some people test it and post their with and without timing results.


## Suggested changelog entry
Performance improvements for the sniff tests. Should be most notable for Windows users.

