### PR TITLE
Tokenizer/PHP: fix handling of "DNF look-a-likes" in named parameters

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3212,7 +3212,17 @@ class PHP extends Tokenizer
                     }
 
                     if ($suspectedType === 'return' && $this->tokens[$x]['code'] === T_COLON) {
-                        $confirmed = true;
+                        // Make sure this is not the colon from a parameter name.
+                        for ($y = ($x - 1); $y > 0; $y--) {
+                            if (isset(Tokens::$emptyTokens[$this->tokens[$y]['code']]) === false) {
+                                break;
+                            }
+                        }
+
+                        if ($this->tokens[$y]['code'] !== T_PARAM_NAME) {
+                            $confirmed = true;
+                        }
+
                         break;
                     }
 

--- a/tests/Core/Tokenizer/PHP/DNFTypesTest.inc
+++ b/tests/Core/Tokenizer/PHP/DNFTypesTest.inc
@@ -44,6 +44,14 @@ list(&$a, &$b) = $array;
 /* testParensNoOwnerFunctionCallwithDNFLookALikeParam */
 $obj->static((CONST_A&CONST_B)|CONST_C | $var);
 
+/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamPlain */
+callMe(label: false);
+
+/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamUnion */
+callMe(label: CONST_A | CONST_B);
+
+/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamIntersect */
+callMe(label: CONST_A & CONST_B);
 
 /*
  * DNF parentheses.

--- a/tests/Core/Tokenizer/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizer/PHP/DNFTypesTest.php
@@ -141,6 +141,15 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
             'parens without owner, function call with DNF look-a-like param'  => [
                 'testMarker' => '/* testParensNoOwnerFunctionCallwithDNFLookALikeParam */',
             ],
+            'parens without owner, function call, named param'                => [
+                'testMarker' => '/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamPlain */',
+            ],
+            'parens without owner, function call, named param + bitwise or'   => [
+                'testMarker' => '/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamUnion */',
+            ],
+            'parens without owner, function call, named param + bitwise and'  => [
+                'testMarker' => '/* testParensNoOwnerFunctionCallWithDNFLookALikeNamedParamIntersect */',
+            ],
 
             'parens without owner in OO const default value'                  => [
                 'testMarker' => '/* testParensNoOwnerOOConstDefaultValue */',

--- a/tests/Core/Tokenizer/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizer/PHP/DNFTypesTest.php
@@ -46,11 +46,19 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
         $this->assertSame(T_CLOSE_PARENTHESIS, $closer['code'], 'Token tokenized as '.$closer['type'].', not T_CLOSE_PARENTHESIS (code)');
         $this->assertSame('T_CLOSE_PARENTHESIS', $closer['type'], 'Token tokenized as '.$closer['type'].', not T_CLOSE_PARENTHESIS (type)');
 
-        for ($i = ($openPtr + 1); $i < $closePtr; $i++) {
-            // If there are ampersands, make sure these are tokenized as bitwise and.
-            if ($skipCheckInside === false && $tokens[$i]['content'] === '&') {
-                $this->assertSame(T_BITWISE_AND, $tokens[$i]['code'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_AND (code)');
-                $this->assertSame('T_BITWISE_AND', $tokens[$i]['type'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_AND (type)');
+        if ($skipCheckInside === false) {
+            for ($i = ($openPtr + 1); $i < $closePtr; $i++) {
+                // If there are ampersands, make sure these are tokenized as bitwise and.
+                if ($tokens[$i]['content'] === '&') {
+                    $this->assertSame(T_BITWISE_AND, $tokens[$i]['code'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_AND (code)');
+                    $this->assertSame('T_BITWISE_AND', $tokens[$i]['type'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_AND (type)');
+                }
+
+                // If there are pipes, make sure these are tokenized as bitwise or.
+                if ($tokens[$i]['content'] === '|') {
+                    $this->assertSame(T_BITWISE_OR, $tokens[$i]['code'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_OR (code)');
+                    $this->assertSame('T_BITWISE_OR', $tokens[$i]['type'], 'Token tokenized as '.$tokens[$i]['type'].', not T_BITWISE_OR (type)');
+                }
             }
         }
 


### PR DESCRIPTION
# Description
The last parameter in a function call using named arguments could be confused with a return type by the tokenizer layer handling type declarations.

The net effect of this was that the close parenthesis of the function call would be retokenized to `T_TYPE_CLOSE_PARENTHESIS`, which is incorrect and would lead to sniffs incorrectly acting on that information.

Fixed now.

Includes tests.


## Suggested changelog entry
* The tokenizer could inadvertently mistake the last parameter in a function call using named arguments for a DNF type.

## Related issues/external references

Fixes #504
Fixes #505

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
