### PR TITLE
AbstractMethodUnitTest: improve finding of target token

### DIFF
--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
+use Exception;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Ruleset;
@@ -110,6 +111,9 @@ abstract class AbstractMethodUnitTest extends TestCase
      * @param string                      $tokenContent  Optional. The token content for the target token.
      *
      * @return int
+     *
+     * @throws Exception When the test delimiter comment is not found.
+     * @throws Exception When the test target token is not found.
      */
     public static function getTargetTokenFromFile(File $phpcsFile, $commentString, $tokenType, $tokenContent=null)
     {
@@ -121,6 +125,12 @@ abstract class AbstractMethodUnitTest extends TestCase
             false,
             $commentString
         );
+
+        if ($comment === false) {
+            throw new Exception(
+                sprintf('Failed to find the test marker: %s in test case file %s', $commentString, $phpcsFile->getFilename())
+            );
+        }
 
         $tokens = $phpcsFile->getTokens();
         $end    = ($start + 1);
@@ -148,10 +158,10 @@ abstract class AbstractMethodUnitTest extends TestCase
         if ($target === false) {
             $msg = 'Failed to find test target token for comment string: '.$commentString;
             if ($tokenContent !== null) {
-                $msg .= ' With token content: '.$tokenContent;
+                $msg .= ' with token content: '.$tokenContent;
             }
 
-            self::assertFalse(true, $msg);
+            throw new Exception($msg);
         }
 
         return $target;


### PR DESCRIPTION
# Description

These changes are similar to changes previously made in the same method in PHPCSUtils.

As things were, there could be a situation where the `getTargetTokenFromFile()` method did not find the delimiter comment. In that case, the method would search for the target token starting at token 0, which would generally lead to an incorrect token being identified as the target token.

This has now been fixed by verifying the outcome of the `findPrevious()` call and throwing an exception (causing the test to fail) when the delimiter comment was not found.

Along the same lines, when the target token would not be found, an exception will now be thrown as well.


## Suggested changelog entry
_N/A_ (this is an internal use class, if external standards want to use a base class for testing utility methods, they should use the PHPCSUtils `UtilityMethodTestCase`).

## Related issues/external references

* https://github.com/PHPCSStandards/PHPCSUtils/pull/248
* https://github.com/PHPCSStandards/PHPCSUtils/pull/273
* https://github.com/PHPCSStandards/PHPCSUtils/pull/371
* https://github.com/PHPCSStandards/PHPCSUtils/pull/372


