### PR TITLE
Partially revert PR #621

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -13,9 +13,7 @@
         {
             "skipUrlPatterns": [
                 "^https?://github\\.com/PHPCSStandards/PHP_CodeSniffer/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
-                "^https?://github\\.com/[A-Za-z0-9-]+",
-                "^https?://pear\\.php\\.net/user/.+",
-                "^https?://pear\\.php\\.net/bugs/bug\\.php\\?id=[0-9]+"
+                "^https?://github\\.com/[A-Za-z0-9-]+"
             ]
         }
     ],

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/squizlabs/php_codesniffer?label=Stable)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
 [![Validate](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml)
 [![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=master)][GHA-test]
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/PHPCSStandards/PHP_CodeSniffer?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHP_CodeSniffer/badge.svg?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
 [![License](https://img.shields.io/github/license/PHPCSStandards/PHP_CodeSniffer)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt)
 
-![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/squizlabs/php_codesniffer/php)
+![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/squizlabs/php_codesniffer/php.svg)
 [![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-brightgreen.svg?maxAge=2419200)][GHA-test]
 
 [GHA-test]: https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml


### PR DESCRIPTION
# Description

### Partially revert "README/Changelog: fix a few URLs which have changed"

This partially reverts commit a57d5f9 after improvements upstream in the Remark no-dead-urls module.

Ref: remarkjs/remark-lint-no-dead-urls#54

### Revert "Remark config: skip select PEAR URLs"

This reverts commit c7a0f5a.