### PR TITLE
Tokenizers/Comment: add tests + fix two edge case bugs

### DIFF
--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -41,9 +41,16 @@ class Comment
             extra star when they are used for function and class comments.
         */
 
-        $char    = ($numChars - strlen(ltrim($string, '/*')));
-        $openTag = substr($string, 0, $char);
-        $string  = ltrim($string, '/*');
+        $char      = ($numChars - strlen(ltrim($string, '/*')));
+        $lastChars = substr($string, -2);
+        if ($char === $numChars && $lastChars === '*/') {
+            // Edge case: docblock without whitespace or contents.
+            $openTag = substr($string, 0, -2);
+            $string  = $lastChars;
+        } else {
+            $openTag = substr($string, 0, $char);
+            $string  = ltrim($string, '/*');
+        }
 
         $tokens[$stackPtr] = [
             'content'      => $openTag,

--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -25,7 +25,7 @@ class Comment
      * @param string $eolChar  The EOL character to use for splitting strings.
      * @param int    $stackPtr The position of the first token in the file.
      *
-     * @return array
+     * @return array<int, array<string, string|int|array<int>>>
      */
     public function tokenizeString($string, $eolChar, $stackPtr)
     {
@@ -81,6 +81,7 @@ class Comment
         ];
 
         if ($closeTag['content'] === false) {
+            // In PHP < 8.0 substr() can return `false` instead of always returning a string.
             $closeTag['content'] = '';
         }
 
@@ -178,7 +179,7 @@ class Comment
      * @param int    $start   The position in the string to start processing.
      * @param int    $end     The position in the string to end processing.
      *
-     * @return array
+     * @return array<int, array<string, string|int>>
      */
     private function processLine($string, $eolChar, $start, $end)
     {
@@ -253,7 +254,7 @@ class Comment
      * @param int    $start  The position in the string to start processing.
      * @param int    $end    The position in the string to end processing.
      *
-     * @return array|null
+     * @return array<string, string|int>|null
      */
     private function collectWhitespace($string, $start, $end)
     {
@@ -270,13 +271,11 @@ class Comment
             return null;
         }
 
-        $token = [
+        return [
             'content' => $space,
             'code'    => T_DOC_COMMENT_WHITESPACE,
             'type'    => 'T_DOC_COMMENT_WHITESPACE',
         ];
-
-        return $token;
 
     }//end collectWhitespace()
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -786,7 +786,7 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && ($token[0] === T_DOC_COMMENT
-                || ($token[0] === T_COMMENT && strpos($token[1], '/**') === 0))
+                || ($token[0] === T_COMMENT && strpos($token[1], '/**') === 0 && $token[1] !== '/**/'))
             ) {
                 $commentTokens = $commentTokenizer->tokenizeString($token[1], $this->eolChar, $newStackPtr);
                 foreach ($commentTokens as $commentToken) {

--- a/tests/Core/Tokenizer/Comment/CommentTestCase.php
+++ b/tests/Core/Tokenizer/Comment/CommentTestCase.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Base class for testing DocBlock comment tokenization.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizer\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Base class for testing DocBlock comment tokenization.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+abstract class CommentTestCase extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test whether the docblock opener and closer have the expected extra keys.
+     *
+     * @param string     $marker       The comment prefacing the target token.
+     * @param int        $closerOffset The offset of the closer from the opener.
+     * @param array<int> $expectedTags The expected tags offsets array.
+     *
+     * @dataProvider dataDocblockOpenerCloser
+     *
+     * @return void
+     */
+    public function testDocblockOpenerCloser($marker, $closerOffset, $expectedTags)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+        $target = $this->getTargetToken($marker, [T_DOC_COMMENT_OPEN_TAG]);
+
+        $opener = $tokens[$target];
+
+        $this->assertArrayHasKey('comment_closer', $opener, 'Comment opener: comment_closer index is not set');
+        $this->assertArrayHasKey('comment_tags', $opener, 'Comment opener: comment_tags index is not set');
+
+        $expectedCloser = ($target + $closerOffset);
+        $this->assertSame($expectedCloser, $opener['comment_closer'], 'Comment opener: comment_closer not set to the expected stack pointer');
+
+        // Update the tags expectations.
+        foreach ($expectedTags as $i => $ptr) {
+            $expectedTags[$i] += $target;
+        }
+
+        $this->assertSame($expectedTags, $opener['comment_tags'], 'Comment opener: recorded tags do not match expected tags');
+
+        $closer = $tokens[$opener['comment_closer']];
+
+        $this->assertArrayHasKey('comment_opener', $closer, 'Comment closer: comment_opener index is not set');
+        $this->assertSame($target, $closer['comment_opener'], 'Comment closer: comment_opener not set to the expected stack pointer');
+
+    }//end testDocblockOpenerCloser()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    abstract public static function dataDocblockOpenerCloser();
+
+
+    /**
+     * Test helper. Check a token sequence complies with an expected token sequence.
+     *
+     * @param int                              $startPtr         The position in the file to start checking from.
+     * @param array<array<int|string, string>> $expectedSequence The consecutive token constants and their contents to expect.
+     *
+     * @return void
+     */
+    protected function checkTokenSequence($startPtr, array $expectedSequence)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        $sequenceKey   = 0;
+        $sequenceCount = count($expectedSequence);
+
+        for ($i = $startPtr; $sequenceKey < $sequenceCount; $i++, $sequenceKey++) {
+            $currentItem     = $expectedSequence[$sequenceKey];
+            $expectedCode    = key($currentItem);
+            $expectedType    = Tokens::tokenName($expectedCode);
+            $expectedContent = current($currentItem);
+            $errorMsgSuffix  = PHP_EOL.'(StackPtr: '.$i.' | Position in sequence: '.$sequenceKey.' | Expected: '.$expectedType.')';
+
+            $this->assertSame(
+                $expectedCode,
+                $tokens[$i]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$i]['code']).', not '.$expectedType.' (code)'.$errorMsgSuffix
+            );
+
+            $this->assertSame(
+                $expectedType,
+                $tokens[$i]['type'],
+                'Token tokenized as '.$tokens[$i]['type'].', not '.$expectedType.' (type)'.$errorMsgSuffix
+            );
+
+            $this->assertSame(
+                $expectedContent,
+                $tokens[$i]['content'],
+                'Token content did not match expectations'.$errorMsgSuffix
+            );
+        }//end for
+
+    }//end checkTokenSequence()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/LiveCoding1Test.inc
+++ b/tests/Core/Tokenizer/Comment/LiveCoding1Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+/* testLiveCoding */
+/**
+ * Unclosed docblock, live coding.... with no blank line at end of file.
+ *

--- a/tests/Core/Tokenizer/Comment/LiveCoding1Test.php
+++ b/tests/Core/Tokenizer/Comment/LiveCoding1Test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class LiveCoding1Test extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'live coding: unclosed docblock, no blank line at end of file' => [
+                'marker'       => '/* testLiveCoding */',
+                'closerOffset' => 8,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of the DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testLiveCoding()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Unclosed docblock, live coding.... with no blank line at end of file.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testLiveCoding()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/LiveCoding2Test.inc
+++ b/tests/Core/Tokenizer/Comment/LiveCoding2Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+/* testLiveCoding */
+/**
+ * Unclosed docblock, live coding.... with a blank line at end of file.

--- a/tests/Core/Tokenizer/Comment/LiveCoding2Test.php
+++ b/tests/Core/Tokenizer/Comment/LiveCoding2Test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class LiveCoding2Test extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'live coding: unclosed docblock with blank line at end of file' => [
+                'marker'       => '/* testLiveCoding */',
+                'closerOffset' => 7,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of the DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testLiveCoding()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Unclosed docblock, live coding.... with a blank line at end of file.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_CLOSE_TAG  => ''],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testLiveCoding()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/LiveCoding3Test.inc
+++ b/tests/Core/Tokenizer/Comment/LiveCoding3Test.inc
@@ -1,0 +1,4 @@
+<?php
+
+/* testLiveCoding */
+/**

--- a/tests/Core/Tokenizer/Comment/LiveCoding3Test.php
+++ b/tests/Core/Tokenizer/Comment/LiveCoding3Test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class LiveCoding3Test extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'live coding: unclosed docblock, no contents, no blank line at end of file' => [
+                'marker'       => '/* testLiveCoding */',
+                'closerOffset' => 1,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of the DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testLiveCoding()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_CLOSE_TAG  => ''],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testLiveCoding()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/LiveCoding4Test.inc
+++ b/tests/Core/Tokenizer/Comment/LiveCoding4Test.inc
@@ -1,0 +1,7 @@
+<?php
+
+/* testLiveCoding */
+/**
+ * The last line of this test must have trailing whitespace.
+ * So, be careful when saving this file!
+ *                 

--- a/tests/Core/Tokenizer/Comment/LiveCoding4Test.php
+++ b/tests/Core/Tokenizer/Comment/LiveCoding4Test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that unclosed docblocks during live coding are handled correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class LiveCoding4Test extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'live coding: unclosed docblock, trailing whitespace on last line, no blank line at end of file' => [
+                'marker'       => '/* testLiveCoding */',
+                'closerOffset' => 15,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of the DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testLiveCoding()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'The last line of this test must have trailing whitespace.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'So, be careful when saving this file!'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => '                 '],
+            [T_DOC_COMMENT_CLOSE_TAG  => ''],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testLiveCoding()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/MultiLineDocBlockTest.inc
+++ b/tests/Core/Tokenizer/Comment/MultiLineDocBlockTest.inc
@@ -1,0 +1,81 @@
+<?php
+
+/* testEmptyDocblock */
+/**
+ */
+
+/* testMultilineDocblock */
+/**
+ * This is a multi-line docblock.
+ *
+ * With blank lines, stars, tags, and tag descriptions.
+ *
+ * @tagWithoutDescription
+ *
+ * @since 10.3
+ * @deprecated 11.5
+ *
+ * @requires PHP 7.1 -- PHPUnit tag.
+ *
+ * @tag-with-dashes-is-suppported Description.
+ * @tag_with_underscores          Description.
+ *
+ * @param string    $p1 Description 1.
+ * @param int|false $p2 Description 2.
+ *
+ * @return void
+ */
+function base($p1, $p2) {}
+
+/* testMultilineDocblockNoStars */
+/****
+    This is a multi-line docblock, but the lines are not marked with stars.
+    Then again, the opener and closer have an abundance of stars.
+
+    @since 10.3
+
+    @param string    $p1 Description 1.
+    @param int|false $p2 Description 2.
+
+    @return void
+ **/
+function noStars($p1, $p2) {}
+
+class Spaces {
+    /* testMultilineDocblockIndented */
+    /**
+     * This is a multi-line indented docblock.
+     *
+     * With blank lines, stars, tags, and tag descriptions.
+     *
+     * @since 10.3
+     * @deprecated 11.5
+     *
+     * @param string    $p1 Description 1.
+     * @param int|false $p2 Description 2.
+     *
+     * @return void
+     */
+    function foo($p1, $p2) {}
+}
+
+/* testMultilineDocblockOpenerNotOnOwnLine */
+/** Start of description
+ * description continued.
+ */
+
+/* testMultilineDocblockCloserNotOnOwnLine */
+/**
+ * Start of description
+ * description continued. */
+
+/* testMultilineDocblockStarsNotAligned */
+/**
+* Start of description.
+*   Line below this is missing a star.
+
+   Text
+
+    * Star indented.
+    * Closer indented.
+    */

