### PR TITLE
Generic/DisallowSpaceIndent: flag heredoc/nowdoc closer using space indent

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -78,6 +78,8 @@ class DisallowSpaceIndentSniff implements Sniff
             T_INLINE_HTML            => true,
             T_DOC_COMMENT_WHITESPACE => true,
             T_COMMENT                => true,
+            T_END_HEREDOC            => true,
+            T_END_NOWDOC             => true,
         ];
 
         $eolLen = strlen($phpcsFile->eolChar);
@@ -202,8 +204,18 @@ class DisallowSpaceIndentSniff implements Sniff
                 }
             }//end if
 
-            $error = 'Tabs must be used to indent lines; spaces are not allowed';
-            $fix   = $phpcsFile->addFixableError($error, $i, 'SpacesUsed');
+            $error     = 'Tabs must be used to indent lines; spaces are not allowed';
+            $errorCode = 'SpacesUsed';
+
+            // Report, but don't auto-fix space identation for a PHP 7.3+ flexible heredoc/nowdoc closer.
+            // Auto-fixing this would cause parse errors as the indentation of the heredoc/nowdoc contents
+            // needs to use the same type of indentation. Also see: https://3v4l.org/7OF3M .
+            if ($tokens[$i]['code'] === T_END_HEREDOC || $tokens[$i]['code'] === T_END_NOWDOC) {
+                $phpcsFile->addError($error, $i, $errorCode.'HeredocCloser');
+                continue;
+            }
+
+            $fix = $phpcsFile->addFixableError($error, $i, $errorCode);
             if ($fix === true) {
                 $padding  = str_repeat("\t", $expectedTabs);
                 $padding .= str_repeat(' ', $expectedSpaces);

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.4.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.4.inc
@@ -1,0 +1,13 @@
+<?php
+
+$heredoc = <<<"END"
+        a
+        b
+        c
+    END;
+
+$nowdoc = <<<'END'
+        a
+        b
+        c
+    END;

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -102,6 +102,17 @@ final class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
                 15 => 1,
             ];
 
+        case 'DisallowSpaceIndentUnitTest.4.inc':
+            if (PHP_VERSION_ID >= 70300) {
+                return [
+                    7  => 1,
+                    13 => 1,
+                ];
+            }
+
+            // PHP 7.2 or lower: PHP version which doesn't support flexible heredocs/nowdocs yet.
+            return [];
+
         case 'DisallowSpaceIndentUnitTest.js':
             return [3 => 1];
 


### PR DESCRIPTION
# Description
This is the same fix for the `Generic.WhiteSpace.DisallowSpaceIndent` sniff as was previously made in squizlabs/PHP_CodeSniffer#3640 and #533 for the sister-sniff `Generic.WhiteSpace.DisallowTabIndent`.

---

Since PHP 7.3, heredoc/nowdoc closers may be indented. This indent can use either tabs or spaces and the indent is included in the `T_END_HEREDOC`/`T_END_NOWDOC` token contents as received from the PHP native tokenizer.

However, these tokens were not included in the tokens to look at for the `Generic.WhiteSpace.DisallowSpaceIndent` sniff, which could lead to false negatives.

Fixed now, includes tests.

And along the same lines as per #533:
* The error for space indentation of heredoc/nowdoc closers is not auto-fixable to prevent the fixer creating parse errors as the indentation of the _contents_ of the heredoc/nowdoc has to be the same as for the closer.
* The error for space indentation of heredoc/nowdoc closers has its own error code to allow for selectively ignoring the indentation of heredoc/nowdoc closers.


## Suggested changelog entry
Generic.WhiteSpace.DisallowSpaceIndent not reporting errors for PHP 7.3 flexible heredoc/nowdoc syntax

## Related issues/external references

* https://github.com/squizlabs/PHP_CodeSniffer/pull/3639
* https://github.com/squizlabs/PHP_CodeSniffer/pull/3640
* #533


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
