### PR TITLE
Tests/File::findStartOfStatement(): fix dataproviders

### DIFF
--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -710,45 +710,45 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
             // These were already working correctly.
             'Closure function keyword should be start of closure - closure keyword'                   => [
                 'testMarker'     => '/* test437ClosureDeclaration */',
-                'targets'        => T_CLOSURE,
+                'target'         => T_CLOSURE,
                 'expectedTarget' => T_CLOSURE,
             ],
             'Open curly is a statement/expression opener - open curly'                                => [
                 'testMarker'     => '/* test437ClosureDeclaration */',
-                'targets'        => T_OPEN_CURLY_BRACKET,
+                'target'         => T_OPEN_CURLY_BRACKET,
                 'expectedTarget' => T_OPEN_CURLY_BRACKET,
             ],
 
             'Echo should be start for expression - echo keyword'                                      => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_ECHO,
+                'target'         => T_ECHO,
                 'expectedTarget' => T_ECHO,
             ],
             'Echo should be start for expression - variable'                                          => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_ECHO,
             ],
             'Echo should be start for expression - comma'                                             => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_COMMA,
+                'target'         => T_COMMA,
                 'expectedTarget' => T_ECHO,
             ],
 
             // These were not working correctly and would previously return the close curly of the match expression.
             'First token after comma in echo expression should be start for expression - text string' => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_CONSTANT_ENCAPSED_STRING,
+                'target'         => T_CONSTANT_ENCAPSED_STRING,
                 'expectedTarget' => T_CONSTANT_ENCAPSED_STRING,
             ],
             'First token after comma in echo expression - PHP_EOL constant'                           => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_STRING,
+                'target'         => T_STRING,
                 'expectedTarget' => T_STRING,
             ],
             'First token after comma in echo expression - semicolon'                                  => [
                 'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
-                'targets'        => T_SEMICOLON,
+                'target'         => T_SEMICOLON,
                 'expectedTarget' => T_STRING,
             ],
         ];
@@ -791,44 +791,44 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
         return [
             'Array item itself should be start for first array item'                       => [
                 'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
-                'targets'        => T_LNUMBER,
+                'target'         => T_LNUMBER,
                 'expectedTarget' => T_LNUMBER,
             ],
             'Array item itself should be start for second array item'                      => [
                 'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
-                'targets'        => T_DNUMBER,
+                'target'         => T_DNUMBER,
                 'expectedTarget' => T_DNUMBER,
             ],
             'Array item itself should be start for third array item'                       => [
                 'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
 
             'Parameter itself should be start for first param passed to function call'     => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
-                'targets'        => T_LNUMBER,
+                'target'         => T_LNUMBER,
                 'expectedTarget' => T_LNUMBER,
             ],
             'Parameter itself should be start for second param passed to function call'    => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
             'Parameter itself should be start for third param passed to function call'     => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
-                'targets'        => T_DNUMBER,
+                'target'         => T_DNUMBER,
                 'expectedTarget' => T_DNUMBER,
             ],
 
             'Parameter itself should be start for first param declared in arrow function'  => [
                 'testMarker'     => '/* test437NestedArrowFunctionWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
             'Parameter itself should be start for second param declared in arrow function' => [
                 'testMarker'     => '/* test437FnSecondParamWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
         ];
@@ -872,44 +872,44 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
         return [
             'Array item itself should be start for first array item'                       => [
                 'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
-                'targets'        => T_LNUMBER,
+                'target'         => T_LNUMBER,
                 'expectedTarget' => T_LNUMBER,
             ],
             'Array item itself should be start for second array item'                      => [
                 'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
-                'targets'        => T_DNUMBER,
+                'target'         => T_DNUMBER,
                 'expectedTarget' => T_DNUMBER,
             ],
             'Array item itself should be start for third array item'                       => [
                 'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
 
             'Parameter itself should be start for first param passed to function call'     => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
-                'targets'        => T_LNUMBER,
+                'target'         => T_LNUMBER,
                 'expectedTarget' => T_LNUMBER,
             ],
             'Parameter itself should be start for second param passed to function call'    => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
             'Parameter itself should be start for third param passed to function call'     => [
                 'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
-                'targets'        => T_DNUMBER,
+                'target'         => T_DNUMBER,
                 'expectedTarget' => T_DNUMBER,
             ],
 
             'Parameter itself should be start for first param declared in arrow function'  => [
                 'testMarker'     => '/* test437NestedArrowFunctionWithinNestedMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
             'Parameter itself should be start for second param declared in arrow function' => [
                 'testMarker'     => '/* test437FnSecondParamWithinNestedMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
         ];
@@ -952,17 +952,17 @@ final class FindStartOfStatementTest extends AbstractMethodUnitTest
         return [
             'Array item itself should be start for first array item'  => [
                 'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
-                'targets'        => T_LNUMBER,
+                'target'         => T_LNUMBER,
                 'expectedTarget' => T_LNUMBER,
             ],
             'Array item itself should be start for second array item' => [
                 'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
-                'targets'        => T_DNUMBER,
+                'target'         => T_DNUMBER,
                 'expectedTarget' => T_DNUMBER,
             ],
             'Array item itself should be start for third array item'  => [
                 'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
-                'targets'        => T_VARIABLE,
+                'target'         => T_VARIABLE,
                 'expectedTarget' => T_VARIABLE,
             ],
         ];


### PR DESCRIPTION
# Description

Follow up on #502

If a data set uses an associative array, the keys should match the test method parameter names exactly to prevent issues on PHPUnit 10/11 (name would be interpreted as named parameter and not match the actual parameter name).



## Suggested changelog entry
_N/A_
