### PR TITLE
Generic/InlineControlStructure: fix error when handling `else if`

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -75,7 +75,7 @@ class InlineControlStructureSniff implements Sniff
 
         // Ignore the ELSE in ELSE IF. We'll process the IF part later.
         if ($tokens[$stackPtr]['code'] === T_ELSE) {
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($tokens[$next]['code'] === T_IF) {
                 return;
             }

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
@@ -272,3 +272,7 @@ function testFinally()
         } finally {
         }
 }
+
+if ($something) {
+    echo 'hello';
+} else /* comment */ if ($somethingElse) echo 'hi';

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
@@ -307,3 +307,8 @@ function testFinally()
         }
     }
 }
+
+if ($something) {
+    echo 'hello';
+} else /* comment */ if ($somethingElse) { echo 'hi';
+}

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js
@@ -29,3 +29,7 @@ if ($("#myid").rotationDegrees()=='90')
 
 if ($("#myid").rotationDegrees()=='90')
     $foo = {'transform': 'rotate(90deg)'};
+
+if (something) {
+    alert('hello');
+} else /* comment */ if (somethingElse) alert('hi');

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js.fixed
@@ -37,3 +37,8 @@ if ($("#myid").rotationDegrees()=='90') {
 if ($("#myid").rotationDegrees()=='90') {
     $foo = {'transform': 'rotate(90deg)'};
 }
+
+if (something) {
+    alert('hello');
+} else /* comment */ if (somethingElse) { alert('hi');
+}

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -78,6 +78,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
                 242 => 1,
                 260 => 1,
                 269 => 1,
+                278 => 1,
             ];
 
         case 'InlineControlStructureUnitTest.js':
@@ -90,6 +91,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
                 21 => 1,
                 27 => 1,
                 30 => 1,
+                35 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

This PR fixes a bug in the Generic.ControlStructures.InlineControlStructure sniff where it would not handle correctly `else if` statements when there is a comment between the `else` and `if` tokens.

The affected code was added in https://github.com/squizlabs/PHP_CodeSniffer/commit/18f98cc9a48bacf026c1a61208d03f6b88c2f69e to fix a similar bug when there is more than one whitespace between `else` and `if`, but it failed to consider that there might be comment tokens between `else` and `if`.

This change was originally part of PR #482, but it was decided to split it into multiple smaller PRs.

## Suggested changelog entry
Generic.ControlStructures.InlineControlStructure: properly handle else if statements where there is a comment between else and if

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.