### PR TITLE
[Documentation] Squiz: Scope Closing Brace

### DIFF
--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -12,6 +12,21 @@ function foo()
     echo 'opening brace at column 1';
     echo 'closing brace at column 1';
 <em>}</em>
+
+class Foo {
+    echo 'class keyword starts at column 1';
+    echo 'closing brace at column 1';
+<em>}</em>
+
+if ($a > $b) {
+    echo 'conditional starts at column 1';
+    echo 'closing brace at column 1';
+<em>}</em>
+
+<?php if ($something) { ?>
+    <p>conditional opening tag at column 1</p>
+    <p>conditional closing tag at column 1</p>
+<?php } ?>
         ]]>
         </code>
         <code title="Invalid: Closing brace misaligned with opening brace.">
@@ -21,42 +36,21 @@ function foo()
     echo 'opening brace at column 1';
     echo 'closing brace at column 2';
 <em> }</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <code_comparison>
-        <code title="Valid: Closing brace aligned with class keyword.">
-        <![CDATA[
-class Foo {
-    echo 'class keyword starts at column 1';
-    echo 'closing brace at column 1';
-<em>}</em>
-        ]]>
-        </code>
-        <code title="Invalid: Closing brace misaligned with class keyword.">
-        <![CDATA[
+
 class Foo {
     echo 'class keyword starts at column 1';
     echo 'closing brace at column 2';
 <em> }</em>
-        ]]>
-        </code>
-    </code_comparison>
-    <code_comparison>
-        <code title="Valid: Closing brace aligned with if keyword.">
-        <![CDATA[
-if ($a > $b) {
-    echo 'conditional starts at column 1';
-    echo 'closing brace at column 1';
-<em>}</em>
-        ]]>
-        </code>
-        <code title="Invalid: Closing brace aligned with content.">
-        <![CDATA[
+
 if ($a > $b) {
     echo 'conditional starts at column 1';
     echo 'closing brace at column 5';
 <em>    }</em>
+
+<?php if ($something) { ?>
+    <p>conditional opening tag at column 1</p>
+    <p>conditional closing tag at column 2</p>
+ <?php } ?>
         ]]>
         </code>
     </code_comparison>
@@ -66,13 +60,13 @@ if ($a > $b) {
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Newline before closing brace.">
+        <code title="Valid: Close brace on its own line.">
         <![CDATA[
 enum Foo {
 <em>}</em>
         ]]>
         </code>
-        <code title="Invalid: No newline before closing brace.">
+        <code title="Invalid: Close brace on a line containing other code.">
         <![CDATA[
 enum Foo {<em>}</em>
         ]]>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -1,0 +1,47 @@
+<documentation title="Scope Closing Brace">
+    <standard>
+    <![CDATA[
+    Closing brace indentation must match opening brace.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Closing brace indented correctly.">
+        <![CDATA[
+function foo()
+<em>{</em>
+    echo 'hi';
+}
+]]>
+        </code>
+        <code title="Invalid: Closing brace indented incorrectly.">
+        <![CDATA[
+function foo()
+{
+    echo 'hi';
+<em> }</em>
+]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Closing brace must be on a line by itself.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Closing brace is on a line by itself.">
+        <![CDATA[
+function foo()
+{
+    echo 'hi';
+<em>}</em>
+]]>
+        </code>
+        <code title="Invalid: Closing brace is alongside other content.">
+        <![CDATA[
+function foo()
+{
+    echo 'hi';<em>}</em>
+]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -22,7 +22,7 @@ if (!class_exists('Foo')) {
 
 <?php if ($something) { ?>
     <p>some output</p>
-<?php } ?>
+<em></em><?php } ?>
         ]]>
         </code>
         <code title="Invalid: Closing brace misaligned with line containing opening brace.">
@@ -42,7 +42,7 @@ if (!class_exists('Foo')) {
 
 <?php if ($something) { ?>
     <p>some output</p>
- <?php } ?>
+<em> </em><?php } ?>
         ]]>
         </code>
     </code_comparison>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -9,9 +9,11 @@
         <![CDATA[
 function foo()
 {
-    echo 'opening brace at column 1';
-    echo 'closing brace at column 1';
 <em>}</em>
+
+    function bar()
+    {
+<em>    }</em>
 
 if (!class_exists('Foo')) {
     class Foo {
@@ -19,8 +21,7 @@ if (!class_exists('Foo')) {
 <em>}</em>
 
 <?php if ($something) { ?>
-    <p>conditional opening tag at column 1</p>
-    <p>conditional closing tag at column 1</p>
+    <p>some output</p>
 <?php } ?>
         ]]>
         </code>
@@ -28,9 +29,11 @@ if (!class_exists('Foo')) {
         <![CDATA[
 function foo()
 {
-    echo 'opening brace at column 1';
-    echo 'closing brace at column 2';
 <em> }</em>
+
+    function bar()
+    {
+<em>   }</em>
 
 if (!class_exists('Foo')) {
     class Foo {
@@ -38,8 +41,7 @@ if (!class_exists('Foo')) {
 <em>  }</em>
 
 <?php if ($something) { ?>
-    <p>conditional opening tag at column 1</p>
-    <p>conditional closing tag at column 2</p>
+    <p>some output</p>
  <?php } ?>
         ]]>
         </code>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -11,18 +11,14 @@ function foo()
 {
 <em>}</em>
 
-    function bar()
-    {
-<em>    }</em>
-
 if (!class_exists('Foo')) {
     class Foo {
     <em>}</em>
 <em>}</em>
 
 <?php if ($something) { ?>
-    <p>some output</p>
-<em></em><?php } ?>
+    <span>some output</span>
+<em><?php }</em> ?>
         ]]>
         </code>
         <code title="Invalid: Closing brace misaligned with line containing opening brace.">
@@ -31,18 +27,14 @@ function foo()
 {
 <em> }</em>
 
-    function bar()
-    {
-<em>   }</em>
-
 if (!class_exists('Foo')) {
     class Foo {
-    <em>  }</em>
-<em>  }</em>
+<em>}</em>
+<em>    }</em>
 
 <?php if ($something) { ?>
-    <p>some output</p>
-<em> </em><?php } ?>
+    <span>some output</span>
+<em> <?php }</em> ?>
         ]]>
         </code>
     </code_comparison>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -5,7 +5,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Closing brace aligned with opening brace.">
