### PR TITLE
Composer: avoid writing a lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
         "bin/phpcbf",
         "bin/phpcs"
     ],
+    "config": {
+        "lock": false
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"


### PR DESCRIPTION
# Description

When working with this repository as a developer, we should be using the latest compatible packages. By writing a lock file for Composer, we may get into a state where we are "stuck" on an older version of a dependency. This change avoids such a situation by telling Composer to not write out a lock file in the project.

## Suggested changelog entry
*None required*

## Types of changes
- Chore - internal maintenance task with no impact on external dependencies nor consumers of the project.

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- ~~I have added tests to cover my changes.~~
- [x] I have verified that the code complies with the projects coding standards.
- ~~\[Required for new sniffs\] I have added XML documentation for the sniff.~~