### PR TITLE
Tests: stability tweaks for the non-sniff tests

### DIFF
--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -73,6 +73,22 @@ final class ConfigDouble extends Config
 
 
     /**
+     * Ensures the static properties in the Config class are reset to their default values
+     * when the ConfigDouble is no longer used.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->setStaticConfigProperty('overriddenDefaults', []);
+        $this->setStaticConfigProperty('executablePaths', []);
+        $this->setStaticConfigProperty('configData', null);
+        $this->setStaticConfigProperty('configDataFile', null);
+
+    }//end __destruct()
+
+
+    /**
      * Sets the command line values and optionally prevents a file system search for a custom ruleset.
      *
      * @param array<string> $args An array of command line arguments to set.

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -92,6 +92,14 @@ abstract class AbstractMethodUnitTest extends TestCase
      */
     public static function reset()
     {
+        // Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+        // The explicit method call prevents potential stray test-local references to the $config object
+        // preventing the destructor from running the clean up (which without stray references would be
+        // automagically triggered when `self::$phpcsFile` is reset, but we can't definitively rely on that).
+        if (isset(self::$phpcsFile) === true) {
+            self::$phpcsFile->config->__destruct();
+        }
+
         self::$fileExtension = 'inc';
         self::$tabWidth      = 4;
         self::$phpcsFile     = null;

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -81,6 +81,25 @@ abstract class AbstractMethodUnitTest extends TestCase
 
 
     /**
+     * Clean up after finished test by resetting all static properties on the class to their default values.
+     *
+     * Note: This is a PHPUnit cross-version compatible {@see \PHPUnit\Framework\TestCase::tearDownAfterClass()}
+     * method.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function reset()
+    {
+        self::$fileExtension = 'inc';
+        self::$tabWidth      = 4;
+        self::$phpcsFile     = null;
+
+    }//end reset()
+
+
+    /**
      * Get the token pointer for a target token based on a specific comment found on the line before.
      *
      * Note: the test delimiter comment MUST start with "/* test" to allow this function to

--- a/tests/Core/Filters/AbstractFilterTestCase.php
+++ b/tests/Core/Filters/AbstractFilterTestCase.php
@@ -52,6 +52,29 @@ abstract class AbstractFilterTestCase extends TestCase
 
 
     /**
+     * Clean up after finished test by resetting all static properties on the Config class to their default values.
+     *
+     * Note: This is a PHPUnit cross-version compatible {@see \PHPUnit\Framework\TestCase::tearDownAfterClass()}
+     * method.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function reset()
+    {
+        // Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+        // The explicit method call prevents potential stray test-local references to the $config object
+        // preventing the destructor from running the clean up (which without stray references would be
+        // automagically triggered when `self::$phpcsFile` is reset, but we can't definitively rely on that).
+        if (isset(self::$config) === true) {
+            self::$config->__destruct();
+        }
+
+    }//end reset()
+
+
+    /**
      * Helper method to retrieve a mock object for a Filter class.
      *
      * The `setMethods()` method was silently deprecated in PHPUnit 9 and removed in PHPUnit 10.


### PR DESCRIPTION
# Description

### AbstractMethodUnitTest: add "tear down" method to reset static properties

... to prevent changes to the values of these for one test, influencing another test.

This is only a stability tweak, there are no existing tests affected by this issue at this time.

### Tests/ConfigDouble: bug fix - always reset Config statics after use

The `Config` class uses a number of static properties, which may be updated during tests. These were previously - prior to #275 - reset to their default values in the `AbstractMethodUnitTest::resetTestFile()` method, but this reset was inadvertently removed with the reasoning that, if all tests use the `ConfigDouble`, the reset would no longer be needed as the `ConfigDouble` resets on being initialized.

The flaw in this logic is that not all tests are guaranteed to use the `ConfigDouble`, which means that without the reset, the `Config` class may be left "dirty" after tests using the `ConfigDouble`, which could break tests.

This commit fixes this issue by:
* Adding a `__destruct()` method to the `ConfigDouble` class which will reset the static properties on the PHPCS native `Config` class whenever an object created from this class is destroyed.
* Explicitly calling the `__destruct()` method from the `AbstractMethodUnitTest::reset()` method to ensure it is always run after a test has finished ("after class"), even if there would still be a lingering reference to the object.

This is only a stability tweak, there are no existing tests affected by this issue at this time.

## Suggested changelog entry
_N/A_
