### PR TITLE
README/Changelog: fix a few URLs which have changed

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -13,7 +13,9 @@
         {
             "skipUrlPatterns": [
                 "^https?://github\\.com/PHPCSStandards/PHP_CodeSniffer/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
-                "^https?://github\\.com/[A-Za-z0-9-]+"
+                "^https?://github\\.com/[A-Za-z0-9-]+",
+                "^https?://pear\\.php\\.net/user/.+",
+                "^https?://pear\\.php\\.net/bugs/bug\\.php\\?id=[0-9]+"
             ]
         }
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ _Nothing yet._
 [#608]: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/608
 
 [ghcli]:    https://cli.github.com/
-[ghattest]: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+[ghattest]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
 
 ## [3.10.2] - 2024-07-22
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 <div aria-hidden="true">
 
-[![Latest Stable Version](http://poser.pugx.org/phpcsstandards/php_codesniffer/v)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
+[![Latest Stable Version](https://img.shields.io/packagist/v/squizlabs/php_codesniffer?label=Stable)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
 [![Validate](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml)
 [![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=master)][GHA-test]
-[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHP_CodeSniffer/badge.svg?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
-[![License](http://poser.pugx.org/phpcsstandards/php_codesniffer/license)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt)
+[![Coveralls](https://img.shields.io/coverallsCoverage/github/PHPCSStandards/PHP_CodeSniffer?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
+[![License](https://img.shields.io/github/license/PHPCSStandards/PHP_CodeSniffer)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt)
 
-![Minimum PHP Version](https://img.shields.io/packagist/php-v/squizlabs/php_codesniffer.svg?maxAge=3600)
-[![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)][GHA-test]
+![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/squizlabs/php_codesniffer/php)
+[![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-brightgreen.svg?maxAge=2419200)][GHA-test]
 
 [GHA-test]: https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml
 
@@ -50,7 +50,7 @@ php phpcbf.phar -h
 These Phars are signed with the official Release key for PHPCS with the
 fingerprint `689D AD77 8FF0 8760 E046 228B A978 2203 05CD 5C32`.
 
-As of PHP_CodeSniffer 3.10.3, the provenance of PHAR files associated with a release can be verified via [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) using the [GitHub CLI tool](https://cli.github.com/) with the following command: `gh attestation verify [phpcs|phpcbf].phar -o PHPCSStandards`.
+As of PHP_CodeSniffer 3.10.3, the provenance of PHAR files associated with a release can be verified via [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) using the [GitHub CLI tool](https://cli.github.com/) with the following command: `gh attestation verify [phpcs|phpcbf].phar -o PHPCSStandards`.
 
 ### Composer
 If you use Composer, you can install PHP_CodeSniffer system-wide with the following command:


### PR DESCRIPTION
# Description

### README/Changelog: fix a few URLs which have changed

Fix a few URLs which were being redirected.

Includes:
* Replacing badges from poser.pugx.org with badges using img.shields.io.
* Adding PHP 8.4 to the "tested on" badge.

### Remark config: skip select PEAR URLs

Looks like PEAR has added some type of rate limiting/DDOS protected which causes the check against dead URLs to fail due to time-outs.

Let's skip the typical user and bug report URLs for now to allow the builds to pass.

## Suggested changelog entry
_N/A_