### PR TITLE
Fix fixer conflict: `PSR12` / `Squiz.Functions.FunctionDeclarationArgumentSpacing`

### DIFF
--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
@@ -109,3 +109,7 @@ $a = function ($var1, $var2=false) use (
 ) {};
 
 fn ($a,$b = null) => $a($b);
+
+function multipleWhitespaceTokensAfterType(int
+
+    $number) {}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
@@ -109,3 +109,5 @@ $a = function ($var1, $var2=false) use (
 ) {};
 
 fn ($a, $b=null) => $a($b);
+
+function multipleWhitespaceTokensAfterType(int $number) {}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -68,6 +68,7 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnit
             106 => 1,
             107 => 2,
             111 => 3,
+            113 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
While looking into a fixer conflict for the PSR12 standard regarding the `tests/Core/File/GetMethodParametersTest.inc` file, it was noted that there is a conflict between `Squiz.Functions.FunctionDeclarationArgumentSpacing` and `Squiz.WhiteSpace.SuperfluousWhitespace`.

To see this, run: `php bin/phpcbf --standard=PSR12 -v tests/Core/File/GetMethodParametersTest.inc`

With verbosity increased, we can see the conflict:

```
* fixed 1 violations, starting loop 47 *
Squiz.Functions.FunctionDeclarationArgumentSpacing:252 replaced token 1585 (T_FALSE on line 337) "false" => "false·"
      => Fixing file: 1/169 violations remaining [made 47 passes]...
* fixed 1 violations, starting loop 48 *
Squiz.WhiteSpace.SuperfluousWhitespace:212 replaced token 1586 (T_WHITESPACE on line 337) "·\n····" => "\n····"
      => Fixing file: 1/169 violations remaining [made 48 passes]...
* fixed 1 violations, starting loop 49 *
Squiz.Functions.FunctionDeclarationArgumentSpacing:252 replaced token 1585 (T_FALSE on line 337) "false" => "false·"
      => Fixing file: 1/169 violations remaining [made 49 passes]...
* fixed 1 violations, starting loop 50 *
Squiz.WhiteSpace.SuperfluousWhitespace:212 replaced token 1586 (T_WHITESPACE on line 337) "·\n····" => "\n····"
      => Fixing file: 1/169 violations remaining [made 50 passes]...
* fixed 1 violations, starting loop 51 *
*** Reached maximum number of loops with 1 violations left unfixed ***
```

Here is a small reproducible test case. Note the newline after the parameter type.

```php
<?php

public function example(int
$number) {}
```

This pull request fixes the conflict by changing the logic within the sniff to no longer look at only one `T_WHITESPACE` token (and its length), but instead all `T_WHITESPACE` tokens between the type and parameter tokens, and validate on their content (not length).

## Suggested changelog entry
Fix a fixer conflict: `PSR12` / `Squiz.Functions.FunctionDeclarationArgumentSpacing` - newlines after type are now fixed properly.

## Related issues/external references

#152

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
