### PR TITLE
Generic/CallTimePassByReference: add support for self, parent and static

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -28,6 +28,9 @@ class CallTimePassByReferenceSniff implements Sniff
             T_STRING,
             T_VARIABLE,
             T_ANON_CLASS,
+            T_PARENT,
+            T_SELF,
+            T_STATIC,
         ];
 
     }//end register()

--- a/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.1.inc
@@ -52,3 +52,15 @@ $instance = new MyClass(&$a);
 
 $anon = new class($a) {};
 $anon = new class(&$a) {};
+
+class Foo extends Bar {
+    function myMethod() {
+        $a = new static($var);
+        $b = new self($var);
+        $c = new parent($var);
+
+        $d = new static(&$var);
+        $e = new self(&$var);
+        $f = new parent(&$var);
+    }
+}

--- a/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.php
@@ -45,11 +45,14 @@ final class CallTimePassByReferenceUnitTest extends AbstractSniffUnitTest
                 50 => 1,
                 51 => 1,
                 54 => 1,
+                62 => 1,
+                63 => 1,
+                64 => 1,
             ];
 
         default:
             return [];
-        }
+        }//end switch
 
     }//end getErrorList()
 


### PR DESCRIPTION
# Description

This PR changes the Generic.Functions.CallTimePassByReference sniff to trigger an error when the parent, self, or static tokens are used to instantiate a class containing a variable passed by reference. In a separate commit, it also sorts alphabetically the list of tokens this sniff listens to.

## Suggested changelog entry

Generic.Functions.CallTimePassByReference: flag call-time pass-by-reference when instantiating a class using parent, self, or static.

## Related issues/external references

Suggested in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/394#pullrequestreview-2015022891


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
