### PR TITLE
Tokenizer/PHP: add tests for tokenization of yield and yield from + minor bug fix

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -606,6 +606,27 @@ class PHP extends Tokenizer
             }
 
             /*
+                Before PHP 5.5, the yield keyword was tokenized as
+                T_STRING. So look for and change this token in
+                earlier versions.
+            */
+
+            if (PHP_VERSION_ID < 50500
+                && $tokenIsArray === true
+                && $token[0] === T_STRING
+                && strtolower($token[1]) === 'yield'
+                && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
+            ) {
+                // Could still be a context sensitive keyword or "yield from" and potentially multi-line,
+                // so adjust the token stack in place.
+                $token[0] = T_YIELD;
+
+                if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                    echo "\t\t* token $stackPtr changed from T_STRING to T_YIELD".PHP_EOL;
+                }
+            }
+
+            /*
                 Tokenize context sensitive keyword as string when it should be string.
             */
 
@@ -1491,26 +1512,6 @@ class PHP extends Tokenizer
 
                 continue;
             }//end if
-
-            /*
-                Before PHP 5.5, the yield keyword was tokenized as
-                T_STRING. So look for and change this token in
-                earlier versions.
-            */
-
-            if (PHP_VERSION_ID < 50500
-                && $tokenIsArray === true
-                && $token[0] === T_STRING
-                && strtolower($token[1]) === 'yield'
-                && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
-            ) {
-                // Could still be "yield from" and potentially multi-line, so adjust the token stack.
-                $token[0] = T_YIELD;
-
-                if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    echo "\t\t* token $stackPtr changed from T_STRING to T_YIELD".PHP_EOL;
-                }
-            }
 
             /*
                 Before PHP 7.0, the "yield from" was tokenized as

--- a/tests/Core/Tokenizers/PHP/YieldTest.inc
+++ b/tests/Core/Tokenizers/PHP/YieldTest.inc
@@ -42,6 +42,9 @@ class Yield {
         /* testFromUsedForClassConstantAccess1 */
         echo MyClass::FROM;
     }
+
+    /* testYieldUsedAsMethodNameReturnByRef */
+    public function &yield() {}
 }
 
 function myGen() {

--- a/tests/Core/Tokenizers/PHP/YieldTest.inc
+++ b/tests/Core/Tokenizers/PHP/YieldTest.inc
@@ -1,0 +1,49 @@
+<?php
+
+function generator()
+{
+    /* testYield */
+    yield 1;
+
+    /* testYieldFollowedByComment */
+    YIELD/*comment*/ 2;
+
+    /* testYieldFrom */
+    yield from gen2();
+
+    /* testYieldFromWithExtraSpacesBetween */
+    Yield           From gen2();
+
+    /* testYieldFromWithTabBetween */
+    yield	from gen2();
+
+    /* testYieldFromSplitByNewLines */
+    yield
+
+    FROM
+    gen2();
+}
+
+/* testYieldUsedAsClassName */
+class Yield {
+    /* testYieldUsedAsClassConstantName */
+    const Type YIELD = 'foo';
+
+    /* testYieldUsedAsMethodName */
+    public function yield() {
+        /* testYieldUsedAsPropertyName1 */
+        echo $obj->yield;
+
+        /* testYieldUsedAsPropertyName2 */
+        echo $obj?->yield();
+
+        /* testYieldUsedForClassConstantAccess1 */
+        echo MyClass::YIELD;
+        /* testFromUsedForClassConstantAccess1 */
+        echo MyClass::FROM;
+    }
+}
+
+function myGen() {
+    /* testYieldLiveCoding */
+    yield

--- a/tests/Core/Tokenizers/PHP/YieldTest.php
+++ b/tests/Core/Tokenizers/PHP/YieldTest.php
@@ -232,6 +232,7 @@ final class YieldTest extends AbstractTokenizerTestCase
             'yield used as property access 2'     => ['/* testYieldUsedAsPropertyName2 */'],
             'yield used as class constant access' => ['/* testYieldUsedForClassConstantAccess1 */'],
             'from used as class constant access'  => ['/* testFromUsedForClassConstantAccess1 */'],
+            'yield used as method name with ref'  => ['/* testYieldUsedAsMethodNameReturnByRef */'],
         ];
 
     }//end dataYieldNonKeyword()


### PR DESCRIPTION
# Description

### Tokenizer/PHP: add tests for tokenization of yield and yield from

.. to document and safeguard the existing behaviour.

Includes skipping one particular assertion on PHP 5.4.

This assertion would fail on PHP 5.4 with PHPUnit 4 as PHPUnit polyfills the `T_YIELD` token too, but with a different value, which causes the token 'type' to be set to `UNKNOWN`.

This issue _only_ occurs when running the tests, not when running PHPCS outside of a test situation, so this is not a real problem when running PHPCS on PHP 5.4.

For reference: the PHPUnit polyfilled token is declared in the PHP_CodeCoverage_Report_HTML_Renderer_File class in vendor/phpunit/php-code-coverage/src/CodeCoverage/Report/HTML/Renderer/File.php

### Tokenizer/PHP: simplify the "yield"/"yield from" polyfill code

By moving the check a `T_STRING` "yield" keyword up and always adjusting the token in the original token stream, we can remove a lot of duplicate code.

### Tokenizer/PHP: bug fix - "yield" vs function return by ref (PHP 5.4)

On PHP 5.4, where PHP doesn't natively have the `T_YIELD` token yet, a `yield` function name for a function declared to return by reference would be tokenized as `T_YIELD`, instead of `T_STRING` due to the `T_YIELD` polyfill happening _after_ the context sensitive keyword check has already run.

By moving the check for a `T_STRING` "yield" keyword up to above the check for context sensitive keywords, this bug is fixed.

Includes additional test.


## Suggested changelog entry
Fixed bug: on PHP 5.4, if `yield` was used as the declaration name for a function declared to return by reference, the function name would incorrectly be tokenized as `T_YIELD` instead of `T_STRING`.

