### PR TITLE
Generic/HereNowdocIdentifierSpacing: add metrics

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
@@ -48,8 +48,11 @@ class HereNowdocIdentifierSpacingSniff implements Sniff
             && strpos($tokens[$stackPtr]['content'], "\t") === false
         ) {
             // Nothing to do.
+            $phpcsFile->recordMetric($stackPtr, 'Heredoc/nowdoc identifier', 'no space between <<< and ID');
             return;
         }
+
+        $phpcsFile->recordMetric($stackPtr, 'Heredoc/nowdoc identifier', 'space between <<< and ID');
 
         $error = 'There should be no space between the <<< and the heredoc/nowdoc identifier string';
         $data  = [$tokens[$stackPtr]['content']];


### PR DESCRIPTION
# Description
This commit adds metrics to the new `Generic.WhiteSpace.HereNowdocIdentifierSpacing` sniff to allow for collecting statistical information on how often spacing is found between the `<<<` and the doc ID.



## Suggested changelog entry
_N/A_ covered by the changelog entry about the introduction of the sniff


## Related issues/external references

Related #586

