### PR TITLE
Generic/DisallowYodaConditions: `??` should not trigger the sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -25,7 +25,10 @@ class DisallowYodaConditionsSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$comparisonTokens;
+        $tokens = Tokens::$comparisonTokens;
+        unset($tokens[T_COALESCE]);
+
+        return $tokens;
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.inc
@@ -173,3 +173,5 @@ echo match ($text) {
     'foo' => 10 === $y,
     10 === $y => 'bar',
 };
+
+1 ?? $nullCoalescingShouldNotTriggerSniff;


### PR DESCRIPTION
# Description

This PR changes the Generic.ControlStructures.DisallowYodaConditions sniff so that the null coalescing operator (`??`) does not trigger it.

## Suggested changelog entry

Generic.ControlStructures.DisallowYodaConditions: null coalescing operator (`??`) should not trigger the sniff

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
