### PR TITLE
GH Actions: update merge conflict check workflow

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -20,7 +20,8 @@ jobs:
     name: Check PRs for merge conflicts
 
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
+      - name: Check PRs for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
-          CONFLICT_LABEL_NAME: "Status: has merge conflict"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dirtyLabel: "Status: has merge conflict"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
The `mschilde/auto-label-merge-conflicts` action runner is not actively maintained and is currently failing due to an unhandled deprecation notice. [Example](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/runs/9380398878/job/25827454084)

I've evaluated the action runners available for this kind of thing and am proposing to switch to the `eps1lon/actions-label-merge-conflict` action runner, which should be a one-on-one replacement for the currently used functionality.

Additionally, that action has an option to post a comment when a conflict is detected as well as when the conflict has been resolved. While not currently used, this feature might be useful in the future.

Note: unfortunately, I won't be able to test the change until merged into the `master` branch, so this may need further tweaks once merged.

Refs:
* https://github.com/marketplace?query=label+merge+conflicts
* https://github.com/mschilde/auto-label-merge-conflicts
* https://github.com/eps1lon/actions-label-merge-conflict

## Suggested changelog entry
_N/A_