### PR TITLE
:sparkles: New `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff

### DIFF
--- a/src/Standards/Generic/Docs/WhiteSpace/HereNowdocIdentifierSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/HereNowdocIdentifierSpacingStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="Heredoc Nowdoc Identifier Spacing">
+    <standard>
+    <![CDATA[
+    There should be no space between the <<< and the heredoc/nowdoc identifier string.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space between the <<< and the identifier string.">
+        <![CDATA[
+$heredoc = <em><<<EOD</em>
+some text
+EOD;
+        ]]>
+        </code>
+        <code title="Invalid: Whitespace between the <<< and the identifier string.">
+        <![CDATA[
+$heredoc = <em><<<   END</em>
+some text
+END;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Ensures heredoc/nowdoc identifiers do not have any whitespace before them.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class HereNowdocIdentifierSpacingSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_START_HEREDOC,
+            T_START_NOWDOC,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (strpos($tokens[$stackPtr]['content'], ' ') === false
+            && strpos($tokens[$stackPtr]['content'], "\t") === false
+        ) {
+            // Nothing to do.
+            return;
+        }
+
+        $error = 'There should be no space between the <<< and the heredoc/nowdoc identifier string';
+        $data  = [$tokens[$stackPtr]['content']];
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceFound', $data);
+        if ($fix === true) {
+            $replacement = str_replace([' ', "\t"], '', $tokens[$stackPtr]['content']);
+            $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.inc
@@ -1,0 +1,25 @@
+<?php
+
+$heredoc = <<<EOD
+some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+EOD;
+
+$heredoc = <<< END
+some text
+END;
+
+$nowdoc = <<<             'END'
+some text
+END;
+
+$heredoc = <<<			"END"
+some text
+END;
+
+$nowdoc = <<<	'END'
+some text
+END;

--- a/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.inc.fixed
@@ -1,0 +1,25 @@
+<?php
+
+$heredoc = <<<EOD
+some text
+EOD;
+
+$nowdoc = <<<'EOD'
+some text
+EOD;
+
+$heredoc = <<<END
+some text
+END;
+
+$nowdoc = <<<'END'
+some text
+END;
+
+$heredoc = <<<"END"
+some text
+END;
+
+$nowdoc = <<<'END'
+some text
+END;

--- a/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Unit test class for the HereNowdocIdentifierSpacing sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the LanguageConstructSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\HereNowdocIdentifierSpacingSniff
+ */
+final class HereNowdocIdentifierSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            11 => 1,
+            15 => 1,
+            19 => 1,
+            23 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
# Description

New `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff which forbids whitespace between the `<<<` and the identifier string in heredoc/nowdoc start tokens.

Includes fixer.
Includes tests.
Includes XML docs.

## Suggested changelog entry
New `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff which forbids whitespace between the `<<<` and the identifier string in heredoc/nowdoc start tokens.

## Related issues/external references

#585

## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
