### PR TITLE
Allow phpcbf to use the cache

### DIFF
--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -146,6 +146,8 @@ class Fixer
             return false;
         }
 
+        $this->currentFile->disableCaching();
+
         $this->enabled = true;
 
         $this->loops = 0;

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -190,13 +190,11 @@ class Runner
             }
 
             // Override some of the command line settings that might break the fixes.
-            $this->config->generator    = null;
-            $this->config->explain      = false;
-            $this->config->interactive  = false;
-            $this->config->cache        = false;
-            $this->config->showSources  = false;
-            $this->config->recordErrors = false;
-            $this->config->reportFile   = null;
+            $this->config->generator   = null;
+            $this->config->explain     = false;
+            $this->config->interactive = false;
+            $this->config->showSources = false;
+            $this->config->reportFile  = null;
 
             // Only use the "Cbf" report, but allow for the Performance report as well.
             $originalReports = array_change_key_case($this->config->reports, CASE_LOWER);


### PR DESCRIPTION
# Description
As part of the development process, I often find myself using `phpcbf` followed by `phpcs` in order to check that the code I've written complies with the configured coding standard for the codebase in question. I have recently also started using the `--cache` parameter on the command-line to speed up this process. This has a significant positive impact on the time taken for `phpcs`, however `phpcbf` seemed to take the same time as usual.

This pull request enables `phpcbf` to use the cache, just like `phpcs` does. In my use-case where I run `phpcbf` immediately followed by `phpcs` (with the same flags), the `phpcs` run is always very fast as it can use the cache and doesn't need to re-scan every file.

## Suggested changelog entry
- Allow `phpcbf` to use the cache

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that would cause existing functionality to change)_
- Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- \[Required for new sniffs\] I have added XML documentation for the sniff.

Fixes #485