### PR TITLE
Add test file for PSR12.Operators.OperatorSpacing

### DIFF
--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.3.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.3.inc
@@ -1,0 +1,6 @@
+<?php
+// There is logic in the sniff which protects itself from reading beyond the end
+// of a file when an inline-if (ternary) operator is detected. This test case
+// covers that scenario. This is an intentional parse error.
+// Note that there is (intentionally) no trailing newline at the end of this file.
+$var = true ?


### PR DESCRIPTION
# Description

The PSR12.Operators.OperatorSpacing sniff has specific logic to avoid an out-of-bounds array offset access. Before now, there were no tests which covered this logic. This commit adds such a test. The sniff already handles this, so there are no changes required there.

This particular omission was detected by [infection/infection](https://github.com/infection/infection).

```diff
src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php:104    [M] FalseValue

@@ @@
             }
         } else {
             // Skip partial files.
-            $checkAfter = false;
+            $checkAfter = true;
         }
         if ($checkBefore === true && $tokens[$stackPtr - 1]['code'] !== T_WHITESPACE) {
             $error = 'Expected at least 1 space before "%s"; 0 found';
```

## Suggested changelog entry
No special remarks required in the changelog for this change. Perhaps a generic note about improvements to tests.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- ~~\[Required for new sniffs\] I have added XML documentation for the sniff.~~
