### PR TITLE
Ignore errors/warnings which are ignored

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -994,6 +994,11 @@ class File
             return false;
         }
 
+        if ($severity === 0) {
+            // Do not remember / record any messages which will be hidden always.
+            return false;
+        }
+
         // Make sure we are not ignoring this file.
         $included = null;
         if (trim($this->path, '\'"') === 'STDIN') {

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -1275,4 +1275,31 @@ EOD;
     }//end dataCommenting()
 
 
+    /**
+     * Ensure that when the cache is enabled, and we are recording error messages, issues with serverity=0 are not included in the results.
+     *
+     * @return void
+     */
+    public function testErrorSeverityZeroWithCacheEnabled()
+    {
+        $config            = new ConfigDouble();
+        $config->standards = ['Generic'];
+        $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
+        $config->cache     = true;
+        $config->recordErrors = true;
+
+        $ruleset = new Ruleset($config);
+        $ruleset->ruleset['Generic.PHP.LowerCaseConstant.Found']['severity'] = 0;
+
+        $content = '<?php $var = FALSE;';
+
+        $file = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $this->assertSame(0, $file->getErrorCount());
+        $this->assertSame([], $file->getErrors());
+
+    }//end testErrorSeverityZeroWithCacheEnabled()
+
+
 }//end class


### PR DESCRIPTION
# Description
While working on #481, I noticed that the `fixableCount` property had an incorrect value. Upon investigation, I found that issues with severity zero are still being included in the count for how many issues can be fixed. This is misleading, as running `phpcbf` does not fix these.

Unfortunately there don't appear to be any tests which cover this functionality, so getting suitable test coverage may be considered a blocker to this pull request.

## Reproduction details
In order to reproduce this bug, run the following commands:
- `php bin/phpcbf autoload.php` to fix any fixable errors. Notice that there are no errors reported as fixable.
- `php bin/phpcs --cache=local-test-file.json autoload.php` to create a cache file. Notice that there are no errors reported (fixable or otherwise).
- `jq < local-test-file.json '.["'$PWD'/autoload.php"] | "\(.errorCount) errors, \(.warningCount) warning, \(.fixableCount) fixable issues"'` to see the number of errors/warnings/fixable recorded in the cache.
  I expect these to match the output of `phpcs`, but they are all non-zero.

## Suggested changelog entry
Fix bug where internal property `fixableCount` was incorrectly including issues with severity zero.

## Related issues/external references

This is related #481 - without this change, that pull request is somewhat less effective.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that would cause existing functionality to change)_
    - [x] This change is only breaking for integrators, not for external standards or end-users.
- Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- \[Required for new sniffs\] I have added XML documentation for the sniff.