### PR TITLE
CS: use `implode()` not `join()`

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -89,7 +89,7 @@ class JumbledIncrementerSniff implements Sniff
 
             if (count($diff) !== 0) {
                 $error = 'Loop incrementor (%s) jumbling with inner loop';
-                $data  = [join(', ', $diff)];
+                $data  = [implode(', ', $diff)];
                 $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
             }
         }

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -67,7 +67,7 @@ class JavaScriptLintSniff implements Sniff
         // provide useful error reporting.
         if ($retval === 2 || $retval === 4) {
             if (is_array($output) === true) {
-                $msg = join('\n', $output);
+                $msg = implode('\n', $output);
             }
 
             throw new RuntimeException("Failed invoking JavaScript Lint, retval was [$retval], output was [$msg]");

--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -69,7 +69,7 @@ class CodeAnalyzerSniff implements Sniff
         // provide useful error reporting.
         if (is_numeric($exitCode) === true && $exitCode > 0) {
             if (is_array($output) === true) {
-                $msg = join('\n', $output);
+                $msg = implode('\n', $output);
             }
 
             throw new RuntimeException("Failed invoking ZendCodeAnalyzer, exitcode was [$exitCode], retval was [$retval], output was [$msg]");


### PR DESCRIPTION
## Description
The `join()` function in PHP is an alias of `implode()`, so let's use the proper function name.


## Suggested changelog entry
_N/A_