### PR TITLE
[Documentation] Squiz: Member Var Spacing

### DIFF
--- a/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
@@ -1,0 +1,142 @@
+<documentation title="Member Var Spacing">
+    <standard>
+    <![CDATA[
+    There should be one blank line before the first member var.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One blank line before the first member var.">
+        <![CDATA[
+class MyClass
+{<em>
+
+</em>    protected $var1 = 'value';
+}
+
+interface MyInterface {<em>
+
+</em>    public $var1;
+}
+
+trait MyTrait {<em>
+
+</em>    public $var1 = 'value';
+}
+        ]]>
+        </code>
+        <code title="Invalid: Incorrect number of blank lines before the first member var.">
+        <![CDATA[
+class MyClass
+{<em>
+</em>    protected $var1 = 'value';
+}
+
+
+interface MyInterface {<em>
+</em>    public $var1;
+}
+
+
+trait MyTrait {<em>
+
+
+</em>    public $var1 = 'value';
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be one blank line between member vars.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: One blank line between each member var.">
+        <![CDATA[
+class MyClass
+{
+
+    protected $var1 = 'value';<em>
+
+</em>    protected $var2 = 'value2';
+}
+
+interface MyInterface {
+
+    public $var1;<em>
+
+</em>    public $var2;
+}
+
+trait MyTrait {
+
+    public $var1 = 'value';<em>
+
+</em>    public $var2 = 'value2';
+}
+        ]]>
+        </code>
+        <code title="Invalid: Incorrect number of blank lines between each member var.">
+        <![CDATA[
+class MyClass
+{
+
+    protected $var1 = 'value';<em>
+</em>    protected $var2 = 'value2';
+}
+
+
+interface MyInterface {
+
+    public $var1;<em>
+</em>    public $var2;
+}
+
+
+trait MyTrait {
+
+    public $var1 = 'value';<em>
+
+
+</em>    public $var2 = 'value2';
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    There should be no blank line between a member var's comment and the member var.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No blank lines between comment and member var.">
+        <![CDATA[
+class MyClass
+{
+
+    /**
+     * The actions that this class can perform.
+     *
+     * @var array
+     */<em>
+</em>    public $actions = array();
+}
+        ]]>
+        </code>
+        <code title="Invalid: Blank line(s) between comment and member var.">
+        <![CDATA[
+class MyClass
+{
+
+    /**
+     * The actions that this class can perform.
+     *
+     * @var array
+     */<em>
+
+</em>    public $actions = array();
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
@@ -1,73 +1,36 @@
 <documentation title="Member Var Spacing">
     <standard>
     <![CDATA[
-    There should be one blank line before the first member var.
+    There should be one blank line before the first property (member variable).
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: One blank line before the first member var.">
+        <code title="Valid: One blank line before the first property.">
         <![CDATA[
 class MyClass
 {<em>
 
 </em>    protected $var1 = 'value';
-}
-
-interface MyInterface {<em>
-
-</em>    public $var1;
-}
-
-trait MyTrait {<em>
-
-</em>    public $var1 = 'value';
 }
         ]]>
         </code>
-        <code title="Invalid: Incorrect number of blank lines before the first member var.">
+        <code title="Invalid: Incorrect number of blank lines before the first property.">
         <![CDATA[
 class MyClass
 {<em>
 </em>    protected $var1 = 'value';
-}
-
-
-interface MyInterface {<em>
-</em>    public $var1;
-}
-
-
-trait MyTrait {<em>
-
-
-</em>    public $var1 = 'value';
 }
         ]]>
         </code>
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be one blank line between member vars.
+    There should be one blank line between properties.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: One blank line between each member var.">
+        <code title="Valid: One blank line between each property.">
         <![CDATA[
-class MyClass
-{
-
-    protected $var1 = 'value';<em>
-
-</em>    protected $var2 = 'value2';
-}
-
-interface MyInterface {
-
-    public $var1;<em>
-
-</em>    public $var2;
-}
-
 trait MyTrait {
 
     public $var1 = 'value';<em>
@@ -76,23 +39,8 @@ trait MyTrait {
 }
         ]]>
         </code>
-        <code title="Invalid: Incorrect number of blank lines between each member var.">
+        <code title="Invalid: Incorrect number of blank lines between each property.">
         <![CDATA[
-class MyClass
-{
-
-    protected $var1 = 'value';<em>
-</em>    protected $var2 = 'value2';
-}
-
-
-interface MyInterface {
-
-    public $var1;<em>
-</em>    public $var2;
-}
-
-
 trait MyTrait {
 
     public $var1 = 'value';<em>
@@ -105,14 +53,13 @@ trait MyTrait {
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be no blank line between a member var's comment and the member var.
+    There should be no blank lines between a property DocBlock and the property declaration the DocBlock applies to.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: No blank lines between comment and member var.">
+        <code title="Valid: No blank lines between DocBlock and its property.">
         <![CDATA[
-class MyClass
-{
+new class {
 
     /**
      * The actions that this class can perform.
@@ -123,10 +70,9 @@ class MyClass
 }
         ]]>
         </code>
-        <code title="Invalid: Blank line(s) between comment and member var.">
+        <code title="Invalid: Blank line(s) between DocBlock and its property.">
         <![CDATA[
-class MyClass
-{
+new class {
 
     /**
      * The actions that this class can perform.

--- a/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
@@ -62,7 +62,7 @@ trait MyTrait {
     <code_comparison>
         <code title="Valid: No blank lines between DocBlock and its property.">
         <![CDATA[
-new class {
+$anon = new class {
 
     /**
      * The actions that this class can perform.
@@ -70,12 +70,12 @@ new class {
      * @var array
      */<em>
 </em>    public $actions = array();
-}
+};
         ]]>
         </code>
         <code title="Invalid: Blank line(s) between DocBlock and its property.">
         <![CDATA[
-new class {
+$anon = new class {
 
     /**
      * The actions that this class can perform.
@@ -84,7 +84,7 @@ new class {
      */<em>
 
 </em>    public $actions = array();
-}
+};
         ]]>
         </code>
     </code_comparison>

--- a/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
@@ -35,7 +35,9 @@ trait MyTrait {
 
     public $var1 = 'value';<em>
 
-</em>    public $var2 = 'value2';
+</em>    public $var2 = 'value2';<em>
+
+</em>    public $var3 = 'value3';
 }
         ]]>
         </code>
@@ -46,7 +48,8 @@ trait MyTrait {
     public $var1 = 'value';<em>
 
 
-</em>    public $var2 = 'value2';
+</em>    public $var2 = 'value2';<em>
+</em>    public $var3 = 'value3';
 }
         ]]>
         </code>

--- a/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
+++ b/src/Standards/Squiz/Docs/WhiteSpace/MemberVarSpacingStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Member Var Spacing">
     <standard>
     <![CDATA[
-    There should be one blank line before the first property (member variable).
+    There should be exactly one blank line before the first property (member variable).
     ]]>
     </standard>
     <code_comparison>
@@ -25,7 +25,7 @@ class MyClass
     </code_comparison>
     <standard>
     <![CDATA[
-    There should be one blank line between properties.
+    There should be exactly one blank line between properties.
     ]]>
     </standard>
     <code_comparison>


### PR DESCRIPTION
## Description
This PR adds documentation for the `Squiz.WhiteSpace.MemberVarSpacing` sniff.

## Suggested changelog entry
Add documentation for the Squiz Member Var Spacing sniff

## Related issues/external references
Part of #148 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

