### PR TITLE
docs: Correct semi-colon for semicolon (without dash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1651,7 +1651,7 @@ Additionally, thanks to [Alexander Turek][@derrabus] for consulting on the repo 
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Squiz.WhiteSpace.SuperfluousWhitespace no longer throws errors for spacing between functions and properties in anon classes
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
-- Zend.Files.ClosingTag no longer adds a semi-colon during fixing of a file that only contains a comment
+- Zend.Files.ClosingTag no longer adds a semicolon during fixing of a file that only contains a comment
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch
 - Zend.NamingConventions.ValidVariableName now supports variables inside anonymous classes correctly
     - Thanks to [Juliette Reinders Folmer][@jrfnl] for the patch

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2260,7 +2260,7 @@ class File
      *                                  be returned.
      * @param bool             $local   If true, tokens outside the current statement
      *                                  will not be checked. IE. checking will stop
-     *                                  at the previous semi-colon found.
+     *                                  at the previous semicolon found.
      *
      * @return int|false
      * @see    findNext()
@@ -2341,7 +2341,7 @@ class File
      *                                  be returned.
      * @param bool             $local   If true, tokens outside the current statement
      *                                  will not be checked. i.e., checking will stop
-     *                                  at the next semi-colon found.
+     *                                  at the next semicolon found.
      *
      * @return int|false
      * @see    findPrevious()

--- a/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
+++ b/src/Standards/Generic/Docs/CodeAnalysis/EmptyPHPStatementStandard.xml
@@ -20,11 +20,11 @@
     </code_comparison>
     <standard>
     <![CDATA[
-    Superfluous semi-colons are not allowed.
+    Superfluous semicolons are not allowed.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: There is no superfluous semi-colon after a PHP statement.">
+        <code title="Valid: There is no superfluous semicolon after a PHP statement.">
             <![CDATA[
 function_call()<em>;</em>
 if (true) {
@@ -32,7 +32,7 @@ if (true) {
 }
         ]]>
         </code>
-        <code title="Invalid: There are one or more superfluous semi-colons after a PHP statement.">
+        <code title="Invalid: There are one or more superfluous semicolons after a PHP statement.">
             <![CDATA[
 function_call()<em>;;;</em>
 if (true) {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -2,7 +2,7 @@
 /**
  * Checks against empty PHP statements.
  *
- * - Check against two semi-colons with no executable code in between.
+ * - Check against two semicolons with no executable code in between.
  * - Check against an empty PHP open - close tag combination.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
@@ -76,7 +76,7 @@ class EmptyPHPStatementSniff implements Sniff
                     return;
                 }
 
-                // Else, it's something like `if (foo) {};` and the semi-colon is not needed.
+                // Else, it's something like `if (foo) {};` and the semicolon is not needed.
             }
 
             if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
@@ -91,7 +91,7 @@ class EmptyPHPStatementSniff implements Sniff
             }
 
             $fix = $phpcsFile->addFixableWarning(
-                'Empty PHP statement detected: superfluous semi-colon.',
+                'Empty PHP statement detected: superfluous semicolon.',
                 $stackPtr,
                 'SemicolonWithoutCodeDetected'
             );
@@ -101,7 +101,7 @@ class EmptyPHPStatementSniff implements Sniff
                 if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG
                     || $tokens[$prevNonEmpty]['code'] === T_OPEN_TAG_WITH_ECHO
                 ) {
-                    // Check for superfluous whitespace after the semi-colon which will be
+                    // Check for superfluous whitespace after the semicolon which will be
                     // removed as the `<?php ` open tag token already contains whitespace,
                     // either a space or a new line.
                     if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semi-colons without executable code between them.
+ * Test empty statement: two consecutive semicolons without executable code between them.
  */
 function_call(); // OK.
 
@@ -50,10 +50,10 @@ function_call();
 <input name="<?= ; ?>" /> <!-- Bad. -->
 
 <?php
-// Guard against false positives for two consecutive semi-colons in a for statement.
+// Guard against false positives for two consecutive semicolons in a for statement.
 for ( $i = 0; ; $i++ ) {}
 
-// Test for useless semi-colons
+// Test for useless semicolons
 for ( $i = 0; ; $i++ ) {};
 
 if (true) {};

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semi-colons without executable code between them.
+ * Test empty statement: two consecutive semicolons without executable code between them.
  */
 function_call(); // OK.
 
@@ -45,10 +45,10 @@ function_call();
 <input name="" /> <!-- Bad. -->
 
 <?php
-// Guard against false positives for two consecutive semi-colons in a for statement.
+// Guard against false positives for two consecutive semicolons in a for statement.
 for ( $i = 0; ; $i++ ) {}
 
-// Test for useless semi-colons
+// Test for useless semicolons
 for ( $i = 0; ; $i++ ) {}
 
 if (true) {}

--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -105,7 +105,7 @@
     <!-- checked by PSR12.Namespaces.CompoundNamespaceDepth -->
 
     <!-- When wishing to declare strict types in files containing markup outside PHP opening and closing tags, the declaration MUST be on the first line of the file and include an opening PHP tag, the strict types declaration and closing tag. -->
-    <!-- Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semi-colon terminator). -->
+    <!-- Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semicolon terminator). -->
     <!-- Block declare statements are allowed and MUST be formatted as below. -->
     <!-- checked by PSR12.Files.DeclareStatement -->
 

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -152,7 +152,7 @@ class UseDeclarationSniff implements Sniff
                             }
                         } while ($next !== false);
 
-                        // Remove closing curly,semicolon and any whitespace between last child and closing curly.
+                        // Remove closing curly, semicolon and any whitespace between last child and closing curly.
                         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
                         if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
                             // Parse error, forgotten semicolon.

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -152,10 +152,10 @@ class UseDeclarationSniff implements Sniff
                             }
                         } while ($next !== false);
 
-                        // Remove closing curly,semi-colon and any whitespace between last child and closing curly.
+                        // Remove closing curly,semicolon and any whitespace between last child and closing curly.
                         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
                         if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
-                            // Parse error, forgotten semi-colon.
+                            // Parse error, forgotten semicolon.
                             $next = $closingCurly;
                         }
 

