### PR TITLE
Generic/JumbledIncrementer: fix inconsistency

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -67,7 +67,7 @@ class JumbledIncrementerSniff implements Sniff
             return;
         }
 
-        // Find incrementors for outer loop.
+        // Find incrementers for outer loop.
         $outer = $this->findIncrementers($tokens, $token);
 
         // Skip if empty.
@@ -88,7 +88,7 @@ class JumbledIncrementerSniff implements Sniff
             $diff  = array_intersect($outer, $inner);
 
             if (count($diff) !== 0) {
-                $error = 'Loop incrementor (%s) jumbling with inner loop';
+                $error = 'Loop incrementer (%s) jumbling with inner loop';
                 $data  = [implode(', ', $diff)];
                 $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
             }


### PR DESCRIPTION
## Description
The name of the sniff uses "Incrementer", while the error message uses "Incrementor". This feels inconsistent.

Based on some light research, both terms can be used interchangable, so I'm proposing to make the error message consistent with the sniff name, as changing the sniff name would be a breaking change.


## Suggested changelog entry
Generic.CodeAnalysis.JumbledIncrementer: fix typo in warning message.


## Related issues/external references

Seen while reviewing #385
