### PR TITLE
Fixing the title of the Generic.Docs.NoSpaceAfterCastStandard docs

### DIFF
--- a/src/Standards/Generic/Docs/Formatting/NoSpaceAfterCastStandard.xml
+++ b/src/Standards/Generic/Docs/Formatting/NoSpaceAfterCastStandard.xml
@@ -1,4 +1,4 @@
-<documentation title="No Space After Casts">
+<documentation title="No Space After Cast">
     <standard>
     <![CDATA[
     Spaces are not allowed after casting operators.

--- a/src/Standards/Generic/Docs/Formatting/NoSpaceAfterCastStandard.xml
+++ b/src/Standards/Generic/Docs/Formatting/NoSpaceAfterCastStandard.xml
@@ -1,4 +1,4 @@
-<documentation title="Space After Casts">
+<documentation title="No Space After Casts">
     <standard>
     <![CDATA[
     Spaces are not allowed after casting operators.

--- a/src/Standards/Generic/Docs/Formatting/SpaceAfterCastStandard.xml
+++ b/src/Standards/Generic/Docs/Formatting/SpaceAfterCastStandard.xml
@@ -1,4 +1,4 @@
-<documentation title="Space After Casts">
+<documentation title="Space After Cast">
     <standard>
     <![CDATA[
     Exactly one space is allowed after a cast.


### PR DESCRIPTION
## Description
The aim of this PR is to fix the title of the XML documentation for the Sniff Generic.Formatting.NoSpaceAfterCastStandard. The current title states "Space After Casts" which seems different to the file name and the standard description.

## Related issues/external references
Fixes #383

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [X] Documentation improvement


## PR checklist
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [X] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.