### PR TITLE
Correct typos and language

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -302,7 +302,7 @@ the code should be flagged or not. Additionally, making auto-fixes to code in a 
 
 This defensive coding in a sniff should, of course, also be safeguarded via tests.
 
-Parse/compile errors can take various forms. Some can be handled without much problems by PHPCS, some can not.
+Parse/compile errors can take various forms. Some can be handled without many problems by PHPCS, some can not.
 
 If a code snippet to be tested could lead to a broken token stream due to a parse/compile error, the code snippet should always
 be put in a separate test case file by itself and be accompanied by a comment stating the test is an intentional parse error.

--- a/.github/community-cc-list.md
+++ b/.github/community-cc-list.md
@@ -4,7 +4,7 @@
 This list will be used on select tickets to ping the wider PHP_CodeSniffer community for input.
 
 If you want to be on this list, feel free to submit a PR to add yourself.
-If you want to be removed from the list, dito, submit a PR to remove yourself and it will be merged without questions.
+If you want to be removed from the list, dito, submit a PR to remove yourself, and it will be merged without questions.
 
 PRs adding/removing other people to/from the list will only be merged if the people being added/removed leave a comment on the PR consenting to it.
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,7 +119,7 @@ jobs:
         run: npm install --global remark-cli --foreground-scripts true --fund false
 
       # To allow for creating a custom config which references rules which are included
-      # in the presets, without having to install all rules individually, a local install
+      # in the presets, without having to install all rules individually, a local installation
       # works best (and installing the presets in the first place, of course).
       #
       # Note: the first group of packages are all part of the mono "Remark lint" repo.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -64,7 +64,7 @@ config:
     heading_line_length: 100
     # Number of characters for code blocks.
     code_block_line_length: 100
