### PR TITLE
Generic/DisallowYodaConditions: add code coverage ignore annotation for untestable line

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -145,8 +145,10 @@ class DisallowYodaConditionsSniff implements Sniff
             $start = $tokens[$arrayToken]['parenthesis_opener'];
             $end   = $tokens[$arrayToken]['parenthesis_closer'];
         } else {
+            // @codeCoverageIgnoreStart
             // Shouldn't be possible but may happen if external sniffs are using this method.
             return true;
+            // @codeCoverageIgnoreEnd
         }
 
         $staticTokens  = Tokens::$emptyTokens;


### PR DESCRIPTION
# Description

This PR adds the `@codeCoverageIgnoreStart/@codeCoverageIgnoreEnd` PHPUnit annotations to ignore, for the purposes of code coverage, a line that can't be tested. I considered doing this initially when I worked on improving code coverage for this sniff in #465, but I wrongly assumed that was not an option due to the `Squiz.Commenting.InlineComment.InvalidEndChar` error (which is part of the standard used by PHPCS).

What I failed to notice back then is that I was adding the annotation below a comment, and this triggers the error:

```
// Shouldn't be possible but may happen if external sniffs are using this method.
// @codeCoverageIgnoreStart
```

Adding the annotation before the comment as it is done in this PR does not trigger the error because the `Squiz.Commenting.InlineComment` sniff will only trigger the `InvalidEndChar` error if the first character of the comment is a letter.

I also considered using `return true; // @codeCoverageIgnore`, but this is not an option because it triggers `Squiz.Commenting.PostStatementComment.Found`.

## Related issues/external references

Part of #146 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
