### PR TITLE
Generic/LineLength: ignore line length for use statements

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -46,6 +46,13 @@ class LineLengthSniff implements Sniff
      */
     public $ignoreComments = false;
 
+    /**
+     * Whether or not to ignore use statements.
+     *
+     * @var boolean
+     */
+    public $ignoreUseStatements = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -139,6 +146,16 @@ class LineLengthSniff implements Sniff
             }
 
             $lineLength -= $tokens[$stackPtr]['length'];
+        }
+
+        if ($this->ignoreUseStatements === true
+            && $lineLength > $this->lineLimit
+        ) {
+            $prevUseStatement = $phpcsFile->findPrevious([T_USE], ($stackPtr - 1));
+            if ($tokens[$stackPtr]['line'] === $tokens[$prevUseStatement]['line']) {
+                // Ignore use statements as these can only be on one line
+                return;
+            }
         }
 
         // Record metrics for common line length groupings.

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
@@ -82,3 +82,9 @@ $ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab;
 $a = $b; // phpcs:ignore Standard.Category.Sniff.ErrorCode1,Standard.Category.Sniff.ErrorCode2 -- for reasons ...
 
 if (($anotherReallyLongVarName === true) {} // This comment makes the line too long.
+
+?>
+
+<?php
+
+use ThisReallyLong\Long\Loooooooooooooooong\Loooooooooooooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong;

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -1,0 +1,8 @@
+phpcs:set Generic.Files.LineLength ignoreUseStatements true
+<?php
+
+/* This line is fine. */
+use ThisShort\UseStatement\ThatShouldBeAllowed;
+
+/* This line is too long but will be ignored. This line is too long but will be ignored. */
+use ThisReallyLong\Long\Loooooooooooooooong\Loooooooooooooooong\UseStatement\ThatShouldBeAllowed\AndThrowNoWarningsOrErrors;

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -54,6 +54,7 @@ final class LineLengthUnitTest extends AbstractSniffUnitTest
                 34 => 1,
                 45 => 1,
                 82 => 1,
+                90 => 1,
             ];
 
         case 'LineLengthUnitTest.2.inc':


### PR DESCRIPTION
From PHP8 on use statements are considered a single token. For this reason they cannot be splitted up to shorter namespaces.

PHPCS doesn't account for that and will throw line length errors and warnings for the use statements. This change ignores the line length for the use statements.

Ofcourse this changes the current behavior so I want to use this PR to further discuss what might be needed to implement this change.

RFC link: https://wiki.php.net/rfc/namespaced_names_as_token
Issue link: https://github.com/squizlabs/PHP_CodeSniffer/issues/3606


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->


## Related issues/external references

Fixes https://github.com/squizlabs/PHP_CodeSniffer/issues/3606


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
