### PR TITLE
Generic/LowerCaseKeyword: remove some redundant code

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -29,14 +29,10 @@ class LowerCaseKeywordSniff implements Sniff
         $targets += [
             T_ANON_CLASS    => T_ANON_CLASS,
             T_CLOSURE       => T_CLOSURE,
-            T_EMPTY         => T_EMPTY,
             T_ENUM_CASE     => T_ENUM_CASE,
-            T_EVAL          => T_EVAL,
-            T_ISSET         => T_ISSET,
             T_MATCH_DEFAULT => T_MATCH_DEFAULT,
             T_PARENT        => T_PARENT,
             T_SELF          => T_SELF,
-            T_UNSET         => T_UNSET,
         ];
 
         return $targets;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -48,5 +48,10 @@ new Class {};
 new clasS extends stdClass {};
 new class {};
 
+if (isset($a) && !empty($a)) { unset($a); }
+if (ISSET($a) && !Empty($a)) { UnSeT($a); }
+eval('foo');
+eVaL('foo');
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -48,5 +48,10 @@ new class {};
 new class extends stdClass {};
 new class {};
 
+if (isset($a) && !empty($a)) { unset($a); }
+if (isset($a) && !empty($a)) { unset($a); }
+eval('foo');
+eval('foo');
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -50,6 +50,8 @@ final class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             44 => 1,
             47 => 1,
             48 => 1,
+            52 => 3,
+            54 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

The `Tokens::$contextSensitiveKeywords` token array was introduced in PHPCS 3.7.0 via PR squizlabs/PHP_CodeSniffer#3484.

PR squizlabs/PHP_CodeSniffer#3574 build onto that by removing the bulk of the target tokens from the `register()` method for the Generic/LowerCaseKeyword sniff in favour of using the predefined `Tokens::$contextSensitiveKeywords` token array.

The `T_EMPTY`, `T_EVAL`, `T_ISSET` and `T_UNSET` tokens were initially missing from the `Tokens::$contextSensitiveKeywords` array. This was fixed in PHPCS 3.7.1 via PRs squizlabs/PHP_CodeSniffer#3608 and squizlabs/PHP_CodeSniffer#3610.

This means those tokens no longer need to be explicitly added as targets for the Generic/LowerCaseKeyword sniff as they are now (and have been since PHPCS 3.7.1) inherited via the `Tokens::$contextSensitiveKeywords` token array.

This commit removes the redundancy, but also adds tests to safeguard that those keywords will still be checked by the sniff.


## Suggested changelog entry
_N/A_


## Related issues/external references

Noticed the redundancy while reviewing #597.