### PR TITLE
File::find[Start|End]OfStatement(): add QA tests

### DIFF
--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::findEndOfStatement method.
@@ -18,6 +19,42 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  */
 final class FindEndOfStatementTest extends AbstractMethodUnitTest
 {
+
+
+    /**
+     * Test that end of statement is NEVER before the "current" token.
+     *
+     * @return void
+     */
+    public function testEndIsNeverLessThanCurrentToken()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+        $errors = [];
+
+        for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            $end = self::$phpcsFile->findEndOfStatement($i);
+
+            // Collect all the errors.
+            if ($end < $i) {
+                $errors[] = sprintf(
+                    'End of statement for token %1$d (%2$s: %3$s) on line %4$d is %5$d (%6$s), which is less than %1$d',
+                    $i,
+                    $tokens[$i]['type'],
+                    $tokens[$i]['content'],
+                    $tokens[$i]['line'],
+                    $end,
+                    $tokens[$end]['type']
+                );
+            }
+        }
+
+        $this->assertSame([], $errors);
+
+    }//end testEndIsNeverLessThanCurrentToken()
 
 
     /**

--- a/tests/Core/File/FindStartOfStatementTest.inc
+++ b/tests/Core/File/FindStartOfStatementTest.inc
@@ -14,7 +14,7 @@ while(true) {}
 $a = 1;
 
 /* testClosureAssignment */
-$a = function($b=false;){};
+$a = function($b=false){};
 
 /* testHeredocFunctionArg */
 myFunction(<<<END
@@ -39,8 +39,8 @@ use Vendor\Package\{ClassA as A, ClassB, ClassC as C};
 
 $a = [
     /* testArrowFunctionArrayValue */
-    'a' => fn() => return 1,
-    'b' => fn() => return 1,
+    'a' => fn() => 1,
+    'b' => fn() => 1,
 ];
 
 /* testStaticArrowFunction */
@@ -139,11 +139,11 @@ switch ($foo) {
         /* testInsideCaseStatement */
         $var = doSomething();
         /* testInsideCaseBreakStatement */
-        break 2;
+        break 1;
 
     case 2:
         /* testInsideCaseContinueStatement */
-        continue 2;
+        continue 1;
 
     case 3:
         /* testInsideCaseReturnStatement */

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -92,7 +92,7 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
         $start = $this->getTargetToken('/* testClosureAssignment */', T_CLOSE_CURLY_BRACKET);
         $found = self::$phpcsFile->findStartOfStatement($start);
 
-        $this->assertSame(($start - 12), $found);
+        $this->assertSame(($start - 11), $found);
 
     }//end testClosureAssignment()
 
@@ -224,7 +224,7 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
         $start = $this->getTargetToken('/* testArrowFunctionArrayValue */', T_COMMA);
         $found = self::$phpcsFile->findStartOfStatement($start);
 
-        $this->assertSame(($start - 9), $found);
+        $this->assertSame(($start - 7), $found);
 
     }//end testArrowFunctionArrayValue()
 

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -12,6 +12,7 @@
 namespace PHP_CodeSniffer\Tests\Core\File;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:findStartOfStatement method.
@@ -20,6 +21,42 @@ use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
  */
 final class FindStartOfStatementTest extends AbstractMethodUnitTest
 {
+
+
+    /**
+     * Test that start of statement is NEVER beyond the "current" token.
+     *
+     * @return void
+     */
+    public function testStartIsNeverMoreThanCurrentToken()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+        $errors = [];
+
+        for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            $start = self::$phpcsFile->findStartOfStatement($i);
+
+            // Collect all the errors.
+            if ($start > $i) {
+                $errors[] = sprintf(
+                    'Start of statement for token %1$d (%2$s: %3$s) on line %4$d is %5$d (%6$s), which is more than %1$d',
+                    $i,
+                    $tokens[$i]['type'],
+                    $tokens[$i]['content'],
+                    $tokens[$i]['line'],
+                    $start,
+                    $tokens[$start]['type']
+                );
+            }
+        }
+
+        $this->assertSame([], $errors);
+
+    }//end testStartIsNeverMoreThanCurrentToken()
 
 
     /**


### PR DESCRIPTION
# Description

Follow up on #502

### File::findStartOfStatement(): fix some unintentional parse errors in the test case file

### File::find[Start|End]OfStatement(): add QA tests

This commit adds two QA tests to find potential bugs in the `File::find[Start|End]OfStatement()` methods.

1. It adds a test to ensure that the return value of `File::findStartOfStatement()` is never _after_ the passed `$start` stack pointer.
2. It adds a test to ensure that the return value of `File::findEndOfStatement()` is never _before_ the passed `$start` stack pointer.

The tests use the existing test code, but tests all non-empty tokens within the file.

Note: this test doesn't test that the stack pointer returned is _correct_, only that it _could_ be correct.


## Suggested changelog entry
_N/A_