### PR TITLE
Generic/UselessOverridingMethod: improve handling of PHP open/close tags between statements

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -153,15 +153,20 @@ class UselessOverridingMethodSniff implements Sniff
         }//end for
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
-        if ($tokens[$next]['code'] !== T_SEMICOLON) {
+        if ($tokens[$next]['code'] !== T_SEMICOLON && $tokens[$next]['code'] !== T_CLOSE_TAG) {
             return;
         }
+
+        // This list deliberately does not include the `T_OPEN_TAG_WITH_ECHO` as that token implicitly is an echo statement, i.e. content.
+        $nonContent = Tokens::$emptyTokens;
+        $nonContent[T_OPEN_TAG]  = T_OPEN_TAG;
+        $nonContent[T_CLOSE_TAG] = T_CLOSE_TAG;
 
         // Check rest of the scope.
         for (++$next; $next <= $end; ++$next) {
             $code = $tokens[$next]['code'];
             // Skip for any other content.
-            if (isset(Tokens::$emptyTokens[$code]) === false) {
+            if (isset($nonContent[$code]) === false) {
                 return;
             }
         }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.1.inc
@@ -148,3 +148,26 @@ function foo() {
         }
     };
 }
+
+class SniffShouldHandlePHPOpenCloseTagsCorrectly {
+    public function thisIsStillAUselessOverride($a, $b) {
+        return parent::thisIsStillAUselessOverride($a, $b) ?><?php
+        // Even with a comment here.
+    }
+
+    public function butNotWithANewLineBetweenThePHPTagsAsThenWeEchoOutTheNewLine($a, $b) {
+        parent::butNotWithANewLineBetweenThePHPTagsAsThenWeEchoOutTheNewLine($a, $b) ?>
+        <?php
+    }
+
+    public function embeddedHTMLAfterCallingParent() {
+        parent::embeddedHTMLAfterCallingParent() ?>
+        <div>HTML</div>
+        <?php
+    }
+
+    public function contentAfterUselessEmbedBlock() {
+        parent::contentAfterUselessEmbedBlock() ?><?php
+        return 1;
+    }
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -60,6 +60,7 @@ final class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
                 116 => 1,
                 134 => 1,
                 146 => 1,
+                153 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION

# Description
This change prevents an edge-case false negative where a `parent::method()` function call statement ended by a PHP close tag without any "function content" of note after it, would not be reported as a useless overriding method.

Includes unit tests.


## Suggested changelog entry
Generic.CodeAnalysis.UselessOverridingMethod: prevent edge case false negative when the call to the parent method would end on a PHP close tag.


## Related issues/external references

Related to #552


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
