### PR TITLE
Tokenizer/PHP: add tests for arrow functions with intersection types

### DIFF
--- a/tests/Core/Tokenizer/BackfillFnTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.inc
@@ -113,6 +113,12 @@ $arrowWithUnionReturn = fn($param) : int|true => $param | 10;
 /* testUnionReturnTypeWithFalse */
 $arrowWithUnionReturn = fn($param) : string|FALSE => $param | 10;
 
+/* testIntersectionParamType */
+$arrowWithUnionParam = fn(Traversable&Countable $param) : int => (new SomeClass($param))->getValue();
+
+/* testIntersectionReturnType */
+$arrowWithUnionReturn = fn($param) : \MyFoo&SomeInterface => new SomeClass($param);
+
 /* testTernary */
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -516,6 +516,38 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
 
 
     /**
+     * Test arrow function with an intersection parameter type.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testIntersectionParamType()
+    {
+        $token = $this->getTargetToken('/* testIntersectionParamType */', T_FN);
+        $this->backfillHelper($token);
+        $this->scopePositionTestHelper($token, 13, 27);
+
+    }//end testIntersectionParamType()
+
+
+    /**
+     * Test arrow function with an intersection return type.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testIntersectionReturnType()
+    {
+        $token = $this->getTargetToken('/* testIntersectionReturnType */', T_FN);
+        $this->backfillHelper($token);
+        $this->scopePositionTestHelper($token, 12, 20);
+
+    }//end testIntersectionReturnType()
+
+
+    /**
      * Test arrow functions used in ternary operators.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional


### PR DESCRIPTION
# Description

This was already handled correctly by the Tokenizer, but not safeguarded via tests.


## Suggested changelog entry
_N/A_