--- a/tests/Core/Tokenizer/Comment/MultiLineDocBlockTest.php
+++ b/tests/Core/Tokenizer/Comment/MultiLineDocBlockTest.php
@@ -1,0 +1,439 @@
+<?php
+/**
+ * Tests that multiline docblocks are tokenized correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that multiline docblocks are tokenized correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class MultiLineDocBlockTest extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'Multi line docblock: no contents'              => [
+                'marker'       => '/* testEmptyDocblock */',
+                'closerOffset' => 3,
+                'expectedTags' => [],
+            ],
+            'Multi line docblock: variety of text and tags' => [
+                'marker'       => '/* testMultilineDocblock */',
+                'closerOffset' => 95,
+                // phpcs:ignore Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed
+                'expectedTags' => [21, 29, 36, 46, 56, 63, 73, 80, 90],
+            ],
+            'Multi line docblock: no leading stars'         => [
+                'marker'       => '/* testMultilineDocblockNoStars */',
+                'closerOffset' => 32,
+                // phpcs:ignore Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed
+                'expectedTags' => [10, 16, 21, 27],
+            ],
+            'Multi line docblock: indented'                 => [
+                'marker'       => '/* testMultilineDocblockIndented */',
+                'closerOffset' => 60,
+                // phpcs:ignore Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed
+                'expectedTags' => [21, 28, 38, 45, 55],
+            ],
+            'Multi line docblock: opener not on own line'   => [
+                'marker'       => '/* testMultilineDocblockOpenerNotOnOwnLine */',
+                'closerOffset' => 10,
+                'expectedTags' => [],
+            ],
+            'Multi line docblock: closer not on own line'   => [
+                'marker'       => '/* testMultilineDocblockCloserNotOnOwnLine */',
+                'closerOffset' => 11,
+                'expectedTags' => [],
+            ],
+            'Multi line docblock: stars not aligned'        => [
+                'marker'       => '/* testMultilineDocblockStarsNotAligned */',
+                'closerOffset' => 26,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of an empty, multi-line DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testEmptyDocblock()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testEmptyDocblock()
+
+
+    /**
+     * Verify tokenization of a multi-line DocBlock containing all possible tokens.
+     *
+     * @return void
+     */
+    public function testMultilineDocblock()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'This is a multi-line docblock.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With blank lines, stars, tags, and tag descriptions.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagWithoutDescription'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@since'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '10.3'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@deprecated'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '11.5'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@requires'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'PHP 7.1 -- PHPUnit tag.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tag-with-dashes-is-suppported'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Description.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tag_with_underscores'],
+            [T_DOC_COMMENT_WHITESPACE => '          '],
+            [T_DOC_COMMENT_STRING     => 'Description.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'string    $p1 Description 1.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'int|false $p2 Description 2.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@return'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'void'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblock()
+
+
+    /**
+     * Verify tokenization of a multi-line DocBlock with extra starts for the opener/closer and no stars on the lines between.
+     *
+     * @return void
+     */
+    public function testMultilineDocblockNoStars()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/****'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_STRING     => 'This is a multi-line docblock, but the lines are not marked with stars.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_STRING     => 'Then again, the opener and closer have an abundance of stars.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_TAG        => '@since'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '10.3'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'string    $p1 Description 1.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'int|false $p2 Description 2.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_TAG        => '@return'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'void'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '**/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblockNoStars()
+
+
+    /**
+     * Verify tokenization of a multi-line, indented DocBlock.
+     *
+     * @return void
+     */
+    public function testMultilineDocblockIndented()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'This is a multi-line indented docblock.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With blank lines, stars, tags, and tag descriptions.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@since'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '10.3'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@deprecated'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '11.5'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'string    $p1 Description 1.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@param'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'int|false $p2 Description 2.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@return'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'void'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '     '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblockIndented()
+
+
+    /**
+     * Verify tokenization of a multi-line DocBlock, where the opener is not on its own line.
+     *
+     * @return void
+     */
+    public function testMultilineDocblockOpenerNotOnOwnLine()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Start of description'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'description continued.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblockOpenerNotOnOwnLine()
+
+
+    /**
+     * Verify tokenization of a multi-line DocBlock, where the closer is not on its own line.
+     *
+     * @return void
+     */
+    public function testMultilineDocblockCloserNotOnOwnLine()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Start of description'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'description continued. '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblockCloserNotOnOwnLine()
+
+
+    /**
+     * Verify tokenization of a multi-line DocBlock with inconsistent indentation.
+     *
+     * @return void
+     */
+    public function testMultilineDocblockStarsNotAligned()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Start of description.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => '   '],
+            [T_DOC_COMMENT_STRING     => 'Line below this is missing a star.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '   '],
+            [T_DOC_COMMENT_STRING     => 'Text'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Star indented.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Closer indented.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => '    '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultilineDocblockStarsNotAligned()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/PhpcsAnnotationsInDocBlockTest.inc
+++ b/tests/Core/Tokenizer/Comment/PhpcsAnnotationsInDocBlockTest.inc
@@ -1,0 +1,116 @@
+<?php
+
+/* testSingleLineDocIgnoreFileAnnotation */
+/** @phpcs:ignoreFile */
+function singleLineIgnoreFile() {}
+
+/* testSingleLineDocIgnoreAnnotation */
+/** @phpcs:ignore Stnd.Cat.SniffName -- With reason */
+function singleLineIgnore() {}
+
+/* testSingleLineDocDisableAnnotation */
+/** @phpcs:disable Stnd.Cat.SniffName,Stnd.Other */
+function singleLineDisable() {}
+
+/* testSingleLineDocEnableAnnotationNoWhitespace */
+/**@phpcs:enable Stnd.Cat.SniffName*/
+function singleLineEnable() {}
+
+/* testMultiLineDocIgnoreFileAnnotationAtStart */
+/**
+ * @phpcs:ignoreFile
+ * Something.
+ */
+function MLStartIgnoreFile() {}
+
+/* testMultiLineDocIgnoreAnnotationAtStart */
+/**
+ * @phpcs:ignore Stnd.Cat.SniffName
+ * @tag
+ */
+function MLStartIgnore() {}
+
+/* testMultiLineDocDisableAnnotationAtStart */
+/**
+ * @phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.
+ * Something.
+ */
+function MLStartDisable() {}
+
+/* testMultiLineDocEnableAnnotationAtStart */
+/**
+ * @phpcs:enable Stnd.Cat,Stnd.Other
+ *
+ * @tag With description.
+ */
+function MLStartEnable() {}
+
+/* testMultiLineDocIgnoreFileAnnotationInMiddle */
+/**
+ * Check tokenization of PHPCS annotations within docblocks.
+ * @phpcs:ignoreFile
+ *
+ * Something.
+ */
+function MLMiddleIgnoreFile() {}
+
+/* testMultiLineDocIgnoreAnnotationInMiddle */
+/**
+ * @tagBefore With Description
+ *
+ * @phpcs:ignore Stnd.Cat.SniffName
+ * Something.
+ */
+function MLMiddleIgnore() {}
+
+/* testMultiLineDocDisableAnnotationInMiddle */
+/**
+ * Check tokenization of PHPCS annotations within docblocks.
+ *
+ * @phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.
+ *
+ * @tagAfter With Description
+ */
+function MLMiddleDisable() {}
+
+/* testMultiLineDocEnableAnnotationInMiddle */
+/**
+ * Check tokenization of PHPCS annotations within docblocks.
+ *
+ * @phpcs:enable Stnd.Cat,Stnd.Other
+ *
+ * @tagAfter
+ */
+function MLMiddleEnable() {}
+
+/* testMultiLineDocIgnoreFileAnnotationAtEnd */
+/**
+ * @tagBefore
+ *
+ * @phpcs:ignoreFile
+ */
+function MLEndIgnoreFile() {}
+
+/* testMultiLineDocIgnoreAnnotationAtEnd */
+/**
+ * Check tokenization of PHPCS annotations within docblocks.
+ *
+ * @phpcs:ignore Stnd.Cat.SniffName
+ */
+function MLEndIgnore() {}
+
+/* testMultiLineDocDisableAnnotationAtEnd */
+/**
+ * @tagBefore With Description.
+ *
+ * @phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.
+ */
+function MLEndDisable() {}
+
+/* testMultiLineDocEnableAnnotationAtEnd */
+/**
+ * Check tokenization of PHPCS annotations within docblocks.
+ *
+ * @phpcs:enable Stnd.Cat,Stnd.Other
+ */
+function MLEndEnable() {}

--- a/tests/Core/Tokenizer/Comment/PhpcsAnnotationsInDocBlockTest.php
+++ b/tests/Core/Tokenizer/Comment/PhpcsAnnotationsInDocBlockTest.php
@@ -1,0 +1,637 @@
+<?php
+/**
+ * Tests that PHPCS native annotations in docblocks are tokenized correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that PHPCS native annotations in docblocks are tokenized correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class PhpcsAnnotationsInDocBlockTest extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'Single-line: @phpcs:ignoreFile annotation'            => [
+                'marker'       => '/* testSingleLineDocIgnoreFileAnnotation */',
+                'closerOffset' => 3,
+                'expectedTags' => [],
+            ],
+            'Single-line: @phpcs:ignore annotation'                => [
+                'marker'       => '/* testSingleLineDocIgnoreAnnotation */',
+                'closerOffset' => 3,
+                'expectedTags' => [],
+            ],
+            'Single-line: @phpcs:disable annotation'               => [
+                'marker'       => '/* testSingleLineDocDisableAnnotation */',
+                'closerOffset' => 3,
+                'expectedTags' => [],
+            ],
+            'Single-line: @phpcs:enable annotation; no whitespace' => [
+                'marker'       => '/* testSingleLineDocEnableAnnotationNoWhitespace */',
+                'closerOffset' => 2,
+                'expectedTags' => [],
+            ],
+
+            'Multi-line: @phpcs:ignoreFile at the start'           => [
+                'marker'       => '/* testMultiLineDocIgnoreFileAnnotationAtStart */',
+                'closerOffset' => 13,
+                'expectedTags' => [],
+            ],
+            'Multi-line: @phpcs:ignore at the start'               => [
+                'marker'       => '/* testMultiLineDocIgnoreAnnotationAtStart */',
+                'closerOffset' => 13,
+                'expectedTags' => [10],
+            ],
+            'Multi-line: @phpcs:disable at the start'              => [
+                'marker'       => '/* testMultiLineDocDisableAnnotationAtStart */',
+                'closerOffset' => 13,
+                'expectedTags' => [],
+            ],
+            'Multi-line: @phpcs:enable at the start'               => [
+                'marker'       => '/* testMultiLineDocEnableAnnotationAtStart */',
+                'closerOffset' => 18,
+                'expectedTags' => [13],
+            ],
+
+            'Multi-line: @phpcs:ignoreFile in the middle'          => [
+                'marker'       => '/* testMultiLineDocIgnoreFileAnnotationInMiddle */',
+                'closerOffset' => 21,
+                'expectedTags' => [],
+            ],
+            'Multi-line: @phpcs:ignore in the middle'              => [
+                'marker'       => '/* testMultiLineDocIgnoreAnnotationInMiddle */',
+                'closerOffset' => 23,
+                'expectedTags' => [5],
+            ],
+            'Multi-line: @phpcs:disable in the middle'             => [
+                'marker'       => '/* testMultiLineDocDisableAnnotationInMiddle */',
+                'closerOffset' => 26,
+                'expectedTags' => [21],
+            ],
+            'Multi-line: @phpcs:enable in the middle'              => [
+                'marker'       => '/* testMultiLineDocEnableAnnotationInMiddle */',
+                'closerOffset' => 24,
+                'expectedTags' => [21],
+            ],
+
+            'Multi-line: @phpcs:ignoreFile at the end'             => [
+                'marker'       => '/* testMultiLineDocIgnoreFileAnnotationAtEnd */',
+                'closerOffset' => 16,
+                'expectedTags' => [5],
+            ],
+            'Multi-line: @phpcs:ignore at the end'                 => [
+                'marker'       => '/* testMultiLineDocIgnoreAnnotationAtEnd */',
+                'closerOffset' => 16,
+                'expectedTags' => [],
+            ],
+            'Multi-line: @phpcs:disable at the end'                => [
+                'marker'       => '/* testMultiLineDocDisableAnnotationAtEnd */',
+                'closerOffset' => 18,
+                'expectedTags' => [5],
+            ],
+            'Multi-line: @phpcs:enable at the end'                 => [
+                'marker'       => '/* testMultiLineDocEnableAnnotationAtEnd */',
+                'closerOffset' => 16,
+                'expectedTags' => [],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignoreFile annotation.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testSingleLineDocIgnoreFileAnnotation()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE_FILE      => '@phpcs:ignoreFile '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocIgnoreFileAnnotation()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignore annotation.
+     *
+     * @return void
+     */
+    public function testSingleLineDocIgnoreAnnotation()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE           => '@phpcs:ignore Stnd.Cat.SniffName -- With reason '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocIgnoreAnnotation()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS disable annotation.
+     *
+     * @return void
+     */
+    public function testSingleLineDocDisableAnnotation()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_DISABLE          => '@phpcs:disable Stnd.Cat.SniffName,Stnd.Other '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocDisableAnnotation()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS enable annotation.
+     *
+     * @return void
+     */
+    public function testSingleLineDocEnableAnnotationNoWhitespace()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_PHPCS_ENABLE           => '@phpcs:enable Stnd.Cat.SniffName'],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocEnableAnnotationNoWhitespace()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignoreFile annotation at the start.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreFileAnnotationAtStart()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE_FILE      => '@phpcs:ignoreFile'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Something.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreFileAnnotationAtStart()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignore annotation at the start.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreAnnotationAtStart()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE           => '@phpcs:ignore Stnd.Cat.SniffName'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tag'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreAnnotationAtStart()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS disable annotation at the start.
+     *
+     * @return void
+     */
+    public function testMultiLineDocDisableAnnotationAtStart()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_DISABLE          => '@phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Something.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocDisableAnnotationAtStart()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS enable annotation at the start.
+     *
+     * @return void
+     */
+    public function testMultiLineDocEnableAnnotationAtStart()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_ENABLE           => '@phpcs:enable Stnd.Cat,Stnd.Other'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tag'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With description.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocEnableAnnotationAtStart()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignoreFile annotation in the middle.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreFileAnnotationInMiddle()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Check tokenization of PHPCS annotations within docblocks.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE_FILE      => '@phpcs:ignoreFile'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Something.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreFileAnnotationInMiddle()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignore annotation in the middle.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreAnnotationInMiddle()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagBefore'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With Description'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE           => '@phpcs:ignore Stnd.Cat.SniffName'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Something.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreAnnotationInMiddle()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS disable annotation in the middle.
+     *
+     * @return void
+     */
+    public function testMultiLineDocDisableAnnotationInMiddle()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Check tokenization of PHPCS annotations within docblocks.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_DISABLE          => '@phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagAfter'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With Description'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocDisableAnnotationInMiddle()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS enable annotation in the middle.
+     *
+     * @return void
+     */
+    public function testMultiLineDocEnableAnnotationInMiddle()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Check tokenization of PHPCS annotations within docblocks.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_ENABLE           => '@phpcs:enable Stnd.Cat,Stnd.Other'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagAfter'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocEnableAnnotationInMiddle()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignoreFile annotation at the end.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreFileAnnotationAtEnd()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagBefore'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE_FILE      => '@phpcs:ignoreFile'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreFileAnnotationAtEnd()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS ignore annotation at the end.
+     *
+     * @return void
+     */
+    public function testMultiLineDocIgnoreAnnotationAtEnd()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Check tokenization of PHPCS annotations within docblocks.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_IGNORE           => '@phpcs:ignore Stnd.Cat.SniffName'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocIgnoreAnnotationAtEnd()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS disable annotation at the end.
+     *
+     * @return void
+     */
+    public function testMultiLineDocDisableAnnotationAtEnd()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@tagBefore'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'With Description.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_DISABLE          => '@phpcs:disable Stnd.Cat.SniffName -- Ensure PHPCS annotations are also retokenized correctly.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocDisableAnnotationAtEnd()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock containing a PHPCS enable annotation at the end.
+     *
+     * @return void
+     */
+    public function testMultiLineDocEnableAnnotationAtEnd()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Check tokenization of PHPCS annotations within docblocks.'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STAR       => '*'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_PHPCS_ENABLE           => '@phpcs:enable Stnd.Cat,Stnd.Other'],
+            [T_DOC_COMMENT_WHITESPACE => "\n"],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testMultiLineDocEnableAnnotationAtEnd()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
@@ -1,5 +1,8 @@
 <?php
 
+/* testEmptyBlockCommentNoWhiteSpace */
+/**/
+
 /* testEmptyDocblockWithWhiteSpace */
 /** */
 

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
@@ -1,0 +1,20 @@
+<?php
+
+/* testEmptyDocblockWithWhiteSpace */
+/** */
+
+/* testSingleLineDocblockNoTag */
+/** Just some text */
+$var = doSomething();
+
+/* testSingleLineDocblockWithTag1 */
+/** @var \SomeClass[] $var */
+$var = doSomething();
+
+/* testSingleLineDocblockWithTag2 */
+/** @var $var \SomeClass[] */
+$var = doSomething();
+
+/* testSingleLineDocblockWithTag3 */
+/** @see Something::Else */
+$var = doSomething();

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.inc
@@ -3,6 +3,9 @@
 /* testEmptyBlockCommentNoWhiteSpace */
 /**/
 
+/* testEmptyDocblockNoWhiteSpace */
+/***/
+
 /* testEmptyDocblockWithWhiteSpace */
 /** */
 

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
@@ -28,6 +28,11 @@ final class SingleLineDocBlockTest extends CommentTestCase
     public static function dataDocblockOpenerCloser()
     {
         return [
+            'Single line docblock: empty, no whitespace'  => [
+                'marker'       => '/* testEmptyDocblockNoWhiteSpace */',
+                'closerOffset' => 1,
+                'expectedTags' => [],
+            ],
             'Single line docblock: only whitespace'       => [
                 'marker'       => '/* testEmptyDocblockWithWhiteSpace */',
                 'closerOffset' => 2,
@@ -79,9 +84,28 @@ final class SingleLineDocBlockTest extends CommentTestCase
 
 
     /**
-     * Verify tokenization of an empty, single line DocBlock.
+     * Verify tokenization of an empty, single line DocBlock without whitespace between the opener and closer.
      *
      * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testEmptyDocblockNoWhiteSpace()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testEmptyDocblockNoWhiteSpace()
+
+
+    /**
+     * Verify tokenization of an empty, single line DocBlock.
      *
      * @return void
      */

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests that single line docblocks are tokenized correctly.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\Comment;
+
+/**
+ * Tests that single line docblocks are tokenized correctly.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\Comment
+ */
+final class SingleLineDocBlockTest extends CommentTestCase
+{
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDocblockOpenerCloser()
+     *
+     * @return array<string, array<string, string|int|array<int>>>
+     */
+    public static function dataDocblockOpenerCloser()
+    {
+        return [
+            'Single line docblock: only whitespace'       => [
+                'marker'       => '/* testEmptyDocblockWithWhiteSpace */',
+                'closerOffset' => 2,
+                'expectedTags' => [],
+            ],
+            'Single line docblock: just text'             => [
+                'marker'       => '/* testSingleLineDocblockNoTag */',
+                'closerOffset' => 3,
+                'expectedTags' => [],
+            ],
+            'Single line docblock: @var type before name' => [
+                'marker'       => '/* testSingleLineDocblockWithTag1 */',
+                'closerOffset' => 5,
+                'expectedTags' => [2],
+            ],
+            'Single line docblock: @var name before type' => [
+                'marker'       => '/* testSingleLineDocblockWithTag2 */',
+                'closerOffset' => 5,
+                'expectedTags' => [2],
+            ],
+            'Single line docblock: @see with description' => [
+                'marker'       => '/* testSingleLineDocblockWithTag3 */',
+                'closerOffset' => 5,
+                'expectedTags' => [2],
+            ],
+        ];
+
+    }//end dataDocblockOpenerCloser()
+
+
+    /**
+     * Verify tokenization of an empty, single line DocBlock.
+     *
+     * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.
+     *
+     * @return void
+     */
+    public function testEmptyDocblockWithWhiteSpace()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testEmptyDocblockWithWhiteSpace()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock.
+     *
+     * @return void
+     */
+    public function testSingleLineDocblockNoTag()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Just some text '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocblockNoTag()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock with a tag.
+     *
+     * @return void
+     */
+    public function testSingleLineDocblockWithTag1()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@var'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '\SomeClass[] $var '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocblockWithTag1()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock with a tag.
+     *
+     * @return void
+     */
+    public function testSingleLineDocblockWithTag2()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@var'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => '$var \SomeClass[] '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocblockWithTag2()
+
+
+    /**
+     * Verify tokenization of a single line DocBlock with a tag.
+     *
+     * @return void
+     */
+    public function testSingleLineDocblockWithTag3()
+    {
+        $expectedSequence = [
+            [T_DOC_COMMENT_OPEN_TAG   => '/**'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_TAG        => '@see'],
+            [T_DOC_COMMENT_WHITESPACE => ' '],
+            [T_DOC_COMMENT_STRING     => 'Something::Else '],
+            [T_DOC_COMMENT_CLOSE_TAG  => '*/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', T_DOC_COMMENT_OPEN_TAG);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testSingleLineDocblockWithTag3()
+
+
+}//end class

--- a/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
+++ b/tests/Core/Tokenizer/Comment/SingleLineDocBlockTest.php
@@ -59,6 +59,26 @@ final class SingleLineDocBlockTest extends CommentTestCase
 
 
     /**
+     * Verify an empty block comment is tokenized as T_COMMENT, not as a docblock.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testEmptyBlockCommentNoWhiteSpace()
+    {
+        $expectedSequence = [
+            [T_COMMENT => '/**/'],
+        ];
+
+        $target = $this->getTargetToken('/* '.__FUNCTION__.' */', [T_COMMENT, T_DOC_COMMENT_OPEN_TAG]);
+
+        $this->checkTokenSequence($target, $expectedSequence);
+
+    }//end testEmptyBlockCommentNoWhiteSpace()
+
+
+    /**
      * Verify tokenization of an empty, single line DocBlock.
      *
      * @phpcs:disable Squiz.Arrays.ArrayDeclaration.SpaceBeforeDoubleArrow -- Readability is better with alignment.


### PR DESCRIPTION
# Description

### Tokenizers/Comment: add tests

The `Tokenizers\Comment` class did not have any tests associated with it. This commit fixes that and documents the existing behaviour.

Note: code coverage is as high as it can go, but not 100%. The reason for this, is the tokenizer debug statements, which are conditional on a verbosity flag, which is turned off for the tests.

Loosely related to #484.

### Tokenizers/PHP: bug fix - empty block comment

This commit fixes an edge case tokenizer bug, where a - completely empty, not even whitespace - _block comment_, would be tokenized as a docblock.

Without this commit, the `/**/` code snippet was tokenized as:
```
  8 | L07 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  4]: /**/
  9 | L07 | C  5 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  0]:
```

With the fix applied, it will be tokenized as:
```
  8 | L07 | C  1 | CC 0 | ( 0) | T_COMMENT                  | [  4]: /**/
```

### Tokenizers/Comment: bug fix - empty docblock

This commit fixes an edge case tokenizer bug, where a - completely empty, not even whitespace - _DocBlock_, would not be tokenized correctly.

Without this commit, the `/***/` code snippet was tokenized as:
```
 13 | L10 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  5]: /***/
 14 | L10 | C  6 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  0]:
```

With the fix applied, it will be tokenized as:
```
 13 | L10 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  3]: /**
 14 | L10 | C  4 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  2]: */
```

### Tokenizers/Comment: minor tweaks

Girlscouting.

* Remove an unnecessary interim variable.
* Add a comment clarifying certain code.
* Specify the array format in the `@return` tags.

## Suggested changelog entry
* Fixed an edge case bug where an empty block comment would not be tokenized correctly.
* Fixed an edge case bug where an empty single-line DocBlock would not be tokenized correctly.


## Related issues/external references

Preliminary work to allow for #484 later on.

Related #146


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_


