### PR TITLE
Variable sniffs: minor performance tweak

### DIFF
--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -10,10 +10,25 @@
 namespace PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ValidVariableNameSniff extends AbstractVariableSniff
 {
+
+
+    /**
+     * Only listen to variables within OO scopes.
+     */
+    public function __construct()
+    {
+        $scopes = Tokens::$ooScopeTokens;
+        $listen = [T_VARIABLE];
+
+        AbstractScopeSniff::__construct($scopes, $listen, false);
+
+    }//end __construct()
 
 
     /**

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -11,11 +11,25 @@ namespace PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes;
 
 use Exception;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Tokens;
 
 class PropertyDeclarationSniff extends AbstractVariableSniff
 {
+
+
+    /**
+     * Only listen to variables within OO scopes.
+     */
+    public function __construct()
+    {
+        $scopes = Tokens::$ooScopeTokens;
+        $listen = [T_VARIABLE];
+
+        AbstractScopeSniff::__construct($scopes, $listen, false);
+
+    }//end __construct()
 
 
     /**

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -10,11 +10,26 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableCommentSniff extends AbstractVariableSniff
 {
+
+
+    /**
+     * Only listen to variables within OO scopes.
+     */
+    public function __construct()
+    {
+        $scopes = Tokens::$ooScopeTokens;
+        $listen = [T_VARIABLE];
+
+        AbstractScopeSniff::__construct($scopes, $listen, false);
+
+    }//end __construct()
 
 
     /**

--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -10,10 +10,25 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class MemberVarScopeSniff extends AbstractVariableSniff
 {
+
+
+    /**
+     * Only listen to variables within OO scopes.
+     */
+    public function __construct()
+    {
+        $scopes = Tokens::$ooScopeTokens;
+        $listen = [T_VARIABLE];
+
+        AbstractScopeSniff::__construct($scopes, $listen, false);
+
+    }//end __construct()
 
 
     /**

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Tokens;
 
@@ -29,6 +30,19 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
      * @var integer
      */
     public $spacingBeforeFirst = 1;
+
+
+    /**
+     * Only listen to variables within OO scopes.
+     */
+    public function __construct()
+    {
+        $scopes = Tokens::$ooScopeTokens;
+        $listen = [T_VARIABLE];
+
+        AbstractScopeSniff::__construct($scopes, $listen, false);
+
+    }//end __construct()
 
 
     /**


### PR DESCRIPTION
## Description
The `AbstractVariableSniff` by default listens to all `T_VARIABLE`, `T_DOUBLE_QUOTED_STRING` and `T_HEREDOC` tokens.

The majority of the sniffs extending the `AbstractVariableSniff`, however, only handle `T_VARIABLE` tokens and in particular, only handle `T_VARIABLE` tokens when in an OO scope and nothing more.

This small tweak means these sniffs will no longer "listen" to `T_DOUBLE_QUOTED_STRING` and `T_HEREDOC` tokens, which should make them marginally faster, in particular for code bases containing lots of `T_DOUBLE_QUOTED_STRING` and `T_HEREDOC` tokens.

It also means that these sniff will no longer be triggered for `T_VARIABLE` tokens outside of an OO context.

## Suggested changelog entry
Small performance improvement for five sniffs.