-    # Stern length checking (applies to tables, code blocks etc which have their own max line length).
+    # Stern length checking (applies to tables, code blocks etc. which have their own max line length).
     stern: true
 
   # MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md022.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Nothing yet._
     - Thanks to [Rodrigo Primo][@rodrigoprimo] for the patches.
 - Performance improvement for the "Diff" report. Should be most notable for Windows users. [#355]
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch.
-- The test suite has received some performance improvements. Should be most notable contributors using Windows. [#351]
+- The test suite has received some performance improvements. Should be the most notable for contributors using Windows. [#351]
     - External standards with sniff tests using the PHP_CodeSniffer native test framework will also benefit from these changes.
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch.
 - Various housekeeping, including improvements to the tests and documentation.
@@ -100,7 +100,7 @@ _Nothing yet._
     - The Javascript and CSS Tokenizers, all Javascript and CSS specific sniffs, and support for JS and CSS in select sniffs which support multiple file types, will be removed in version 4.0.0.
 - The abstract `PHP_CodeSniffer\Filters\ExactMatch::getBlacklist()` and `PHP_CodeSniffer\Filters\ExactMatch::getWhitelist()` methods are deprecated and will be removed in the 4.0 release. See [#198].
     - In version 4.0, these methods will be replaced with abstract `ExactMatch::getDisallowedFiles()` and `ExactMatch::getAllowedFiles()` methods
-    - To make Filters extending `ExactMatch` cross-version compatible with both PHP_CodeSniffer 3.9.0+ as well as 4.0+, implement the new `getDisallowedFiles()` and `getAllowedFiles()` methods.
+    - To make Filters extending `ExactMatch` cross-version compatible with both PHP_CodeSniffer 3.9.0+ and 4.0+, implement the new `getDisallowedFiles()` and `getAllowedFiles()` methods.
         - When both the `getDisallowedFiles()` and `getAllowedFiles()` methods as well as the `getBlacklist()` and `getWhitelist()` are available, the new methods will take precedence over the old methods.
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - The MySource standard and all sniffs in it. See [#2471][sq-2471].
@@ -226,7 +226,7 @@ _Nothing yet._
     - Users who download the PHAR files using curl or wget, will need to update the download URL from `https://squizlabs.github.io/PHP_CodeSniffer/[phpcs|phpcbf].phar` or `https://github.com/squizlabs/PHP_CodeSnifffer/releases/latest/download/[phpcs|phpcbf].phar` to `https://phars.phpcodesniffer.com/[phpcs|phpcbf].phar`.
     - For users who install PHP_CodeSniffer via the [Setup-PHP](https://github.com/shivammathur/setup-php/) action runner for GitHub Actions, nothing changes.
     - Users using a git clone will need to update the clone address from `git@github.com:squizlabs/PHP_CodeSniffer.git` to `git@github.com:PHPCSStandards/PHP_CodeSniffer.git`.
-        - Contributors will need to fork the new repo and add both the new fork as well as the new repo as remotes to their local git copy of PHP_CodeSniffer.
+        - Contributors will need to fork the new repo and add both the new fork and the new repo as remotes to their local git copy of PHP_CodeSniffer.
         - Users who have (valid) open issues or pull requests in the `squizlabs/PHP_CodeSniffer` repository are invited to resubmit these to the `PHPCSStandards/PHP_CodeSniffer` repository.
 
 ### Added
@@ -807,7 +807,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Include patterns are now ignored when processing STDIN
     - Previously, checks using include patterns were excluded when processing STDIN when no file path was provided via --stdin-path
     - Now, all include and exclude rules are ignored when no file path is provided, allowing all checks to run
-    - If you want include and exclude rules enforced when checking STDIN, use --stdin-path to set the file path
+    - If you want to include and exclude rules enforced when checking STDIN, use --stdin-path to set the file path
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Spaces are now correctly escaped in the paths to external on Windows
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
@@ -966,7 +966,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Sergei Morozov][@morozov] for the patch
 - Fixed bug [#3066][sq-3066] : No support for namespace operator used in type declarations
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Fixed bug [#3075][sq-3075] : PSR12.ControlStructures.BooleanOperatorPlacement false positive when operator is the only content on line
+- Fixed bug [#3075][sq-3075] : PSR12.ControlStructures.BooleanOperatorPlacement false positive when operator is the only content on the line
 - Fixed bug [#3099][sq-3099] : Squiz.WhiteSpace.OperatorSpacing false positive when exiting with negative number
     - Thanks to [Sergei Morozov][@morozov] for the patch
 - Fixed bug [#3102][sq-3102] : PSR12.Squiz.OperatorSpacing false positive for default values of arrow functions
@@ -1734,9 +1734,9 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Default remains FALSE, so newlines are not allowed
     - Override the "ignoreNewlines" setting in a ruleset.xml file to change
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- PEAR.Functions.FunctionDeclaration now checks spacing before the opening parenthesis of functions with no body
+- PEAR.Functions.FunctionDeclaration now checks spacing before the opening parenthesis of functions without body
     - Thanks to [Chris Wilkinson][@thewilkybarkid] for the patch
-- PEAR.Functions.FunctionDeclaration now enforces no space before the semicolon in functions with no body
+- PEAR.Functions.FunctionDeclaration now enforces no space before the semicolon in functions without body
     - Thanks to [Chris Wilkinson][@thewilkybarkid] for the patch
 - PSR2.Classes.PropertyDeclaration now checks the order of property modifier keywords
     - This is a rule that is documented in PSR-2 but was not enforced by the included PSR2 standard until now
@@ -3085,7 +3085,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Developers of custom standards with custom test runners can now have their standards ignored by the built-in test runner
     - Set the value of an environment variable called PHPCS_IGNORE_TESTS with a comma separated list of your standard names
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- The unit test runner now loads the test sniff outside of the standard's ruleset so that exclude rules do not get applied
+- The unit test runner now loads the test sniff outside the standard's ruleset so that exclude rules do not get applied
     - This may have caused problems when testing custom sniffs inside custom standards
     - Also makes the unit tests runs a little faster
 - The SVN pre-commit hook now works correctly when installed via composer
@@ -3093,7 +3093,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 
 ### Fixed
 - Fixed bug [#1135][sq-1135] : PEAR.ControlStructures.MultiLineCondition.CloseBracketNewLine not detected if preceded by multiline function call
-- Fixed bug [#1138][sq-1138] : PEAR.ControlStructures.MultiLineCondition.Alignment not detected if closing brace is first token on line
+- Fixed bug [#1138][sq-1138] : PEAR.ControlStructures.MultiLineCondition.Alignment not detected if closing brace is first token on the line
 - Fixed bug [#1141][sq-1141] : Sniffs that check EOF newlines don't detect newlines properly when the last token is a doc block
 - Fixed bug [#1150][sq-1150] : Squiz.Strings.EchoedStrings does not properly fix bracketed statements
 - Fixed bug [#1156][sq-1156] : Generic.Formatting.DisallowMultipleStatements errors when multiple short echo tags are used on the same line
@@ -3249,7 +3249,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 
 ### Fixed
 - Fixed bug [#790][sq-790] : Incorrect missing @throws error in methods that use closures
-- Fixed bug [#908][sq-908] : PSR2 standard is not checking that closing brace is on line following the body
+- Fixed bug [#908][sq-908] : PSR2 standard is not checking that closing brace is on the line following the body
 - Fixed bug [#945][sq-945] : Incorrect indent behavior using deep-nested function and arrays
 - Fixed bug [#961][sq-961] : Two anonymous functions passed as function/method arguments cause indentation false positive
 - Fixed bug [#1005][sq-1005] : Using global composer vendor autoload breaks PHP lowercase built-in function sniff
@@ -3524,7 +3524,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed bug [#807][sq-807] : Cannot fix line endings when open PHP tag is not on the first line
 - Fixed bug [#808][sq-808] : JS tokenizer incorrectly setting some function and class names to control structure tokens
 - Fixed bug [#809][sq-809] : PHPCBF can break a require_once statement with a space before the open parenthesis
-- Fixed bug [#813][sq-813] : PEAR FunctionCallSignature checks wrong indent when first token on line is part of a multi-line string
+- Fixed bug [#813][sq-813] : PEAR FunctionCallSignature checks wrong indent when first token on the line is part of a multi-line string
 
 [sq-560]: https://github.com/squizlabs/PHP_CodeSniffer/issues/560
 [sq-583]: https://github.com/squizlabs/PHP_CodeSniffer/issues/583
@@ -6096,7 +6096,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Squiz SwitchDeclarationSniff now supports checking of JS files
 - Squiz CommentedOutCodeSniff now supports checking of CSS files
 - Squiz DisallowSizeFunctionsInLoopsSniff now supports checking of JS files for the use of object.length
-- Squiz DisallowSizeFunctionsInLoopsSniff no longer complains about size functions outside of the FOR condition
+- Squiz DisallowSizeFunctionsInLoopsSniff no longer complains about size functions outside the FOR condition
 - Squiz ControlStructureSpacingSniff now bans blank lines at the end of a control structure
 - Squiz ForLoopDeclarationSniff no longer throws errors for JS FOR loops without semicolons
 - Squiz MultipleStatementAlignmentSniff no longer throws errors if a statement would take more than 8 spaces to align
@@ -6261,7 +6261,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed error in Squiz FunctionSpacingSniff where functions after member vars reported incorrect spacing
 - Fixed bug [#13062][pear-13062] : Interface comments aren't handled in PEAR standard
     - Thanks to [Manuel Pichler][@manuelpichler] for the path
-- Fixed bug [#13119][pear-13119] : PHP minimum requirement need to be fix
+- Fixed bug [#13119][pear-13119] : PHP minimum requirement need to be fixed
 - Fixed bug [#13156][pear-13156] : Bug in Squiz_Sniffs_PHP_NonExecutableCodeSniff
 - Fixed bug [#13158][pear-13158] : Strange behaviour in AbstractPatternSniff
 - Fixed bug [#13169][pear-13169] : Undefined variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,7 +306,7 @@ _Nothing yet._
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - PSR2.Classes.PropertyDeclaration now enforces that the readonly modifier comes after the visibility modifier
     - PSR2 and PSR12 do not have documented rules for this as they pre-date the readonly modifier
-    - PSR-PER has been used to confirm the order of this keyword so it can be applied to PSR2 and PSR12 correctly
+    - PSR-PER has been used to confirm the order of this keyword, so it can be applied to PSR2 and PSR12 correctly
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - PEAR.Commenting.FunctionComment + Squiz.Commenting.FunctionComment: the SpacingAfter error can now be auto-fixed
     - Thanks to [Dan Wallis][@fredden] for the patch
@@ -1538,7 +1538,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - PHPCS will now refuse to run if any of the required PHP extensions are not loaded
     - Previously, PHPCS only relied on requirements being checked by PEAR and Composer
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Ruleset XML parsing errors are now displayed in a readable format so they are easier to correct
+- Ruleset XML parsing errors are now displayed in a readable format, so they are easier to correct
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - The PSR2 standard no longer throws duplicate errors for spacing around FOR loop parentheses
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
@@ -1966,7 +1966,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - The T_RETURN_TYPE token has been deprecated and will be removed in version 4
     - The token was used to ensure array/self/parent/callable return types were tokenized consistently
     - For namespaced return types, only the last part of the string (the class name) was tokenized as T_RETURN_TYPE
-    - This was not consistent and so return types are now left using their original token types so they are not skipped by sniffs
+    - This was not consistent and so return types are now left using their original token types, so they are not skipped by sniffs
         - The exception are array return types, which are tokenized as T_STRING instead of T_ARRAY, as they are for type hints
     - Sniffs referencing this token type will continue to run without error until version 4, but will not find any T_RETUTN_TYPE tokens
     - To get the return-type of a function, use the File::getMethodProperties() method, which now contains a "return_type" array index
@@ -2104,7 +2104,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - It could previously be confused by comparisons used as function arguments
 - Squiz.PHP.CommentedOutCode now ignores simple @-style annotation comments so they are not flagged as commented out code
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Squiz.PHP.CommentedOutCode now ignores a greater number of short comments so they are not flagged as commented out code
+- Squiz.PHP.CommentedOutCode now ignores a greater number of short comments, so they are not flagged as commented out code
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Squiz.PHP.DisallowComparisonAssignment no longer errors when using the null coalescing operator
     - Given this operator is used almost exclusively to assign values, it didn't make sense to generate an error
@@ -2592,7 +2592,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
         - e.g., you run PHPCS over libraries that you did not write
         - e.g., you provide a web service that runs PHPCS over user-uploaded files or 3rd-party repositories
         - e.g., you allow external tool paths to be set by user-defined values
-    - If you are unable to upgrade but you check 3rd-party code, ensure you are not using the Git modified filter
+    - If you are unable to upgrade, but you check 3rd-party code, ensure you are not using the Git modified filter
     - This advisory does not affect PHP_CodeSniffer version 2.
     - Thanks to [Sergei Morozov][@morozov] for the report and patch
 
@@ -2697,7 +2697,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
         - e.g., you run PHPCS over libraries that you did not write
         - e.g., you provide a web service that runs PHPCS over user-uploaded files or 3rd-party repositories
         - e.g., you allow external tool paths to be set by user-defined values
-    - If you are unable to upgrade but you check 3rd-party code, ensure you are not using the following features:
+    - If you are unable to upgrade, but you check 3rd-party code, ensure you are not using the following features:
         - The diff report
         - The notify-send report
         - The Generic.PHP.Syntax sniff
@@ -2735,7 +2735,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Custom sniffs that support JS and listen for T_FUNCTION tokens can't assume the token represents the word "function"
     - Check the contents of the token first, or use $phpcsFile->getDeclarationName($stackPtr) if you just want its name
     - There is no change for custom sniffs that only check PHP code
-- PHPCBF exit codes have been changed so they are now more useful (request [#1270][sq-1270])
+- PHPCBF exit codes have been changed, so they are now more useful (request [#1270][sq-1270])
     - Exit code 0 is now used to indicate that no fixable errors were found, and so nothing was fixed
     - Exit code 1 is now used to indicate that all fixable errors were fixed correctly
     - Exit code 2 is now used to indicate that PHPCBF failed to fix some of the fixable errors it found
@@ -2907,7 +2907,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Stops conflicts between this sniff and comment spacing sniffs
 - Squiz.WhiteSpace.OperatorSpacing no longer checks the equal sign in declare statements
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Added missing error codes for a couple of sniffs so they can now be customised as normal
+- Added missing error codes for a couple of sniffs, so they can now be customised as normal
 
 ### Fixed
 - Fixed bug [#1266][sq-1266] : PEAR.WhiteSpace.ScopeClosingBrace can throw an error while fixing mixed PHP/HTML
@@ -2948,7 +2948,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
           - e.g., you run PHPCS over libraries that you did not write
           - e.g., you provide a web service that runs PHPCS over user-uploaded files or 3rd-party repositories
           - e.g., you allow external tool paths to be set by user-defined values
-    - If you are unable to upgrade but you check 3rd-party code, ensure you are not using the following features:
+    - If you are unable to upgrade, but you check 3rd-party code, ensure you are not using the following features:
           - The diff report
           - The notify-send report
           - The Generic.PHP.Syntax sniff
@@ -3235,7 +3235,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Added a new --exclude CLI argument to exclude a list of sniffs from checking and fixing (request [#904][sq-904])
     - Accepts the same sniff codes as the --sniffs command line argument, but provides the opposite functionality
 - Added a new -q command line argument to disable progress and verbose information from being printed (request [#969][sq-969])
-    - Useful if a coding standard hard-codes progress or verbose output but you want PHPCS to be quiet
+    - Useful if a coding standard hard-codes progress or verbose output, but you want PHPCS to be quiet
     - Use the command "phpcs --config-set quiet true" to turn quiet mode on by default
 - Generic LineLength sniff no longer errors for comments that cannot be broken out onto a new line (request [#766][sq-766])
     - A typical case is a comment that contains a very long URL
@@ -4161,7 +4161,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 
 ### Changed
 - Minified JS and CSS files are now detected and skipped (fixes bug [#252][sq-252] and bug [#19899][pear-19899])
-    - A warning will be added to the file so it can be found in the report and ignored in the future
+    - A warning will be added to the file, so it can be found in the report and ignored in the future
 - Fixed incorrect length of JS object operator tokens
 - PHP tokenizer no longer converts class/function names to special tokens types
     - Class/function names such as parent and true would become special tokens such as T_PARENT and T_TRUE
@@ -4393,7 +4393,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Generic DisallowTabIndent and DisallowSpaceIndent sniffs no longer error when detecting mixed indent types
     - Only the first type of indent found on a line (space or indent) is considered
 - Lots of little performance improvements that can add up to a substantial saving over large code bases
-    - Added a "length" array index to tokens so you don't need to call strlen() of them, or deal with encoding
+    - Added a "length" array index to tokens, so you don't need to call strlen() of them, or deal with encoding
     - Can now use isset() to find tokens inside the PHP_CodeSniffer_Tokens static vars instead of in_array()
 - Custom reports can now specify a $recordErrors member var; this previously only worked for built-in reports
     - When set to FALSE, error messages will not be recorded and only totals will be returned
@@ -4495,7 +4495,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - If returned, the sniff will not be executed again until the passed token is reached in the file
     - Useful if you are looking for tokens like T_OPEN_TAG but only want to process the first one
 - Removed the comment parser classes and replaced it with a simple comment tokenizer
-    - T_DOC_COMMENT tokens are now tokenized into T_DOC_COMMENT_* tokens so they can be used more easily
+    - T_DOC_COMMENT tokens are now tokenized into T_DOC_COMMENT_* tokens, so they can be used more easily
     - This change requires a significant rewrite of sniffs that use the comment parser
     - This change requires minor changes to sniffs that listen for T_DOC_COMMENT tokens directly
 - Added Generic DocCommentSniff to check generic doc block formatting
@@ -4510,7 +4510,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - NoSpaceBeforeTag becomes NoSpaceAfterStar
     - SpaceBeforeTag becomes SpaceAfterStar
     - SpaceBeforeAsterisk becomes SpaceBeforeStar
-- Generic MultipleStatementAlignment now aligns assignments within a block so they fit within their max padding setting
+- Generic MultipleStatementAlignment now aligns assignments within a block, so they fit within their max padding setting
     - The sniff previously requested the padding as 1 space if max padding was exceeded
     - It now aligns the assignment with surrounding assignments if it can
     - Removed property ignoreMultiline as multi-line assignments are now handled correctly and should not be ignored
@@ -4955,7 +4955,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Override the "spacing" setting in a ruleset.xml file to change
 - Squiz LowercasePHPFunctionSniff no longer throws errors for the limited set of PHP keywords it was checking
     - Add a rule for Generic.PHP.LowerCaseKeyword to your ruleset to replicate this functionality
-- Added support for the PHP 5.4 T_CALLABLE token so it can be used in lower PHP versions
+- Added support for the PHP 5.4 T_CALLABLE token, so it can be used in lower PHP versions
 - Generic EndFileNoNewlineSniff now supports checking of CSS and JS files
 - PSR2 SwitchDeclarationSniff now has a setting to specify how many spaces code should be indented
     - Default remains at 4; override the indent setting in a ruleset.xml file to change
@@ -4994,7 +4994,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Override the "spacing" setting in a ruleset.xml file to change
 - Squiz LowercasePHPFunctionSniff no longer throws errors for the limited set of PHP keywords it was checking
     - Add a rule for Generic.PHP.LowerCaseKeyword to your ruleset to replicate this functionality
-- Added support for the PHP 5.4 T_CALLABLE token so it can be used in lower PHP versions
+- Added support for the PHP 5.4 T_CALLABLE token, so it can be used in lower PHP versions
 - Generic EndFileNoNewlineSniff now supports checking of CSS and JS files
 - PSR2 SwitchDeclarationSniff now has a setting to specify how many spaces code should be indented
     - Default remains at 4; override the indent setting in a ruleset.xml file to change
@@ -6113,10 +6113,10 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - JavaScript tokenizer now identifies object definitions as a new token type and matches curly braces for them
 - JavaScript tokenizer now identifies DIV_EQUAL and MUL_EQUAL tokens
 - Improved regular expression detection in the JavaScript tokenizer
-- Improve AbstractPatternSniff support so it can listen for any token type, not just weighted tokens
+- Improve AbstractPatternSniff support, so it can listen for any token type, not just weighted tokens
 
 ### Fixed
-- Fixed Squiz DoubleQuoteUsageSniff so it works correctly with short_open_tag=Off
+- Fixed Squiz DoubleQuoteUsageSniff, so it works correctly with short_open_tag=Off
 - Fixed bug [#14409][pear-14409] : Output of warnings to log file
 - Fixed bug [#14520][pear-14520] : Notice: Undefined offset: 1 in `CodeSniffer/File.php` on line
 - Fixed bug [#14637][pear-14637] : Call to processUnknownArguments() misses second parameter $pos
@@ -6352,7 +6352,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Modified the scope map to keep checking after 3 lines for some tokens (feature request [#12561][pear-12561])
     - Those tokens that must have an opener (like T_CLASS) now keep looking until EOF
     - Other tokens (like T_FUNCTION) still stop after 3 lines for performance
-- You can now escape commas in ignore patterns so they can be matched in file names
+- You can now escape commas in ignore patterns, so they can be matched in file names
     - Thanks to [Carsten Wiedmann][pear-cwiedmann] for the patch
 - Config data is now cached in a global var so the file system is not hit so often
     - You can also set config data temporarily for the script if you are using your own external script
@@ -6667,7 +6667,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 ### Changed
 - Standard name specified with --standard command line argument is no longer case-sensitive
 - Long error and warning messages are now wrapped to 80 characters in the full error report (thanks Endre Czirbesz)
-- Shortened a lot of error and warning messages so they don't take up so much room
+- Shortened a lot of error and warning messages, so they don't take up so much room
 - Squiz FunctionCommentSniff now checks that param comments start with a capital letter and end with a full stop
 - Squiz FunctionSpacingSniff now reports incorrect lines below function on closing brace, not function keyword
 - Squiz FileCommentSniff now checks that there are no blank lines between the open PHP tag and the comment
@@ -6678,7 +6678,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed missing error when multiple statements are not aligned correctly with object operators
 - Fixed incorrect errors for some PHP special variables in Squiz ValidVariableNameSniff
 - Fixed incorrect errors for arrays that only contain other arrays in Squiz ArrayDeclarationSniff
-- Fixed bug [#9844][pear-9844] : throw new Exception(\n accidentally reported as error but it ain't
+- Fixed bug [#9844][pear-9844] : throw new Exception(\n accidentally reported as error, but it ain't
 
 [pear-9844]: https://pear.php.net/bugs/bug.php?id=9844
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1284,7 +1284,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed bug [#2621][sq-2621] : PSR12.Classes.AnonClassDeclaration.CloseBraceSameLine false positive for anon class passed as function argument
     - Thanks to [Martins Sipenko][@martinssipenko] for the patch
 - Fixed bug [#2623][sq-2623] : PSR12.ControlStructures.ControlStructureSpacing not ignoring indentation inside multi-line string arguments
-- Fixed bug [#2624][sq-2624] : PSR12.Traits.UseDeclaration doesnt apply the correct indent during auto fixing
+- Fixed bug [#2624][sq-2624] : PSR12.Traits.UseDeclaration doesn't apply the correct indent during auto fixing
 - Fixed bug [#2626][sq-2626] : PSR12.Files.FileHeader detects @var annotations as file docblocks
 - Fixed bug [#2628][sq-2628] : PSR12.Traits.UseDeclaration does not allow comments above a USE declaration
 - Fixed bug [#2632][sq-2632] : Incorrect indentation of lines starting with "static" inside closures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3107,7 +3107,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed bug [#1190][sq-1190] : phpcbf on if/else with trailing comment generates erroneous code
 - Fixed bug [#1191][sq-1191] : Javascript sniffer fails with function called "Function"
 - Fixed bug [#1203][sq-1203] : Inconsistent behavior of PHP_CodeSniffer_File::findEndOfStatement
-- Fixed bug [#1218][sq-1218] : CASE conditions using class constants named NAMESPACE/INTERFACE/TRAIT etc are incorrectly tokenized
+- Fixed bug [#1218][sq-1218] : CASE conditions using class constants named NAMESPACE/INTERFACE/TRAIT etc. are incorrectly tokenized
 - Fixed bug [#1221][sq-1221] : Indented function call with multiple closure arguments can cause scope indent error
 - Fixed bug [#1224][sq-1224] : PHPCBF fails to fix code with heredoc/nowdoc as first argument to a function
 
@@ -6567,7 +6567,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Torsten Roehr][pear-troehr] for the patch
 - Private methods in commenting sniffs and comment parser are now protected (feature request [#11087][pear-11087])
 - Added Generic LineEndingsSniff to check the EOL character of a file
-- PEAR standard now only throws one error per file for incorrect line endings (eg. /r/n)
+- PEAR standard now only throws one error per file for incorrect line endings (e.g. /r/n)
 - Command line arg -v now shows number of registered sniffs
 - Command line arg -vvv now shows list of registered sniffs
 - Squiz ControlStructureSpacingSniff no longer throws errors if the control structure is at the end of the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,7 +386,7 @@ _Nothing yet._
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Fixed bug [#3790][sq-3790] : PSR12/AnonClassDeclaration: prevent fixer creating parse error when there was no space before the open brace
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Fixed bug [#3797][sq-3797] : Tokenizer/PHP: more context sensitive keyword fixes
+- Fixed bug [#3797][sq-3797] : Tokenizer/PHP: more context-sensitive keyword fixes
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Fixed bug [#3801][sq-3801] : File::getMethodParameters(): allow for readonly promoted properties without visibility
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
@@ -580,7 +580,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Fixed bug [#3575][sq-3575] :  Squiz.Scope.MethodScope misses visibility keyword on previous line
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Fixed bug [#3604][sq-3604] :  Tokenizer/PHP: bug fix for double quoted strings using ${
+- Fixed bug [#3604][sq-3604] :  Tokenizer/PHP: bug fix for double-quoted strings using ${
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 
 [sq-3502]: https://github.com/squizlabs/PHP_CodeSniffer/issues/3502
@@ -1028,7 +1028,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Petr Bugyík][@o5] for the patch
 - Fixed bug [#2977][sq-2977] : File::isReference() does not detect return by reference for closures
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Fixed bug [#2994][sq-2994] : Generic.Formatting.DisallowMultipleStatements false positive for FOR loop with no body
+- Fixed bug [#2994][sq-2994] : Generic.Formatting.DisallowMultipleStatements false positive for FOR-loop without a body
 - Fixed bug [#3033][sq-3033] : Error generated during tokenizing of goto statements on PHP 8
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 
@@ -1597,7 +1597,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Squiz.WhiteSpace.SuperfluousWhitespace no longer throws errors for spacing between functions and properties in anon classes
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Zend.Files.ClosingTag no longer adds a semi-colon during fixing of a file that only contains a comment
+- Zend.Files.ClosingTag no longer adds a semicolon during fixing of a file that only contains a comment
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Zend.NamingConventions.ValidVariableName now supports variables inside anonymous classes correctly
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
@@ -1969,7 +1969,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - This was not consistent and so return types are now left using their original token types so they are not skipped by sniffs
         - The exception are array return types, which are tokenized as T_STRING instead of T_ARRAY, as they are for type hints
     - Sniffs referencing this token type will continue to run without error until version 4, but will not find any T_RETUTN_TYPE tokens
-    - To get the return type of a function, use the File::getMethodProperties() method, which now contains a "return_type" array index
+    - To get the return-type of a function, use the File::getMethodProperties() method, which now contains a "return_type" array index
         - This contains the return type of the function or closer, or a blank string if not specified
         - If the return type is nullable, the return type will contain the leading ?
             - A nullable_return_type array index in the return value will also be set to true
@@ -3450,7 +3450,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Fixed bug [#828][sq-828] : Null classname is tokenized as T_NULL instead of T_STRING
 - Fixed bug [#829][sq-829] : Short array argument not fixed correctly when multiple function arguments are on the same line
 - Fixed bug [#831][sq-831] : PHPCS freezes in an infinite loop under Windows if no standard is passed
-- Fixed bug [#832][sq-832] : Tokenizer does not support context sensitive parsing
+- Fixed bug [#832][sq-832] : Tokenizer does not support context-sensitive parsing
     - Thanks to [Jaroslav Hanslík][@kukulich] for the patch
 - Fixed bug [#835][sq-835] : PEAR.Functions.FunctionCallSignature broken when closure uses return types
 - Fixed bug [#838][sq-838] : CSS indentation fixer changes color codes
@@ -4590,7 +4590,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Installed standards appear when using the -i arg, and can be referenced in rulesets using only their name
     - Set paths by running: phpcs --config-set installed_paths /path/one,/path/two,...
 - PSR2 ClassDeclarationSniff now allows a list of extended interfaces to be split across multiple lines
-- Squiz DoubleQuoteUsageSniff now allows \b in double quoted strings
+- Squiz DoubleQuoteUsageSniff now allows \b in double-quoted strings
 - Generic ForbiddenFunctionsSniff now ignores object creation
     - This is a further fix for bug [#20100][pear-20100] : incorrect Function mysql() has been deprecated report
 
@@ -5553,7 +5553,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 - Add a new token T_CLOSURE that replaces T_FUNCTION if the function keyword is anonymous
 - Many Squiz sniffs no longer report errors when checking closures; they are now ignored
 - Fixed some error messages in PEAR MultiLineConditionSniff that were not using placeholders for message data
-- AbstractVariableSniff now correctly finds variable names wrapped with curly braces inside double quoted strings
+- AbstractVariableSniff now correctly finds variable names wrapped with curly braces inside double-quoted strings
 - PEAR FunctionDeclarationSniff now ignores arrays in argument default values when checking multi-line declarations
 
 ### Fixed
@@ -6665,7 +6665,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
 ## 0.4.0 - 2007-02-19
 
 ### Changed
-- Standard name specified with --standard command line argument is no longer case sensitive
+- Standard name specified with --standard command line argument is no longer case-sensitive
 - Long error and warning messages are now wrapped to 80 characters in the full error report (thanks Endre Czirbesz)
 - Shortened a lot of error and warning messages so they don't take up so much room
 - Squiz FunctionCommentSniff now checks that param comments start with a capital letter and end with a full stop

--- a/autoload.php
+++ b/autoload.php
@@ -204,7 +204,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             }
 
             // Since PHP 7.4 get_declared_classes() does not guarantee any order, making
-            // it impossible to use order to determine which is the parent an which is the child.
+            // it impossible to use order to determine which is the parent and which is the child.
             // Let's reduce the list of candidates by removing all the classes known to be "parents".
             // That way, at the end, only the "main" class just included will remain.
             $newClasses = array_reduce(

--- a/autoload.php
+++ b/autoload.php
@@ -68,7 +68,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
         {
             // Include the composer autoloader if there is one, but re-register it
             // so this autoloader runs before the composer one as we need to include
-            // all files so we can figure out what the class/interface/trait name is.
+            // all files, so we can figure out what the class/interface/trait name is.
             if (self::$composerAutoloader === null) {
                 // Make sure we don't try to load any of Composer's classes
                 // while the autoloader is being setup.

--- a/reproductions/3875.php
+++ b/reproductions/3875.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/src/Config.php
+++ b/src/Config.php
@@ -61,7 +61,7 @@ use PHP_CodeSniffer\Util\Standards;
  * @property bool       $stdin           Read content from STDIN instead of supplied files.
  * @property string     $stdinContent    Content passed directly to PHPCS on STDIN.
  * @property string     $stdinPath       The path to use for content passed on STDIN.
- * @property bool       $trackTime       Whether or not to track sniff run time.
+ * @property bool       $trackTime       Whether to track sniff run time.
  *
  * @property array<string, string>      $extensions File extensions that should be checked, and what tokenizer to use.
  *                                                  E.g., array('inc' => 'PHP');
@@ -152,7 +152,7 @@ class Config
     ];
 
     /**
-     * Whether or not to kill the process when an unknown command line arg is found.
+     * Whether to kill the process when an unknown command line arg is found.
      *
      * If FALSE, arguments that are not command line options or file/directory paths
      * will be ignored and execution will continue. These values will be stored in
@@ -364,7 +364,7 @@ class Config
      * Creates a Config object and populates it with command line values.
      *
      * @param array $cliArgs         An array of values gathered from CLI args.
-     * @param bool  $dieOnUnknownArg Whether or not to kill the process when an
+     * @param bool  $dieOnUnknownArg Whether to kill the process when an
      *                               unknown command line arg is found.
      *
      * @return void

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2260,7 +2260,7 @@ class File
      *                                  be returned.
      * @param bool             $local   If true, tokens outside the current statement
      *                                  will not be checked. IE. checking will stop
-     *                                  at the previous semi-colon found.
+     *                                  at the previous semicolon found.
      *
      * @return int|false
      * @see    findNext()
@@ -2341,7 +2341,7 @@ class File
      *                                  be returned.
      * @param bool             $local   If true, tokens outside the current statement
      *                                  will not be checked. i.e., checking will stop
-     *                                  at the next semi-colon found.
+     *                                  at the next semicolon found.
      *
      * @return int|false
      * @see    findPrevious()

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -608,7 +608,7 @@ class File
 
         $this->numTokens = count($this->tokens);
 
-        // Check for mixed line endings as these can cause tokenizer errors and we
+        // Check for mixed line endings as these can cause tokenizer errors, and we
         // should let the user know that the results they get may be incorrect.
         // This is done by removing all backslashes, removing the newline char we
         // detected, then converting newlines chars into text. If any backslashes
@@ -1861,7 +1861,7 @@ class File
                 && ($this->tokens[$ptr]['code'] === T_INTERFACE
                 || $this->tokens[$ptr]['code'] === T_ENUM)
             ) {
-                // T_VARIABLEs in interfaces/enums can actually be method arguments
+                // T_VARIABLEs in interfaces/enums can actually be method arguments,
                 // but they won't be seen as being inside the method because there
                 // are no scope openers and closers for abstract methods. If it is in
                 // parentheses, we can be pretty sure it is a method argument.
@@ -2479,7 +2479,7 @@ class File
         // If we are starting at a token that ends a scope block, skip to
         // the start and continue from there.
         // If we are starting at a token that ends a statement, skip this
-        // token so we find the true start of the statement.
+        // token, so we find the true start of the statement.
         while (isset($endTokens[$this->tokens[$start]['code']]) === true
             || (isset($this->tokens[$start]['scope_condition']) === true
             && $start === $this->tokens[$start]['scope_closer'])
@@ -2582,7 +2582,7 @@ class File
                     $prevComma = $this->findNext(T_COMMA, ($prevMatchArrow + 1), $start);
                     if ($prevComma === false) {
                         // No comma between this token and the last match arrow,
-                        // so this token exists after the arrow and we can continue
+                        // so this token exists after the arrow, and we can continue
                         // checking as normal.
                         $beforeArrow = false;
                     }

--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -84,7 +84,7 @@ abstract class ExactMatch extends Filter
     /**
      * Returns an iterator for the current entry.
      *
-     * Ensures that the disallowed files list and the allowed files list are preserved so they don't have
+     * Ensures that the disallowed files list and the allowed files list are preserved, so they don't have
      * to be generated each time.
      *
      * @return \RecursiveIterator

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -130,7 +130,7 @@ class Filter extends RecursiveFilterIterator
     /**
      * Returns an iterator for the current entry.
      *
-     * Ensures that the ignore patterns are preserved so they don't have
+     * Ensures that the ignore patterns are preserved, so they don't have
      * to be generated each time.
      *
      * @return \RecursiveIterator
@@ -146,7 +146,7 @@ class Filter extends RecursiveFilterIterator
             $this->ruleset
         );
 
-        // Set the ignore patterns so we don't have to generate them again.
+        // Set the ignore patterns, so we don't have to generate them again.
         $children->ignoreDirPatterns  = $this->ignoreDirPatterns;
         $children->ignoreFilePatterns = $this->ignoreFilePatterns;
         $children->acceptedPaths      = $this->acceptedPaths;
@@ -167,7 +167,7 @@ class Filter extends RecursiveFilterIterator
     protected function shouldProcessFile($path)
     {
         // Check that the file's extension is one we are checking.
-        // We are strict about checking the extension and we don't
+        // We are strict about checking the extension, and we don't
         // let files through with no extension or that start with a dot.
         $fileName  = basename($path);
         $fileParts = explode('.', $fileName);
@@ -175,7 +175,7 @@ class Filter extends RecursiveFilterIterator
             return false;
         }
 
-        // Checking multi-part file extensions, so need to create a
+        // Checking multipart file extensions, so need to create a
         // complete extension list and make sure one is allowed.
         $extensions = [];
         array_shift($fileParts);

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -82,7 +82,7 @@ abstract class Generator
     /**
      * Generates the documentation for a standard.
      *
-     * It's probably wise for doc generators to override this method so they
+     * It's probably wise for doc generators to override this method, so they
      * have control over how the docs are produced. Otherwise, the processSniff
      * method should be overridden to output content for each sniff.
      *

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -166,7 +166,7 @@ class HTML extends Generator
      */
     protected function printFooter()
     {
-        // Turn off errors so we don't get timezone warnings if people
+        // Turn off errors, so we don't get timezone warnings if people
         // don't have their timezone set.
         $errorLevel = error_reporting(0);
         echo '  <div class="tag-line">';

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -65,7 +65,7 @@ class Markdown extends Generator
      */
     protected function printFooter()
     {
-        // Turn off errors so we don't get timezone warnings if people
+        // Turn off errors, so we don't get timezone warnings if people
         // don't have their timezone set.
         error_reporting(0);
         echo 'Documentation generated on '.date('r');

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -138,7 +138,7 @@ class Text extends Generator
         foreach ($words as $word) {
             if (strlen($tempTitle.$word) >= 45) {
                 if (strlen($tempTitle.$word) === 45) {
-                    // Adding the extra space will push us to the edge
+                    // Adding the extra space will push us to the edge,
                     // so we are done.
                     $firstTitleLines[] = $tempTitle.$word;
                     $tempTitle         = '';
@@ -173,7 +173,7 @@ class Text extends Generator
         foreach ($words as $word) {
             if (strlen($tempTitle.$word) >= 45) {
                 if (strlen($tempTitle.$word) === 45) {
-                    // Adding the extra space will push us to the edge
+                    // Adding the extra space will push us to the edge,
                     // so we are done.
                     $secondTitleLines[] = $tempTitle.$word;
                     $tempTitle          = '';

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -82,7 +82,7 @@ class Cbf implements Report
         }
 
         if ($fixed === true) {
-            // The filename in the report may be truncated due to a basepath setting
+            // The filename in the report may be truncated due to a basepath setting,
             // but we are using it for writing here and not display,
             // so find the correct path if basepath is in use.
             $newFilename = $report['filename'].$phpcsFile->config->suffix;

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -94,7 +94,7 @@ class Code implements Report
         }
 
         // Make sure the last token in the file sits on an imaginary
-        // last line so it is easier to generate code snippets at the
+        // last line, so it is easier to generate code snippets at the
         // end of the file.
         $lineTokens[$lastLine]['end'] = $stackPtr;
 

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -312,7 +312,7 @@ class Source implements Report
                         if ($i < ($length - 1)) {
                             $next = $name[($i + 1)];
                             if (strtolower($next) === $next) {
-                                // Next char is lowercase so it is a word boundary.
+                                // Next char is lowercase, so it is a word boundary.
                                 $name[$i] = strtolower($name[$i]);
                             }
                         }

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -257,7 +257,7 @@ class Ruleset
 
         $sniffCount = count($sniffs);
 
-        // Add a dummy entry to the end so we loop one last time
+        // Add a dummy entry to the end, so we loop one last time
         // and echo out the collected info about the last standard.
         $sniffs[] = '';
 
@@ -1321,7 +1321,7 @@ class Ruleset
         $listeners = [];
 
         foreach ($files as $file) {
-            // Work out where the position of /StandardName/Sniffs/... is
+            // Work out where the position of /StandardName/Sniffs/... is,
             // so we can determine what the class will be called.
             $sniffPos = strrpos($file, DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR);
             if ($sniffPos === false) {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -944,7 +944,7 @@ class Ruleset
 
                 if ($newRef === false) {
                     // The sniff is not locally installed, so check if it is being
-                    // referenced as a remote sniff outside the install. We do this
+                    // referenced as a remote sniff outside the installation. We do this
                     // by looking through all directories where we have found ruleset
                     // files before, looking for ones for this particular standard,
                     // and seeing if it is in there.

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -101,7 +101,7 @@ class Runner
                 return 0;
             }
 
-            // Other report formats don't really make sense in interactive mode
+            // Other report formats don't really make sense in interactive mode,
             // so we hard-code the full report here and when outputting.
             // We also ensure parallel processing is off because we need to do one file at a time.
             if ($this->config->interactive === true) {
@@ -122,7 +122,7 @@ class Runner
             $toScreen = $this->reporter->printReports();
 
             // Only print timer output if no reports were
-            // printed to the screen so we don't put additional output
+            // printed to the screen, so we don't put additional output
             // in something like an XML report. If we are printing to screen,
             // the report types would have already worked out who should
             // print the timer info.
@@ -173,7 +173,7 @@ class Runner
             // values the user has set.
             $this->config = new Config();
 
-            // When processing STDIN, we can't output anything to the screen
+            // When processing STDIN, we can't output anything to the screen,
             // or it will end up mixed in with the file output.
             if ($this->config->stdin === true) {
                 $this->config->verbosity = 0;
@@ -182,7 +182,7 @@ class Runner
             // Init the run and load the rulesets to set additional config vars.
             $this->init();
 
-            // When processing STDIN, we only process one file at a time and
+            // When processing STDIN, we only process one file at a time, and
             // we don't process all the way through, so we can't use the parallel
             // running system.
             if ($this->config->stdin === true) {
@@ -525,7 +525,7 @@ class Runner
                     $debugOutput = ob_get_contents();
                     ob_end_clean();
 
-                    // Write information about the run to the filesystem
+                    // Write information about the run to the filesystem,
                     // so it can be picked up by the main process.
                     $childOutput = [
                         'totalFiles'    => $this->reporter->totalFiles,

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -430,7 +430,7 @@ abstract class AbstractPatternSniff implements Sniff
                             continue;
                         }
 
-                        // If the next token is a comment, the we need to skip the
+                        // If the next token is a comment, then we need to skip the
                         // current token as we should allow a space before a
                         // comment for readability.
                         if (isset($tokens[($stackPtr + 1)]) === true
@@ -812,7 +812,7 @@ abstract class AbstractPatternSniff implements Sniff
                     // if any, to the start of this special pattern.
                     if ($lastToken === 0) {
                         // Note that if the last special token was zero characters ago,
-                        // there will be nothing to process so we can skip this bit.
+                        // there will be nothing to process, so we can skip this bit.
                         // This happens if you have something like: EOL... in your pattern.
                         $str = '';
                     } else {

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -39,7 +39,7 @@ abstract class AbstractPatternSniff implements Sniff
     private $parsedPatterns = [];
 
     /**
-     * Tokens that this sniff wishes to process outside of the patterns.
+     * Tokens that this sniff wishes to process outside the patterns.
      *
      * @var int[]
      * @see registerSupplementary()
@@ -337,7 +337,7 @@ abstract class AbstractPatternSniff implements Sniff
                     );
 
                     if ($next === false || isset($tokens[$next][$to]) === false) {
-                        // If there was not opener, then we must be
+                        // If there was no opener, then we must be
                         // using the wrong pattern.
                         return false;
                     }
@@ -598,7 +598,7 @@ abstract class AbstractPatternSniff implements Sniff
                     if ($next === false
                         || isset($tokens[$next][$pattern[$i]['to']]) === false
                     ) {
-                        // If there was not opener, then we must
+                        // If there was no opener, then we must
                         // be using the wrong pattern.
                         return false;
                     }

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -47,7 +47,7 @@ abstract class AbstractScopeSniff implements Sniff
     private $scopeTokens = [];
 
     /**
-     * True if this test should fire on tokens outside of the scope.
+     * True if this test should fire on tokens outside the scope.
      *
      * @var boolean
      */

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -209,14 +209,14 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
 
 
     /**
-     * Called to process variables found in double quoted strings or heredocs.
+     * Called to process variables found in double-quoted strings or heredocs.
      *
      * Note that there may be more than one variable in the string, which will
      * result only in one call for the string or one call per line for heredocs.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this
      *                                               token was found.
-     * @param int                         $stackPtr  The position where the double quoted
+     * @param int                         $stackPtr  The position where the double-quoted
      *                                               string was found.
      *
      * @return void|int Optionally returns a stack pointer. The sniff will not be

--- a/src/Standards/Generic/Docs/CodeAnalysis/EmptyStatementStandard.xml
+++ b/src/Standards/Generic/Docs/CodeAnalysis/EmptyStatementStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Empty Statements">
     <standard>
     <![CDATA[
-    Control Structures must have at least one statement inside of the body.
+    Control Structures must have at least one statement inside the body.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -111,7 +111,7 @@ class ArrayIndentSniff extends AbstractArraySniff
 
             $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($start - 1), null, true);
             if ($tokens[$prev]['line'] === $tokens[$start]['line']) {
-                // This index isn't the only content on the line
+                // This index isn't the only content on the line,
                 // so we can't check indent rules.
                 continue;
             }

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -2,7 +2,7 @@
 /**
  * Checks against empty PHP statements.
  *
- * - Check against two semi-colons with no executable code in between.
+ * - Check against two semicolons with no executable code in between.
  * - Check against an empty PHP open - close tag combination.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
@@ -76,7 +76,7 @@ class EmptyPHPStatementSniff implements Sniff
                     return;
                 }
 
-                // Else, it's something like `if (foo) {};` and the semi-colon is not needed.
+                // Else, it's something like `if (foo) {};` and the semicolon is not needed.
             }
 
             if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
@@ -101,7 +101,7 @@ class EmptyPHPStatementSniff implements Sniff
                 if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG
                     || $tokens[$prevNonEmpty]['code'] === T_OPEN_TAG_WITH_ECHO
                 ) {
-                    // Check for superfluous whitespace after the semi-colon which will be
+                    // Check for superfluous whitespace after the semicolon which will be
                     // removed as the `<?php ` open tag token already contains whitespace,
                     // either a space or a new line.
                     if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -3,7 +3,7 @@
  * This sniff class detected empty statement.
  *
  * This sniff implements the common algorithm for empty statement body detection.
- * A body is considered as empty if it is completely empty or it only contains
+ * A body is considered as empty if it is completely empty, or it only contains
  * whitespace characters and/or comments.
  *
  * <code>

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
@@ -84,7 +84,7 @@ class ForLoopWithTestFunctionCallSniff implements Sniff
                 continue;
             }
 
-            // Find next non empty token, if it is a open parenthesis we have a
+            // Find next non-empty token, if it is an open parenthesis we have a
             // function call.
             $index = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Detects unnecessary final modifiers inside of final classes.
+ * Detects unnecessary final modifiers inside final classes.
  *
  * This rule is based on the PMD rule catalogue. The Unnecessary Final Modifier
- * sniff detects the use of the final modifier inside of a final class which
+ * sniff detects the use of the final modifier inside a final class which
  * is unnecessary.
  *
  * <code>

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -108,7 +108,7 @@ class UselessOverridingMethodSniff implements Sniff
             return;
         }
 
-        // Find next non empty token index, should be double colon.
+        // Find next non-empty token index, should be double colon.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code.
@@ -116,7 +116,7 @@ class UselessOverridingMethodSniff implements Sniff
             return;
         }
 
-        // Find next non empty token index, should be the name of the method being called.
+        // Find next non-empty token index, should be the name of the method being called.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code or other method.
@@ -124,7 +124,7 @@ class UselessOverridingMethodSniff implements Sniff
             return;
         }
 
-        // Find next non empty token index, should be the open parenthesis.
+        // Find next non-empty token index, should be the open parenthesis.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
 
         // Skip for invalid code.

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -107,7 +107,7 @@ class DisallowYodaConditionsSniff implements Sniff
                     return;
                 }
 
-                // If there is nothing inside the parenthesis, it it not a Yoda.
+                // If there is nothing inside the parenthesis, it is not a Yoda.
                 $opener = $tokens[$previousIndex]['parenthesis_opener'];
                 $prev   = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousIndex - 1), ($opener + 1), true);
                 if ($prev === false) {

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -37,7 +37,7 @@ class LineLengthSniff implements Sniff
     public $absoluteLineLimit = 100;
 
     /**
-     * Whether or not to ignore trailing comments.
+     * Whether to ignore trailing comments.
      *
      * This has the effect of also ignoring all lines
      * that only contain comments.

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -242,7 +242,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                     continue;
                 }
 
-                // Make sure it is not assigned inside a condition (eg. IF, FOR).
+                // Make sure it is not assigned inside a condition (e.g. IF, FOR).
                 if (isset($tokens[$assign]['nested_parenthesis']) === true) {
                     // If the parenthesis is on the same line as the assignment,
                     // then it should be ignored as it is specifically being grouped.

--- a/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -52,7 +52,7 @@ class CallTimePassByReferenceSniff implements Sniff
 
         // Skip tokens that are the names of functions or classes
         // within their definitions. For example: function myFunction...
-        // "myFunction" is T_STRING but we should skip because it is not a
+        // "myFunction" is T_STRING, but we should skip because it is not a
         // function or method *call*.
         $prevCode = $tokens[$prev]['code'];
         if ($prevCode === T_FUNCTION || $prevCode === T_CLASS) {

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -55,7 +55,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
         // Skip tokens that are the names of functions or classes
         // within their definitions. For example:
         // function myFunction...
-        // "myFunction" is T_STRING but we should skip because it is not a
+        // "myFunction" is T_STRING, but we should skip because it is not a
         // function or method *call*.
         $functionName    = $stackPtr;
         $ignoreTokens    = Tokens::$emptyTokens;

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -186,7 +186,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
         }
 
         // We need to actually find the first piece of content on this line,
-        // as if this is a method with tokens before it (public, static etc)
+        // as if this is a method with tokens before it (public, static etc.)
         // or an if with an else before it, then we need to start the scope
         // checking from there, rather than the current token.
         $lineStart = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);

--- a/src/Standards/Generic/Sniffs/NamingConventions/AbstractClassNamePrefixSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/AbstractClassNamePrefixSniff.php
@@ -39,7 +39,7 @@ class AbstractClassNamePrefixSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         if ($phpcsFile->getClassProperties($stackPtr)['is_abstract'] === false) {
-            // This class is not abstract so we don't need to check it.
+            // This class is not abstract, so we don't need to check it.
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
@@ -76,7 +76,7 @@ class CharacterBeforePHPOpeningTagSniff implements Sniff
             $phpcsFile->addError($error, $stackPtr, 'Found');
         }
 
-        // Skip the rest of the file so we don't pick up additional
+        // Skip the rest of the file, so we don't pick up additional
         // open tags, typically embedded in HTML.
         return $phpcsFile->numTokens;
 

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -121,7 +121,7 @@ class LowerCaseConstantSniff implements Sniff
          * Skip over type declarations for properties.
          *
          * Note: for other uses of the visibility modifiers (functions, constants, trait use),
-         * nothing relevant will be skipped as the next non-empty token will be an "non-skippable"
+         * nothing relevant will be skipped as the next non-empty token will be a "non-skippable"
          * one.
          * Functions are handled separately below (and then skip to their scope opener), so
          * this should also not cause any confusion for constructor property promotion.

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -156,7 +156,7 @@ class DisallowTabIndentSniff implements Sniff
                     }
                 }//end if
             } else {
-                // Look for tabs so we can report and replace, but don't
+                // Look for tabs, so we can report and replace, but don't
                 // record any metrics about them because they aren't
                 // line indent tokens.
                 if ($foundTabs > 0) {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -901,7 +901,7 @@ class ScopeIndentSniff implements Sniff
                 $exact = true;
             }
 
-            // Open PHP tags needs to be indented to exact column positions
+            // Open PHP tags needs to be indented to exact column positions,
             // so they don't cause problems with indent checks for the code
             // within them, but they don't need to line up with the current indent
             // in most cases.
@@ -941,7 +941,7 @@ class ScopeIndentSniff implements Sniff
 
             // Special case for ELSE statements that are not on the same
             // line as the previous IF statements closing brace. They still need
-            // to have the same indent or it will break code after the block.
+            // to have the same indent, or it will break code after the block.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_ELSE) {
                 $exact = true;
             }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -895,7 +895,7 @@ class ScopeIndentSniff implements Sniff
                 }//end if
             }//end if
 
-            // JS property indentation has to be exact or else if will break
+            // JS property indentation has to be exact or else it will break
             // things like function and object indentation.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_PROPERTY) {
                 $exact = true;

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semi-colons without executable code between them.
+ * Test empty statement: two consecutive semicolons without executable code between them.
  */
 function_call(); // OK.
 
@@ -50,7 +50,7 @@ function_call();
 <input name="<?= ; ?>" /> <!-- Bad. -->
 
 <?php
-// Guard against false positives for two consecutive semi-colons in a for statement.
+// Guard against false positives for two consecutive semicolons in a for statement.
 for ( $i = 0; ; $i++ ) {}
 
 // Test for useless semi-colons

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
@@ -11,7 +11,7 @@ if (($reallyLongVarName === true) || (is_array($anotherLongVarName) === false)) 
 }
 
 
-// This line is is too long.
+// This line is too long.
 if (($anotherReallyLongVarName === true) || (is_array($anotherReallyLongVarName) === false)) {
     // Do something.
 }

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.4.inc
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.4.inc
@@ -24,7 +24,7 @@ should also be detected.
 EOT;
 >>>>>>> ref/heads/other-branchname
 
-// Merge conflict starter outside with a closer inside of the heredoc.
+// Merge conflict starter outside with a closer inside the heredoc.
 // This breaks the tokenizer.
 <<<<<<< HEAD
 $string =

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -114,7 +114,7 @@ class IncludeSystemSniff extends AbstractScopeSniff
             $name = $this->getIncludedClassFromToken($phpcsFile, $tokens, $i);
             if ($name !== false) {
                 $includedClasses[$name] = true;
-                // Special case for Widgets cause they are, well, special.
+                // Special case for Widgets because they are, well, special.
             } else if (strtolower($tokens[$i]['content']) === 'includewidget') {
                 $typeName = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($i + 1));
                 $typeName = trim($tokens[$typeName]['content'], " '");
@@ -257,7 +257,7 @@ class IncludeSystemSniff extends AbstractScopeSniff
             $name = $this->getIncludedClassFromToken($phpcsFile, $tokens, $i);
             if ($name !== false) {
                 $includedClasses[$name] = true;
-                // Special case for Widgets cause they are, well, special.
+                // Special case for Widgets because they are, well, special.
             } else if (strtolower($tokens[$i]['content']) === 'includewidget') {
                 $typeName = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, ($i + 1));
                 $typeName = trim($tokens[$typeName]['content'], " '");

--- a/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
+++ b/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
@@ -89,7 +89,7 @@ class IncludingFileSniff implements Sniff
         // it's conditional.
         $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset(Tokens::$assignmentTokens[$tokens[$previous]['code']]) === true) {
-            // The have assigned the return value to it, so its conditional.
+            // They have assigned the return value to it, so its conditional.
             $inCondition = true;
         }
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -49,7 +49,7 @@ class ScopeClosingBraceSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // If this is an inline condition (ie. there is no scope opener), then
+        // If this is an inline condition (i.e. there is no scope opener), then
         // return, as this is not a new scope.
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             return;
@@ -68,7 +68,7 @@ class ScopeClosingBraceSniff implements Sniff
         }
 
         // We need to actually find the first piece of content on this line,
-        // because if this is a method with tokens before it (public, static etc)
+        // because if this is a method with tokens before it (public, static etc.)
         // or an if with an else before it, then we need to start the scope
         // checking from there, rather than the current token.
         $lineStart = ($stackPtr - 1);

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -59,7 +59,7 @@ class ScopeClosingBraceSniff implements Sniff
         $scopeEnd   = $tokens[$stackPtr]['scope_closer'];
 
         // If the scope closer doesn't think it belongs to this scope opener
-        // then the opener is sharing its closer with other tokens. We only
+        // then the opener is sharing it's closer with other tokens. We only
         // want to process the closer once, so skip this one.
         if (isset($tokens[$scopeEnd]['scope_condition']) === false
             || $tokens[$scopeEnd]['scope_condition'] !== $stackPtr
@@ -92,7 +92,7 @@ class ScopeClosingBraceSniff implements Sniff
             }
         }
 
-        // Check that the closing brace is on it's own line.
+        // Check that the closing brace is on its own line.
         for ($lastContent = ($scopeEnd - 1); $lastContent > $scopeStart; $lastContent--) {
             if ($tokens[$lastContent]['code'] === T_WHITESPACE || $tokens[$lastContent]['code'] === T_OPEN_TAG) {
                 continue;

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.1.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.1.inc
@@ -17,7 +17,7 @@ declare(encoding='utf-8');
 * that is available through the world-wide-web at the following URI:
 * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
 * the PHP License and are unable to obtain it through the web, please
-* send a note to license@php.net so we can mail you a copy immediately.
+* send a note to license@php.net, so we can mail you a copy immediately.
 * @category   _wrong_category
 * @package    PHP_CodeSniffer
 * @package    ADDITIONAL PACKAGE TAG

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -167,7 +167,7 @@ class DeclareStatementSniff implements Sniff
                 }
             } else if ($tokens[$token]['type'] === 'T_CLOSE_TAG') {
                 if ($tokens[($parenthesis)]['line'] !== $tokens[$token]['line']) {
-                    // Close tag must be on the same line..
+                    // Close tag must be on the same line.
                     $error = 'The close tag must be on the same line as the declare statement';
                     $fix   = $phpcsFile->addFixableError($error, $parenthesis, 'CloseTagOnNewLine');
                     if ($fix === true) {

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -401,7 +401,7 @@ class FileHeaderSniff implements Sniff
             if ($orderedType === false) {
                 // We didn't find the block type in the rest of the
                 // ordered array, so it is out of place.
-                // Error and reset the array to the correct position
+                // Error and reset the array to the correct position,
                 // so we can check the next block.
                 reset($blockOrder);
                 $prevValidType = 'tag';

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -190,7 +190,7 @@ class FileHeaderSniff implements Sniff
                     && isset(Tokens::$methodPrefixes[$tokens[$docToken]['code']]) === false
                     && $tokens[$docToken]['code'] !== T_READONLY
                 ) {
-                    // Check for an @var annotation.
+                    // Check for a @var annotation.
                     $annotation = false;
                     for ($i = $next; $i < $end; $i++) {
                         if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG

--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -105,7 +105,7 @@
     <!-- checked by PSR12.Namespaces.CompoundNamespaceDepth -->
 
     <!-- When wishing to declare strict types in files containing markup outside PHP opening and closing tags, the declaration MUST be on the first line of the file and include an opening PHP tag, the strict types declaration and closing tag. -->
-    <!-- Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semi-colon terminator). -->
+    <!-- Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semicolon terminator). -->
     <!-- Block declare statements are allowed and MUST be formatted as below. -->
     <!-- checked by PSR12.Files.DeclareStatement -->
 

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -519,7 +519,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         }//end if
 
         if ($tokens[$stackPtr]['code'] !== T_ANON_CLASS) {
-            // Check the closing brace is on it's own line, but allow
+            // Check the closing brace is on its own line, but allow
             // for comments like "//end class".
             $ignoreTokens   = Tokens::$phpcsCommentTokens;
             $ignoreTokens[] = T_WHITESPACE;

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -37,7 +37,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         }
 
         // Detect multiple properties defined at the same time. Throw an error
-        // for this, but also only process the first property in the list so we don't
+        // for this, but also only process the first property in the list, so we don't
         // repeat errors.
         $find   = Tokens::$scopeModifiers;
         $find[] = T_VARIABLE;

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -333,7 +333,7 @@ class SwitchDeclarationSniff implements Sniff
                     $endOfSwitch     = $tokens[$prevToken]['scope_closer'];
                     $nextCase        = $prevToken;
 
-                    // We look for a terminating statement within every blocks.
+                    // We look for a terminating statement within every block.
                     while (($nextCase = $this->findNextCase($phpcsFile, ($nextCase + 1), $endOfSwitch)) !== false) {
                         if ($tokens[$nextCase]['code'] === T_DEFAULT) {
                             $hasDefaultBlock = true;

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -152,7 +152,7 @@ class UseDeclarationSniff implements Sniff
                             }
                         } while ($next !== false);
 
-                        // Remove closing curly,semi-colon and any whitespace between last child and closing curly.
+                        // Remove closing curly, semicolon and any whitespace between last child and closing curly.
                         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
                         if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
                             // Parse error, forgotten semi-colon.

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -48,7 +48,7 @@ class ArrayDeclarationSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_ARRAY) {
             $phpcsFile->recordMetric($stackPtr, 'Short array syntax used', 'no');
 
-            // Array keyword should be lower case.
+            // Array keyword should be lowercase.
             if ($tokens[$stackPtr]['content'] !== strtolower($tokens[$stackPtr]['content'])) {
                 if ($tokens[$stackPtr]['content'] === strtoupper($tokens[$stackPtr]['content'])) {
                     $phpcsFile->recordMetric($stackPtr, 'Array keyword case', 'upper');
@@ -718,7 +718,7 @@ class ArrayDeclarationSniff implements Sniff
             a double arrow is not aligned, and when a value is not
             aligned correctly.
             If an error is found in one of the above areas, then errors
-            are not reported for the rest of the line to avoid reporting
+            will not be reported for the rest of the line to avoid reporting
             spaces and columns incorrectly. Often fixing the first
             problem will fix the other 2 anyway.
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -637,7 +637,7 @@ class ArrayDeclarationSniff implements Sniff
 
             foreach ($indices as $valuePosition => $value) {
                 if (empty($value['value']) === true) {
-                    // Array was malformed and we couldn't figure out
+                    // Array was malformed, and we couldn't figure out
                     // the array value correctly, so we have to ignore it.
                     // Other parts of this sniff will correct the error.
                     continue;

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -80,7 +80,7 @@ class DuplicateClassDefinitionSniff implements Sniff
                 $scope = 'main';
             }
 
-            // Create a sorted name for the class so we can compare classes
+            // Create a sorted name for the class, so we can compare classes
             // even when the individual names are all over the place.
             $name = '';
             for ($i = ($prev + 1); $i < $next; $i++) {

--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Ensure each style definition has a semi-colon and it is spaced correctly.
+ * Ensure each style definition has a semicolon and it is spaced correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -73,7 +73,7 @@ class SemicolonSpacingSniff implements Sniff
             return;
         }
 
-        // There is a semi-colon, so now find the last token in the statement.
+        // There is a semicolon, so now find the last token in the statement.
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($endOfThisStatement - 1), null, true);
         $found        = $tokens[($endOfThisStatement - 1)]['length'];
         if ($tokens[$prevNonEmpty]['line'] !== $tokens[$endOfThisStatement]['line']) {

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -38,7 +38,7 @@ class ClosingDeclarationCommentSniff implements Sniff
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens..
+     *                                               stack passed in $tokens.
      *
      * @return void
      */

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -296,7 +296,7 @@ class InlineCommentSniff implements Sniff
 
             if ($tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
                 // If this inline comment is followed by a docblock,
-                // ignore spacing as docblock/function etc spacing rules
+                // ignore spacing as docblock/function etc. spacing rules
                 // are likely to conflict with our rules.
                 return ($lastCommentToken + 1);
             }

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -156,7 +156,7 @@ class LongConditionClosingCommentSniff implements Sniff
         }
 
         if ($startCondition['code'] === T_MATCH) {
-            // Move the stackPtr to after the semi-colon/comma if there is one.
+            // Move the stackPtr to after the semicolon/comma if there is one.
             $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
             if ($nextToken !== false
                 && ($tokens[$nextToken]['code'] === T_SEMICOLON

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -170,7 +170,7 @@ class VariableCommentSniff extends AbstractVariableSniff
      * Not required for this sniff.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this token was found.
-     * @param int                         $stackPtr  The position where the double quoted
+     * @param int                         $stackPtr  The position where the double-quoted
      *                                               string was found.
      *
      * @return void
@@ -182,12 +182,12 @@ class VariableCommentSniff extends AbstractVariableSniff
 
 
     /**
-     * Called to process variables found in double quoted strings.
+     * Called to process variables found in double-quoted strings.
      *
      * Not required for this sniff.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this token was found.
-     * @param int                         $stackPtr  The position where the double quoted
+     * @param int                         $stackPtr  The position where the double-quoted
      *                                               string was found.
      *
      * @return void

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -164,7 +164,7 @@ class OperatorBracketSniff implements Sniff
 
                 if ($prevCode === T_ISSET) {
                     // This operation is inside an isset() call, but has
-                    // no bracket of it's own.
+                    // no bracket of its own.
                     break;
                 }
 

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -53,7 +53,7 @@ class OperatorBracketSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         if ($phpcsFile->tokenizerType === 'JS' && $tokens[$stackPtr]['code'] === T_PLUS) {
-            // JavaScript uses the plus operator for string concatenation as well
+            // JavaScript uses the plus operator for string concatenation as well,
             // so we cannot accurately determine if it is a string concat or addition.
             // So just ignore it.
             return;
@@ -206,7 +206,7 @@ class OperatorBracketSniff implements Sniff
 
                 if (in_array($prevCode, Tokens::$scopeOpeners, true) === true) {
                     // This operation is inside a control structure like FOREACH
-                    // or IF, but has no bracket of it's own.
+                    // or IF, but has no bracket of its own.
                     // The only control structures allowed to do this are SWITCH and MATCH.
                     if ($prevCode !== T_SWITCH && $prevCode !== T_MATCH) {
                         break;

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -32,7 +32,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        // If it's a php reserved var, then its ok.
+        // If it's a php reserved var, then it's ok.
         if (isset($this->phpReservedVars[$varName]) === true) {
             return;
         }
@@ -171,7 +171,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
 
         if (preg_match_all('|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
-                // If it's a php reserved var, then its ok.
+                // If it's a php reserved var, then it's ok.
                 if (isset($this->phpReservedVars[$varName]) === true) {
                     continue;
                 }

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -157,10 +157,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
 
 
     /**
-     * Processes the variable found within a double quoted string.
+     * Processes the variable found within a double-quoted string.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the double quoted
+     * @param int                         $stackPtr  The position of the double-quoted
      *                                               string.
      *
      * @return void

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -203,7 +203,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                     $foundOps = $requiredOps;
                 }
 
-                // If we get to here and we have not found the right number of
+                // If we get to here, and we have not found the right number of
                 // comparison operators, then we must have had an implicit
                 // true operation i.e., if ($a) instead of the required
                 // if ($a === true), so let's add an error.

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -70,7 +70,7 @@ class IncrementDecrementUsageSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Work out where the variable is so we know where to
+        // Work out where the variable is, so we know where to
         // start looking for other operators.
         if ($tokens[($stackPtr - 1)]['code'] === T_VARIABLE
             || ($tokens[($stackPtr - 1)]['code'] === T_STRING

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -265,7 +265,7 @@ class CommentedOutCodeSniff implements Sniff
         }
 
         // Ignore comments with only two or less non-whitespace tokens.
-        // Sample size too small for a reliably determination.
+        // Sample size too small for a reliable determination.
         if ($numNonWhitespace <= 2) {
             return ($lastCommentBlockToken + 1);
         }

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -104,7 +104,7 @@ class CommentedOutCodeSniff implements Sniff
             }
 
             /*
-                Trim as much off the comment as possible so we don't
+                Trim as much off the comment as possible, so we don't
                 have additional whitespace tokens or comment tokens
             */
 

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -471,7 +471,7 @@ class EmbeddedPhpSniff implements Sniff
 
 
     /**
-     * Report and fix an set of empty PHP tags.
+     * Report and fix a set of empty PHP tags.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the current token in the

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -17,7 +17,7 @@ class LowercasePHPFunctionsSniff implements Sniff
 {
 
     /**
-     * String -> int hash map of all php built in function names
+     * String -> int hash map of all php built-in function names
      *
      * @var array
      */

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -72,12 +72,12 @@ class DoubleQuoteUsageSniff implements Sniff
 
         $skipTo = ($lastStringToken + 1);
 
-        // Check if it's a double quoted string.
+        // Check if it's a double-quoted string.
         if ($workingString[0] !== '"' || substr($workingString, -1) !== '"') {
             return $skipTo;
         }
 
-        // The use of variables in double quoted strings is not allowed.
+        // The use of variables in double-quoted strings is not allowed.
         if ($tokens[$stackPtr]['code'] === T_DOUBLE_QUOTED_STRING) {
             $stringTokens = token_get_all('<?php '.$workingString);
             foreach ($stringTokens as $token) {

--- a/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
@@ -51,7 +51,7 @@ class EchoedStringsSniff implements Sniff
 
         $end = $phpcsFile->findNext([T_SEMICOLON, T_CLOSE_TAG], $stackPtr, null, false);
 
-        // If the token before the semi-colon is not a closing parenthesis, then we are not concerned.
+        // If the token before the semicolon is not a closing parenthesis, then we are not concerned.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($end - 1), null, true);
         if ($tokens[$prev]['code'] !== T_CLOSE_PARENTHESIS) {
             $phpcsFile->recordMetric($stackPtr, 'Brackets around echoed strings', 'no');

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -299,7 +299,7 @@ class ControlStructureSpacingSniff implements Sniff
             $owner = $tokens[$trailingContent]['scope_condition'];
             if ($tokens[$owner]['code'] === T_FUNCTION) {
                 // The next content is the closing brace of a function
-                // so normal function rules apply and we can ignore it.
+                // so normal function rules apply, and we can ignore it.
                 return;
             }
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -58,7 +58,7 @@ class OperatorSpacingSniff implements Sniff
     public function register()
     {
         /*
-            First we setup an array of all the tokens that can come before
+            First we set up an array of all the tokens that can come before
             a T_MINUS or T_PLUS token to indicate that the token is not being
             used as an operator.
         */

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -257,7 +257,7 @@ class OperatorSpacingSniff implements Sniff
 
                 if (isset(Tokens::$commentTokens[$tokens[$prevNonWhitespace]['code']]) === true) {
                     // Throw a non-fixable error if the token on the previous line is a comment token,
-                    // as in that case it's not for the sniff to decide where the comment should be moved to
+                    // as in that case it's not for the sniff to decide where the comment should be moved to,
                     // and it would get us into unfixable situations as the new line char is included
                     // in the contents of the comment token.
                     $phpcsFile->addError($error, $stackPtr, 'SpacingBefore', $data);

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -42,14 +42,14 @@ class ScopeClosingBraceSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // If this is an inline condition (ie. there is no scope opener), then
+        // If this is an inline condition (i.e. there is no scope opener), then
         // return, as this is not a new scope.
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             return;
         }
 
         // We need to actually find the first piece of content on this line,
-        // as if this is a method with tokens before it (public, static etc)
+        // as if this is a method with tokens before it (public, static etc.)
         // or an if with an else before it, then we need to start the scope
         // checking from there, rather than the current token.
         $lineStart = $phpcsFile->findFirstOnLine([T_WHITESPACE, T_INLINE_HTML], $stackPtr, true);

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -63,7 +63,7 @@ class ScopeClosingBraceSniff implements Sniff
         $scopeStart  = $tokens[$stackPtr]['scope_opener'];
         $scopeEnd    = $tokens[$stackPtr]['scope_closer'];
 
-        // Check that the closing brace is on it's own line.
+        // Check that the closing brace is on its own line.
         $lastContent = $phpcsFile->findPrevious([T_INLINE_HTML, T_WHITESPACE, T_OPEN_TAG], ($scopeEnd - 1), $scopeStart, true);
         for ($lineStart = $scopeEnd; $tokens[$lineStart]['column'] > 1; $lineStart--);
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -59,7 +59,7 @@ class SemicolonSpacingSniff implements Sniff
 
         $nonSpace = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 2), null, true);
 
-        // Detect whether this is a semi-colon for a condition in a `for()` control structure.
+        // Detect whether this is a semicolon for a condition in a `for()` control structure.
         $forCondition = false;
         if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
             $nestedParens     = $tokens[$stackPtr]['nested_parenthesis'];

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
@@ -8,7 +8,7 @@ trait ClassFileNameUnitTest {}
 enum ClassFileNameUnitTest {}
 enum ClassFileNameUnitTest: int {}
 
-// Invalid filename matching class name (case sensitive).
+// Invalid filename matching class name (case-sensitive).
 class classFileNameUnitTest {}
 class classfilenameunittest {}
 class CLASSFILENAMEUNITTEST {}

--- a/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.inc
@@ -17,7 +17,7 @@ try {
     // Try something.
     $variable = 'string';
 } catch (Exception $e) {
-    // Dont want to do anything.
+    // Don't want to do anything.
 }
 
 try {

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc
@@ -17,7 +17,7 @@
 * that is available through the world-wide-web at the following URI:
 * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
 * the PHP License and are unable to obtain it through the web, please
-* send a note to license@php.net so we can mail you a copy immediately.
+* send a note to license@php.net, so we can mail you a copy immediately.
 * @package    SquizCMS
 * @package    ADDITIONAL PACKAGE TAG
 * @subpkg     not_camelcased

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.js
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.js
@@ -17,7 +17,7 @@
 * that is available through the world-wide-web at the following URI:
 * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
 * the PHP License and are unable to obtain it through the web, please
-* send a note to license@php.net so we can mail you a copy immediately.
+* send a note to license@php.net, so we can mail you a copy immediately.
 * @package    SquizCMS
 * @package    ADDITIONAL PACKAGE TAG
 * @subpkg     not_camelcased

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.9.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.9.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * This should not be recognized as a file comment, but as a enum comment.
+ * This should not be recognized as a file comment, but as an enum comment.
  *
  * @package    Package
  * @subpackage Subpackage

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc
@@ -111,7 +111,7 @@ for (
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
 for ($i = function() { return $this->i; }; $i < function() { return $this->max; }  ;   $i++) {}
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
@@ -117,7 +117,7 @@ for (
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for (i = function() {self.widgetLoaded(widget.id)  ;  }; i < function() {self.widgetLoaded(widget.id);}; i++) {}
 for (i = function() {self.widgetLoaded(widget.id);}; i < function() {self.widgetLoaded(widget.id);}  ;   i++) {}
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
@@ -18,14 +18,14 @@ $sum = $a /* + $b
     + $c */ ;
 
 /*
- * Test that the sniff does *not* throw incorrect errors for semi-colons in
+ * Test that the sniff does *not* throw incorrect errors for semicolons in
  * "empty" parts of a `for` control structure.
  */
 for ($i = 1; ; $i++) {}
 for ( ; $ptr >= 0; $ptr-- ) {}
 for ( ; ; ) {}
 
-// But it should when the semi-colon in a `for` follows a comment (but shouldn't move the semi-colon).
+// But it should when the semicolon in a `for` follows a comment (but shouldn't move the semicolon).
 for ( /* Deliberately left empty. */ ; $ptr >= 0; $ptr-- ) {}
 for ( $i = 1 ; /* Deliberately left empty. */ ; $i++ ) {}
 

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -32,7 +32,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        // If it's a php reserved var, then its ok.
+        // If it's a php reserved var, then it's ok.
         if (isset($this->phpReservedVars[$varName]) === true) {
             return;
         }
@@ -173,7 +173,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
 
         if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
-                // If it's a php reserved var, then its ok.
+                // If it's a php reserved var, then it's ok.
                 if (isset($this->phpReservedVars[$varName]) === true) {
                     continue;
                 }

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -159,10 +159,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
 
 
     /**
-     * Processes the variable found within a double quoted string.
+     * Processes the variable found within a double-quoted string.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the double quoted
+     * @param int                         $stackPtr  The position of the double-quoted
      *                                               string.
      *
      * @return void

--- a/src/Tokenizers/CSS.php
+++ b/src/Tokenizers/CSS.php
@@ -80,8 +80,8 @@ class CSS extends PHP
         for ($stackPtr = 1; $stackPtr < $numTokens; $stackPtr++) {
             $token = $tokens[$stackPtr];
 
-            // CSS files don't have lists, breaks etc, so convert these to
-            // standard strings early so they can be converted into T_STYLE
+            // CSS files don't have lists, breaks etc., so convert these to
+            // standard strings early, so they can be converted into T_STYLE
             // tokens and joined with other strings if needed.
             if ($token['code'] === T_BREAK
                 || $token['code'] === T_LIST
@@ -140,7 +140,7 @@ class CSS extends PHP
             }//end if
 
             if ($token['code'] === T_GOTO_LABEL) {
-                // Convert these back to T_STRING followed by T_COLON so we can
+                // Convert these back to T_STRING followed by T_COLON, so we can
                 // more easily process style definitions.
                 $finalTokens[$newStackPtr] = [
                     'type'    => 'T_STRING',
@@ -441,7 +441,7 @@ class CSS extends PHP
                     $stackPtr = $i;
 
                     // If the content inside the "url()" is in double quotes
-                    // there will only be one token and so we don't have to do
+                    // there will only be one token, and so we don't have to do
                     // anything except change its type. If it is not empty,
                     // we need to do some token merging.
                     $finalTokens[($x + 1)]['type'] = 'T_URL';

--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -61,7 +61,7 @@ class Comment
         }
 
         /*
-            Strip off the close tag so it doesn't interfere with any
+            Strip off the close tag, so it doesn't interfere with any
             of our comment line processing. The token will be added to the
             stack just before we return it.
         */

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -995,7 +995,7 @@ class JS extends Tokenizer
 
         while (preg_match('|[a-zA-Z]|', $chars[($next + 1)]) !== 0) {
             // The token directly after the end of the regex can
-            // be modifiers like global and case insensitive
+            // be modifiers like global and case-insensitive
             // (.e.g, /pattern/gi).
             $next++;
         }

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -498,7 +498,7 @@ class JS extends Tokenizer
                         }
 
                         if (isset($this->tokenValues[strtolower($charBuffer)]) === true) {
-                            // We've found something larger that matches
+                            // We've found something larger that matches,
                             // so we can ignore this char. Except for 1 very specific
                             // case where a comment like /**/ needs to tokenize as
                             // T_COMMENT and not T_DOC_COMMENT.
@@ -589,7 +589,7 @@ class JS extends Tokenizer
                     }
 
                     if (isset($this->tokenValues[strtolower($charBuffer)]) === true) {
-                        // We've found something larger that matches
+                        // We've found something larger that matches,
                         // so we can ignore this char.
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             $type = $this->tokenValues[strtolower($charBuffer)];
@@ -737,7 +737,7 @@ class JS extends Tokenizer
 
         /*
             Now that we have done some basic tokenizing, we need to
-            modify the tokens to join some together and split some apart
+            modify the tokens to join some together and split some apart,
             so they match what the PHP tokenizer does.
         */
 
@@ -765,7 +765,7 @@ class JS extends Tokenizer
                         && strpos($tokenContent, $this->eolChar) !== false
                     ) {
                         // A null end token means the comment ends at the end of
-                        // the line so we look for newlines and split the token.
+                        // the line, so we look for newlines and split the token.
                         $tokens[$stackPtr]['content'] = substr(
                             $tokenContent,
                             (strpos($tokenContent, $this->eolChar) + strlen($this->eolChar))

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1200,7 +1200,7 @@ class PHP extends Tokenizer
             /*
                 As of PHP 8.0 fully qualified, partially qualified and namespace relative
                 identifier names are tokenized differently.
-                This "undoes" the new tokenization so the tokenization will be the same in
+                This "undoes" the new tokenization so the tokenization will be the same
                 in PHP 5, 7 and 8.
             */
 
@@ -1538,7 +1538,7 @@ class PHP extends Tokenizer
                     && $tokens[($stackPtr + 2)][0] === T_STRING
                     && strtolower($tokens[($stackPtr + 2)][1]) === 'from'
                 ) {
-                    // Could be multi-line, so just just the token stack.
+                    // Could be multi-line, so just the token stack.
                     $token[0]  = T_YIELD_FROM;
                     $token[1] .= $tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -604,7 +604,7 @@ class PHP extends Tokenizer
             }
 
             /*
-                Tokenize context sensitive keyword as string when it should be string.
+                Tokenize context-sensitive keyword as string when it should be string.
             */
 
             if ($tokenIsArray === true
@@ -894,7 +894,7 @@ class PHP extends Tokenizer
             }
 
             /*
-                If this is a double quoted string, PHP will tokenize the whole
+                If this is a double-quoted string, PHP will tokenize the whole
                 thing which causes problems with the scope map when braces are
                 within the string. So we need to merge the tokens together to
                 provide a single string.
@@ -936,14 +936,14 @@ class PHP extends Tokenizer
                         && $subToken[0] === '"'
                         && empty($nestedVars) === true
                     ) {
-                        // We found the other end of the double quoted string.
+                        // We found the other end of the double-quoted string.
                         break;
                     }
                 }//end for
 
                 $stackPtr = $i;
 
-                // Convert each line within the double quoted string to a
+                // Convert each line within the double-quoted string to a
                 // new token, so it conforms with other multiple line tokens.
                 $tokenLines = explode($this->eolChar, $tokenContent);
                 $numLines   = count($tokenLines);

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3351,7 +3351,7 @@ class PHP extends Tokenizer
                 unset($this->tokens[$scopeCloser]['scope_closer']);
             } else {
                 // We were using a shared closer. All tokens that were
-                // sharing this closer with us, except for the scope condition
+                // sharing this closer with us, except for the scope condition,
                 // and it's opener, need to now point to the new closer.
                 $condition = $this->tokens[$scopeCloser]['scope_condition'];
                 $start     = ($this->tokens[$condition]['scope_opener'] + 1);

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1461,7 +1461,7 @@ abstract class Tokenizer
 
                         $ignore--;
                     } else {
-                        // We found a token that closes the scope but it doesn't
+                        // We found a token that closes the scope, but it doesn't
                         // have a condition, so it belongs to another token and
                         // our token doesn't have a closer, so pretend this is
                         // the closer.

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1554,7 +1554,7 @@ abstract class Tokenizer
                     // conditions where there was none. This happens for T_CASE
                     // statements that are using the same break statement.
                     if ($lastOpener !== null && $this->tokens[$lastOpener]['scope_closer'] === $this->tokens[$i]['scope_closer']) {
-                        // This opener shares its closer with the previous opener,
+                        // This opener shares it's closer with the previous opener,
                         // but we still need to check if the two openers share their
                         // closer with each other directly (like CASE and DEFAULT)
                         // or if they are just sharing because one doesn't have a

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -924,7 +924,7 @@ abstract class Tokenizer
      * Recurses though the scope openers to build a scope map.
      *
      * @param int $stackPtr The position in the stack of the token that
-     *                      opened the scope (eg. an IF token or FOR token).
+     *                      opened the scope (e.g. an IF token or FOR token).
      * @param int $depth    How many scope levels down we are.
      * @param int $ignore   How many curly braces we are ignoring.
      *
@@ -1393,7 +1393,7 @@ abstract class Tokenizer
                         && isset($this->tokens[$i]['parenthesis_closer']) === true
                     ) {
                         // If we get into here, then we opened a parenthesis for
-                        // a scope (eg. an if or else if) so we need to update the
+                        // a scope (e.g. an if or else if) so we need to update the
                         // start of the line so that when we check to see
                         // if the closing parenthesis is more than n lines away from
                         // the statement, we check from the closing parenthesis.

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1355,7 +1355,7 @@ abstract class Tokenizer
                         || ($openerNested === true
                         && $this->tokens[$i]['nested_parenthesis'] !== $this->tokens[$stackPtr]['nested_parenthesis'])
                     ) {
-                        // We found the a token that looks like the opener, but it's nested differently.
+                        // We found the token that looks like the opener, but it's nested differently.
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             $type = $this->tokens[$i]['type'];
                             echo str_repeat("\t", $depth);

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -315,7 +315,7 @@ class Common
     /**
      * Returns true if the specified string is in the camel caps format.
      *
-     * @param string  $string      The string the verify.
+     * @param string  $string      The string to verify.
      * @param boolean $classFormat If true, check to see if the string is in the
      *                             class format. Class format strings must start
      *                             with a capital letter and contain no

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -238,14 +238,14 @@ class Standards
             return true;
         } else {
             // This could be a custom standard, installed outside our
-            // standards directory.
+            // standards' directory.
             $standard = Common::realPath($standard);
             if ($standard === false) {
                 return false;
             }
 
             // Might be an actual ruleset file itUtil.
-            // If it has an XML extension, let's at least try it.
+            // If it has an XML extension, lets at least try it.
             if (is_file($standard) === true
                 && (substr(strtolower($standard), -4) === '.xml'
                 || substr(strtolower($standard), -9) === '.xml.dist')

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -41,7 +41,7 @@ class Timing
 
 
     /**
-     * Get the duration of the run up to "now".
+     * Get the duration of the run-up to "now".
      *
      * @return float Duration in microseconds.
      */
@@ -58,7 +58,7 @@ class Timing
 
 
     /**
-     * Convert a duration in microseconds to a human readable duration string.
+     * Convert a duration in microseconds to a human-readable duration string.
      *
      * @param float $duration Duration in microseconds.
      *

--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -8,7 +8,7 @@
  *
  * This class is a "double" of the Config class which prevents this from happening.
  * In _most_ cases, tests should be using this class instead of the "normal" Config,
- * with the exception of select tests for the Config class itself.
+ * except select tests for the Config class itself.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
@@ -24,7 +24,7 @@ final class ConfigDouble extends Config
 {
 
     /**
-     * Whether or not the setting of a standard should be skipped.
+     * Whether the setting of a standard should be skipped.
      *
      * @var boolean
      */

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -49,7 +49,7 @@ abstract class AbstractMethodUnitTest extends TestCase
      * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
      *
      * The test case file for a unit test class has to be in the same directory
-     * directory and use the same file name as the test class, using the .inc extension.
+     * and use the same file name as the test class, using the .inc extension.
      *
      * @beforeClass
      *

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -387,7 +387,7 @@ EOD;
                 'expectedErrors' => 2,
             ],
 
-            // With suppression on line before.
+            // With suppression on the line before.
             'ignore: line before, slash comment'         => [
                 'before' => '// phpcs:ignore',
             ],
@@ -474,7 +474,7 @@ EOD;
 
         $ruleset = new Ruleset($config);
 
-        // Process with @ suppression on line before inside docblock.
+        // Process with @ suppression on the line before inside docblock.
         $comment = str_repeat('a ', 50);
         $content = <<<EOD
 <?php

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -21,7 +21,7 @@ final class GetClassPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test receiving an expected exception when a non class token is passed.
+     * Test receiving an expected exception when a non-class token is passed.
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $tokenType  The type of token to look for after the marker.

--- a/tests/Core/File/GetConditionTest.php
+++ b/tests/Core/File/GetConditionTest.php
@@ -163,7 +163,7 @@ final class GetConditionTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test passing a non conditional token.
+     * Test passing a non-conditional token.
      *
      * @return void
      */

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -1982,7 +1982,7 @@ final class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
-     * Verify recognition of PHP8 constructor with both property promotion as well as normal parameters.
+     * Verify recognition of PHP8 constructor with both property promotion and normal parameters.
      *
      * @return void
      */

--- a/tests/Core/File/GetTokensAsStringTest.php
+++ b/tests/Core/File/GetTokensAsStringTest.php
@@ -102,7 +102,7 @@ final class GetTokensAsStringTest extends AbstractMethodUnitTest
      * Test getting a token set as a string.
      *
      * @param string     $testMarker     The comment which prefaces the target token in the test file.
-     * @param int|string $startTokenType The type of token(s) to look for for the start of the string.
+     * @param int|string $startTokenType The type of token(s) to look for the start of the string.
      * @param int        $length         Token length to get.
      * @param string     $expected       The expected function return value.
      *
@@ -277,7 +277,7 @@ final class GetTokensAsStringTest extends AbstractMethodUnitTest
      * Test getting a token set as a string with the original, non tab-replaced content.
      *
      * @param string     $testMarker     The comment which prefaces the target token in the test file.
-     * @param int|string $startTokenType The type of token(s) to look for for the start of the string.
+     * @param int|string $startTokenType The type of token(s) to look for the start of the string.
      * @param int        $length         Token length to get.
      * @param string     $expected       The expected function return value.
      *

--- a/tests/Core/Filters/AbstractFilterTestCase.php
+++ b/tests/Core/Filters/AbstractFilterTestCase.php
@@ -197,7 +197,7 @@ abstract class AbstractFilterTestCase extends TestCase
     /**
      * Translate Linux paths to Windows paths, when necessary.
      *
-     * These type of tests should be able to run and pass on both *nix as well as Windows
+     * These type of tests should be able to run and pass on both *nix and Windows
      * based dev systems. This method is a helper to allow for this.
      *
      * @param array<string|array> $paths A single or multi-dimensional array containing

--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -238,7 +238,7 @@ final class GitModifiedTest extends AbstractFilterTestCase
      *
      * {@internal Missing: test with a command which yields a `false` return value.
      *            JRF: I've not managed to find a command which does so, let alone one, which then
-     *            doesn't have side-effects of uncatchable output while running the tests.}
+     *            doesn't have side effects of uncatchable output while running the tests.}
      *
      * @return array<string, array<string, string|array<string>>>
      */

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -238,7 +238,7 @@ final class GitStagedTest extends AbstractFilterTestCase
      *
      * {@internal Missing: test with a command which yields a `false` return value.
      *            JRF: I've not managed to find a command which does so, let alone one, which then
-     *            doesn't have side-effects of uncatchable output while running the tests.}
+     *            doesn't have side effects of uncatchable output while running the tests.}
      *
      * @return array<string, array<string, array<string>>>
      */

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -126,7 +126,7 @@ final class ExplainTest extends TestCase
      * Verifies that:
      * - The "standard" name is taken from the custom ruleset.
      * - Any and all sniff additions and exclusions in the ruleset are taken into account correctly.
-     * - That the displayed list will have both the standards as well as the sniff names
+     * - That the displayed list will have both the standards and the sniff names
      *   ordered alphabetically.
      *
      * @return void

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
 /**
- * These tests specifically focus on the changes made to work around the PHP 8.2 dynamic properties deprecation.
+ * These tests specifically focus on the changes made to work around the PHP 8.2 dynamic properties' deprecation.
  *
  * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
  */

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -373,7 +373,7 @@ final class ShowSniffDeprecationsTest extends TestCase
                     .'future.'.PHP_EOL.PHP_EOL,
             ],
             'Report width matches longest line: 666; the message should not wrap'                   => [
-                // Length = 4 padding + 75 base line + 587 custom message.
+                // Length = 4 padding + 75 baseline + 587 custom message.
                 'reportWidth'    => 666,
                 'expectedOutput' => $summaryLine.str_repeat('-', 666).PHP_EOL
                     .'-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL

--- a/tests/Core/Sniffs/AbstractArraySniffTest.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTest.php
@@ -34,7 +34,7 @@ final class AbstractArraySniffTest extends AbstractMethodUnitTest
      * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
      *
      * The test case file for a unit test class has to be in the same directory
-     * directory and use the same file name as the test class, using the .inc extension.
+     * and use the same file name as the test class, using the .inc extension.
      *
      * @beforeClass
      *

--- a/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizer/AbstractTokenizerTestCase.php
@@ -53,7 +53,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
      * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
      *
      * The test case file for a unit test class has to be in the same directory
-     * directory and use the same file name as the test class, using the .inc extension.
+     * and use the same file name as the test class, using the .inc extension.
      *
      * @before
      *

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the conversion of PHP native context sensitive keywords to T_STRING.
+ * Tests the conversion of PHP native context-sensitive keywords to T_STRING.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
  * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -16,7 +16,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that context sensitive keyword is tokenized as string when it should be string.
+     * Test that context-sensitive keyword is tokenized as string when it should be string.
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      *
@@ -141,7 +141,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that context sensitive keyword is tokenized as keyword when it should be keyword.
+     * Test that context-sensitive keyword is tokenized as keyword when it should be keyword.
      *
      * @param string $testMarker        The comment which prefaces the target token in the test file.
      * @param string $expectedTokenType The expected token type.

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Tests that embedded variables and expressions in double quoted strings are tokenized
- * as one double quoted string token.
+ * Tests that embedded variables and expressions in double-quoted strings are tokenized
+ * as one double-quoted string token.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -15,10 +15,10 @@ final class DoubleQuotedStringTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that double quoted strings contain the complete string.
+     * Test that double-quoted strings contain the complete string.
      *
      * @param string $testMarker      The comment which prefaces the target token in the test file.
-     * @param string $expectedContent The expected content of the double quoted string.
+     * @param string $expectedContent The expected content of the double-quoted string.
      *
      * @dataProvider dataDoubleQuotedString
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize

--- a/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/OtherContextSensitiveKeywordsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the conversion of PHPCS native context sensitive keyword tokens to T_STRING.
+ * Tests the conversion of PHPCS native context-sensitive keyword tokens to T_STRING.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -10,7 +10,7 @@
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 /**
- * Tests the conversion of PHPCS native context sensitive keyword tokens to T_STRING.
+ * Tests the conversion of PHPCS native context-sensitive keyword tokens to T_STRING.
  *
  * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
  * @covers PHP_CodeSniffer\Tokenizers\PHP::standardiseToken
@@ -35,7 +35,7 @@ final class OtherContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that context sensitive keyword is tokenized as string when it should be string.
+     * Test that context-sensitive keyword is tokenized as string when it should be string.
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      *
@@ -98,7 +98,7 @@ final class OtherContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that context sensitive keyword is tokenized as keyword when it should be keyword.
+     * Test that context-sensitive keyword is tokenized as keyword when it should be keyword.
      *
      * @param string $testMarker        The comment which prefaces the target token in the test file.
      * @param string $expectedTokenType The expected token type.

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -70,7 +70,7 @@ final class TypeIntersectionTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that bitwise and tokens when used as part of a intersection type are tokenized as `T_TYPE_INTERSECTION`.
+     * Test that bitwise and tokens when used as part of an intersection type are tokenized as `T_TYPE_INTERSECTION`.
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      *

--- a/tests/Core/Tokenizer/TypedConstantsTest.php
+++ b/tests/Core/Tokenizer/TypedConstantsTest.php
@@ -107,7 +107,7 @@ final class TypedConstantsTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test the tokens in the type of a typed constant as well as the constant name are tokenized correctly.
+     * Test the tokens in the type of typed constant as well as the constant name are tokenized correctly.
      *
      * @param string $testMarker The comment prefacing the target token.
      * @param string $sequence   The expected token sequence.


### PR DESCRIPTION
This PR addresses several typos and language constructs found throughout the sources. I've groups the fixes in individual commits in an attempt to make review easiest. Making individual PR for each type of typo feels weird and one for each file feels like an overhead.

# Description
This PR address typos as found bij PHPStorm using the Problems view. Especially for the one where the introduction of a comma was suggested I've been withholding in addressing each issues as found by the editor. Especially for short sentences this would be not that helpfull.


## Suggested changelog entry
Correct typos and language


## Related issues/external references
_N/A_

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [X] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [X] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.