### PR TITLE
New Common::stripColors() method

### DIFF
--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -236,7 +236,7 @@ class Reporter
         ob_end_clean();
 
         if ($this->config->colors !== true || $reportFile !== null) {
-            $generatedReport = preg_replace('`\033\[[0-9;]+m`', '', $generatedReport);
+            $generatedReport = Common::stripColors($generatedReport);
         }
 
         if ($reportFile !== null) {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -414,11 +414,7 @@ class Ruleset
                 $sniffCode = substr($sniffCode, 0, ($maxMessageWidth - 3)).'...';
             }
 
-            $message = '-  '.$sniffCode.PHP_EOL;
-            if ($this->config->colors === true) {
-                $message = '-  '."\033[36m".$sniffCode."\033[0m".PHP_EOL;
-            }
-
+            $message        = '-  '."\033[36m".$sniffCode."\033[0m".PHP_EOL;
             $maxActualWidth = max($maxActualWidth, strlen($sniffCode));
 
             // Normalize new line characters in custom message.
@@ -451,8 +447,13 @@ class Ruleset
             echo $summaryLine.PHP_EOL;
         }
 
+        $messages = implode(PHP_EOL, $messages);
+        if ($this->config->colors === false) {
+            $messages = Common::stripColors($messages);
+        }
+
         echo str_repeat('-', min(($maxActualWidth + 4), $reportWidth)).PHP_EOL;
-        echo implode(PHP_EOL, $messages);
+        echo $messages;
 
         $closer = wordwrap('Deprecated sniffs are still run, but will stop working at some point in the future.', $reportWidth, PHP_EOL);
         echo PHP_EOL.PHP_EOL.$closer.PHP_EOL.PHP_EOL;

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -313,6 +313,20 @@ class Common
 
 
     /**
+     * Strip colors from a text for output to screen.
+     *
+     * @param string $text The text to process.
+     *
+     * @return string
+     */
+    public static function stripColors($text)
+    {
+        return preg_replace('`\033\[[0-9;]+m`', '', $text);
+
+    }//end stripColors()
+
+
+    /**
      * Returns true if the specified string is in the camel caps format.
      *
      * @param string  $string      The string the verify.

--- a/tests/Core/Util/StripColorsTest.php
+++ b/tests/Core/Util/StripColorsTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Util\Sniffs\Common::stripColors() method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Util;
+
+use PHP_CodeSniffer\Util\Common;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Util\Sniffs\Common::stripColors() method.
+ *
+ * @covers \PHP_CodeSniffer\Util\Common::stripColors
+ */
+final class StripColorsTest extends TestCase
+{
+
+
+    /**
+     * Test stripping color codes from a text.
+     *
+     * @param string $text     The text provided.
+     * @param string $expected Expected function output.
+     *
+     * @dataProvider dataStripColors
+     *
+     * @return void
+     */
+    public function testStripColors($text, $expected)
+    {
+        $this->assertSame($expected, Common::stripColors($text));
+
+    }//end testStripColors()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testStripColors()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataStripColors()
+    {
+        return [
+            'Text is empty'                                                      => [
+                'text'     => '',
+                'expected' => '',
+            ],
+            'Text enclosed in color code'                                        => [
+                'text'     => "\033[36mSome text\033[0m",
+                'expected' => 'Some text',
+            ],
+            'Text containing color code'                                         => [
+                'text'     => "Some text \033[33mSome other text",
+                'expected' => 'Some text Some other text',
+            ],
+            'Text enclosed in color code, bold'                                  => [
+                'text'     => "\033[1;32mSome text\033[0m",
+                'expected' => 'Some text',
+            ],
+            'Text enclosed in color code, with escaped text'                     => [
+                'text'     => "\033[30;1m\\n\033[0m",
+                'expected' => '\n',
+            ],
+            'Text enclosed in color code, bold, dark, italic'                    => [
+                'text'     => "\033[1;2;3mtext\033[0m",
+                'expected' => 'text',
+            ],
+            'Text enclosed in color code, foreground color'                      => [
+                'text'     => "\033[38;5;255mtext\033[0m",
+                'expected' => 'text',
+            ],
+            'Text enclosed in color code, foreground color and background color' => [
+                'text'     => "\033[38;5;200;48;5;255mtext\033[0m",
+                'expected' => 'text',
+            ],
+            'Multiline text containing multiple color codes'                     => [
+                'text'     => "First \033[36mSecond\033[0m
+Third \033[1;2;3mFourth
+Next line\033[0m Last",
+                'expected' => 'First Second
+Third Fourth
+Next line Last',
+            ],
+        ];
+
+    }//end dataStripColors()
+
+
+}//end class


### PR DESCRIPTION
## Description

This commit introduces a new static `Common::stripColors()` method to allow for stripping CLI color codes from an arbitrary text.

Includes starting to use the function in a few places.

Includes unit tests.


## Suggested changelog entry
_N/A_ This method is intended for internal use.
