### PR TITLE
Generic/UselessOverridingMethod: small improvements to the sniff code

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -97,11 +97,11 @@ class UselessOverridingMethodSniff implements Sniff
             return;
         }
 
-        // Find next non empty token index, should be the function name.
+        // Find next non empty token index, should be the name of the method being called.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code or other method.
-        if ($next === false || $tokens[$next]['content'] !== $methodName) {
+        if ($next === false || strcasecmp($tokens[$next]['content'], $methodName) !== 0) {
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -56,7 +56,7 @@ class UselessOverridingMethodSniff implements Sniff
         $token  = $tokens[$stackPtr];
 
         // Skip function without body.
-        if (isset($token['scope_opener']) === false) {
+        if (isset($token['scope_opener'], $token['scope_closer']) === false) {
             return;
         }
 
@@ -93,7 +93,7 @@ class UselessOverridingMethodSniff implements Sniff
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code.
-        if ($next === false || $tokens[$next]['code'] !== T_DOUBLE_COLON) {
+        if ($tokens[$next]['code'] !== T_DOUBLE_COLON) {
             return;
         }
 
@@ -101,7 +101,7 @@ class UselessOverridingMethodSniff implements Sniff
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code or other method.
-        if ($next === false || strcasecmp($tokens[$next]['content'], $methodName) !== 0) {
+        if (strcasecmp($tokens[$next]['content'], $methodName) !== 0) {
             return;
         }
 
@@ -109,7 +109,7 @@ class UselessOverridingMethodSniff implements Sniff
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code.
-        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS || isset($tokens[$next]['parenthesis_closer']) === false) {
+        if ($tokens[$next]['code'] !== T_OPEN_PARENTHESIS || isset($tokens[$next]['parenthesis_closer']) === false) {
             return;
         }
 
@@ -134,7 +134,7 @@ class UselessOverridingMethodSniff implements Sniff
         }//end for
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
-        if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
+        if ($tokens[$next]['code'] !== T_SEMICOLON) {
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -28,6 +28,17 @@ use PHP_CodeSniffer\Util\Tokens;
 class UselessOverridingMethodSniff implements Sniff
 {
 
+    /**
+     * Object-Oriented scopes in which a call to parent::method() can exist.
+     *
+     * @var array<int|string, bool> Keys are the token constants, value is irrelevant.
+     */
+    private $validOOScopes = [
+        T_CLASS      => true,
+        T_ANON_CLASS => true,
+        T_TRAIT      => true,
+    ];
+
 
     /**
      * Registers the tokens that this sniff wants to listen for.
@@ -57,6 +68,14 @@ class UselessOverridingMethodSniff implements Sniff
 
         // Skip function without body.
         if (isset($token['scope_opener'], $token['scope_closer']) === false) {
+            return;
+        }
+
+        $conditions    = $token['conditions'];
+        $lastCondition = end($conditions);
+
+        // Skip functions that are not a method part of a class, anon class or trait.
+        if (isset($this->validOOScopes[$lastCondition]) === false) {
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -109,7 +109,7 @@ class UselessOverridingMethodSniff implements Sniff
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code.
-        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS || isset($tokens[$next]['parenthesis_closer']) === false) {
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -115,8 +115,7 @@ class UselessOverridingMethodSniff implements Sniff
 
         $parameters       = [''];
         $parenthesisCount = 1;
-        $count            = count($tokens);
-        for (++$next; $next < $count; ++$next) {
+        for (++$next; $next < $phpcsFile->numTokens; ++$next) {
             $code = $tokens[$next]['code'];
 
             if ($code === T_OPEN_PARENTHESIS) {

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
@@ -78,10 +78,26 @@ class Bar {
         // This should not be flagged as non-ASCII chars have changed case, making this a different method name.
         return parent::DIFFERENTcaseDifferentNonAnsiiCharÁctÊrs();
     }
+
+    public function nestedFunctionShouldBailEarly() {
+        function nestedFunctionShouldBailEarly() {
+            // Invalid code needed to ensure an error is NOT triggered and the sniff bails early when handling nested function.
+            parent::nestedFunctionShouldBailEarly();
+        }
+    }
 }
 
 abstract class AbstractFoo {
     abstract public function sniffShouldBailEarly();
+
+    public function uselessMethodInAbstractClass() {
+        parent::uselessMethodInAbstractClass();
+    }
+
+    public function usefulMethodInAbstractClass() {
+        $a = 1;
+        parent::usefulMethodInAbstractClass($a);
+    }
 }
 
 interface InterfaceFoo {
@@ -90,4 +106,45 @@ interface InterfaceFoo {
 
 trait TraitFoo {
     abstract public function sniffShouldBailEarly();
+
+    public function usefulMethodInTrait() {
+        parent::usefulMethodInTrait();
+
+        return 1;
+    }
+
+    public function uselessMethodInTrait() {
+        return parent::uselessMethodInTrait();
+    }
+}
+
+enum EnumFoo {
+    public function sniffShouldBailEarly() {
+        // Invalid code needed to ensure an error is NOT triggered and the sniff bails early when handling an enum method.
+        parent::sniffShouldBailEarly();
+    }
+}
+
+function shouldBailEarly() {
+    // Invalid code needed to ensure an error is NOT triggered and the sniff bails early when handling a regular function.
+    parent::shouldBailEarly();
+}
+
+$anon = new class extends ParentClass {
+    public function uselessOverridingMethod() {
+        parent::uselessOverridingMethod();
+    }
+
+    public function usefulOverridingMethod() {
+        $a = 10;
+        parent::usefulOverridingMethod($a);
+    }
+};
+
+function foo() {
+    $anon = new class extends ParentClass {
+        public function uselessOverridingMethod() {
+            parent::uselessOverridingMethod();
+        }
+    };
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
@@ -64,6 +64,20 @@ class Bar {
     public function sameNumberDifferentParameters($a, $b) {
         return parent::sameNumberDifferentParameters($this->prop[$a], $this->{$b});
     }
+
+    public function differentCase() {
+        return parent::DIFFERENTcase();
+    }
+
+    public function differentCaseSameNonAnsiiCharáctêrs() {
+        // This should be flagged, only ASCII chars have changed case.
+        return parent::DIFFERENTcaseSameNonAnsiiCharáctêrs();
+    }
+
+    public function differentCaseDifferentNonAnsiiCharáctêrs() {
+        // This should not be flagged as non-ASCII chars have changed case, making this a different method name.
+        return parent::DIFFERENTcaseDifferentNonAnsiiCharÁctÊrs();
+    }
 }
 
 abstract class AbstractFoo {

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.6.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.6.inc
@@ -1,0 +1,10 @@
+<?php
+
+// Intentional parse error (missing closing parenthesis in parent method call).
+// Testing that the sniff is *not* triggered in this case.
+
+class FooBar {
+    public function __construct() {
+        parent::__construct(
+    }
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -54,6 +54,8 @@ final class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
                 16 => 1,
                 38 => 1,
                 56 => 1,
+                68 => 1,
+                72 => 1,
             ];
         default:
             return [];

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -50,12 +50,16 @@ final class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'UselessOverridingMethodUnitTest.1.inc':
             return [
-                4  => 1,
-                16 => 1,
-                38 => 1,
-                56 => 1,
-                68 => 1,
-                72 => 1,
+                4   => 1,
+                16  => 1,
+                38  => 1,
+                56  => 1,
+                68  => 1,
+                72  => 1,
+                93  => 1,
+                116 => 1,
+                134 => 1,
+                146 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
## Description

This PR implements the following improvements to the Generic.CodeAnalysis.UselessOverridingMethod sniff, which were suggested by @jrfnl in [this comment](https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/250#pullrequestreview-1897345369) in another PR:

> 3. The "Skip for ... other method." block is now covered via the `differentParentMethod()` code snippet.
>     I can see a bug in the condition though - function/method names in PHP are case-insensitive.
>     There is currently no test where the function declaration name is not in the same case as the name used in the function call.
>     Such a test should be added and the code should be flagged as potentially useless override, which would need a small fix in the condition of that code block.
> 4. I'm missing a test where the function call has an open parenthesis, but no close parenthesis.
>     Adding this test would highlight that some extra defensive coding would be helpful.
>     The "Skip for invalid code." block, which checks for the open parenthesis, should probably also check for a matching close parenthesis via `isset($tokens[$next]['parenthesis_closer']) !== false`.
>     The redundant function call on line 118 - `count($tokens)` - can then be also removed and the `$count` in the `for` condition replaced. (That function call was redundant anyhow and should have used `$phpcsFile->numTokens` instead)

> 9. Looking critically, the `$next === false` condition seems redundant in nearly all conditions (and there are no tests conceivable which could ever hit the condition).
>     If the function declaration would not have a scope closer, the scope opener would not be set, so `$next` can never be `false` as there will always be a close curly after whatever code we're looking at.
>     Having said that, if the `$next === false` bits would be removed, it might be prudent to update the "Skip function without body." block to also verify there is a scope closer.
> 10. I'm missing a test with non-OO function declaration. Use of the `parent` keyword in the body of such a function would be invalid no matter what, however, for the purposes of this sniff, I think it would be more appropriate to ignore such functions as they are, for sure, not a "method override".


~~Item number 10 was implemented in two commits. One for removing the redundant `$next === false` condition and another to handle non-OO function declarations.~~ As for handling non-OO function declarations, I changed the sniff code to bail early when the T_FUNCTION does not correspond to a class or anonymous class method. I used `$phpcsFile->hasCondition()` for that. This is the first time that I'm using this method, please let me know if you see a problem with this approach or if there is something that I missed. My assumption is that functions and also trait, interface, and enum methods cannot have a parent so the sniff can bail early in those cases.

Please let me know if you prefer that I split all those fixes into multiple PRs.

## Suggested changelog entry

Generic/UselessOverridingMethod: account for method and parent methods with the same name but different case

I'm unsure if the other changes should be mentioned in the changelog or not. Maybe a second entry referencing "minor performance improvements" (which is most of the other changes but not all other changes)?

## Related issues/external references

Discussed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/250#pullrequestreview-1897345369


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.