### PR TITLE
Autoloader: fix missing return value

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -73,7 +73,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                 // Make sure we don't try to load any of Composer's classes
                 // while the autoloader is being setup.
                 if (strpos($class, 'Composer\\') === 0) {
-                    return;
+                    return false;
                 }
 
                 if (strpos(__DIR__, 'phar://') !== 0


### PR DESCRIPTION
# Description
An autoloader should always return a boolean value to indicate whether or not it has loaded a file. This allows for chaining autoloaders.

In most cases, the `return` statement in the autoloader already returned a boolean, this was the only exception.

## Suggested changelog entry
_N/A_