### PR TITLE
Correct error code in Squiz.ControlStructures.ForEachLoopDeclaration

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -90,7 +90,7 @@ class ForEachLoopDeclarationSniff implements Sniff
                     $this->requiredSpacesAfterOpen,
                     $spaceAfterOpen,
                 ];
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterOpen', $data);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterOpen', $data);
                 if ($fix === true) {
                     $padding = str_repeat(' ', $this->requiredSpacesAfterOpen);
                     if ($spaceAfterOpen === 0) {


### PR DESCRIPTION
# Description
From what we can determine, this is a typographical error / mistake. It seems that the intention here was to use the same error code for both sides of this if/else block.

This inconsistency was detected as part of reviewing a fixer conflict with the PSR12 standard and the `src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.inc` test file. See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/152#issuecomment-2227504202 for full details on this conflict and https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/152#issuecomment-2255751041 for a decision on how to move forward / resolve the inconsistency.

Note that we are not fixing other inconsistencies in this sniff as doing so would have little return on investment.

## Suggested changelog entry
Squiz.ControlStructures.ForEachLoopDeclaration: change error code from `SpacingAfterOpen` to `SpaceAfterOpen`. The latter is an existing code and the former seems to have been a typographical error.

## Related issues/external references

#152

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
