### PR TITLE
Tokenizer/PHP: add extra hardening to the (DNF) type handling + efficiency improvement

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3132,8 +3132,13 @@ class PHP extends Tokenizer
 
                 $typeTokenCountBefore = 0;
                 $typeOperators        = [$i];
+                $parenthesesCount     = 0;
                 $confirmed            = false;
                 $maybeNullable        = null;
+
+                if ($this->tokens[$i]['code'] === T_OPEN_PARENTHESIS || $this->tokens[$i]['code'] === T_CLOSE_PARENTHESIS) {
+                    ++$parenthesesCount;
+                }
 
                 for ($x = ($i - 1); $x >= 0; $x--) {
                     if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
@@ -3201,11 +3206,13 @@ class PHP extends Tokenizer
                         continue;
                     }
 
-                    if ($this->tokens[$x]['code'] === T_BITWISE_OR
-                        || $this->tokens[$x]['code'] === T_BITWISE_AND
-                        || $this->tokens[$x]['code'] === T_OPEN_PARENTHESIS
-                        || $this->tokens[$x]['code'] === T_CLOSE_PARENTHESIS
-                    ) {
+                    if ($this->tokens[$x]['code'] === T_BITWISE_OR || $this->tokens[$x]['code'] === T_BITWISE_AND) {
+                        $typeOperators[] = $x;
+                        continue;
+                    }
+
+                    if ($this->tokens[$x]['code'] === T_OPEN_PARENTHESIS || $this->tokens[$x]['code'] === T_CLOSE_PARENTHESIS) {
+                        ++$parenthesesCount;
                         $typeOperators[] = $x;
                         continue;
                     }
@@ -3287,8 +3294,8 @@ class PHP extends Tokenizer
                     unset($parens, $last);
                 }//end if
 
