### PR TITLE
Squiz/ObjectInstantiation: remove keyword context test

### DIFF
--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -47,7 +47,3 @@ $a = $b !== null
         default => 5,
     }
     : new Foo;
-
-// Intentional parse error. This must be the last test in the file.
-function new
-?>


### PR DESCRIPTION
Originally, this test was added in
[squizlabs/PHP_CodeSniffer#836](https://github.com/squizlabs/PHP_CodeSniffer/pull/836)
as part of testing for allowing keywords to be used in other contexts (like
function names). This has been superseded in [squizlabs/PHP_CodeSniffer#3484](https://github.com/squizlabs/PHP_CodeSniffer/pull/3484) to cover keywords used in different contexts in the core Tokenizer tests.

Live coding scenarios would not trigger this sniff as it only looks for
context before the 'new' keyword.


<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Remove an unneeded test from `Squiz/Objects/ObjectInstantiation` that is no longer needed.

The original check for `new` keyword used in other contexts is covered elsewhere in the core tokenizer tests.

It is not needed as a parse error test for live coding either, as this sniff only looks for context before rather than after the `new` keyword.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

N/A

## Related issues/external references

See #543 for discussion. Related to #143.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->