### PR TITLE
File::getMethodProperties(): skip over closure use statements

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1757,6 +1757,20 @@ class File
                     break;
                 }
 
+                if ($this->tokens[$i]['code'] === T_USE) {
+                    // Skip over closure use statements.
+                    for ($j = ($i + 1); $j < $this->numTokens && isset(Tokens::$emptyTokens[$this->tokens[$j]['code']]) === true; $j++);
+                    if ($this->tokens[$j]['code'] === T_OPEN_PARENTHESIS) {
+                        if (isset($this->tokens[$j]['parenthesis_closer']) === false) {
+                            // Live coding/parse error, stop parsing.
+                            break;
+                        }
+
+                        $i = $this->tokens[$j]['parenthesis_closer'];
+                        continue;
+                    }
+                }
+
                 if ($this->tokens[$i]['code'] === T_NULLABLE) {
                     $nullableReturnType = true;
                 }

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -190,6 +190,18 @@ $value = $obj->fn(true);
 /* testFunctionDeclarationNestedInTernaryPHPCS2975 */
 return (!$a ? [ new class { public function b(): c {} } ] : []);
 
+/* testClosureWithUseNoReturnType */
+$closure = function () use($a) /*comment*/ {};
+
+/* testClosureWithUseNoReturnTypeIllegalUseProp */
+$closure = function () use ($this->prop){};
+
+/* testClosureWithUseWithReturnType */
+$closure = function () use /*comment*/ ($a): Type {};
+
+/* testClosureWithUseMultiParamWithReturnType */
+$closure = function () use ($a, &$b, $c, $d, $e, $f, $g): ?array {};
+
 /* testArrowFunctionLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 $fn = fn

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -1298,6 +1298,111 @@ final class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test handling of closure declarations with a use variable import without a return type declaration.
+     *
+     * @return void
+     */
+    public function testClosureWithUseNoReturnType()
+    {
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testClosureWithUseNoReturnType()
+
+
+    /**
+     * Test handling of closure declarations with an illegal use variable for a property import (not allowed in PHP)
+     * without a return type declaration.
+     *
+     * @return void
+     */
+    public function testClosureWithUseNoReturnTypeIllegalUseProp()
+    {
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testClosureWithUseNoReturnTypeIllegalUseProp()
+
+
+    /**
+     * Test handling of closure declarations with a use variable import with a return type declaration.
+     *
+     * @return void
+     */
+    public function testClosureWithUseWithReturnType()
+    {
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'Type',
+            'return_type_token'     => 14,
+            'return_type_end_token' => 14,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testClosureWithUseWithReturnType()
+
+
+    /**
+     * Test handling of closure declarations with a use variable import with a return type declaration.
+     *
+     * @return void
+     */
+    public function testClosureWithUseMultiParamWithReturnType()
+    {
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?array',
+            'return_type_token'     => 32,
+            'return_type_end_token' => 32,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testClosureWithUseMultiParamWithReturnType()
+
+
+    /**
      * Test helper.
      *
      * @param string                         $commentString The comment which preceeds the test.


### PR DESCRIPTION
## Description
This PR improves performance of the `File::getMethodProperties()` method and prevents incorrect return type information for closure `use` clauses containing invalid variable imports in the `use` clause (defensive coding).

Closure `use` statements can only import plain variables, not properties or other more complex variables.

As things were, when such "illegal" variables were imported in a closure `use`, the information for the return type could get mangled.
While this would be a parse error, for the purposes of static analysis, the `File::getMethodProperties()` method should still handle this correctly.

This commit updates the `File::getMethodProperties()` method to always skip over the complete `use` clause, which prevents the issue and improves performance as the same time (less token walking).

Includes unit tests.


## Suggested changelog entry
File::getMethodProperties(): small performance improvement & more defensive coding