-                if ($confirmed === false) {
-                    // Not a union or intersection type after all, move on.
+                if ($confirmed === false || ($parenthesesCount % 2) !== 0) {
+                    // Not a (valid) union, intersection or DNF type after all, move on.
                     continue;
                 }
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3179,7 +3179,7 @@ class PHP extends Tokenizer
                             $confirmed = true;
                             break;
                         } else {
-                            // This may still be an arrow function which hasn't be handled yet.
+                            // This may still be an arrow function which hasn't been handled yet.
                             for ($y = ($x - 1); $y > 0; $y--) {
                                 if (isset(Tokens::$emptyTokens[$this->tokens[$y]['code']]) === false
                                     && $this->tokens[$y]['code'] !== T_BITWISE_AND

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3036,7 +3036,6 @@ class PHP extends Tokenizer
                 continue;
             } else if ($this->tokens[$i]['code'] === T_BITWISE_OR
                 || $this->tokens[$i]['code'] === T_BITWISE_AND
-                || $this->tokens[$i]['code'] === T_OPEN_PARENTHESIS
                 || $this->tokens[$i]['code'] === T_CLOSE_PARENTHESIS
             ) {
                 /*

--- a/tests/Core/Tokenizer/PHP/DNFTypesParseError1Test.inc
+++ b/tests/Core/Tokenizer/PHP/DNFTypesParseError1Test.inc
@@ -1,0 +1,17 @@
+<?php
+
+// Parentheses in broken DNF type declarations will remain tokenized as normal parentheses.
+// This test is in a separate file as the 'nested_parenthesis' indexes will be off after this code.
+class ParseErrors {
+    /* testBrokenConstDNFTypeEndOnOpenParenthesis */
+    const A|(B PARSE_ERROR = null;
+
+    /* testBrokenPropertyDNFTypeEndOnOpenParenthesis */
+    public A|(B $parseError;
+
+    function unmatchedParens {
+        /* testBrokenParamDNFTypeEndOnOpenParenthesis */
+        A|(B $parseError,
+    /* testBrokenReturnDNFTypeEndOnOpenParenthesis */
+    ) : A|(B {}
+}

--- a/tests/Core/Tokenizer/PHP/DNFTypesParseError1Test.php
+++ b/tests/Core/Tokenizer/PHP/DNFTypesParseError1Test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests that parentheses tokens are not converted to type parentheses tokens in broken DNF types.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizer\AbstractTokenizerTestCase;
+
+final class DNFTypesParseError1Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Document handling for a DNF type / parse error where the last significant type specific token is an open parenthesis.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataBrokenDNFTypeCantEndOnOpenParenthesis
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testBrokenDNFTypeCantEndOnOpenParenthesis($testMarker)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        $openPtr = $this->getTargetToken($testMarker, [T_OPEN_PARENTHESIS, T_TYPE_OPEN_PARENTHESIS], '(');
+        $token   = $tokens[$openPtr];
+
+        // Verify that the open parenthesis is tokenized as a normal parenthesis.
+        $this->assertSame(T_OPEN_PARENTHESIS, $token['code'], 'Token tokenized as '.$token['type'].', not T_OPEN_PARENTHESIS (code)');
+        $this->assertSame('T_OPEN_PARENTHESIS', $token['type'], 'Token tokenized as '.$token['type'].', not T_OPEN_PARENTHESIS (type)');
+
+        // Verify that the type union is still tokenized as T_BITWISE_OR as the type declaration
+        // is not recognized as a valid type declaration.
+        $unionPtr = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION], '|');
+        $token    = $tokens[$unionPtr];
+
+        $this->assertSame(T_BITWISE_OR, $token['code'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (code)');
+        $this->assertSame('T_BITWISE_OR', $token['type'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (type)');
+
+    }//end testBrokenDNFTypeCantEndOnOpenParenthesis()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBrokenDNFTypeCantEndOnOpenParenthesis()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataBrokenDNFTypeCantEndOnOpenParenthesis()
+    {
+        return [
+            'OO const type'    => ['/* testBrokenConstDNFTypeEndOnOpenParenthesis */'],
+            'OO property type' => ['/* testBrokenPropertyDNFTypeEndOnOpenParenthesis */'],
+            'Parameter type'   => ['/* testBrokenParamDNFTypeEndOnOpenParenthesis */'],
+            'Return type'      => ['/* testBrokenReturnDNFTypeEndOnOpenParenthesis */'],
+        ];
+
+    }//end dataBrokenDNFTypeCantEndOnOpenParenthesis()
+
+
+}//end class

--- a/tests/Core/Tokenizer/PHP/DNFTypesParseError2Test.inc
+++ b/tests/Core/Tokenizer/PHP/DNFTypesParseError2Test.inc
@@ -1,0 +1,48 @@
+<?php
+
+// Parentheses in broken DNF type declarations will remain tokenized as normal parentheses.
+// This test is in a separate file as the 'nested_parenthesis' indexes will be off after this code.
+//
+// Also note that the order of these tests is deliberate to try and trick the parentheses handling
+// in the Tokenizer class into matching parentheses pairs, even though the parentheses do
+// no belong together.
+
+class UnmatchedParentheses {
+    /* testBrokenConstDNFTypeParensMissingClose */
+    const A|(B&C PARSE_ERROR_1 = null;
+
+    /* testBrokenConstDNFTypeParensMissingOpen */
+    const A|B&C) PARSE_ERROR_2 = null;
+
+    /* testBrokenPropertyDNFTypeParensMissingClose */
+    private A|(B&C $parseError1;
+
+    /* testBrokenPropertyDNFTypeParensMissingOpen */
+    protected A|B&C) $parseError2;
+
+    function unmatchedParens1 (
+        /* testBrokenParamDNFTypeParensMissingClose */
+        A|(B&C $parseError,
+    /* testBrokenReturnDNFTypeParensMissingOpen */
+    ) : A|B&C) {}
+
+    function unmatchedParens2 (
+        /* testBrokenParamDNFTypeParensMissingOpen */
+        A|B&C) $parseError
+    /* testBrokenReturnDNFTypeParensMissingClose */
+    ) : A|(B&C {}
+}
+
+class MatchedAndUnmatchedParentheses {
+    /* testBrokenConstDNFTypeParensMissingOneClose */
+    const (A&B)|(B&C PARSE_ERROR = null;
+
+    /* testBrokenPropertyDNFTypeParensMissingOneOpen */
+    protected (A&B)|B&C) $parseError;
+
+    function unmatchedParens (
+        /* testBrokenParamDNFTypeParensMissingOneClose */
+        (A&B)|(B&C $parseError,
+    /* testBrokenReturnDNFTypeParensMissingOneOpen */
+    ) : (A&B)|B&C) {}
+}

--- a/tests/Core/Tokenizer/PHP/DNFTypesParseError2Test.php
+++ b/tests/Core/Tokenizer/PHP/DNFTypesParseError2Test.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Tests that parentheses tokens are not converted to type parentheses tokens in broken DNF types.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizer\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+final class DNFTypesParseError2Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Document handling for a DNF type / parse error where the type declaration contains an unmatched parenthesis.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens($testMarker)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        // Verify that the type union is still tokenized as T_BITWISE_OR as the type declaration
+        // is not recognized as a valid type declaration.
+        $unionPtr = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION], '|');
+        $token    = $tokens[$unionPtr];
+
+        $this->assertSame(T_BITWISE_OR, $token['code'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (code)');
+        $this->assertSame('T_BITWISE_OR', $token['type'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (type)');
+
+        // Verify that the unmatched open parenthesis is tokenized as a normal parenthesis.
+        $openPtr = $this->getTargetToken($testMarker, [T_OPEN_PARENTHESIS, T_TYPE_OPEN_PARENTHESIS], '(');
+        $token   = $tokens[$openPtr];
+
+        $this->assertSame(T_OPEN_PARENTHESIS, $token['code'], 'Token tokenized as '.$token['type'].', not T_OPEN_PARENTHESIS (code)');
+        $this->assertSame('T_OPEN_PARENTHESIS', $token['type'], 'Token tokenized as '.$token['type'].', not T_OPEN_PARENTHESIS (type)');
+
+        // Verify that the type intersection is still tokenized as T_BITWISE_AND as the type declaration
+        // is not recognized as a valid type declaration.
+        $intersectPtr = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION], '&');
+        $token        = $tokens[$intersectPtr];
+
+        $this->assertSame(T_BITWISE_AND, $token['code'], 'Token tokenized as '.$token['type'].', not T_BITWISE_AND (code)');
+        $this->assertSame('T_BITWISE_AND', $token['type'], 'Token tokenized as '.$token['type'].', not T_BITWISE_AND (type)');
+
+    }//end testBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens()
+    {
+        return [
+            'OO const type'    => ['/* testBrokenConstDNFTypeParensMissingClose */'],
+            'OO property type' => ['/* testBrokenPropertyDNFTypeParensMissingClose */'],
+            'Parameter type'   => ['/* testBrokenParamDNFTypeParensMissingClose */'],
+            'Return type'      => ['/* testBrokenReturnDNFTypeParensMissingClose */'],
+        ];
+
+    }//end dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingCloseParens()
+
+
+    /**
+     * Document handling for a DNF type / parse error where the type declaration contains an unmatched parenthesis.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens($testMarker)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        // Verify that the type union is still tokenized as T_BITWISE_OR as the type declaration
+        // is not recognized as a valid type declaration.
+        $unionPtr = $this->getTargetToken($testMarker, [T_BITWISE_OR, T_TYPE_UNION], '|');
+        $token    = $tokens[$unionPtr];
+
+        $this->assertSame(T_BITWISE_OR, $token['code'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (code)');
+        $this->assertSame('T_BITWISE_OR', $token['type'], 'Token tokenized as '.$token['type'].', not T_BITWISE_OR (type)');
+
+        // Verify that the unmatched open parenthesis is tokenized as a normal parenthesis.
+        $closePtr = $this->getTargetToken($testMarker, [T_CLOSE_PARENTHESIS, T_TYPE_CLOSE_PARENTHESIS], ')');
+        $token    = $tokens[$closePtr];
+
+        $this->assertSame(T_CLOSE_PARENTHESIS, $token['code'], 'Token tokenized as '.$token['type'].', not T_CLOSE_PARENTHESIS (code)');
+        $this->assertSame('T_CLOSE_PARENTHESIS', $token['type'], 'Token tokenized as '.$token['type'].', not T_CLOSE_PARENTHESIS (type)');
+
+        // Verify that the type intersection is still tokenized as T_BITWISE_AND as the type declaration
+        // is not recognized as a valid type declaration.
+        $intersectPtr = $this->getTargetToken($testMarker, [T_BITWISE_AND, T_TYPE_INTERSECTION], '&');
+        $token        = $tokens[$intersectPtr];
+
+        $this->assertSame(T_BITWISE_AND, $token['code'], 'Token tokenized as '.$token['type'].', not T_BITWISE_AND (code)');
+        $this->assertSame('T_BITWISE_AND', $token['type'], 'Token tokenized as '.$token['type'].', not T_BITWISE_AND (type)');
+
+    }//end testBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens()
+    {
+        return [
+            'OO const type'    => ['/* testBrokenConstDNFTypeParensMissingOpen */'],
+            'OO property type' => ['/* testBrokenPropertyDNFTypeParensMissingOpen */'],
+            'Parameter type'   => ['/* testBrokenParamDNFTypeParensMissingOpen */'],
+            'Return type'      => ['/* testBrokenReturnDNFTypeParensMissingOpen */'],
+        ];
+
+    }//end dataBrokenDNFTypeParensShouldAlwaysBeAPairMissingOpenParens()
+
+
+    /**
+     * Document handling for a DNF type / parse error where the type declaration contains an unmatched parenthesis,
+     * but also contains a set of matched parentheses.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched($testMarker)
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $startPtr = $this->getTargetToken($testMarker, [T_OPEN_PARENTHESIS, T_TYPE_OPEN_PARENTHESIS], '(');
+
+        for ($i = $startPtr; $i < $this->phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === T_EQUAL
+                || $tokens[$i]['code'] === T_VARIABLE
+                || $tokens[$i]['code'] === T_OPEN_CURLY_BRACKET
+            ) {
+                // Reached the end of the type.
+                break;
+            }
+
+            $errorPrefix = 'Token tokenized as '.$tokens[$i]['type'];
+
+            // Verify that type tokens have not been retokenized to `T_TYPE_*` tokens for broken type declarations.
+            switch ($tokens[$i]['content']) {
+            case '|':
+                $this->assertSame(T_BITWISE_OR, $tokens[$i]['code'], $errorPrefix.', not T_BITWISE_OR (code)');
+                $this->assertSame('T_BITWISE_OR', $tokens[$i]['type'], $errorPrefix.', not T_BITWISE_OR (type)');
+                break;
+
+            case '&':
+                $this->assertSame(T_BITWISE_AND, $tokens[$i]['code'], $errorPrefix.', not T_BITWISE_AND (code)');
+                $this->assertSame('T_BITWISE_AND', $tokens[$i]['type'], $errorPrefix.', not T_BITWISE_AND (type)');
+                break;
+
+            case '(':
+                // Verify that the open parenthesis is tokenized as a normal parenthesis.
+                $this->assertSame(T_OPEN_PARENTHESIS, $tokens[$i]['code'], $errorPrefix.', not T_OPEN_PARENTHESIS (code)');
+                $this->assertSame('T_OPEN_PARENTHESIS', $tokens[$i]['type'], $errorPrefix.', not T_OPEN_PARENTHESIS (type)');
+                break;
+
+            case ')':
+                $this->assertSame(T_CLOSE_PARENTHESIS, $tokens[$i]['code'], $errorPrefix.', not T_CLOSE_PARENTHESIS (code)');
+                $this->assertSame('T_CLOSE_PARENTHESIS', $tokens[$i]['type'], $errorPrefix.', not T_CLOSE_PARENTHESIS (type)');
+                break;
+
+            default:
+                break;
+            }//end switch
+        }//end for
+
+    }//end testBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched()
+    {
+        return [
+            'OO const type - missing one close parenthesis'   => ['/* testBrokenConstDNFTypeParensMissingOneClose */'],
+            'OO property type - missing one open parenthesis' => ['/* testBrokenPropertyDNFTypeParensMissingOneOpen */'],
+            'Parameter type - missing one close parenthesis'  => ['/* testBrokenParamDNFTypeParensMissingOneClose */'],
+            'Return type - missing one open parenthesis'      => ['/* testBrokenReturnDNFTypeParensMissingOneOpen */'],
+        ];
+
+    }//end dataBrokenDNFTypeParensShouldAlwaysBeAPairMatchedAndUnmatched()
+
+
+}//end class


