### PR TITLE
Issue templates: add extra checkbox + config file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -66,5 +66,6 @@ Add any other context about the problem here.
 ## Please confirm
 
 - [ ] I have searched the issue list and am not opening a duplicate issue.
+- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md) and this is not a [support question](https://github.com/PHPCSStandards/PHP_CodeSniffer/discussions).
 - [ ] I confirm that this bug is a bug in PHP_CodeSniffer and not in one of the external standards.
 - [ ] I have verified the issue still exists in the `master` branch of PHP_CodeSniffer.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community Support
+    url: https://github.com/PHPCSStandards/PHP_CodeSniffer/discussions?discussions_q=-category%3AAnnouncements
+    about: Support questions belong in Discussions, not in the issue tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,4 +21,5 @@ code samples of what should *not* be flagged.
 ## Additional context (optional)
 <!-- Add any other context or screenshots about the feature request here. -->
 
+- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md) and this is not a [support question](https://github.com/PHPCSStandards/PHP_CodeSniffer/discussions).
 - [ ] I intend to create a pull request to implement this feature.


### PR DESCRIPTION
# Description

### Issue templates: add extra checkbox
The issue tracker is for bug reports, feature requests and structural improvement proposals only. Not for support requests.

As per the contributing guide, those belong on StackOverflow or in the discussion forum, not in the issue tracker.

Let's see if this helps to reduce the noise of people posting support requests as "bugs".

### Issue templates: add configuration file

This configuration file:
* Continues to allow blank issues to be opened.
* Adds an extra item to the issue template chooser pointing people with support questions to Discussions.

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser


## Suggested changelog entry
_N/A_