### PR TITLE
Generic/DisallowShortOpenTag: improve code coverage

### DIFF
--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
@@ -1,6 +1,6 @@
 // Test warning for when short_open_tag is off.
 
-Some content <? echo $var; ?> Some more content after PHP code
+Some content <? echo $var; ?> Some more content
 
 // Test multi-line.
 Some content <?
@@ -11,6 +11,9 @@ echo $var;
 Some content <?
 echo '<?';
 ?> Some more content
+
+// Test snippet clipping with a line that has more than 40 characters after the PHP open tag.
+Some content <? echo $var; ?> Some longer content to trigger snippet clipping
 
 // Only recognize closing tag after opener.
 Some?> content <?

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
@@ -16,4 +16,5 @@ echo '<?';
 Some content <? echo $var; ?> Some longer content to trigger snippet clipping
 
 // Only recognize closing tag after opener.
+// The test below must be the last test in the file because there must be no PHP close tag after it.
 Some?> content <?

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.3.inc
@@ -1,6 +1,6 @@
 // Test warning for when short_open_tag is off.
 
-Some content <? echo $var; ?> Some more content
+Some content <? echo $var; ?> Some more content after PHP code
 
 // Test multi-line.
 Some content <?

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.4.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.4.inc
@@ -1,0 +1,6 @@
+// Although not the focus of this test, this is an intentional parse error when short_open_tag is on.
+// This should be the only test in this file.
+// Test that the sniff bails when short_open_tag is off and there is a token other than
+// T_INLINE_HTML after the short open tag and before the close tag.
+
+<?<?php

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -98,6 +98,7 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
                 3  => 1,
                 6  => 1,
                 11 => 1,
+                16 => 1,
             ];
         default:
             return [];

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -36,6 +36,7 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
             $testFiles[] = $testFileBase.'2.inc';
         } else {
             $testFiles[] = $testFileBase.'3.inc';
+            $testFiles[] = $testFileBase.'4.inc';
         }
 
         return $testFiles;


### PR DESCRIPTION
# Description

This PR improves code coverage for the `Generic.PHP.DisallowShortOpenTag` sniff.

## Related issues/external references

Part of https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/146


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.