### PR TITLE
Generic/ByteOrderMark: small performance improvement

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
@@ -49,13 +49,13 @@ class ByteOrderMarkSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {
         // The BOM will be the very first token in the file.
         if ($stackPtr !== 0) {
-            return;
+            return $phpcsFile->numTokens;
         }
 
         $tokens = $phpcsFile->getTokens();
@@ -68,11 +68,13 @@ class ByteOrderMarkSniff implements Sniff
                 $error     = 'File contains %s byte order mark, which may corrupt your application';
                 $phpcsFile->addError($error, $stackPtr, 'Found', $errorData);
                 $phpcsFile->recordMetric($stackPtr, 'Using byte order mark', 'yes');
-                return;
+                return $phpcsFile->numTokens;
             }
         }
 
         $phpcsFile->recordMetric($stackPtr, 'Using byte order mark', 'no');
+
+        return $phpcsFile->numTokens;
 
     }//end process()
 


### PR DESCRIPTION
## Description

The BOM character must be the first character of the file. This means that this sniff only needs to check the file once, but its code was executed for each occurrence of the T_INLINE_HTML token.

As discussed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/278#issuecomment-1911143720, this PR changes the sniff code to return the number of tokens in all of its exit points to ensure that PHPCS executes it just a single time per file.

I noticed that some sniffs return `$phpcsFile->numTokens` while others return `($phpcsFile->numTokens + 1)` to ignore the rest of the file. As far as I could check, returning the number of tokens is enough as the [code](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/8b83793a5ce336464b71859192691789fa2331ae/src/Files/File.php#L449) checks if the returned value is greater than the current position in the token array, so I went with this option. It is not clear to me why some sniffs return the number of tokens plus one. Highlighting this in case I'm missing something, and the code in this PR should return `($phpcsFile->numTokens + 1)`.


## Suggested changelog entry

Small performance improvement for the Generic.Files.ByteOrderMark sniff


## Related issues/external references

Discussed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/278#issuecomment-1911143720


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.