### PR TITLE
Generic/RequireExplicitBooleanOperatorPrecedence: remove unreachable condition

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
@@ -53,8 +53,7 @@ class RequireExplicitBooleanOperatorPrecedenceSniff implements Sniff
      */
     public function register()
     {
-        $this->searchTargets  = Tokens::$booleanOperators;
-        $this->searchTargets += Tokens::$blockOpeners;
+        $this->searchTargets = Tokens::$booleanOperators;
         $this->searchTargets[T_INLINE_THEN] = T_INLINE_THEN;
         $this->searchTargets[T_INLINE_ELSE] = T_INLINE_ELSE;
 
@@ -99,12 +98,6 @@ class RequireExplicitBooleanOperatorPrecedenceSniff implements Sniff
 
         if (in_array($tokens[$previous]['code'], [T_INLINE_THEN, T_INLINE_ELSE], true) === true) {
             // Beginning of the expression found for the ternary conditional operator.
-            return;
-        }
-
-        if (isset(Tokens::$blockOpeners[$tokens[$previous]['code']]) === true) {
-            // Beginning of the expression found for a block opener. Needed to
-            // correctly handle match arms.
             return;
         }
 


### PR DESCRIPTION
# Description

This PR reverts the changes to the `Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence` sniff introduced in https://github.com/PHPCSStandards/PHPCSExtra/pull/271/commits/7b38efb98c3383b84819a79f85828d517919f17d. The sniff's tests remain relevant, so they were preserved.

The original commit was added to fix false positives that the sniff was triggering when handling boolean operators inside a match (see https://github.com/PHPCSStandards/PHPCSExtra/pull/271#pullrequestreview -1634348864 and https://github.com/PHPCSStandards/PHPCSExtra/pull/271#issuecomment-1729104556 ). Example:

```php
match (true) {
    $a || ($b && $c) => true,
};
```

I believe the false positive was actually caused by a bug in `File::findStartOfStatement()`. This bug was then fixed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/502/commits/b82438f2e1199fb29f4825782dad686168f70352 which rendered the changes to the sniff itself unnecessary and the removed condition unreachable.

Before this fix, when processing the code example above, `File::findStartOfStatement()` returned the variable `$a` as the start of the statement for the `&&` boolean operator. This meant that `$previous` would be set to `||`, and the removed condition would be needed to ensure the sniff would bail instead of triggering an error.

After this fix, `File::findStartOfStatement()` returns `$b` as the start of the statement, and then `$previous` is set to `false`. Thus, the sniff bails before reaching the removed condition.

Including `Tokens::$blockOpeners` in `RequireExplicitBooleanOperatorPrecedenceSniff::$searchTargets` was necessary only for the removed condition, so it was removed as well.

cc @TimWolla in case you are available to check this change you are the author of the sniff.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.