--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Ensure each style definition has a semi-colon and it is spaced correctly.
+ * Ensure each style definition has a semicolon and it is spaced correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -73,7 +73,7 @@ class SemicolonSpacingSniff implements Sniff
             return;
         }
 
-        // There is a semi-colon, so now find the last token in the statement.
+        // There is a semicolon, so now find the last token in the statement.
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($endOfThisStatement - 1), null, true);
         $found        = $tokens[($endOfThisStatement - 1)]['length'];
         if ($tokens[$prevNonEmpty]['line'] !== $tokens[$endOfThisStatement]['line']) {

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -156,7 +156,7 @@ class LongConditionClosingCommentSniff implements Sniff
         }
 
         if ($startCondition['code'] === T_MATCH) {
-            // Move the stackPtr to after the semi-colon/comma if there is one.
+            // Move the stackPtr to after the semicolon/comma if there is one.
             $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
             if ($nextToken !== false
                 && ($tokens[$nextToken]['code'] === T_SEMICOLON

--- a/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
@@ -51,7 +51,7 @@ class EchoedStringsSniff implements Sniff
 
         $end = $phpcsFile->findNext([T_SEMICOLON, T_CLOSE_TAG], $stackPtr, null, false);
 
-        // If the token before the semi-colon is not a closing parenthesis, then we are not concerned.
+        // If the token before the semicolon is not a closing parenthesis, then we are not concerned.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($end - 1), null, true);
         if ($tokens[$prev]['code'] !== T_CLOSE_PARENTHESIS) {
             $phpcsFile->recordMetric($stackPtr, 'Brackets around echoed strings', 'no');

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -59,7 +59,7 @@ class SemicolonSpacingSniff implements Sniff
 
         $nonSpace = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 2), null, true);
 
-        // Detect whether this is a semi-colon for a condition in a `for()` control structure.
+        // Detect whether this is a semicolon for a condition in a `for()` control structure.
         $forCondition = false;
         if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
             $nestedParens     = $tokens[$stackPtr]['nested_parenthesis'];

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc
@@ -111,7 +111,7 @@ for (
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
 for ($i = function() { return $this->i; }; $i < function() { return $this->max; }  ;   $i++) {}
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.1.inc.fixed
@@ -77,7 +77,7 @@ for ( $i = 0; $i < 10; $i++ ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
 for ($i = function() { return $this->i; }; $i < function() { return $this->max; }; $i++) {}
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
@@ -117,7 +117,7 @@ for (
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for (i = function() {self.widgetLoaded(widget.id)  ;  }; i < function() {self.widgetLoaded(widget.id);}; i++) {}
 for (i = function() {self.widgetLoaded(widget.id);}; i < function() {self.widgetLoaded(widget.id);}  ;   i++) {}
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
@@ -83,7 +83,7 @@ for ( i = 0; i < 10; i++ ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
-// Test with semi-colon not belonging to for.
+// Test with semicolon not belonging to for.
 for (i = function() {self.widgetLoaded(widget.id)  ;  }; i < function() {self.widgetLoaded(widget.id);}; i++) {}
 for (i = function() {self.widgetLoaded(widget.id);}; i < function() {self.widgetLoaded(widget.id);}; i++) {}
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -77,7 +77,7 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 
-    // Intentionally missing a semi-colon for testing.
+    // Intentionally missing a semicolon for testing.
     public
         $varS,
         $varT

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -72,7 +72,7 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 
-    // Intentionally missing a semi-colon for testing.
+    // Intentionally missing a semicolon for testing.
     public
         $varS,
         $varT

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
@@ -18,14 +18,14 @@ $sum = $a /* + $b
     + $c */ ;
 
 /*
- * Test that the sniff does *not* throw incorrect errors for semi-colons in
+ * Test that the sniff does *not* throw incorrect errors for semicolons in
  * "empty" parts of a `for` control structure.
  */
 for ($i = 1; ; $i++) {}
 for ( ; $ptr >= 0; $ptr-- ) {}
 for ( ; ; ) {}
 
-// But it should when the semi-colon in a `for` follows a comment (but shouldn't move the semi-colon).
+// But it should when the semicolon in a `for` follows a comment (but shouldn't move the semicolon).
 for ( /* Deliberately left empty. */ ; $ptr >= 0; $ptr-- ) {}
 for ( $i = 1 ; /* Deliberately left empty. */ ; $i++ ) {}
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
@@ -18,14 +18,14 @@ $sum = $a; /* + $b
     + $c */
 
 /*
- * Test that the sniff does *not* throw incorrect errors for semi-colons in
+ * Test that the sniff does *not* throw incorrect errors for semicolons in
  * "empty" parts of a `for` control structure.
  */
 for ($i = 1; ; $i++) {}
 for ( ; $ptr >= 0; $ptr-- ) {}
 for ( ; ; ) {}
 
-// But it should when the semi-colon in a `for` follows a comment (but shouldn't move the semi-colon).
+// But it should when the semicolon in a `for` follows a comment (but shouldn't move the semicolon).
 for ( /* Deliberately left empty. */; $ptr >= 0; $ptr-- ) {}
 for ( $i = 1; /* Deliberately left empty. */; $i++ ) {}
 


### PR DESCRIPTION
Semicolon is the correct spelling based on the Oxford Dictionary and dictionary.com. This PR changes all occurrences found into `semicolon`

# Description
This PR is a split on changes proposed earlier in #457 but limiting to only fixing typos of the word `semicolon`. 
Sources for the correct spelling are:
- https://www.oed.com/dictionary/semicolon_n?tab=factsheet#23549945
- https://www.dictionary.com/browse/semicolon
- https://en.bab.la/dictionary/english/semicolon
- https://en.wikipedia.org/wiki/Semicolon

Also Google trends show a difference between `semicolon` and `semi-colon`

## Suggested changelog entry
Correct semi-colon with semicolon

## Related issues/external references
**N/A**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [X] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.