### PR TITLE
Common::getSniffCode(): add tests, more defensive coding and minor simplification

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -873,9 +873,13 @@ class File
         $parts = explode('.', $code);
         if ($parts[0] === 'Internal') {
             // An internal message.
-            $listenerCode = Common::getSniffCode($this->activeListener);
-            $sniffCode    = $code;
-            $checkCodes   = [$sniffCode];
+            $listenerCode = '';
+            if ($this->activeListener !== '') {
+                $listenerCode = Common::getSniffCode($this->activeListener);
+            }
+
+            $sniffCode  = $code;
+            $checkCodes = [$sniffCode];
         } else {
             if ($parts[0] !== $code) {
                 // The full message code has been passed in.

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -532,6 +532,7 @@ class Common
      * @return string
      *
      * @throws \InvalidArgumentException When $sniffClass is not a non-empty string.
+     * @throws \InvalidArgumentException When $sniffClass is not a FQN for a sniff(test) class.
      */
     public static function getSniffCode($sniffClass)
     {
@@ -540,6 +541,12 @@ class Common
         }
 
         $parts = explode('\\', $sniffClass);
+        if (count($parts) < 4) {
+            throw new InvalidArgumentException(
+                'The $sniffClass parameter was not passed a fully qualified sniff class name. Received: '.$sniffClass
+            );
+        }
+
         $sniff = array_pop($parts);
 
         if (substr($sniff, -5) === 'Sniff') {

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -543,7 +543,7 @@ class Common
         $parts = explode('\\', $sniffClass);
         if (count($parts) < 4) {
             throw new InvalidArgumentException(
-                'The $sniffClass parameter was not passed a fully qualified sniff class name. Received: '.$sniffClass
+                'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received: '.$sniffClass
             );
         }
 
@@ -552,9 +552,13 @@ class Common
         if (substr($sniff, -5) === 'Sniff') {
             // Sniff class name.
             $sniff = substr($sniff, 0, -5);
-        } else {
+        } else if (substr($sniff, -8) === 'UnitTest') {
             // Unit test class name.
             $sniff = substr($sniff, 0, -8);
+        } else {
+            throw new InvalidArgumentException(
+                'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received: '.$sniffClass
+            );
         }
 
         $category = array_pop($parts);

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -540,14 +540,15 @@ class Common
             throw new InvalidArgumentException('The $sniffClass parameter must be a non-empty string');
         }
 
-        $parts = explode('\\', $sniffClass);
-        if (count($parts) < 4) {
+        $parts      = explode('\\', $sniffClass);
+        $partsCount = count($parts);
+        if ($partsCount < 4) {
             throw new InvalidArgumentException(
                 'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received: '.$sniffClass
             );
         }
 
-        $sniff = array_pop($parts);
+        $sniff = $parts[($partsCount - 1)];
 
         if (substr($sniff, -5) === 'Sniff') {
             // Sniff class name.
@@ -561,11 +562,9 @@ class Common
             );
         }
 
-        $category = array_pop($parts);
-        $sniffDir = array_pop($parts);
-        $standard = array_pop($parts);
-        $code     = $standard.'.'.$category.'.'.$sniff;
-        return $code;
+        $standard = $parts[($partsCount - 4)];
+        $category = $parts[($partsCount - 2)];
+        return $standard.'.'.$category.'.'.$sniff;
 
     }//end getSniffCode()
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Util;
 
+use InvalidArgumentException;
 use Phar;
 
 class Common
@@ -529,9 +530,15 @@ class Common
      * @param string $sniffClass The fully qualified sniff class name.
      *
      * @return string
+     *
+     * @throws \InvalidArgumentException When $sniffClass is not a non-empty string.
      */
     public static function getSniffCode($sniffClass)
     {
+        if (is_string($sniffClass) === false || $sniffClass === '') {
+            throw new InvalidArgumentException('The $sniffClass parameter must be a non-empty string');
+        }
+
         $parts = explode('\\', $sniffClass);
         $sniff = array_pop($parts);
 

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -79,7 +79,7 @@ final class GetSniffCodeTest extends TestCase
     public function testGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass($input)
     {
         $exception = 'InvalidArgumentException';
-        $message   = 'The $sniffClass parameter was not passed a fully qualified sniff class name. Received:';
+        $message   = 'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received:';
 
         if (method_exists($this, 'expectException') === true) {
             // PHPUnit 5+.
@@ -105,8 +105,9 @@ final class GetSniffCodeTest extends TestCase
     public static function dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
     {
         return [
-            'Unqualified class name'                       => ['ClassName'],
-            'Fully qualified class name, not enough parts' => ['Fully\\Qualified\\ClassName'],
+            'Unqualified class name'                                        => ['ClassName'],
+            'Fully qualified class name, not enough parts'                  => ['Fully\\Qualified\\ClassName'],
+            'Fully qualified class name, doesn\'t end on Sniff or UnitTest' => ['Fully\\Sniffs\\Qualified\\ClassName'],
         ];
 
     }//end dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -22,6 +22,51 @@ final class GetSniffCodeTest extends TestCase
 
 
     /**
+     * Test receiving an expected exception when the $sniffClass parameter is not passed a string value or is passed an empty string.
+     *
+     * @param string $input NOT a fully qualified sniff class name.
+     *
+     * @dataProvider dataGetSniffCodeThrowsExceptionOnInvalidInput
+     *
+     * @return void
+     */
+    public function testGetSniffCodeThrowsExceptionOnInvalidInput($input)
+    {
+        $exception = 'InvalidArgumentException';
+        $message   = 'The $sniffClass parameter must be a non-empty string';
+
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $message);
+        }
+
+        Common::getSniffCode($input);
+
+    }//end testGetSniffCodeThrowsExceptionOnInvalidInput()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testGetSniffCodeThrowsExceptionOnInvalidInput()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataGetSniffCodeThrowsExceptionOnInvalidInput()
+    {
+        return [
+            'Class name is not a string' => [true],
+            'Class name is empty'        => [''],
+        ];
+
+    }//end dataGetSniffCodeThrowsExceptionOnInvalidInput()
+
+
+    /**
      * Test transforming a sniff class name to a sniff code.
      *
      * @param string $fqnClass A fully qualified sniff class name.

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -67,6 +67,52 @@ final class GetSniffCodeTest extends TestCase
 
 
     /**
+     * Test receiving an expected exception when the $sniffClass parameter is not passed a value which
+     * could be a fully qualified sniff(test) class name.
+     *
+     * @param string $input String input which can not be a fully qualified sniff(test) class name.
+     *
+     * @dataProvider dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass
+     *
+     * @return void
+     */
+    public function testGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass($input)
+    {
+        $exception = 'InvalidArgumentException';
+        $message   = 'The $sniffClass parameter was not passed a fully qualified sniff class name. Received:';
+
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $message);
+        }
+
+        Common::getSniffCode($input);
+
+    }//end testGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
+    {
+        return [
+            'Unqualified class name'                       => ['ClassName'],
+            'Fully qualified class name, not enough parts' => ['Fully\\Qualified\\ClassName'],
+        ];
+
+    }//end dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
+
+
+    /**
      * Test transforming a sniff class name to a sniff code.
      *
      * @param string $fqnClass A fully qualified sniff class name.

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Util\Common::getSniffCode() method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Util\Common;
+
+use PHP_CodeSniffer\Util\Common;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Util\Common::getSniffCode() method.
+ *
+ * @covers \PHP_CodeSniffer\Util\Common::getSniffCode
+ */
+final class GetSniffCodeTest extends TestCase
+{
+
+
+    /**
+     * Test transforming a sniff class name to a sniff code.
+     *
+     * @param string $fqnClass A fully qualified sniff class name.
+     * @param string $expected Expected function output.
+     *
+     * @dataProvider dataGetSniffCode
+     *
+     * @return void
+     */
+    public function testGetSniffCode($fqnClass, $expected)
+    {
+        $this->assertSame($expected, Common::getSniffCode($fqnClass));
+
+    }//end testGetSniffCode()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testGetSniffCode()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataGetSniffCode()
+    {
+        return [
+            'PHPCS native sniff'                                  => [
+                'fqnClass' => 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\Arrays\\ArrayIndentSniff',
+                'expected' => 'Generic.Arrays.ArrayIndent',
+            ],
+            'Class is a PHPCS native test class'                  => [
+                'fqnClass' => 'PHP_CodeSniffer\\Standards\\Generic\\Tests\\Arrays\\ArrayIndentUnitTest',
+                'expected' => 'Generic.Arrays.ArrayIndent',
+            ],
+            'Sniff in external standard without namespace prefix' => [
+                'fqnClass' => 'MyStandard\\Sniffs\\PHP\\MyNameSniff',
+                'expected' => 'MyStandard.PHP.MyName',
+            ],
+            'Test in external standard without namespace prefix'  => [
+                'fqnClass' => 'MyStandard\\Tests\\PHP\\MyNameSniff',
+                'expected' => 'MyStandard.PHP.MyName',
+            ],
+            'Sniff in external standard with namespace prefix'    => [
+                'fqnClass' => 'Vendor\\Package\\MyStandard\\Sniffs\\Category\\AnalyzeMeSniff',
+                'expected' => 'MyStandard.Category.AnalyzeMe',
+            ],
+            'Test in external standard with namespace prefix'     => [
+                'fqnClass' => 'Vendor\\Package\\MyStandard\\Tests\\Category\\AnalyzeMeUnitTest',
+                'expected' => 'MyStandard.Category.AnalyzeMe',
+            ],
+        ];
+
+    }//end dataGetSniffCode()
+
+
+}//end class


