### PR TITLE
PHPCS ruleset: allow for trailing annotations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,7 +41,9 @@
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
     <rule ref="Squiz.Commenting.InlineComment"/>
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
-    <rule ref="Squiz.Commenting.PostStatementComment"/>
+    <rule ref="Squiz.Commenting.PostStatementComment">
+        <exclude name="Squiz.Commenting.PostStatementComment.AnnotationFound"/>
+    </rule>
     <rule ref="Squiz.Commenting.VariableComment"/>
     <rule ref="Squiz.Formatting.OperatorBracket"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -146,7 +146,7 @@ class DisallowYodaConditionsSniff implements Sniff
             $end   = $tokens[$arrayToken]['parenthesis_closer'];
         } else {
             // Shouldn't be possible but may happen if external sniffs are using this method.
-            return true;
+            return true; // @codeCoverageIgnore
         }
 
         $staticTokens  = Tokens::$emptyTokens;

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
@@ -44,7 +44,7 @@ class UnnecessaryHeredocSniff implements Sniff
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             // Just to be safe. Shouldn't be possible as in that case, the opener shouldn't be tokenized
             // to T_START_HEREDOC by PHP.
-            return;
+            return; // @codeCoverageIgnore
         }
 
         $closer = $tokens[$stackPtr]['scope_closer'];

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -270,8 +270,7 @@ final class Help
     {
         $command = 'phpcs';
         if (defined('PHP_CODESNIFFER_CBF') === true && PHP_CODESNIFFER_CBF === true) {
-            // @codeCoverageIgnore
-            $command = 'phpcbf';
+            $command = 'phpcbf'; // @codeCoverageIgnore
         }
 
         $this->printCategoryHeader('Usage');


### PR DESCRIPTION
# Description
Includes adding a few PHPUnit annotations (as we now can after #627).