+        <code title="Valid: Closing brace aligned with line containing opening brace.">
         <![CDATA[
 function foo()
 {
@@ -13,14 +13,9 @@ function foo()
     echo 'closing brace at column 1';
 <em>}</em>
 
-class Foo {
-    echo 'class keyword starts at column 1';
-    echo 'closing brace at column 1';
-<em>}</em>
-
-if ($a > $b) {
-    echo 'conditional starts at column 1';
-    echo 'closing brace at column 1';
+if (!class_exists('Foo')) {
+    class Foo {
+    <em>}</em>
 <em>}</em>
 
 <?php if ($something) { ?>
@@ -29,7 +24,7 @@ if ($a > $b) {
 <?php } ?>
         ]]>
         </code>
-        <code title="Invalid: Closing brace misaligned with opening brace.">
+        <code title="Invalid: Closing brace misaligned with line containing opening brace.">
         <![CDATA[
 function foo()
 {
@@ -37,15 +32,10 @@ function foo()
     echo 'closing brace at column 2';
 <em> }</em>
 
-class Foo {
-    echo 'class keyword starts at column 1';
-    echo 'closing brace at column 2';
-<em> }</em>
-
-if ($a > $b) {
-    echo 'conditional starts at column 1';
-    echo 'closing brace at column 5';
-<em>    }</em>
+if (!class_exists('Foo')) {
+    class Foo {
+    <em>  }</em>
+<em>  }</em>
 
 <?php if ($something) { ?>
     <p>conditional opening tag at column 1</p>

--- a/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/ScopeClosingBraceStandard.xml
@@ -1,25 +1,63 @@
 <documentation title="Scope Closing Brace">
     <standard>
     <![CDATA[
-    Closing brace indentation must match opening brace.
+    Indentation of a closing brace must match the indentation of the line containing the opening brace.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Closing brace indented correctly.">
-        <![CDATA[
-function foo()
-<em>{</em>
-    echo 'hi';
-}
-]]>
-        </code>
-        <code title="Invalid: Closing brace indented incorrectly.">
+        <code title="Valid: Closing brace aligned with opening brace.">
         <![CDATA[
 function foo()
 {
-    echo 'hi';
+    echo 'opening brace at column 1';
+    echo 'closing brace at column 1';
+<em>}</em>
+        ]]>
+        </code>
+        <code title="Invalid: Closing brace misaligned with opening brace.">
+        <![CDATA[
+function foo()
+{
+    echo 'opening brace at column 1';
+    echo 'closing brace at column 2';
 <em> }</em>
-]]>
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Closing brace aligned with class keyword.">
+        <![CDATA[
+class Foo {
+    echo 'class keyword starts at column 1';
+    echo 'closing brace at column 1';
+<em>}</em>
+        ]]>
+        </code>
+        <code title="Invalid: Closing brace misaligned with class keyword.">
+        <![CDATA[
+class Foo {
+    echo 'class keyword starts at column 1';
+    echo 'closing brace at column 2';
+<em> }</em>
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Closing brace aligned with if keyword.">
+        <![CDATA[
+if ($a > $b) {
+    echo 'conditional starts at column 1';
+    echo 'closing brace at column 1';
+<em>}</em>
+        ]]>
+        </code>
+        <code title="Invalid: Closing brace aligned with content.">
+        <![CDATA[
+if ($a > $b) {
+    echo 'conditional starts at column 1';
+    echo 'closing brace at column 5';
+<em>    }</em>
+        ]]>
         </code>
     </code_comparison>
     <standard>
@@ -28,20 +66,16 @@ function foo()
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Closing brace is on a line by itself.">
+        <code title="Valid: Newline before closing brace.">
         <![CDATA[
-function foo()
-{
-    echo 'hi';
+enum Foo {
 <em>}</em>
-]]>
+        ]]>
         </code>
-        <code title="Invalid: Closing brace is alongside other content.">
+        <code title="Invalid: No newline before closing brace.">
         <![CDATA[
-function foo()
-{
-    echo 'hi';<em>}</em>
-]]>
+enum Foo {<em>}</em>
+        ]]>
         </code>
     </code_comparison>
 </documentation>


### PR DESCRIPTION
## Description
This PR adds documentation for the `Squiz.WhiteSpace.ScopeClosingBrace` sniff.

## Suggested changelog entry
Add documentation for the Squiz Scope Closing Brace sniff

## Related issues/external references
Part of #148 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
