### PR TITLE
Generic/ConstructorName: fix minor bug

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -94,16 +94,18 @@ class ConstructorNameSniff extends AbstractScopeSniff
             return;
         }
 
-        $parentClassName = strtolower($phpcsFile->findExtendedClassName($currScope));
+        $parentClassName = $phpcsFile->findExtendedClassName($currScope);
         if ($parentClassName === false) {
             return;
         }
+
+        $parentClassNameLc = strtolower($parentClassName);
 
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
         $startIndex       = $stackPtr;
         while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) !== false) {
             if ($tokens[($doubleColonIndex + 1)]['code'] === T_STRING
-                && strtolower($tokens[($doubleColonIndex + 1)]['content']) === $parentClassName
+                && strtolower($tokens[($doubleColonIndex + 1)]['content']) === $parentClassNameLc
             ) {
                 $error = 'PHP4 style calls to parent constructors are not allowed; use "parent::__construct()" instead';
                 $phpcsFile->addError($error, ($doubleColonIndex + 1), 'OldStyleCall');


### PR DESCRIPTION
# Description

This PR fixes a minor bug in `Generic.NamingConventions .ConstructorName` when checking if a given class has a parent. The code was checking if the lowercase version of the value returned by `File::findExtendedClassName()` is `false`. The problem is that `strtolower()` never returns `false`. It always returns a `string`. Thus, the condition would never be evaluated as `true`, and the sniff would not bail at this point when a given class has no parent.

As far as I can check, this did not cause any issues to the sniff, even for invalid code, as there is not a scenario where a class method can have a `T_DOUBLE_COLON` token followed by a `T_STRING` token with an empty `content`. This is true even for empty strings as PHPCS includes the quotes in the `content`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
