### PR TITLE
Ensure that Fixer::endChangeset() returns the real outcome

### DIFF
--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -461,7 +461,7 @@ class Fixer
         }
 
         $this->changeset = [];
-        return true;
+        return $success;
 
     }//end endChangeset()
 


### PR DESCRIPTION
## Description

I was debugging a complex sniff that implies multiple potential modifications to the same token (that is, right now, not possible - we could discuss about that another day), when have detected that the `Fixer::endChangeset()` method is returning always true, no matter the changes have been not accepted.

So this just ensures that the method returns the real outcome.

I've been looking to current tests to try to add something to have it covered, but it seems that the `Fixer` is one of those areas needing some coverage, haven't found any test explicitly covering it.

Also, I've searched at github, to see if anybody may be using expressions like:

`$outcome = $phpcsFile->fixer->endChangeset()...`
`if ($phpcsFile->fixer->endChangeset()...`

And [have found zero lines of code](https://github.com/search?q=%2F%5B%5C%28%3D%5D.*-%3Efixer-%3EendChangeset%5C%28%5C%29%2F+language%3APHP&type=code&ref=advsearch) using the return value of the method. Hence, I think it's a safe change to apply.

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->


## Suggested changelog entry
Ensure that Fixer::endChangeset() returns the real outcome


## Related issues/external references

Fixes N/A


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
