### PR TITLE
Documentation: improve information about Report data format + remove unused foreach keys

### DIFF
--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -329,7 +329,29 @@ class Reporter
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file that has been processed.
      *
-     * @return array
+     * @return array<string, string|int|array> Prepared report data.
+     *                                         The format of prepared data is as follows:
+     *                                         ```
+     *                                         array(
+     *                                           'filename' => string The name of the current file.
+     *                                           'errors'   => int    The number of errors seen in the current file.
+     *                                           'warnings' => int    The number of warnings seen in the current file.
+     *                                           'fixable'  => int    The number of fixable issues seen in the current file.
+     *                                           'messages' => array(
+     *                                             int <Line number> => array(
+     *                                               int <Column number> => array(
+     *                                                 int <Message index> => array(
+     *                                                   'message'  => string The error/warning message.
+     *                                                   'source'   => string The full error code for the message.
+     *                                                   'severity' => int    The severity of the message.
+     *                                                   'fixable'  => bool   Whether this error/warning is auto-fixable.
+     *                                                   'type'     => string The type of message. Either 'ERROR' or 'WARNING'.
+     *                                                 )
+     *                                               )
+     *                                             )
+     *                                           )
+     *                                         )
+     *                                         ```
      */
     public function prepareFileReport(File $phpcsFile)
     {

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -28,10 +28,11 @@ class Cbf implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -24,10 +24,11 @@ class Checkstyle implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -122,8 +122,8 @@ class Code implements Report
 
         // Determine the longest error message we will be showing.
         $maxErrorLength = 0;
-        foreach ($report['messages'] as $line => $lineErrors) {
-            foreach ($lineErrors as $column => $colErrors) {
+        foreach ($report['messages'] as $lineErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     $length = strlen($error['message']);
                     if ($showSources === true) {
@@ -265,7 +265,7 @@ class Code implements Report
 
             echo str_repeat('-', $width).PHP_EOL;
 
-            foreach ($lineErrors as $column => $colErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     $padding = ($maxLineNumLength - strlen($line));
                     echo 'LINE '.str_repeat(' ', $padding).$line.': ';

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -25,10 +25,11 @@ class Code implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Csv.php
+++ b/src/Reports/Csv.php
@@ -22,10 +22,11 @@ class Csv implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -22,10 +22,11 @@ class Diff implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Emacs.php
+++ b/src/Reports/Emacs.php
@@ -22,10 +22,11 @@ class Emacs implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -23,10 +23,11 @@ class Full implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -62,8 +62,8 @@ class Full implements Report
 
         // Make sure the report width isn't too big.
         $maxErrorLength = 0;
-        foreach ($report['messages'] as $line => $lineErrors) {
-            foreach ($lineErrors as $column => $colErrors) {
+        foreach ($report['messages'] as $lineErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     // Start with the presumption of a single line error message.
                     $length    = strlen($error['message']);
@@ -139,7 +139,7 @@ class Full implements Report
         $beforeAfterLength = strlen($beforeMsg.$afterMsg);
 
         foreach ($report['messages'] as $line => $lineErrors) {
-            foreach ($lineErrors as $column => $colErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     $errorMsg = wordwrap(
                         $error['message'],

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -23,10 +23,11 @@ class Info implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -23,10 +23,11 @@ class Json implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -25,10 +25,11 @@ class Junit implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -88,10 +88,11 @@ class Notifysend implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Performance.php
+++ b/src/Reports/Performance.php
@@ -24,10 +24,11 @@ class Performance implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -22,10 +22,33 @@ interface Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * The format of the `$report` parameter the function receives is as follows:
+     * ```
+     * array(
+     *   'filename' => string The name of the current file.
+     *   'errors'   => int    The number of errors seen in the current file.
+     *   'warnings' => int    The number of warnings seen in the current file.
+     *   'fixable'  => int    The number of fixable issues seen in the current file.
+     *   'messages' => array(
+     *     int <Line number> => array(
+     *       int <Column number> => array(
+     *         int <Message index> => array(
+     *           'message'  => string The error/warning message.
+     *           'source'   => string The full error code for the message.
+     *           'severity' => int    The severity of the message.
+     *           'fixable'  => bool   Whether this error/warning is auto-fixable.
+     *           'type'     => string The type of message. Either 'ERROR' or 'WARNING'.
+     *         )
+     *       )
+     *     )
+     *   )
+     * )
+     * ```
+     *
+     * @param array<string, string|int|array> $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -40,8 +40,8 @@ class Source implements Report
 
         $sources = [];
 
-        foreach ($report['messages'] as $line => $lineErrors) {
-            foreach ($lineErrors as $column => $colErrors) {
+        foreach ($report['messages'] as $lineErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     $src = $error['source'];
                     if (isset($sources[$src]) === false) {

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -23,10 +23,11 @@ class Source implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -23,10 +23,11 @@ class Summary implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -66,7 +66,7 @@ abstract class VersionControl implements Report
 
             $praiseCache[$author]['bad']++;
 
-            foreach ($lineErrors as $column => $colErrors) {
+            foreach ($lineErrors as $colErrors) {
                 foreach ($colErrors as $error) {
                     $authorCache[$author]++;
 

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -31,10 +31,11 @@ abstract class VersionControl implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -24,10 +24,11 @@ class Xml implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                       $report      Prepared report data.
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
-     * @param bool                        $showSources Show sources?
-     * @param int                         $width       Maximum allowed line width.
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
      *
      * @return bool
      */


### PR DESCRIPTION
# Description

Follow up on PR #446

### Documentation: improve information about report data format

This commit adds detailed information about the array format `Report` classes receive in the `generateFileReport()` method to the `Report` interface and to the `Reporter::prepareFileReport()` method which prepares the data.

It also makes the parameter specification in the individual reports a little more specific and references the `Report` interface for further details.

### CS/QA: remove unused foreach keys from report code

As the array format is now documented, these unused variables are no longer needed for documentation purposes.


## Suggested changelog entry
_N/A_


## Related issues/external references

Related to https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/446#discussion_r1573936634