### PR TITLE
Squiz/EmbeddedPhp: fix false positive when handling short open tags

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -379,8 +379,11 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         // Check that there is one, and only one space at the start of the statement.
-        $leadingSpace = 0;
-        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
+        $leadingSpace  = 0;
+        $isLongOpenTag = $tokens[$stackPtr]['code'] === T_OPEN_TAG
+                         && stripos($tokens[$stackPtr]['content'], '<?php') === 0;
+
+        if ($isLongOpenTag === true) {
             // The long open tag token in a single line tag set always contains a single space after it.
             $leadingSpace = 1;
         }
@@ -394,7 +397,7 @@ class EmbeddedPhpSniff implements Sniff
             $data  = [$leadingSpace];
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterOpen', $data);
             if ($fix === true) {
-                if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
+                if ($isLongOpenTag === true) {
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
                 } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
                     // Short open tag with too much whitespace.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc
@@ -265,6 +265,10 @@ echo 'the PHP tag is correctly indented as an indent less than the previous code
                 echo 'the PHP tag is incorrectly indented as the indent is more than 4 different from the indent of the previous code';
     ?>
 
+<?PHP echo 'Uppercase long open tag'; ?>
+
+<?PHP  echo 'Extra space after uppercase long open tag '; ?>
+
 <?php
 // This test case file MUST always end with an unclosed long open PHP tag (with this comment) to prevent
 // the tests running into the "last PHP closing tag excepted" condition breaking tests.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc.fixed
@@ -277,6 +277,10 @@ echo 'the PHP tag is correctly indented as an indent less than the previous code
         echo 'the PHP tag is incorrectly indented as the indent is more than 4 different from the indent of the previous code';
     ?>
 
+<?PHP echo 'Uppercase long open tag'; ?>
+
+<?PHP echo 'Extra space after uppercase long open tag '; ?>
+
 <?php
 // This test case file MUST always end with an unclosed long open PHP tag (with this comment) to prevent
 // the tests running into the "last PHP closing tag excepted" condition breaking tests.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.24.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.24.inc
@@ -1,0 +1,25 @@
+<?
+
+// This test case file MUST always start with a open PHP tag set (with this comment) to prevent
+// the tests running into the "first PHP open tag excepted" condition breaking the tests.
+// Tests related to that "first PHP open tag excepted" condition should go in separate files.
+
+// This test case file only deals with SHORT OPEN TAGS.
+
+?>
+
+<?
+/* Contrary to the long open tag token, the short open tag token does not contain a space after the
+   tag and the sniff should handle it accordingly. The test below protects against regressions
+   related to https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/588. */
+?>
+<? echo 'one space after short open tag'; ?>
+
+<?  echo 'two spaces after short open tag'; ?>
+
+<?echo 'without space after short open tag'; ?>
+
+<?
+// This test case file MUST always end with an unclosed open PHP tag (with this comment) to prevent
+// the tests running into the "last PHP closing tag excepted" condition breaking tests.
+// Tests related to that "last PHP closing tag excepted" condition should go in separate files.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.24.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.24.inc.fixed
@@ -1,0 +1,25 @@
+<?
+
+// This test case file MUST always start with a open PHP tag set (with this comment) to prevent
+// the tests running into the "first PHP open tag excepted" condition breaking the tests.
+// Tests related to that "first PHP open tag excepted" condition should go in separate files.
+
+// This test case file only deals with SHORT OPEN TAGS.
+
+?>
+
+<?
+/* Contrary to the long open tag token, the short open tag token does not contain a space after the
+   tag and the sniff should handle it accordingly. The test below protects against regressions
+   related to https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/588. */
+?>
+<? echo 'one space after short open tag'; ?>
+
+<? echo 'two spaces after short open tag'; ?>
+
+<? echo 'without space after short open tag'; ?>
+
+<?
+// This test case file MUST always end with an unclosed open PHP tag (with this comment) to prevent
+// the tests running into the "last PHP closing tag excepted" condition breaking tests.
+// Tests related to that "last PHP closing tag excepted" condition should go in separate files.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -100,6 +100,7 @@ final class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
                 258 => 1,
                 263 => 1,
                 264 => 1,
+                270 => 1,
             ];
 
         case 'EmbeddedPhpUnitTest.2.inc':
@@ -189,6 +190,17 @@ final class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
                 14 => 1,
                 22 => 2,
             ];
+
+        case 'EmbeddedPhpUnitTest.24.inc':
+            $shortOpenTagDirective = (bool) ini_get('short_open_tag');
+            if ($shortOpenTagDirective === true) {
+                return [
+                    18 => 1,
+                    20 => 1,
+                ];
+            } else {
+                return [];
+            }
 
         default:
             return [];


### PR DESCRIPTION
# Description

This PR fixes a bug in `Squiz.PHP.EmbeddedPhp` that causes a false positive when handling short open tags and was reported in https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/588.

The content of a PHP long open tag token is `<?php ` (note the space after the tag). The content of a PHP short open tag is `<?` (no space after the tag). The sniff did not account correctly for this difference when checking the expected number of spaces after a short open tag, resulting in false positives and incorrect fixes.

## Suggested changelog entry
 `Squiz.PHP.EmbeddedPhp` false positive when checking spaces after a PHP short open tag.

## Related issues/external references

Fixes #588


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
