### PR TITLE
GH Actions/merge conflicts: also check PRs for the 4.0 branch

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 4.0
   # Check conflicts in new PRs and for resolved conflicts due to an open PR being updated.
   pull_request_target:
     types:


### PR DESCRIPTION
# Description
Based on the logging, the PRs for the 4.0 branch are not checked on pushes. Let's enable that.


## Suggested changelog entry
_N/A_