### PR TITLE
[Documentation]: normalise indentation of CDATA tags in sniff documentation

### DIFF
--- a/src/Standards/Generic/Docs/PHP/DisallowRequestSuperglobalStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/DisallowRequestSuperglobalStandard.xml
@@ -1,6 +1,6 @@
 <documentation title="$_REQUEST Superglobal">
     <standard>
-        <![CDATA[
+    <![CDATA[
     $_REQUEST should never be used due to the ambiguity created as to where the data is coming from. Use $_POST, $_GET, or $_COOKIE instead.
     ]]>
     </standard>

--- a/src/Standards/PSR12/Docs/Functions/NullableTypeDeclarationStandard.xml
+++ b/src/Standards/PSR12/Docs/Functions/NullableTypeDeclarationStandard.xml
@@ -1,12 +1,12 @@
 <documentation title="Nullable Type Declarations Functions">
     <standard>
-        <![CDATA[
+    <![CDATA[
     In nullable type declarations there MUST NOT be a space between the question mark and the type.
     ]]>
     </standard>
     <code_comparison>
         <code title="Valid: no whitespace used.">
-            <![CDATA[
+        <![CDATA[
 public function functionName(
     ?string $arg1,
     ?int $arg2
@@ -26,14 +26,14 @@ public function functionName(
     </code_comparison>
     <code_comparison>
         <code title="Valid: no unexpected characters.">
-            <![CDATA[
+        <![CDATA[
 public function foo(?int $arg): ?string
 {
 }
         ]]>
         </code>
         <code title="Invalid: unexpected characters used.">
-            <![CDATA[
+        <![CDATA[
 public function bar(? /* comment */ int $arg): ?
     // nullable for a reason
     string


### PR DESCRIPTION
## Description

This PR normalises CDATA tag indentation in sniff documentation.  
The original intention was to open separate PRs for changes to every standard, but it was primarily `Squiz` that was affected, which was addressed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/361. These are the last few instances of incorrect indentation that I found across all other standards.

## Suggested changelog entry
Normalise indentation of CDATA tags in sniff documentation.

## Related issues/external references

Per discussion https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/352#issuecomment-1961039186


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
