### PR TITLE
Squiz/SelfMemberReference: handle namespace declaration ending on PHP close tag

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -225,7 +225,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
         $namespaceDeclaration = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
 
         if ($namespaceDeclaration !== false) {
-            $endOfNamespaceDeclaration = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $namespaceDeclaration);
+            $endOfNamespaceDeclaration = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_CLOSE_TAG], $namespaceDeclaration);
             $namespace = $this->getDeclarationNameWithNamespace(
                 $phpcsFile->getTokens(),
                 ($endOfNamespaceDeclaration - 1)

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
@@ -172,3 +172,14 @@ namespace Foo /*comment*/ \ Bah {
         }
     }
 }
+
+namespace EndsIn\CloseTag ?>
+<?php
+
+class Baz {
+    function myFunction()
+    {
+        \EndsIn\CloseTag\Whatever::something();
+        \EndsIn\CloseTag\Baz::something();
+    }
+}

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
@@ -160,3 +160,14 @@ namespace Foo /*comment*/ \ Bah {
         }
     }
 }
+
+namespace EndsIn\CloseTag ?>
+<?php
+
+class Baz {
+    function myFunction()
+    {
+        \EndsIn\CloseTag\Whatever::something();
+        self::something();
+    }
+}

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -46,6 +46,7 @@ final class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
             143 => 2,
             162 => 1,
             171 => 1,
+            183 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
This change prevents an edge-case false negative for a namespaced self reference, when the namespace declaration would be ended by a PHP close tag instead of the expected `T_SEMICOLON` or `T_OPEN_CURLY_BRACE`.

Includes unit test.

## Suggested changelog entry
Squiz.Classes.SelfMemberReference: prevent edge case false negative when the namespace declaration would end on a PHP close tag.


## Related issues/external references

Related to #552


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
