### PR TITLE
Tests: minor stability tweak

### DIFF
--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -57,7 +57,8 @@ abstract class AbstractMethodUnitTest extends TestCase
      */
     public static function initializeFile()
     {
-        $config = new ConfigDouble();
+        $_SERVER['argv'] = [];
+        $config          = new ConfigDouble();
         // Also set a tab-width to enable testing tab-replaced vs `orig_content`.
         $config->tabWidth = static::$tabWidth;
 

--- a/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
@@ -62,7 +62,9 @@ abstract class AbstractTokenizerTestCase extends TestCase
     protected function initializeFile()
     {
         if (isset($this->phpcsFile) === false) {
-            $config = new ConfigDouble();
+            $_SERVER['argv'] = [];
+            $config          = new ConfigDouble();
+
             // Also set a tab-width to enable testing tab-replaced vs `orig_content`.
             $config->tabWidth = $this->tabWidth;
 
@@ -79,7 +81,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
 
             $this->phpcsFile = new DummyFile($contents, $ruleset, $config);
             $this->phpcsFile->parse();
-        }
+        }//end if
 
     }//end initializeFile()
 


### PR DESCRIPTION
## Description
Follow up on #275

While tests should always clean up after themselves, this little tweak at least prevents tests which set the `$_SERVER` global (and don't reset it after the test is finished) from influencing tests which use these abstract test cases.

_Explanation: the `$_SERVER` global is not automatically reset between tests by PHPUnit and the `Config` class _will_ read it out when it is set, so if one tests set the global and doesn't reset it, the next test with get a `Config` instance which will use the args set in the `$_SERVER['argv']` from the previous test._


## Suggested changelog entry
_N/A_