### PR TITLE
PEAR/ScopeClosingBrace: prevent fixer conflict with itself

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -93,16 +93,19 @@ class ScopeClosingBraceSniff implements Sniff
         }
 
         // Check that the closing brace is on it's own line.
-        $lastContent = $phpcsFile->findPrevious(
-            [
-                T_WHITESPACE,
-                T_INLINE_HTML,
-                T_OPEN_TAG,
-            ],
-            ($scopeEnd - 1),
-            $scopeStart,
-            true
-        );
+        for ($lastContent = ($scopeEnd - 1); $lastContent > $scopeStart; $lastContent--) {
+            if ($tokens[$lastContent]['code'] === T_WHITESPACE || $tokens[$lastContent]['code'] === T_OPEN_TAG) {
+                continue;
+            }
+
+            if ($tokens[$lastContent]['code'] === T_INLINE_HTML
+                && ltrim($tokens[$lastContent]['content']) === ''
+            ) {
+                continue;
+            }
+
+            break;
+        }
 
         if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
             $error = 'Closing brace must be on a line by itself';

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
@@ -162,3 +162,9 @@ enum Suits {}
 enum Cards
 {
     }
+
+?>
+<!-- Prevent fixer conflict with itself when the scope closer is preceded by non-empty/non-indentation inline HTML. -->
+<?php if ($someConditional) : ?>
+<div class="container">
+</div> <?php endif;

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -168,3 +168,10 @@ enum Suits {
 enum Cards
 {
 }
+
+?>
+<!-- Prevent fixer conflict with itself when the scope closer is preceded by non-empty/non-indentation inline HTML. -->
+<?php if ($someConditional) : ?>
+<div class="container">
+</div> <?php 
+endif;

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -49,6 +49,7 @@ final class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
             154 => 1,
             160 => 1,
             164 => 1,
+            170 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description
The `PEAR.WhiteSpace.ScopeClosingBrace` sniff could get into a conflict with itself when the scope closer was preceded by a PHP open tag and before that non-empty (i.e. non-indent) inline HTML.

In that case, the sniff would not recognize that the close brace was not on a line by itself, as the search for the last content before would disregard the non-empty HTML and would continue searching, which meant that the "last relevant content before" token would point to a token on a previous line.

This, in turn, then led to the sniff continuing on to the next error "Closing brace indented incorrectly", where the indent would now be incorrectly determined as `-1`, which in the fixer would lead to the original content and the replacement content being exactly the same, which created a fixer conflict.

Fixed now by improving the "last content before" determination.

Includes unit test.

## Suggested changelog entry
Fixed PEAR.WhiteSpace.ScopeClosingBrace: when a close tag was preceded by non-empty inline HTML, the sniff would have a fixer conflict with itself.

## Related issues/external references

Related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
