### PR TITLE
Tests/Core: performance improvement

### DIFF
--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -73,7 +73,7 @@ abstract class AbstractMethodUnitTest extends TestCase
         $contents .= file_get_contents($pathToTestFile);
 
         self::$phpcsFile = new DummyFile($contents, $ruleset, $config);
-        self::$phpcsFile->process();
+        self::$phpcsFile->parse();
 
     }//end initializeFile()
 

--- a/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
@@ -78,7 +78,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
             $contents .= file_get_contents($pathToTestFile);
 
             $this->phpcsFile = new DummyFile($contents, $ruleset, $config);
-            $this->phpcsFile->process();
+            $this->phpcsFile->parse();
         }
 
     }//end initializeFile()


### PR DESCRIPTION
## Description
For tests using the `AbstractMethodUnitTest` or `AbstractTokenizerTestCase` base classes the test case files only need to be parsed (tokenized), not processed (tokenized + sniffs being called).

While not a huge difference, changing the function call from `File::process()` to `File::parse()`, still shaves about 1/7 of the run time off the Core tests without this change having a detrimental effect on any of the tests.


## Suggested changelog entry
_N/A_