### PR TITLE
Generic/ConstructorName: bug fix x 2

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -15,6 +15,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ConstructorNameSniff extends AbstractScopeSniff
 {
@@ -104,14 +105,15 @@ class ConstructorNameSniff extends AbstractScopeSniff
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
         $startIndex       = $stackPtr;
         while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) !== false) {
-            if ($tokens[($doubleColonIndex + 1)]['code'] === T_STRING
-                && strtolower($tokens[($doubleColonIndex + 1)]['content']) === $parentClassNameLc
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($doubleColonIndex + 1), null, true);
+            if ($tokens[$nextNonEmpty]['code'] === T_STRING
+                && strtolower($tokens[$nextNonEmpty]['content']) === $parentClassNameLc
             ) {
                 $error = 'PHP4 style calls to parent constructors are not allowed; use "parent::__construct()" instead';
-                $phpcsFile->addError($error, ($doubleColonIndex + 1), 'OldStyleCall');
+                $phpcsFile->addError($error, $nextNonEmpty, 'OldStyleCall');
             }
 
-            $startIndex = ($doubleColonIndex + 1);
+            $startIndex = $nextNonEmpty;
         }
 
     }//end processTokenWithinScope()

--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -91,7 +91,7 @@ class ConstructorNameSniff extends AbstractScopeSniff
         }
 
         // Stop if the constructor doesn't have a body, like when it is abstract.
-        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
             return;
         }
 
@@ -103,8 +103,8 @@ class ConstructorNameSniff extends AbstractScopeSniff
         $parentClassNameLc = strtolower($parentClassName);
 
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
-        $startIndex       = $stackPtr;
-        while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) !== false) {
+        $startIndex       = $tokens[$stackPtr]['scope_opener'];
+        while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, ($startIndex + 1), $endFunctionIndex)) !== false) {
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($doubleColonIndex + 1), null, true);
             if ($tokens[$nextNonEmpty]['code'] !== T_STRING
                 || strtolower($tokens[$nextNonEmpty]['content']) !== $parentClassNameLc

--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -106,15 +106,26 @@ class ConstructorNameSniff extends AbstractScopeSniff
         $startIndex       = $stackPtr;
         while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) !== false) {
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($doubleColonIndex + 1), null, true);
-            if ($tokens[$nextNonEmpty]['code'] === T_STRING
-                && strtolower($tokens[$nextNonEmpty]['content']) === $parentClassNameLc
+            if ($tokens[$nextNonEmpty]['code'] !== T_STRING
+                || strtolower($tokens[$nextNonEmpty]['content']) !== $parentClassNameLc
+            ) {
+                $startIndex = $nextNonEmpty;
+                continue;
+            }
+
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($doubleColonIndex - 1), null, true);
+            if ($tokens[$prevNonEmpty]['code'] === T_PARENT
+                || $tokens[$prevNonEmpty]['code'] === T_SELF
+                || $tokens[$prevNonEmpty]['code'] === T_STATIC
+                || ($tokens[$prevNonEmpty]['code'] === T_STRING
+                && strtolower($tokens[$prevNonEmpty]['content']) === $parentClassNameLc)
             ) {
                 $error = 'PHP4 style calls to parent constructors are not allowed; use "parent::__construct()" instead';
                 $phpcsFile->addError($error, $nextNonEmpty, 'OldStyleCall');
             }
 
             $startIndex = $nextNonEmpty;
-        }
+        }//end while
 
     }//end processTokenWithinScope()
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
@@ -95,3 +95,20 @@ interface CustomChildCreator
 {
     public function customChildCreator($elementName, Project $project);
 }
+
+// Bug: unconventional spacing and unexpected comments were not handled correctly.
+class UnconventionalSpacing extends MyParent
+{
+    public function UnconventionalSpacing() {
+        self   ::   MyParent();
+        static/*comment*/::/*comment*/MyParent();
+    }
+
+    public function __construct() {
+        parent
+        //comment
+        ::
+        // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
+        MyParent();
+    }
+}

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
@@ -101,7 +101,7 @@ class UnconventionalSpacing extends MyParent
 {
     public function UnconventionalSpacing() {
         self   ::   MyParent();
-        static/*comment*/::/*comment*/MyParent();
+        MyParent/*comment*/::/*comment*/MyParent();
     }
 
     public function __construct() {
@@ -110,5 +110,21 @@ class UnconventionalSpacing extends MyParent
         ::
         // phpcs:ignore Stnd.Cat.SniffName -- for reasons.
         MyParent();
+    }
+}
+
+// Bug: calling a method with the same name as the class being extended on another class, should not be flagged.
+class HierarchyKeywordBeforeColon extends MyParent
+{
+    public function HierarchyKeywordBeforeColon() {
+        parent::MyParent();
+        MyParent::MyParent();
+        SomeOtherClass::MyParent();
+    }
+
+    public function __construct() {
+        self::MyParent();
+        static::MyParent();
+        SomeOtherClass::MyParent();
     }
 }

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -31,11 +31,14 @@ final class ConstructorNameUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            6  => 1,
-            11 => 1,
-            47 => 1,
-            62 => 1,
-            91 => 1,
+            6   => 1,
+            11  => 1,
+            47  => 1,
+            62  => 1,
+            91  => 1,
+            103 => 1,
+            104 => 1,
+            112 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -39,6 +39,10 @@ final class ConstructorNameUnitTest extends AbstractSniffUnitTest
             103 => 1,
             104 => 1,
             112 => 1,
+            120 => 1,
+            121 => 1,
+            126 => 1,
+            127 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
### Generic/ConstructorName: bug fix - allow for unconventional spacing and comments

When determining whether or not a "parent" constructor was being called using a call to a PHP4-style constructor, the sniff would only look at the _next_ token after a double colon, while the next token may be whitespace or a comment, which should be ignored.

Fixed now by making the sniff check for the _next non empty_ token instead.

Includes tests.

### Generic/ConstructorName: bug fix - false positive on static call to other class

When determining whether or not a "parent" constructor was being called using a call to a PHP4-style constructor, the sniff would only look at the _next_ token after a double colon, disregarding completely the class the method is being called on.

This would lead to false positives for method calls to other classes, which would just happen to have a method named the same as the class being extended.

This commit fixes this by verifying that the previous non-empty token before the double colon is either a hierarchy keyword or the name of the class being extended and only throwing an error if that's the case.

Includes tests.


### Generic/ConstructorName: minor efficiency tweak

As things were, the `$startIndex` would be the `function` keyword in the function declaration, which means that the complete declaration (parameters, defaults etc) would be walked, while we only really want to look _inside_ the function body.

Fixed by starting the `while` loop on the `scope_opener` instead.

Additionally, while the `$startIndex` would be moved forward on each loop, it would still examine one token too much (`scope_opener` cannot be a `T_DOUBLE_COLON`, `T_STRING` after `T_DOUBLE_COLON` cannot be a `T_DOUBLE_COLON`).
Also fixed now.


## Suggested changelog entry
- Fixed Generic.NamingConventions.ConstructorName: false positives for PHP-4 style calls to PHP-4 style parent constructor when a method with the same name as the parent class was called on another class.
- Fixed Generic.NamingConventions.ConstructorName: false negatives for PHP-4 style calls to parent constructor for function calls with whitespace and comments in unconventional places.


## Related issues/external references

Inspired by #649


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
