### PR TITLE
OtherContextSensitiveKeywordsTest: add silly number of extra tests

### DIFF
--- a/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.inc
@@ -65,3 +65,141 @@ class TypedConstProp {
     var /* testSelfIsKeywordAsPropertyType */ self $self = new /* testSelfIsKeywordAsPropertyDefault */ self;
     protected /* testParentIsKeywordAsPropertyType */ parent $parent = new /* testParentIsKeywordAsPropertyDefault */ parent;
 }
+
+class UseInUnionTypes {
+    /* testFalseIsKeywordAsConstUnionTypeFirst */
+    const false|Foo UNION_WITH_FALSE_FIRST = SOMETHING;
+    /* testTrueIsKeywordAsConstUnionTypeFirst */
+    const true|string UNION_WITH_TRUE_FIRST = SOMETHING;
+    /* testNullIsKeywordAsConstUnionTypeFirst */
+    const null|int UNION_WITH_NULL_FIRST = SOMETHING;
+    /* testSelfIsKeywordAsConstUnionTypeFirst */
+    const self|Foo UNION_WITH_SELF_FIRST = SOMETHING;
+    /* testParentIsKeywordAsConstUnionTypeFirst */
+    const parent|Bar UNION_WITH_PARENT_FIRST = SOMETHING;
+
+    const int|/* testFalseIsKeywordAsConstUnionTypeMiddle */false|string UNION_WITH_FALSE_MIDDLE = SOMETHING;
+    const bool|/* testTrueIsKeywordAsConstUnionTypeMiddle */ true|Stringable UNION_WITH_TRUE_MIDDLE = SOMETHING;
+    const object|/* testNullIsKeywordAsConstUnionTypeMiddle */null|iterable UNION_WITH_NULL_MIDDLE = SOMETHING;
+    const array | /* testSelfIsKeywordAsConstUnionTypeMiddle */ self | /*comment*/  string UNION_WITH_SELF_MIDDLE = SOMETHING;
+    const Foo|/* testParentIsKeywordAsConstUnionTypeMiddle */parent|float UNION_WITH_PARENT_MIDDLE = SOMETHING;
+
+    const string|/* testFalseIsKeywordAsConstUnionTypeLast */false UNION_WITH_FALSE_LAST = SOMETHING;
+    const float|/* testTrueIsKeywordAsConstUnionTypeLast */true UNION_WITH_TRUE_LAST = SOMETHING;
+    const Something|/* testNullIsKeywordAsConstUnionTypeLast */null UNION_WITH_NULL_LAST = SOMETHING;
+    const Foo|/* testSelfIsKeywordAsConstUnionTypeLast */self UNION_WITH_SELF_LAST = SOMETHING;
+    const Bar|/* testParentIsKeywordAsConstUnionTypeLast */parent UNION_WITH_PARENT_LAST = SOMETHING;
+
+    /* testFalseIsKeywordAsPropertyUnionTypeFirst */
+    public false|string $false = SOMETHING;
+    /* testTrueIsKeywordAsPropertyUnionTypeFirst */
+    protected readonly true|int $true = SOMETHING;
+    /* testNullIsKeywordAsPropertyUnionTypeFirst */
+    static private null|object $null = SOMETHING;
+    /* testSelfIsKeywordAsPropertyUnionTypeFirst */
+    var self|iterable $self = SOMETHING;
+    /* testParentIsKeywordAsPropertyUnionTypeFirst */
+    protected parent|array $parent = SOMETHING;
+
+    public Foo|/* testFalseIsKeywordAsPropertyUnionTypeMiddle */false|Bar $false = SOMETHING;
+    protected readonly Foo|/* testTrueIsKeywordAsPropertyUnionTypeMiddle */true|Bar $true = SOMETHING;
+    static private Foo/* testNullIsKeywordAsPropertyUnionTypeMiddle */|null|Bar $null = SOMETHING;
+    var Foo|/* testSelfIsKeywordAsPropertyUnionTypeMiddle */self|Bar $self = SOMETHING;
+    protected Foo/* testParentIsKeywordAsPropertyUnionTypeMiddle */|parent|Bar $parent = SOMETHING;
+
+    public array|/* testFalseIsKeywordAsPropertyUnionTypeLast */false $false = SOMETHING;
+    protected readonly string /* testTrueIsKeywordAsPropertyUnionTypeLast */| true $true = SOMETHING;
+    static private int|/* testNullIsKeywordAsPropertyUnionTypeLast */null $null = SOMETHING;
+    var object|/* testSelfIsKeywordAsPropertyUnionTypeLast */self $self = SOMETHING;
+    protected Foo/* testParentIsKeywordAsPropertyUnionTypeLast */|parent $parent = SOMETHING;
+
+    function KeywordsInParamUnionTypeFirst(
+        /* testFalseIsKeywordAsParamUnionTypeFirst */ false|Foo $paramA,
+        /* testTrueIsKeywordAsParamUnionTypeFirst */ true|string $paramB,
+        /* testNullIsKeywordAsParamUnionTypeFirst */ null|Bar $paramC,
+        /* testSelfIsKeywordAsParamUnionTypeFirst */ self|float $paramD,
+        /* testParentIsKeywordAsParamUnionTypeFirst */ parent|object $paramE,
+    ) {}
+
+    function KeywordsInParamUnionTypeMiddle(
+        Foo/* testFalseIsKeywordAsParamUnionTypeMiddle */|false|Bar $paramA,
+        Foo|/* testTrueIsKeywordAsParamUnionTypeMiddle */ true|Bar $paramB,
+        Foo/* testNullIsKeywordAsParamUnionTypeMiddle */ |null|Bar $paramC,
+        Foo|/* testSelfIsKeywordAsParamUnionTypeMiddle */ self|Bar $paramD,
+        Foo/* testParentIsKeywordAsParamUnionTypeMiddle */ |parent|Bar $paramE
+    ) {}
+
+    function KeywordsInParamUnionTypeLast (
+        string|/* testFalseIsKeywordAsParamUnionTypeLast */ false $paramA,
+        Something/* testTrueIsKeywordAsParamUnionTypeLast */ |true $paramB,
+        bool|/* testNullIsKeywordAsParamUnionTypeLast */ null $paramC,
+        MeMe/* testSelfIsKeywordAsParamUnionTypeLast */ |self $paramD,
+        int|/* testParentIsKeywordAsParamUnionTypeLast */ parent $paramE,
+    ) {}
+
+    function FalseIsKeywordInReturnTypeFirst(): /* testFalseIsKeywordAsReturnUnionTypeFirst */ false|int {}
+    function TrueIsKeywordInReturnTypeFirst(): /* testTrueIsKeywordAsReturnUnionTypeFirst */ true|bool {}
+    function NullIsKeywordInReturnTypeFirst(): /* testNullIsKeywordAsReturnUnionTypeFirst */ null|float {}
+    function SelfIsKeywordInReturnTypeFirst(): /* testSelfIsKeywordAsReturnUnionTypeFirst */ self|object {}
+    function ParentIsKeywordInReturnTypeFirst(): /* testParentIsKeywordAsReturnUnionTypeFirst */ parent|iterable {}
+
+    function FalseIsKeywordInReturnTypeMiddle(): Foo|/* testFalseIsKeywordAsReturnUnionTypeMiddle */ false|Bar {}
+    function TrueIsKeywordInReturnTypeMiddle(): Foo/* testTrueIsKeywordAsReturnUnionTypeMiddle */ |true|Bar {}
+    function NullIsKeywordInReturnTypeMiddle(): Foo|/* testNullIsKeywordAsReturnUnionTypeMiddle */null|Bar {}
+    function SelfIsKeywordInReturnTypeMiddle(): Foo /* testSelfIsKeywordAsReturnUnionTypeMiddle */ |self|Bar {}
+    function ParentIsKeywordInReturnTypeMiddle(): Foo| /* testParentIsKeywordAsReturnUnionTypeMiddle */ parent|Bar {}
+
+    function FalseIsKeywordInReturnTypeLast(): void|/* testFalseIsKeywordAsReturnUnionTypeLast */false {}
+    function TrueIsKeywordInReturnTypeLast(): Bar|/* testTrueIsKeywordAsReturnUnionTypeLast */true {}
+    function NullIsKeywordInReturnTypeLast(): string/* testNullIsKeywordAsReturnUnionTypeLast */|null {}
+    function SelfIsKeywordInReturnTypeLast(): Foo|/* testSelfIsKeywordAsReturnUnionTypeLast */self {}
+    function ParentIsKeywordInReturnTypeLast(): bool/* testParentIsKeywordAsReturnUnionTypeLast */|parent {}
+}
+
+class UseInIntersectionTypes {
+    /* testSelfIsKeywordAsConstIntersectionTypeFirst */
+    const self&Foo INTERSECTION_SELF_FIRST = SOMETHING;
+    /* testParentIsKeywordAsConstIntersectionTypeFirst */
+    const parent&Bar INTERSECTION_PARENT_FIRST = SOMETHING;
+
+    const Foo&/* testSelfIsKeywordAsConstIntersectionTypeMiddle */self&Bar INTERSECTION_SELF_MIDDLE = SOMETHING;
+    const Foo/* testParentIsKeywordAsConstIntersectionTypeMiddle */&parent&Bar INTERSECTION_PARENT_MIDDLE = SOMETHING;
+
+    const Foo&/* testSelfIsKeywordAsConstIntersectionTypeLast */self INTERSECTION_SELF_LAST = SOMETHING;
+    const Bar/* testParentIsKeywordAsConstIntersectionTypeLast */&parent INTERSECTION_PARENT_LAST = SOMETHING;
+
+    /* testSelfIsKeywordAsPropertyIntersectionTypeFirst */
+    var self&Countable $self = SOMETHING;
+    /* testParentIsKeywordAsPropertyIntersectionTypeFirst */
+    protected parent&DateTime $parent = SOMETHING;
+
+    var Foo/* testSelfIsKeywordAsPropertyIntersectionTypeMiddle */&self&Bar $self = SOMETHING;
+    protected Foo&/* testParentIsKeywordAsPropertyIntersectionTypeMiddle */parent&Bar $parent = SOMETHING;
+
+    var Exception/* testSelfIsKeywordAsPropertyIntersectionTypeLast */&self $self = SOMETHING;
+    protected Foo&/* testParentIsKeywordAsPropertyIntersectionTypeLast */parent $parent = SOMETHING;
+
+    function KeywordsInParamIntersectionTypeFirst(
+        /* testSelfIsKeywordAsParamIntersectionTypeFirst */ self&float $paramD,
+        /* testParentIsKeywordAsParamIntersectionTypeFirst */ parent&object $paramE,
+    ) {}
+
+    function KeywordsInParamIntersectionTypeMiddle(
+        Foo/* testSelfIsKeywordAsParamIntersectionTypeMiddle */ &self&Bar $paramD,
+        Foo&/* testParentIsKeywordAsParamIntersectionTypeMiddle */ parent&Bar $paramE
+    ) {}
+
+    function KeywordsInParamIntersectionTypeLast (
+        MeMe/* testSelfIsKeywordAsParamIntersectionTypeLast */ &self $paramD,
+        int&/* testParentIsKeywordAsParamIntersectionTypeLast */ parent $paramE
+    ) {}
+
+    function SelfIsKeywordInReturnTypeFirst()/* testSelfIsKeywordAsReturnIntersectionTypeFirst */: self&string {}
+    function ParentIsKeywordInReturnTypeFirst():/* testParentIsKeywordAsReturnIntersectionTypeFirst */ parent&iterable {}
+
+    function SelfIsKeywordInReturnTypeMiddle(): Foo/* testSelfIsKeywordAsReturnIntersectionTypeMiddle */&self&Bar {}
+    function ParentIsKeywordInReturnTypeMiddle(): Foo&/* testParentIsKeywordAsReturnIntersectionTypeMiddle */parent&Bar {}
+
+    function SelfIsKeywordInReturnTypeLast(): Foo&/* testSelfIsKeywordAsReturnIntersectionTypeLast */self {}
+    function ParentIsKeywordInReturnTypeLast(): bool&/* testParentIsKeywordAsReturnIntersectionTypeLast */parent {}
+}