### PR DESCRIPTION
# Description

Follow up on PR #507. 

### Tokenizer/PHP: efficiency improvement for DNF type handling

The `PHP::processAdditional()` method walks _back_ from the end of the file to the beginning.

With that in mind, and knowing that a type can never end on an open parenthesis, and an open parenthesis can never be seen in a type before the close parenthesis has been seen (at least for valid/non-parse error types), it makes no sense to trigger the type handling logic for open parentheses.

This should make the tokenizer slightly more efficient as (open) parentheses are used a lot in code ;-)

It also prevents the type handling layer from acting on these type of invalid/parse error types, while it previously would.

Includes tests safeguarding the behaviour of the type handling layer for this type of invalid/parse error types.

Of these tests, the type for the OO constant and for the property were previously not handled consistently/correctly.
The parameter type + the return type were fine.

### Tokenizer/PHP: don't retokenize tokens in a broken type DNF declaration

A DNF type always needs to have matching open and close parentheses. If the parentheses are unbalanced, we can't be sure this is a DNF type and run the risk of retokenizing non-type tokens.

Even if the code under scan was intended as a DNF type, it will be invalid code/contain a parse error if the parentheses are unbalanced.
In that case, retokenizing to the type specific tokens is likely to make the effect of this parse error on sniffs _worse_.

