### PR TITLE
PHP 8.2 | File::getMemberProperties(): add support for DNF types

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1952,17 +1952,19 @@ class File
         if ($i < $stackPtr) {
             // We've found a type.
             $valid = [
-                T_STRING            => T_STRING,
-                T_CALLABLE          => T_CALLABLE,
-                T_SELF              => T_SELF,
-                T_PARENT            => T_PARENT,
-                T_FALSE             => T_FALSE,
-                T_TRUE              => T_TRUE,
-                T_NULL              => T_NULL,
-                T_NAMESPACE         => T_NAMESPACE,
-                T_NS_SEPARATOR      => T_NS_SEPARATOR,
-                T_TYPE_UNION        => T_TYPE_UNION,
-                T_TYPE_INTERSECTION => T_TYPE_INTERSECTION,
+                T_STRING                 => T_STRING,
+                T_CALLABLE               => T_CALLABLE,
+                T_SELF                   => T_SELF,
+                T_PARENT                 => T_PARENT,
+                T_FALSE                  => T_FALSE,
+                T_TRUE                   => T_TRUE,
+                T_NULL                   => T_NULL,
+                T_NAMESPACE              => T_NAMESPACE,
+                T_NS_SEPARATOR           => T_NS_SEPARATOR,
+                T_TYPE_UNION             => T_TYPE_UNION,
+                T_TYPE_INTERSECTION      => T_TYPE_INTERSECTION,
+                T_TYPE_OPEN_PARENTHESIS  => T_TYPE_OPEN_PARENTHESIS,
+                T_TYPE_CLOSE_PARENTHESIS => T_TYPE_CLOSE_PARENTHESIS,
             ];
 
             for ($i; $i < $stackPtr; $i++) {

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -339,3 +339,18 @@ class WhitespaceAndCommentsInTypes {
     /* testIntersectionTypeWithWhitespaceAndComment */
     public \Foo /*comment*/ & Bar $hasWhitespaceAndComment;
 }
+
+trait DNFTypes {
+    /* testPHP82DNFTypeStatic */
+    public static (Foo&\Bar)|bool $propA;
+
+    /* testPHP82DNFTypeReadonlyA */
+    protected readonly float|(Partially\Qualified&Traversable) $propB;
+
+    /* testPHP82DNFTypeReadonlyB */
+    private readonly (namespace\Foo&Bar)|string $propC;
+
+    /* testPHP82DNFTypeIllegalNullable */
+    // Intentional fatal error - nullable operator cannot be combined with DNF.
+    var ?(A&\Pck\B)|bool $propD;
+}

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -1075,6 +1075,58 @@ final class GetMemberPropertiesTest extends AbstractMethodUnitTest
                 ],
             ],
 
+            'php8.2-dnf-with-static'                                       => [
+                'identifier' => '/* testPHP82DNFTypeStatic */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'is_readonly'     => false,
+                    'type'            => '(Foo&\Bar)|bool',
+                    'type_token'      => -9,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-readonly-1'                                   => [
+                'identifier' => '/* testPHP82DNFTypeReadonlyA */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => true,
+                    'type'            => 'float|(Partially\Qualified&Traversable)',
+                    'type_token'      => -10,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-readonly-2'                                   => [
+                'identifier' => '/* testPHP82DNFTypeReadonlyB */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => true,
+                    'type'            => '(namespace\Foo&Bar)|string',
+                    'type_token'      => -10,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-illegal-nullable'                             => [
+                'identifier' => '/* testPHP82DNFTypeIllegalNullable */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => '?(A&\Pck\B)|bool',
+                    'type_token'      => -11,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
 
     }//end dataGetMemberProperties()


### PR DESCRIPTION
# Description

Add support for PHP 8.2 DNF types to the `File::getMemberProperties()` method.

Includes unit tests.

## Suggested changelog entry
The `File::getMemberProperties()` method now supports DNF types.


## Related issues/external references

Related #387, #461