### PR TITLE
Generic/LowerCaseType: add support for examining DNF types

### DIFF
--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -125,6 +125,20 @@ enum TypedEnumConstants {
     public const sTRing | aRRaY | FaLSe FOURTH = 'fourth';
 }
 
+class DNFTypes {
+    const (Parent&Something)|Float CONST_NAME = 1.5;
+
+    public readonly TRUE|(\A&B) $prop;
+
+    function DNFParamTypes (
+        null|(\Package\ClassName&\Package\Other_Class)|INT $DNFinMiddle,
+        (\Package\ClassName&\Package\Other_Class)|ARRAY $parensAtStart,
+        False|(\Package\ClassName&\Package\Other_Class) $parentAtEnd,
+    ) {}
+
+    function DNFReturnTypes ($var): object|(Self&\Package\Other_Class)|sTRINg|false {}
+}
+
 // Intentional error, should be ignored by the sniff.
 interface PropertiesNotAllowed {
     public $notAllowed;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -125,6 +125,20 @@ enum TypedEnumConstants {
     public const string | array | false FOURTH = 'fourth';
 }
 
+class DNFTypes {
+    const (parent&Something)|float CONST_NAME = 1.5;
+
+    public readonly true|(\A&B) $prop;
+
+    function DNFParamTypes (
+        null|(\Package\ClassName&\Package\Other_Class)|int $DNFinMiddle,
+        (\Package\ClassName&\Package\Other_Class)|array $parensAtStart,
+        false|(\Package\ClassName&\Package\Other_Class) $parentAtEnd,
+    ) {}
+
+    function DNFReturnTypes ($var): object|(self&\Package\Other_Class)|string|false {}
+}
+
 // Intentional error, should be ignored by the sniff.
 interface PropertiesNotAllowed {
     public $notAllowed;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -87,6 +87,12 @@ final class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             123 => 2,
             124 => 3,
             125 => 3,
+            129 => 2,
+            131 => 1,
+            134 => 1,
+            135 => 1,
+            136 => 1,
+            139 => 2,
         ];
 
     }//end getErrorList()
@@ -103,7 +109,7 @@ final class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         // Warning from getMemberProperties() about parse error.
-        return [130 => 1];
+        return [144 => 1];
 
     }//end getWarningList()
 


### PR DESCRIPTION
# Description
The `Generic.PHP.LowerCaseType` sniff needs to be updated to also handle non-lowercase types which are part of a DNF type declaration.

This commit updates the `processUnionType()` method to not only examine union types, but to examine all multi-token types and to do so in a slightly more performant manner and calls that method now for all multi-token type declarations.

Note: The method name now doesn't properly cover the functionality anymore, however, renaming the method would be a breaking change as the class is not `final` and the method not `private`.

Includes unit tests.


## Suggested changelog entry
The Generic.PHP.LowerCaseType sniff will now enforce lowercase keyword based types for types used in PHP 8.2+ DNF types.


## Related issues/external references

Related #105, #387, #461, #471, #472, #473

Closes #105