--- a/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
@@ -137,142 +137,494 @@ final class OtherContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public static function dataKeywords()
     {
         return [
-            'self: param type declaration'            => [
+            'self: param type declaration'                                    => [
                 'testMarker'        => '/* testSelfIsKeyword */',
                 'expectedTokenType' => 'T_SELF',
             ],
-            'parent: param type declaration'          => [
+            'parent: param type declaration'                                  => [
                 'testMarker'        => '/* testParentIsKeyword */',
                 'expectedTokenType' => 'T_PARENT',
             ],
 
-            'parent: class instantiation'             => [
+            'parent: class instantiation'                                     => [
                 'testMarker'        => '/* testClassInstantiationParentIsKeyword */',
                 'expectedTokenType' => 'T_PARENT',
             ],
-            'self: class instantiation'               => [
+            'self: class instantiation'                                       => [
                 'testMarker'        => '/* testClassInstantiationSelfIsKeyword */',
                 'expectedTokenType' => 'T_SELF',
             ],
 
-            'false: param type declaration'           => [
+            'false: param type declaration'                                   => [
                 'testMarker'        => '/* testFalseIsKeywordAsParamType */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: param type declaration'            => [
+            'true: param type declaration'                                    => [
                 'testMarker'        => '/* testTrueIsKeywordAsParamType */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: param type declaration'            => [
+            'null: param type declaration'                                    => [
                 'testMarker'        => '/* testNullIsKeywordAsParamType */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'false: return type declaration in union' => [
+            'false: return type declaration in union'                         => [
                 'testMarker'        => '/* testFalseIsKeywordAsReturnType */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: return type declaration in union'  => [
+            'true: return type declaration in union'                          => [
                 'testMarker'        => '/* testTrueIsKeywordAsReturnType */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: return type declaration in union'  => [
+            'null: return type declaration in union'                          => [
                 'testMarker'        => '/* testNullIsKeywordAsReturnType */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'false: in comparison'                    => [
+            'false: in comparison'                                            => [
                 'testMarker'        => '/* testFalseIsKeywordInComparison */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: in comparison'                     => [
+            'true: in comparison'                                             => [
                 'testMarker'        => '/* testTrueIsKeywordInComparison */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: in comparison'                     => [
+            'null: in comparison'                                             => [
                 'testMarker'        => '/* testNullIsKeywordInComparison */',
                 'expectedTokenType' => 'T_NULL',
             ],
 
-            'false: type in OO constant declaration'  => [
+            'false: type in OO constant declaration'                          => [
                 'testMarker'        => '/* testFalseIsKeywordAsConstType */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: type in OO constant declaration'   => [
+            'true: type in OO constant declaration'                           => [
                 'testMarker'        => '/* testTrueIsKeywordAsConstType */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: type in OO constant declaration'   => [
+            'null: type in OO constant declaration'                           => [
                 'testMarker'        => '/* testNullIsKeywordAsConstType */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'self: type in OO constant declaration'   => [
+            'self: type in OO constant declaration'                           => [
                 'testMarker'        => '/* testSelfIsKeywordAsConstType */',
                 'expectedTokenType' => 'T_SELF',
             ],
-            'parent: type in OO constant declaration' => [
+            'parent: type in OO constant declaration'                         => [
                 'testMarker'        => '/* testParentIsKeywordAsConstType */',
                 'expectedTokenType' => 'T_PARENT',
             ],
 
-            'false: value in constant declaration'    => [
+            'false: value in constant declaration'                            => [
                 'testMarker'        => '/* testFalseIsKeywordAsConstDefault */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: value in constant declaration'     => [
+            'true: value in constant declaration'                             => [
                 'testMarker'        => '/* testTrueIsKeywordAsConstDefault */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: value in constant declaration'     => [
+            'null: value in constant declaration'                             => [
                 'testMarker'        => '/* testNullIsKeywordAsConstDefault */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'self: value in constant declaration'     => [
+            'self: value in constant declaration'                             => [
                 'testMarker'        => '/* testSelfIsKeywordAsConstDefault */',
                 'expectedTokenType' => 'T_SELF',
             ],
-            'parent: value in constant declaration'   => [
+            'parent: value in constant declaration'                           => [
                 'testMarker'        => '/* testParentIsKeywordAsConstDefault */',
                 'expectedTokenType' => 'T_PARENT',
             ],
 
-            'false: type in property declaration'     => [
+            'false: type in property declaration'                             => [
                 'testMarker'        => '/* testFalseIsKeywordAsPropertyType */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: type in property declaration'      => [
+            'true: type in property declaration'                              => [
                 'testMarker'        => '/* testTrueIsKeywordAsPropertyType */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: type in property declaration'      => [
+            'null: type in property declaration'                              => [
                 'testMarker'        => '/* testNullIsKeywordAsPropertyType */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'self: type in property declaration'      => [
+            'self: type in property declaration'                              => [
                 'testMarker'        => '/* testSelfIsKeywordAsPropertyType */',
                 'expectedTokenType' => 'T_SELF',
             ],
-            'parent: type in property declaration'    => [
+            'parent: type in property declaration'                            => [
                 'testMarker'        => '/* testParentIsKeywordAsPropertyType */',
                 'expectedTokenType' => 'T_PARENT',
             ],
 
-            'false: value in property declaration'    => [
+            'false: value in property declaration'                            => [
                 'testMarker'        => '/* testFalseIsKeywordAsPropertyDefault */',
                 'expectedTokenType' => 'T_FALSE',
             ],
-            'true: value in property declaration'     => [
+            'true: value in property declaration'                             => [
                 'testMarker'        => '/* testTrueIsKeywordAsPropertyDefault */',
                 'expectedTokenType' => 'T_TRUE',
             ],
-            'null: value in property declaration'     => [
+            'null: value in property declaration'                             => [
                 'testMarker'        => '/* testNullIsKeywordAsPropertyDefault */',
                 'expectedTokenType' => 'T_NULL',
             ],
-            'self: value in property declaration'     => [
+            'self: value in property declaration'                             => [
                 'testMarker'        => '/* testSelfIsKeywordAsPropertyDefault */',
                 'expectedTokenType' => 'T_SELF',
             ],
-            'parent: value in property declaration'   => [
+            'parent: value in property declaration'                           => [
                 'testMarker'        => '/* testParentIsKeywordAsPropertyDefault */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: first in union type for OO constant declaration'          => [
+                'testMarker'        => '/* testFalseIsKeywordAsConstUnionTypeFirst */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: first in union type for OO constant declaration'           => [
+                'testMarker'        => '/* testTrueIsKeywordAsConstUnionTypeFirst */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: first in union type for OO constant declaration'           => [
+                'testMarker'        => '/* testNullIsKeywordAsConstUnionTypeFirst */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: first in union type for OO constant declaration'           => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstUnionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in union type for OO constant declaration'         => [
+                'testMarker'        => '/* testParentIsKeywordAsConstUnionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: middle in union type for OO constant declaration'         => [
+                'testMarker'        => '/* testFalseIsKeywordAsConstUnionTypeMiddle */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: middle in union type for OO constant declaration'          => [
+                'testMarker'        => '/* testTrueIsKeywordAsConstUnionTypeMiddle */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: middle in union type for OO constant declaration'          => [
+                'testMarker'        => '/* testNullIsKeywordAsConstUnionTypeMiddle */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: middle in union type for OO constant declaration'          => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstUnionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in union type for OO constant declaration'        => [
+                'testMarker'        => '/* testParentIsKeywordAsConstUnionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: last in union type for OO constant declaration'           => [
+                'testMarker'        => '/* testFalseIsKeywordAsConstUnionTypeLast */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: last in union type for OO constant declaration'            => [
+                'testMarker'        => '/* testTrueIsKeywordAsConstUnionTypeLast */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: last in union type for OO constant declaration'            => [
+                'testMarker'        => '/* testNullIsKeywordAsConstUnionTypeLast */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: last in union type for OO constant declaration'            => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstUnionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in union type for OO constant declaration'          => [
+                'testMarker'        => '/* testParentIsKeywordAsConstUnionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: first in union type for property declaration'             => [
+                'testMarker'        => '/* testFalseIsKeywordAsPropertyUnionTypeFirst */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: first in union type for property declaration'              => [
+                'testMarker'        => '/* testTrueIsKeywordAsPropertyUnionTypeFirst */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: first in union type for property declaration'              => [
+                'testMarker'        => '/* testNullIsKeywordAsPropertyUnionTypeFirst */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: first in union type for property declaration'              => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyUnionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in union type for property declaration'            => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyUnionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: middle in union type for property declaration'            => [
+                'testMarker'        => '/* testFalseIsKeywordAsPropertyUnionTypeMiddle */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: middle in union type for property declaration'             => [
+                'testMarker'        => '/* testTrueIsKeywordAsPropertyUnionTypeMiddle */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: middle in union type for property declaration'             => [
+                'testMarker'        => '/* testNullIsKeywordAsPropertyUnionTypeMiddle */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: middle in union type for property declaration'             => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyUnionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in union type for property declaration'           => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyUnionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: last in union type for property declaration'              => [
+                'testMarker'        => '/* testFalseIsKeywordAsPropertyUnionTypeLast */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: last in union type for property declaration'               => [
+                'testMarker'        => '/* testTrueIsKeywordAsPropertyUnionTypeLast */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: last in union type for property declaration'               => [
+                'testMarker'        => '/* testNullIsKeywordAsPropertyUnionTypeLast */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: last in union type for property declaration'               => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyUnionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in union type for property declaration'             => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyUnionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: first in union type for param declaration'                => [
+                'testMarker'        => '/* testFalseIsKeywordAsParamUnionTypeFirst */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: first in union type for param declaration'                 => [
+                'testMarker'        => '/* testTrueIsKeywordAsParamUnionTypeFirst */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: first in union type for param declaration'                 => [
+                'testMarker'        => '/* testNullIsKeywordAsParamUnionTypeFirst */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: first in union type for param declaration'                 => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamUnionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in union type for param declaration'               => [
+                'testMarker'        => '/* testParentIsKeywordAsParamUnionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: middle in union type for param declaration'               => [
+                'testMarker'        => '/* testFalseIsKeywordAsParamUnionTypeMiddle */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: middle in union type for param declaration'                => [
+                'testMarker'        => '/* testTrueIsKeywordAsParamUnionTypeMiddle */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: middle in union type for param declaration'                => [
+                'testMarker'        => '/* testNullIsKeywordAsParamUnionTypeMiddle */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: middle in union type for param declaration'                => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamUnionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in union type for param declaration'              => [
+                'testMarker'        => '/* testParentIsKeywordAsParamUnionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: last in union type for param declaration'                 => [
+                'testMarker'        => '/* testFalseIsKeywordAsParamUnionTypeLast */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: last in union type for param declaration'                  => [
+                'testMarker'        => '/* testTrueIsKeywordAsParamUnionTypeLast */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: last in union type for param declaration'                  => [
+                'testMarker'        => '/* testNullIsKeywordAsParamUnionTypeLast */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: last in union type for param declaration'                  => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamUnionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in union type for param declaration'                => [
+                'testMarker'        => '/* testParentIsKeywordAsParamUnionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: first in union type for return declaration'               => [
+                'testMarker'        => '/* testFalseIsKeywordAsReturnUnionTypeFirst */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: first in union type for return declaration'                => [
+                'testMarker'        => '/* testTrueIsKeywordAsReturnUnionTypeFirst */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: first in union type for return declaration'                => [
+                'testMarker'        => '/* testNullIsKeywordAsReturnUnionTypeFirst */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: first in union type for return declaration'                => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnUnionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in union type for return declaration'              => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnUnionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: middle in union type for return declaration'              => [
+                'testMarker'        => '/* testFalseIsKeywordAsReturnUnionTypeMiddle */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: middle in union type for return declaration'               => [
+                'testMarker'        => '/* testTrueIsKeywordAsReturnUnionTypeMiddle */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: middle in union type for return declaration'               => [
+                'testMarker'        => '/* testNullIsKeywordAsReturnUnionTypeMiddle */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: middle in union type for return declaration'               => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnUnionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in union type for return declaration'             => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnUnionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'false: last in union type for return declaration'                => [
+                'testMarker'        => '/* testFalseIsKeywordAsReturnUnionTypeLast */',
+                'expectedTokenType' => 'T_FALSE',
+            ],
+            'true: last in union type for return declaration'                 => [
+                'testMarker'        => '/* testTrueIsKeywordAsReturnUnionTypeLast */',
+                'expectedTokenType' => 'T_TRUE',
+            ],
+            'null: last in union type for return declaration'                 => [
+                'testMarker'        => '/* testNullIsKeywordAsReturnUnionTypeLast */',
+                'expectedTokenType' => 'T_NULL',
+            ],
+            'self: last in union type for return declaration'                 => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnUnionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in union type for return declaration'               => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnUnionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'self: first in intersection type for OO constant declaration'    => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in intersection type for OO constant declaration'  => [
+                'testMarker'        => '/* testParentIsKeywordAsConstIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: middle in intersection type for OO constant declaration'   => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in intersection type for OO constant declaration' => [
+                'testMarker'        => '/* testParentIsKeywordAsConstIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: last in intersection type for OO constant declaration'     => [
+                'testMarker'        => '/* testSelfIsKeywordAsConstIntersectionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in intersection type for OO constant declaration'   => [
+                'testMarker'        => '/* testParentIsKeywordAsConstIntersectionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'self: first in intersection type for property declaration'       => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in intersection type for property declaration'     => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: middle in intersection type for property declaration'      => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in intersection type for property declaration'    => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: last in intersection type for property declaration'        => [
+                'testMarker'        => '/* testSelfIsKeywordAsPropertyIntersectionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in intersection type for property declaration'      => [
+                'testMarker'        => '/* testParentIsKeywordAsPropertyIntersectionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'self: first in intersection type for param declaration'          => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in intersection type for param declaration'        => [
+                'testMarker'        => '/* testParentIsKeywordAsParamIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: middle in intersection type for param declaration'         => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in intersection type for param declaration'       => [
+                'testMarker'        => '/* testParentIsKeywordAsParamIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: last in intersection type for param declaration'           => [
+                'testMarker'        => '/* testSelfIsKeywordAsParamIntersectionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in intersection type for param declaration'         => [
+                'testMarker'        => '/* testParentIsKeywordAsParamIntersectionTypeLast */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+
+            'self: first in intersection type for return declaration'         => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: first in intersection type for return declaration'       => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnIntersectionTypeFirst */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: middle in intersection type for return declaration'        => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: middle in intersection type for return declaration'      => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnIntersectionTypeMiddle */',
+                'expectedTokenType' => 'T_PARENT',
+            ],
+            'self: last in intersection type for return declaration'          => [
+                'testMarker'        => '/* testSelfIsKeywordAsReturnIntersectionTypeLast */',
+                'expectedTokenType' => 'T_SELF',
+            ],
+            'parent: last in intersection type for return declaration'        => [
+                'testMarker'        => '/* testParentIsKeywordAsReturnIntersectionTypeLast */',
                 'expectedTokenType' => 'T_PARENT',
             ],
         ];


### PR DESCRIPTION
# Description
Add silly number of extra tests to safeguard that the `true`/`false`/`null`/`self`/`parent` keywords, when used in type declarations, are correctly tokenized.


## Suggested changelog entry
_N/A_