### PR TITLE
[Documentation] Squiz: Superfluous Whitespace

### DIFF
--- a/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
@@ -1,21 +1,21 @@
 <documentation title="Superfluous Whitespace">
     <standard>
     <![CDATA[
-    There should be no extra whitespace at the start of a file.
+    There should be no superfluous whitespace at the start of a file.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: No whitespace preceding first content in file.">
         <![CDATA[<?php
-echo 'hi';
-]]>
+echo 'opening PHP tag at start of file';
+        ]]>
         </code>
         <code title="Invalid: Whitespace used before content in file.">
         <![CDATA[
-        <em></em>
+<em>        </em>
 <?php
-echo 'hi';
-]]>
+echo 'whitespace before opening PHP tag';
+        ]]>
         </code>
     </code_comparison>
     <standard>
@@ -26,13 +26,13 @@ echo 'hi';
     <code_comparison>
         <code title="Valid: No whitespace found at end of line.">
         <![CDATA[
-echo 'hello';
-]]>
+echo 'semicolon followed by new linechar';
+        ]]>
         </code>
         <code title="Invalid: Whitespace found at end of line.">
         <![CDATA[
-echo 'hello';<em>   </em>
-]]>
+echo 'trailing spaces after semicolon';<em>   </em>
+        ]]>
         </code>
     </code_comparison>
     <standard>
@@ -49,7 +49,7 @@ function myFunction()
 
     echo 'code here';
 }
-]]>
+        ]]>
         </code>
         <code title="Invalid: Functions contain multiple empty lines in a row.">
         <![CDATA[
@@ -60,7 +60,40 @@ function myFunction()
 
     </em>echo 'code here';
 }
-]]>
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be no superfluous whitespace at the end of a file.
+    A single final newline is allowed. A closing PHP tag is optional and ignored.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: A single newline appears after the last content in the file.">
+        <![CDATA[
+function myFunction()
+{
+    echo 'closing curly brace, 1 newline';
+    echo 'optional closing PHP tag';
+    echo 'then EOF';
+}<em>
+</em>
+?>
+        ]]>
+        </code>
+        <code title="Invalid: Multiple newlines appear after the last content in the file.">
+        <![CDATA[
+function myFunction()
+{
+    echo 'closing curly brace, 2 newlines';
+    echo 'optional closing PHP tag';
+    echo 'then EOF';
+}<em>
+
+</em>
+?>
+        ]]>
         </code>
     </code_comparison>
 </documentation>

--- a/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
@@ -26,7 +26,7 @@ echo 'whitespace before opening PHP tag';
     <code_comparison>
         <code title="Valid: No whitespace found at end of line.">
         <![CDATA[
-echo 'semicolon followed by new linechar';
+echo 'semicolon followed by new line char';
         ]]>
         </code>
         <code title="Invalid: Whitespace found at end of line.">

--- a/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
@@ -37,7 +37,7 @@ echo 'trailing spaces after semicolon';<em>   </em>
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be no more than one consecutive blank newline in functions.
+    There should be no consecutive blank lines in functions.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
@@ -1,0 +1,66 @@
+<documentation title="Superfluous Whitespace">
+    <standard>
+    <![CDATA[
+    There should be no extra whitespace at the start of a file.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No whitespace preceding first content in file.">
+        <![CDATA[<?php
+echo 'hi';
+]]>
+        </code>
+        <code title="Invalid: Whitespace used before content in file.">
+        <![CDATA[
+        <em></em>
+<?php
+echo 'hi';
+]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be no trailing whitespace at the end of lines.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No whitespace found at end of line.">
+        <![CDATA[
+echo 'hello';
+]]>
+        </code>
+        <code title="Invalid: Whitespace found at end of line.">
+        <![CDATA[
+echo 'hello';<em>   </em>
+]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be no more than one consecutive blank newline in functions.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Functions do not contain multiple empty lines in a row.">
+        <![CDATA[
+function myFunction()
+{
+    echo 'code here';
+
+    echo 'code here';
+}
+]]>
+        </code>
+        <code title="Invalid: Functions contain multiple empty lines in a row.">
+        <![CDATA[
+function myFunction()
+{
+    echo 'code here';
+    <em>
+
+    </em>echo 'code here';
+}
+]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/SuperfluousWhitespaceStandard.xml
@@ -65,34 +65,33 @@ function myFunction()
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be no superfluous whitespace at the end of a file.
-    A single final newline is allowed. A closing PHP tag is optional and ignored.
+    There should be no superfluous whitespace after the final closing PHP tag in a file.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: A single newline appears after the last content in the file.">
+        <code title="Valid: A single new line appears after the last content in the file.">
         <![CDATA[
 function myFunction()
 {
-    echo 'closing curly brace, 1 newline';
-    echo 'optional closing PHP tag';
-    echo 'then EOF';
-}<em>
+    echo 'Closing PHP tag, then';
+    echo 'Single new line char, then EOF';
+}
+
+?><em>
 </em>
-?>
         ]]>
         </code>
-        <code title="Invalid: Multiple newlines appear after the last content in the file.">
+        <code title="Invalid: Multiple new lines appear after the last content in the file.">
         <![CDATA[
 function myFunction()
 {
-    echo 'closing curly brace, 2 newlines';
-    echo 'optional closing PHP tag';
-    echo 'then EOF';
-}<em>
+    echo 'Closing PHP tag, then';
+    echo 'Multiple new line chars, then EOF';
+}
+
+?><em>
 
 </em>
-?>
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
## Description
This PR adds documentation for the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff.

## Suggested changelog entry
Add documentation for the Squiz Superfluous Whitespace sniff

## Related issues/external references
Part of #148 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
