### PR TITLE
Tests - Generic/ESLint: fix test

### DIFF
--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -52,6 +52,8 @@ final class ESLintUnitTest extends AbstractSniffUnitTest
         $cwd = getcwd();
         file_put_contents($cwd.'/.eslintrc.json', self::ESLINT_CONFIG);
 
+        putenv('ESLINT_USE_FLAT_CONFIG=false');
+
     }//end setUpPrerequisites()
 
 


### PR DESCRIPTION
## Description
ESLint has released a new major which no longer supports the `.eslintrc.json` config format by default.

To still allow for that format, an `ESLINT_USE_FLAT_CONFIG` environment variable has to be set to `false`.

This change is causing the tests for the `Generic.Debug.ESLint` sniff to fail.

Setting the environment variable fixes this.

This is a test-only change for the following reasons:
* If end-users use this sniff, they are responsible for using the correct configuration for the version of ESLint they are using.
* The sniff is deprecated and preferably end-users should move away from using the sniff and run the tool directly.
* As the sniff is deprecated, no time has been spend to add support for the new ESLint configuration format to the sniff. A simple patch to add this support would be accepted as long as PHPCS 4.0 has not been released yet, but maintainers will not spend time on this as the sniff will be removed sooner rather than later.

As an alternative, it was considered to limit the version of `ESLint` being installed in the GH Actions workflow to version 8 of ESlint, but the change as made now is better IMO as it proves that the ESLint sniff does still work on 9, even though only for the old configuration formats.

Refs:
* https://eslint.org/blog/2024/04/eslint-v9.0.0-released/#flat-config-is-now-the-default-and-has-some-changes
* https://eslint.org/docs/latest/use/migrate-to-9.0.0#-new-default-config-format-eslintconfigjs


## Suggested changelog entry
Maybe a note that ESLint >= 9.0 is not supported unless the "old" ESLint configuration formats are being used in combination with setting `ESLINT_USE_FLAT_CONFIG=false` ?


