### PR TITLE
Squiz/SelfMemberReference: bug fix - false negative with namespace keyword as operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -221,15 +221,23 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
      */
     protected function getNamespaceOfScope(File $phpcsFile, $stackPtr)
     {
-        $namespace            = '\\';
-        $namespaceDeclaration = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
+        $namespace = '\\';
+        $tokens    = $phpcsFile->getTokens();
 
-        if ($namespaceDeclaration !== false) {
+        while (($namespaceDeclaration = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr)) !== false) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($namespaceDeclaration + 1), null, true);
+            if ($tokens[$nextNonEmpty]['code'] === T_NS_SEPARATOR) {
+                // Namespace operator. Ignore.
+                $stackPtr = ($namespaceDeclaration - 1);
+                continue;
+            }
+
             $endOfNamespaceDeclaration = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_CLOSE_TAG], $namespaceDeclaration);
             $namespace = $this->getDeclarationNameWithNamespace(
                 $phpcsFile->getTokens(),
                 ($endOfNamespaceDeclaration - 1)
             );
+            break;
         }
 
         return $namespace;

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
@@ -183,3 +183,17 @@ class Baz {
         \EndsIn\CloseTag\Baz::something();
     }
 }
+
+// Issue PHPCSStandards/PHP_CodeSniffer#553.
+namespace TestMe;
+
+namespace\functionCall();
+namespace\anotherFunctionCall();
+
+class SelfMemberReference
+{
+    public function falseNegative()
+    {
+        $testResults[] = \TestMe\SelfMemberReference::test();
+    }
+}

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
@@ -171,3 +171,17 @@ class Baz {
         self::something();
     }
 }
+
+// Issue PHPCSStandards/PHP_CodeSniffer#553.
+namespace TestMe;
+
+namespace\functionCall();
+namespace\anotherFunctionCall();
+
+class SelfMemberReference
+{
+    public function falseNegative()
+    {
+        $testResults[] = self::test();
+    }
+}

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -47,6 +47,7 @@ final class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
             162 => 1,
             171 => 1,
             183 => 1,
+            197 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

> The `namespace` keyword can both be used for namespace declarations as well as as an operator - "magic keyword" - to resolve to the current namespace.
> See: https://www.php.net/manual/en/language.namespaces.nsconstants.php#example-298

> This last case is not correctly taken into account when determining the current namespace, which leads to false negatives.

Fixed now.

Includes test.


## Suggested changelog entry
Fixed: Squiz.Classes.SelfMemberReference: false negatives when namespace keyword used as operator was encountered between the namespace declaration and the OO declaration.


## Related issues/external references


Fixes #553



## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
