### PR TITLE
Tests/Util: move test classes into subdirectories

### DIFF
--- a/tests/Core/Util/Common/IsCamelCapsTest.php
+++ b/tests/Core/Util/Common/IsCamelCapsTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\Util;
+namespace PHP_CodeSniffer\Tests\Core\Util\Common;
 
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;

--- a/tests/Core/Util/Common/StripColorsTest.php
+++ b/tests/Core/Util/Common/StripColorsTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\Util;
+namespace PHP_CodeSniffer\Tests\Core\Util\Common;
 
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;

--- a/tests/Core/Util/Common/SuggestTypeTest.php
+++ b/tests/Core/Util/Common/SuggestTypeTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\Util;
+namespace PHP_CodeSniffer\Tests\Core\Util\Common;
 
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;

--- a/tests/Core/Util/Help/HelpTest.php
+++ b/tests/Core/Util/Help/HelpTest.php
@@ -7,7 +7,7 @@
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\Util;
+namespace PHP_CodeSniffer\Tests\Core\Util\Help;
 
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Util\Help;


### PR DESCRIPTION
# Description
Move test classes into subdirectories mirroring the name of the class holding the code being tested.

Having the tests for each class in their own subdirectory should make it more straight forward to see what code is covered by tests.

## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #146