### PR TITLE
Generic/ArrayIndent: improve code coverage and implement a few small improvements to the sniff code

### DIFF
--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -151,7 +151,7 @@ class ArrayIndentSniff extends AbstractArraySniff
             $error = 'Closing brace of array declaration must be on a new line';
             $fix   = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceNotNewLine');
             if ($fix === true) {
-                $padding = $phpcsFile->eolChar.str_repeat(' ', $expectedIndent);
+                $padding = $phpcsFile->eolChar.str_repeat(' ', $startIndent);
                 $phpcsFile->fixer->addContentBefore($arrayEnd, $padding);
             }
 
@@ -159,20 +159,19 @@ class ArrayIndentSniff extends AbstractArraySniff
         }
 
         // The close brace must be indented one stop less.
-        $expectedIndent -= $this->indent;
-        $foundIndent     = ($tokens[$arrayEnd]['column'] - 1);
-        if ($foundIndent === $expectedIndent) {
+        $foundIndent = ($tokens[$arrayEnd]['column'] - 1);
+        if ($foundIndent === $startIndent) {
             return;
         }
 
         $pluralizeSpace = 's';
-        if ($expectedIndent === 1) {
+        if ($startIndent === 1) {
             $pluralizeSpace = '';
         }
 
         $error = 'Array close brace not indented correctly; expected %s space%s but found %s';
         $data  = [
-            $expectedIndent,
+            $startIndent,
             $pluralizeSpace,
             $foundIndent,
         ];
@@ -181,7 +180,7 @@ class ArrayIndentSniff extends AbstractArraySniff
             return;
         }
 
-        $padding = str_repeat(' ', $expectedIndent);
+        $padding = str_repeat(' ', $startIndent);
         if ($foundIndent === 0) {
             $phpcsFile->fixer->addContentBefore($arrayEnd, $padding);
         } else {

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -62,7 +62,6 @@ class ArrayIndentSniff extends AbstractArraySniff
         // Determine how far indented the entire array declaration should be.
         $ignore     = Tokens::$emptyTokens;
         $ignore[]   = T_DOUBLE_ARROW;
-        $ignore[]   = T_COMMA;
         $prev       = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
         $start      = $phpcsFile->findStartOfStatement($prev);
         $first      = $phpcsFile->findFirstOnLine(T_WHITESPACE, $start, true);

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -149,3 +149,6 @@ $var = [
   ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 4
+
+$array = [1,
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -150,3 +150,6 @@ $var = [
 ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 4
+
+$array = [1,
+];


### PR DESCRIPTION
# Description

This PR improves the code coverage of the `Generic.Arrays.ArrayIndent` sniff and also implements the following minor improvements to the sniff code:

- ~~Use two different variables to hold the values of the expected indentation for array elements and array closing brace. Before, the same variable was being used, and its value modified, which can be confusing.~~
- Avoid unnecessary extra calls to ArrayIndent::processMultiLineArray() when fixing an array closing brace that is not placed on its own line.
- Remove `T_COMMA` from the list of tokens to ignore when looking for a token before the array opening brace. This was necessary in the past due to a bug `File::findStartOfStatement()` that has since been fixed.

I believe `T_DOUBLE_ARROW` can be removed from the [list](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/12645d7258fac768c7904cfce27a511a2df4532c/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php#L64) as well. With `T_COMMA`, I could confirm that when this token was added to the ignore list, the provided test would fail without it. The test started passing when a bug in `File::findStartOfStatement()` was fixed.

I was not able to do the same with `T_DOUBLE_ARROW`. This token was added to the list in 0425342. All the tests pass if I run PHPCS in the 0425342 revision without the `T_DOUBLE_ARROW` token.

## Related issues/external references

Part of #146 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.