### PR TITLE
PSR2/ClassDeclaration: add tests and remove some redundant code

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -525,7 +525,6 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
             $ignoreTokens[] = T_WHITESPACE;
             $ignoreTokens[] = T_COMMENT;
             $ignoreTokens[] = T_SEMICOLON;
-            $ignoreTokens[] = T_COMMA;
             $nextContent    = $phpcsFile->findNext($ignoreTokens, ($closeBrace + 1), null, true);
             if ($tokens[$nextContent]['content'] !== $phpcsFile->eolChar
                 && $tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -526,9 +526,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
             $ignoreTokens[] = T_COMMENT;
             $ignoreTokens[] = T_SEMICOLON;
             $nextContent    = $phpcsFile->findNext($ignoreTokens, ($closeBrace + 1), null, true);
-            if ($tokens[$nextContent]['content'] !== $phpcsFile->eolChar
-                && $tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']
-            ) {
+            if ($tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']) {
                 $type  = strtolower($tokens[$stackPtr]['content']);
                 $error = 'Closing %s brace must be on a line by itself';
                 $data  = [$type];

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -331,3 +331,10 @@ interface ClassBraceNotOnLineByItselfTrailingCommentIsAllowed
 trait ClassBraceNotOnLineByItselfTrailingAnnotationIsAllowed
 {
 } // phpcs:ignore Stnd.Cat.Sniff -- this comment is also allowed.
+
+// Issue squizlabs/PHP_CodeSniffer#2621 - fix was superseded by fix for #2678.
+$foo->bar(
+    new class implements Bar {
+        // ...
+    },
+);

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -316,3 +316,18 @@ class ClassWithMultiLineImplementsAndCommentOnSameLineAsInterfaceName implements
     /* Comment. */ AnotherInterface
 {
 }
+
+// Verify the `CloseBraceSameLine` error code is thrown when expected.
+class ClassBraceNotOnLineByItselfError
+{
+    public $prop;
+} $foo = new ClassBraceNotOnLineByItselfError;
+
+interface ClassBraceNotOnLineByItselfTrailingCommentIsAllowed
+{
+    public function myMethod();
+} //end interface -- this comment is allowed.
+
+trait ClassBraceNotOnLineByItselfTrailingAnnotationIsAllowed
+{
+} // phpcs:ignore Stnd.Cat.Sniff -- this comment is also allowed.

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -338,3 +338,9 @@ $foo->bar(
         // ...
     },
 );
+
+enum BraceNotOnLineByItselfCloseTagError
+{
+} ?>
+
+<?php

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -305,3 +305,18 @@ class ClassWithMultiLineImplementsAndCommentOnSameLineAsInterfaceName implements
     AnotherInterface
 {
 }
+
+// Verify the `CloseBraceSameLine` error code is thrown when expected.
+class ClassBraceNotOnLineByItselfError
+{
+    public $prop;
+} $foo = new ClassBraceNotOnLineByItselfError;
+
+interface ClassBraceNotOnLineByItselfTrailingCommentIsAllowed
+{
+    public function myMethod();
+} //end interface -- this comment is allowed.
+
+trait ClassBraceNotOnLineByItselfTrailingAnnotationIsAllowed
+{
+} // phpcs:ignore Stnd.Cat.Sniff -- this comment is also allowed.

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -320,3 +320,10 @@ interface ClassBraceNotOnLineByItselfTrailingCommentIsAllowed
 trait ClassBraceNotOnLineByItselfTrailingAnnotationIsAllowed
 {
 } // phpcs:ignore Stnd.Cat.Sniff -- this comment is also allowed.
+
+// Issue squizlabs/PHP_CodeSniffer#2621 - fix was superseded by fix for #2678.
+$foo->bar(
+    new class implements Bar {
+        // ...
+    },
+);

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -327,3 +327,9 @@ $foo->bar(
         // ...
     },
 );
+
+enum BraceNotOnLineByItselfCloseTagError
+{
+} ?>
+
+<?php

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -79,6 +79,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             310 => 1,
             316 => 1,
             324 => 1,
+            344 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -78,6 +78,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             282 => 1,
             310 => 1,
             316 => 1,
+            324 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

### PSR2/ClassDeclaration: add tests covering the CloseBraceSameLine error

Previously, there were no dedicated tests for the `CloseBraceSameLine` error.

### PSR2/ClassDeclaration: remove some redundant code [1]

Issue squizlabs/PHP_CodeSniffer#2621 added the `T_COMMA` token to the `$ignoreTokens` (without adding a test) to prevent a false positive for a anonymous class declaration nested within a function call.
That fix was later superseded by another fix for basically the same issue via squizlabs/PHP_CodeSniffer#2678, which excluded anonymous classes completely from the `CloseBraceSameLine` check.

This commit adds the test case from squizlabs/PHP_CodeSniffer#2621 and removed the redundant `T_COMMA` token as the test now confirms it is no longer needed.

### PSR2/ClassDeclaration: remove some redundant code [2]

In the original version of the sniff, only comments tokens after the close brace were ignored for the `CloseBraceSameLine` check.

Since then the sniff has received numerous changes improving on that code to prevent false positives.

Once such change was made in response to issue squizlabs/PHP_CodeSniffer#689, the fix adding ignoring for whitespace tokens to the code block.

This makes the `$tokens[$nextContent]['content'] !== $phpcsFile->eolChar` check redundant as that condition can now never be true anymore (as it could only match on `T_WHITESPACE` tokens and those are now ignored).

This change is covered by the tests previously added.

### PSR2/ClassDeclaration: add test with close brace followed by PHP close tag

Related to #552

This adds a test to the sniff documenting that when a PHP close tag is on the same line as the OO close brace, the sniff will throw an error.

In my opinion, this is the correct and expected behaviour.

## Suggested changelog entry
_N/A_


