### PR TITLE
PSR2/ClassDeclaration: support namespace relative names / prevent fixer conflict

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -314,7 +314,8 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
             if ($checkingImplements === true
                 && $multiLineImplements === true
                 && ($tokens[($className - 1)]['code'] !== T_NS_SEPARATOR
-                || $tokens[($className - 2)]['code'] !== T_STRING)
+                || ($tokens[($className - 2)]['code'] !== T_STRING
+                && $tokens[($className - 2)]['code'] !== T_NAMESPACE))
             ) {
                 $prev = $phpcsFile->findPrevious(
                     [

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -397,9 +397,10 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                     }
                 }//end if
             } else if ($tokens[($className - 1)]['code'] !== T_NS_SEPARATOR
-                || $tokens[($className - 2)]['code'] !== T_STRING
+                || ($tokens[($className - 2)]['code'] !== T_STRING
+                && $tokens[($className - 2)]['code'] !== T_NAMESPACE)
             ) {
-                // Not part of a longer fully qualified class name.
+                // Not part of a longer fully qualified or namespace relative class name.
                 if ($tokens[($className - 1)]['code'] === T_COMMA
                     || ($tokens[($className - 1)]['code'] === T_NS_SEPARATOR
                     && $tokens[($className - 2)]['code'] === T_COMMA)

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -287,3 +287,9 @@ readonly
 interface FooBar extends namespace\BarFoo
 {
 }
+
+// Safeguard against fixer conflict when there are namespace relative interface names in a multi-line implements.
+class BarFoo implements
+    namespace\BarFoo
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -282,3 +282,8 @@ readonly
     class ReadonlyClassWithComment
     {
     }
+
+// Safeguard against fixer conflict when there are namespace relative interface names in extends.
+interface FooBar extends namespace\BarFoo
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -275,3 +275,9 @@ readonly
 interface FooBar extends namespace\BarFoo
 {
 }
+
+// Safeguard against fixer conflict when there are namespace relative interface names in a multi-line implements.
+class BarFoo implements
+    namespace\BarFoo
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -270,3 +270,8 @@ readonly
     class ReadonlyClassWithComment
     {
     }
+
+// Safeguard against fixer conflict when there are namespace relative interface names in extends.
+interface FooBar extends namespace\BarFoo
+{
+}


### PR DESCRIPTION
## Description

### PSR2/ClassDeclaration: prevent fixer conflict with itself [1]

While the `PSR2.Classes.ClassDeclaration` sniff did take partially/fully qualified names into account for interfaces being extended, it did not take _namespace relative_ interface name into account.

This led to a fixer conflict within the sniff, where the sniff would first add a space between the `namespace` keyword and the namespace separator (`SpaceBeforeName` fixer) and in a subsequent loop would remove that same space again as it would think it was a space before a comma (`SpaceBeforeComma` fixer).

Fixed now by adding support for namespace relative interface names in the `extends` checks.

Includes unit test.


### PSR2/ClassDeclaration: prevent fixer conflict with itself [2]

While the `PSR2.Classes.ClassDeclaration` sniff did take partially/fully qualified names into account for interfaces being implemented, it did not take _namespace relative_ interface names into account.

This led to a fixer conflict within the sniff, where the sniff would first add a newline between the `namespace` keyword and the namespace separator (`InterfaceSameLine` fixer) and in a subsequent loop would remove that same new line again as it would think it was a space before a comma (`SpaceBeforeComma` fixer).

Fixed now by adding support for namespace relative interface names in the `implements` check.

Includes unit test.

---

Note: at a glance, this sniff could probably do with a more thorough review and more defensive token walking/more precise checking, but that's outside the scope of this PR.


## Suggested changelog entry
PSR2.Classes.ClassDeclaration: using namespace relative interface names in the extends/implements part of a class declaration would lead to a fixer conflict.


## Related issues/external references

Related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
