### PR TITLE
Generic/DisallowYodaConditions: improve code coverage

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -80,15 +80,15 @@ class DisallowYodaConditionsSniff implements Sniff
 
         // Is it a parenthesis.
         if ($tokens[$previousIndex]['code'] === T_CLOSE_PARENTHESIS) {
-            $closeParenthesisIndex = $phpcsFile->findPrevious(
+            $beforeOpeningParenthesisIndex = $phpcsFile->findPrevious(
                 Tokens::$emptyTokens,
                 ($tokens[$previousIndex]['parenthesis_opener'] - 1),
                 null,
                 true
             );
 
-            if ($closeParenthesisIndex === false || $tokens[$closeParenthesisIndex]['code'] !== T_ARRAY) {
-                if ($tokens[$closeParenthesisIndex]['code'] === T_STRING) {
+            if ($beforeOpeningParenthesisIndex === false || $tokens[$beforeOpeningParenthesisIndex]['code'] !== T_ARRAY) {
+                if ($tokens[$beforeOpeningParenthesisIndex]['code'] === T_STRING) {
                     return;
                 }
 
@@ -110,8 +110,8 @@ class DisallowYodaConditionsSniff implements Sniff
                 if ($prev === false) {
                     return;
                 }
-            } else if ($tokens[$closeParenthesisIndex]['code'] === T_ARRAY
-                && $this->isArrayStatic($phpcsFile, $closeParenthesisIndex) === false
+            } else if ($tokens[$beforeOpeningParenthesisIndex]['code'] === T_ARRAY
+                && $this->isArrayStatic($phpcsFile, $beforeOpeningParenthesisIndex) === false
             ) {
                 return;
             }//end if

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -85,7 +85,6 @@ class DisallowYodaConditionsSniff implements Sniff
 
         // Is it a parenthesis.
         if ($tokens[$previousIndex]['code'] === T_CLOSE_PARENTHESIS) {
-            // Check what exists inside the parenthesis.
             $closeParenthesisIndex = $phpcsFile->findPrevious(
                 Tokens::$emptyTokens,
                 ($tokens[$previousIndex]['parenthesis_opener'] - 1),
@@ -110,7 +109,7 @@ class DisallowYodaConditionsSniff implements Sniff
                     return;
                 }
 
-                // If there is nothing inside the parenthesis, it it not a Yoda.
+                // If there is nothing inside the parenthesis, it is not a Yoda condition.
                 $opener = $tokens[$previousIndex]['parenthesis_opener'];
                 $prev   = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousIndex - 1), ($opener + 1), true);
                 if ($prev === false) {
@@ -144,7 +143,6 @@ class DisallowYodaConditionsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $arrayEnd = null;
         if ($tokens[$arrayToken]['code'] === T_OPEN_SHORT_ARRAY) {
             $start = $arrayToken;
             $end   = $tokens[$arrayToken]['bracket_closer'];

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -57,9 +57,7 @@ class DisallowYodaConditionsSniff implements Sniff
             T_CONSTANT_ENCAPSED_STRING,
         ];
 
-        if ($previousIndex === false
-            || in_array($tokens[$previousIndex]['code'], $relevantTokens, true) === false
-        ) {
+        if (in_array($tokens[$previousIndex]['code'], $relevantTokens, true) === false) {
             return;
         }
 
@@ -71,9 +69,6 @@ class DisallowYodaConditionsSniff implements Sniff
         }
 
         $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousIndex - 1), null, true);
-        if ($prevIndex === false) {
-            return;
-        }
 
         if (in_array($tokens[$prevIndex]['code'], Tokens::$arithmeticTokens, true) === true) {
             return;
@@ -150,6 +145,7 @@ class DisallowYodaConditionsSniff implements Sniff
             $start = $tokens[$arrayToken]['parenthesis_opener'];
             $end   = $tokens[$arrayToken]['parenthesis_closer'];
         } else {
+            // Shouldn't be possible but may happen if external sniffs are using this method.
             return true;
         }
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.inc
@@ -175,3 +175,13 @@ echo match ($text) {
 };
 
 1 ?? $nullCoalescingShouldNotTriggerSniff;
+
+1 + 2 === $sniffBailsArithmeticToken;
+
+'string' . 'concat' === $sniffBailsStringConcatToken;
+
+1 != $value;
+1 <> $value;
+1 >= $value;
+1 <= $value;
+1 <=> $value;

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
@@ -67,6 +67,11 @@ final class DisallowYodaConditionsUnitTest extends AbstractSniffUnitTest
             167 => 1,
             173 => 1,
             174 => 1,
+            183 => 1,
+            184 => 1,
+            185 => 1,
+            186 => 1,
+            187 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

This PR improves code coverage for the Generic.ControlStructures.DisallowYodaConditions sniff. It adds a few tests for uncovered lines and documents using tests a few comparison operators that this sniff listens for that were not part of the tests before.

Besides that, this PR removes an unused variable, fixes a typo in a code comment, removes two unreachable variables, and renames a variable to make it more clear what it contains.

It is impossible to add code coverage for the line below using the current test framework and we should not remove it as external sniffs could be using the `DisallowYodaConditionsSniff::isArrayStatic()` and relying on the current behavior (returning `true` if the passed token index is not an array):

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/30b3148b302aaba28d72bdb2432b144ff9d47751/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php#L152 

I left a comment documenting that the line cannot be covered by tests but cannot be removed as well.

I considered using `// @codeCoverageIgnore` or `// @codeCoverageIgnoreStart` and `// @codeCoverageIgnoreEnd`, but that is not possible as well as those annotations trigger different sniff errors for the coding standard used by PHPCS (`Squiz.Commenting.PostStatementComment.Found` and `Squiz.Commenting.InlineComment.InvalidEndChar`). I will open a separate issue for this.

## Related issues/external references

Part of https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/146


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