### PR DESCRIPTION
# Description

### Common::getSniffCode(): add tests

Add initial set of tests for the `Common::getSniffCode()` method.

Related to #146
Related to [review comment in PR 446](https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/446#discussion_r1573947430).

### Common::getSniffCode(): throw exception on invalid input [1]

Previously, if an empty string was passed, the `Common::getSniffCode()` method would return `..`, which is just confusing.

This commit changes the behaviour to throw an `InvalidArgumentException` instead.

Includes making a potentially superfluous function call to the method conditionally (as it could hit the new exception).

Includes test.

### Common::getSniffCode(): throw exception on invalid input [2a]

Previously, if an invalid (incomplete) class name was passed, the `Common::getSniffCode()` method would return a garbled name, like `.Qualified.C`, which is just confusing.

This commit changes the behaviour to throw an `InvalidArgumentException` instead.

Includes test.

### Common::getSniffCode(): throw exception on invalid input [2b]

Previously, if an invalid class name was passed, which didn't end on `Sniff` or `UnitTest`, the `Common::getSniffCode()` method would return a garbled name, like `Fully.Qualified.C`, which is just confusing.

This commit changes the behaviour to throw an `InvalidArgumentException` instead.

Includes test.

### Common::getSniffCode(): minor simplification

* Remove the use of `array_pop()` in favour of directly referencing the required "parts" by their index in the array.
* Remove the unused `$sniffDir` variable.
* Remove the unnecessary `$code` variable.

Related to [review comment in PR 446](https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/446#discussion_r1573947430).

## Suggested changelog entry
The `Common::getSniffCode()` method will now throw an `InvalidArgumentException` exception if an invalid `$sniffClass` is passed.


