### PR TITLE
Squiz/DisallowMultipleAssignments: fix sniff walking back too far when going in/out of PHP

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -83,9 +83,8 @@ class DisallowMultipleAssignmentsSniff implements Sniff
         */
 
         for ($varToken = ($stackPtr - 1); $varToken >= 0; $varToken--) {
-            if (in_array($tokens[$varToken]['code'], [T_SEMICOLON, T_OPEN_CURLY_BRACKET], true) === true) {
-                // We've reached the next statement, so we
-                // didn't find a variable.
+            if (in_array($tokens[$varToken]['code'], [T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_CLOSE_TAG], true) === true) {
+                // We've reached the previous statement, so we didn't find a variable.
                 return;
             }
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
@@ -108,3 +108,29 @@ function () {
     $b = getB();
 };
 
+?>
+<?= $var = false; ?>
+
+// Issue PHPCSStandards/PHP_CodeSniffer#537.
+<?php $a * $b ?>
+<?php
+list ($c, $d) = explode(',', '1,2');
+?>
+<?= $a * $b ?>
+<?php
+list ($c, $d) = explode(',', '1,2');
+?>
+<?= $a * $b ?>
+<?= list ($c, $d) = explode(',', '1,2');
+?>
+<?php $a * $b ?>
+<?php
+[$c, $d] = explode(',', '1,2');
+?>
+<?= $a * $b ?>
+<?php
+[$c, $d] = explode(',', '1,2');
+?>
+<?= $a * $b ?>
+<?= [$c, $d] = explode(',', '1,2');
+?>


### PR DESCRIPTION
# Description
The sniff did not recognize that when it would encounter a PHP close tag, it had reached a previous statement, leading to false positives for list assignments.

Fixed now. Includes tests.


## Suggested changelog entry
Squiz.PHP.DisallowMultipleAssignments false positive for list assignments at the start of a new PHP block after an embedded PHP statement.

## Related issues/external references

Fixes #537

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

