### PR TITLE
Squiz/PostStatementComment: use a different error code for annotations

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -109,6 +109,14 @@ class PostStatementCommentSniff implements Sniff
             }
         }
 
+        if ($phpcsFile->tokenizerType === 'PHP'
+            && preg_match('|//\s?@[^\s]+|', $tokens[$stackPtr]['content']) === 1
+        ) {
+            $error = 'Annotations may not appear after statements';
+            $phpcsFile->addError($error, $stackPtr, 'AnnotationFound');
+            return;
+        }
+
         $error = 'Comments may not appear after statements';
         $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found');
         if ($fix === true) {

--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -110,7 +110,7 @@ class PostStatementCommentSniff implements Sniff
         }
 
         if ($phpcsFile->tokenizerType === 'PHP'
-            && preg_match('|//\s?@[^\s]+|', $tokens[$stackPtr]['content']) === 1
+            && preg_match('|^//[ \t]*@[^\s]+|', $tokens[$stackPtr]['content']) === 1
         ) {
             $error = 'Annotations may not appear after statements';
             $phpcsFile->addError($error, $stackPtr, 'AnnotationFound');

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
@@ -53,12 +53,12 @@ $match = match($foo // comment
     1 => 1, // comment
 };
 
-// Comments recognized as annotations by PHPCS.
+// Issue #560: Annotations should be reported separately and be non-auto-fixable as their meaning may change when moved.
 $a = 1; //@codeCoverageIgnore
 $b = 2; // @phpstan-ignore variable.undefined
 $c = 3; //  @phpstan-ignore variable.undefined
 $d = 4; //	@tabInsteadOfSpace
 
-// Comments that include `@`, but are not recognized as annotations by PHPCS.
+// Comments that include `@`, but are not recognized as annotations by this sniff.
 $a = 1; // @ = add tag.
 $b = 2; // Some comment. // @username

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
@@ -52,3 +52,7 @@ $match = match($foo // comment
 ) {
     1 => 1, // comment
 };
+
+$a = 1; // @codeCoverageIgnore
+$b = 2; //@phpstan-ignore variable.undefined
+$c = 3; //  @thisIsNotAnAnnotation - more than one space before the @ symbol.

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
@@ -53,6 +53,12 @@ $match = match($foo // comment
     1 => 1, // comment
 };
 
-$a = 1; // @codeCoverageIgnore
-$b = 2; //@phpstan-ignore variable.undefined
-$c = 3; //  @thisIsNotAnAnnotation - more than one space before the @ symbol.
+// Comments recognized as annotations by PHPCS.
+$a = 1; //@codeCoverageIgnore
+$b = 2; // @phpstan-ignore variable.undefined
+$c = 3; //  @phpstan-ignore variable.undefined
+$d = 4; //	@tabInsteadOfSpace
+
+// Comments that include `@`, but are not recognized as annotations by PHPCS.
+$a = 1; // @ = add tag.
+$b = 2; // Some comment. // @username

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -58,13 +58,13 @@ $match = match($foo // comment
 // comment
 };
 
-// Comments recognized as annotations by PHPCS.
+// Issue #560: Annotations should be reported separately and be non-auto-fixable as their meaning may change when moved.
 $a = 1; //@codeCoverageIgnore
 $b = 2; // @phpstan-ignore variable.undefined
 $c = 3; //  @phpstan-ignore variable.undefined
 $d = 4; //	@tabInsteadOfSpace
 
-// Comments that include `@`, but are not recognized as annotations by PHPCS.
+// Comments that include `@`, but are not recognized as annotations by this sniff.
 $a = 1; 
 // @ = add tag.
 $b = 2; 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -58,7 +58,14 @@ $match = match($foo // comment
 // comment
 };
 
-$a = 1; // @codeCoverageIgnore
-$b = 2; //@phpstan-ignore variable.undefined
-$c = 3; 
-//  @thisIsNotAnAnnotation - more than one space before the @ symbol.
+// Comments recognized as annotations by PHPCS.
+$a = 1; //@codeCoverageIgnore
+$b = 2; // @phpstan-ignore variable.undefined
+$c = 3; //  @phpstan-ignore variable.undefined
+$d = 4; //	@tabInsteadOfSpace
+
+// Comments that include `@`, but are not recognized as annotations by PHPCS.
+$a = 1; 
+// @ = add tag.
+$b = 2; 
+// Some comment. // @username

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -57,3 +57,8 @@ $match = match($foo // comment
     1 => 1, 
 // comment
 };
+
+$a = 1; // @codeCoverageIgnore
+$b = 2; //@phpstan-ignore variable.undefined
+$c = 3; 
+//  @thisIsNotAnAnnotation - more than one space before the @ symbol.

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -40,6 +40,9 @@ final class PostStatementCommentUnitTest extends AbstractSniffUnitTest
                 18 => 1,
                 35 => 1,
                 53 => 1,
+                56 => 1,
+                57 => 1,
+                58 => 1,
             ];
 
         case 'PostStatementCommentUnitTest.1.js':

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -40,9 +40,12 @@ final class PostStatementCommentUnitTest extends AbstractSniffUnitTest
                 18 => 1,
                 35 => 1,
                 53 => 1,
-                56 => 1,
                 57 => 1,
                 58 => 1,
+                59 => 1,
+                60 => 1,
+                63 => 1,
+                64 => 1,
             ];
 
         case 'PostStatementCommentUnitTest.1.js':


### PR DESCRIPTION
# Description

As discussed in #560, this PR changes `Squiz.Commenting.PostStatementComment` to use a different error code when an annotation is found. This will allow ruleset maintainers to selectively exclude the flagging of trailing annotations from their ruleset. For example, for PHPCS itself, this will make it possible to use the `// @codeCoverageIgnore` annotation where needed.

An annotation is defined as any comment that starts with an optional space, followed by a `@` and any character, as long as it is not a whitespace. For now, only `//` comments are supported as this is the only type of comment supported by this sniff.

This change only applies to PHP code as support for JS will be dropped soon, and JS doesn't seem to follow the same convention of annotations starting with `@`.


## Suggested changelog entry

`Squiz.Commenting.PostStatementComment`: use a different error code for annotations

## Related issues/external references

Fixes #560 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.