### PR TITLE
Generic/SpreadOperatorSpacingAfter: improve code coverage

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.1.inc
@@ -74,3 +74,5 @@ $map = array_map(strtolower(...), $map);
 
 // Ignore PHP 8.1 first class callable declarations.
 $map = array_map(strtolower( ... ), $map);
+
+bar(... /*comment*/$array);

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.1.inc.fixed
@@ -69,3 +69,5 @@ $map = array_map(strtolower(...), $map);
 
 // Ignore PHP 8.1 first class callable declarations.
 $map = array_map(strtolower( ... ), $map);
+
+bar(... /*comment*/$array);

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -44,6 +44,7 @@ final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
                 60 => 1,
                 61 => 1,
                 66 => 2,
+                78 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

This PR improves code coverage for the `Generic.WhiteSpace.SpreadOperatorSpacingAfter` sniff.

## Related issues/external references

Part of https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/146


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.