### PR TITLE
PHP 8.4 | build-phar: remove use of `E_STRICT`

### DIFF
--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHP_CodeSniffer\Tokenizers\PHP;
 use PHP_CodeSniffer\Util\Tokens;
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 
 if (ini_get('phar.readonly') === '1') {
     echo 'Unable to build, phar.readonly in php.ini is set to read only.'.PHP_EOL;


### PR DESCRIPTION
# Description
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0.

The error level hasn't been in use since PHP 8.0 anyway, so removing the exclusion from the `error_reporting()` setting in the `build-phar` script should make no difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant


## Suggested changelog entry
_N/A_