### PR TITLE
Tests: fix for PHP 8.4 deprecation of implicitly nullable types

### DIFF
--- a/tests/TestSuite7.php
+++ b/tests/TestSuite7.php
@@ -23,7 +23,7 @@ class TestSuite extends PHPUnit_TestSuite
      *
      * @return \PHPUnit\Framework\TestResult
      */
-    public function run(TestResult $result=null): TestResult
+    public function run(?TestResult $result=null): TestResult
     {
         $result = parent::run($result);
         printPHPCodeSnifferTestOutput();


### PR DESCRIPTION
## Description

This should work for now. PHPCS 4.0 will remove the whole outdated TestSuite setup as per #25, so by that time, the problem is gone completely.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

**Note**: the tests won't pass on PHP 8.4 yet as PHPUnit itself (and its dependencies) still need to release a version which fixes similar issues in PHPUnit itself.

## Suggested changelog entry
Test framework: fix PHP 8.4 deprecation