With that in mind, I'm adding extra hardening to the type handling layer in the PHP tokenizer, which will ensure that the retokenization to type specific tokens _only_ happens when there are balanced pairs of DNF parentheses.

Includes tests safeguarding the behaviour of the type handling layer for this type of invalid/parse error types.

Safe for two, all these tests would previously fail on containing at least _some_ type specific tokens.

### Tokenizer/PHP: efficiency fix

Reminder: the PHP::processAdditional()` method walks _back_ from the end of the file to the beginning.

The type handling retokenization layer is triggered for each `&`, `|` and `)` the tokenizer encounters.

When something is recognized as a valid type declaration, the relevant tokens will all be retokenized in one go the first time the type handling layer is triggered, which means that - as the type tokens will have been retokenized already -, the type handling layer will not be triggered again for any of the other type related tokens in the type.

However, if the type is *not* recognized as a valid type, the type handling layer will keep getting retriggered and will (correctly) keep concluding this is not a valid type.

The change in this PR, prevents the type handling layer from doing any work when it is retriggered on a token which was previously already seen and concluded to be, either not part of a type or part of an invalid type.

This should make the tokenizer marginally faster for complex types containing an error, like `(A&B)|(C&D|(E&F)`.

### Tokenizer/PHP: minor doc fix in type handling layer 


## Suggested changelog entry
* Efficiency improvement to the type handling layer in the PHP tokenizer.
* Tokenizer/PHP: extra hardening against handling parse errors in the type handling layer


## Related issues/external references

Loosely related to #504, #505, #507

