### PR TITLE
Generic/DuplicateClassName: 4 bug fixes + performance improvement

### DIFF
--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -109,6 +109,10 @@ class DuplicateClassNameSniff implements Sniff
                         ];
                     }
                 }//end if
+
+                if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                    $stackPtr = $tokens[$stackPtr]['scope_closer'];
+                }
             }//end if
 
             $stackPtr = $phpcsFile->findNext($findTokens, ($stackPtr + 1));

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -74,19 +74,20 @@ class DuplicateClassNameSniff implements Sniff
                     // Ignore namespace keyword used as operator.
                     && $tokens[$nextNonEmpty]['code'] !== T_NS_SEPARATOR
                 ) {
-                    $nsEnd = $phpcsFile->findNext(
-                        [
-                            T_NS_SEPARATOR,
-                            T_STRING,
-                            T_WHITESPACE,
-                        ],
-                        ($stackPtr + 1),
-                        null,
-                        true
-                    );
+                    $namespace = '';
+                    for ($i = $nextNonEmpty; $i < $phpcsFile->numTokens; $i++) {
+                        if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                            continue;
+                        }
 
-                    $namespace = trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($nsEnd - $stackPtr - 1)));
-                    $stackPtr  = $nsEnd;
+                        if ($tokens[$i]['code'] !== T_STRING && $tokens[$i]['code'] !== T_NS_SEPARATOR) {
+                            break;
+                        }
+
+                        $namespace .= $tokens[$i]['content'];
+                    }
+
+                    $stackPtr = $i;
                 }
             } else {
                 $nameToken = $phpcsFile->findNext(T_STRING, $stackPtr);

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -56,17 +56,10 @@ class DuplicateClassNameSniff implements Sniff
             T_TRAIT,
             T_ENUM,
             T_NAMESPACE,
-            T_CLOSE_TAG,
         ];
 
         $stackPtr = $phpcsFile->findNext($findTokens, ($stackPtr + 1));
         while ($stackPtr !== false) {
-            if ($tokens[$stackPtr]['code'] === T_CLOSE_TAG) {
-                // We can stop here. The sniff will continue from the next open
-                // tag when PHPCS reaches that token, if there is one.
-                return;
-            }
-
             // Keep track of what namespace we are in.
             if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
                 $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
@@ -119,6 +112,8 @@ class DuplicateClassNameSniff implements Sniff
 
             $stackPtr = $phpcsFile->findNext($findTokens, ($stackPtr + 1));
         }//end while
+
+        return $phpcsFile->numTokens;
 
     }//end process()
 

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -83,31 +83,32 @@ class DuplicateClassNameSniff implements Sniff
                     $stackPtr = $i;
                 }
             } else {
-                $nameToken = $phpcsFile->findNext(T_STRING, $stackPtr);
-                $name      = $tokens[$nameToken]['content'];
-                if ($namespace !== '') {
-                    $name = $namespace.'\\'.$name;
-                }
+                $name = $phpcsFile->getDeclarationName($stackPtr);
+                if (empty($name) === false) {
+                    if ($namespace !== '') {
+                        $name = $namespace.'\\'.$name;
+                    }
 
-                $compareName = strtolower($name);
-                if (isset($this->foundClasses[$compareName]) === true) {
-                    $type  = strtolower($tokens[$stackPtr]['content']);
-                    $file  = $this->foundClasses[$compareName]['file'];
-                    $line  = $this->foundClasses[$compareName]['line'];
-                    $error = 'Duplicate %s name "%s" found; first defined in %s on line %s';
-                    $data  = [
-                        $type,
-                        $name,
-                        $file,
-                        $line,
-                    ];
-                    $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
-                } else {
-                    $this->foundClasses[$compareName] = [
-                        'file' => $phpcsFile->getFilename(),
-                        'line' => $tokens[$stackPtr]['line'],
-                    ];
-                }
+                    $compareName = strtolower($name);
+                    if (isset($this->foundClasses[$compareName]) === true) {
+                        $type  = strtolower($tokens[$stackPtr]['content']);
+                        $file  = $this->foundClasses[$compareName]['file'];
+                        $line  = $this->foundClasses[$compareName]['line'];
+                        $error = 'Duplicate %s name "%s" found; first defined in %s on line %s';
+                        $data  = [
+                            $type,
+                            $name,
+                            $file,
+                            $line,
+                        ];
+                        $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
+                    } else {
+                        $this->foundClasses[$compareName] = [
+                            'file' => $phpcsFile->getFilename(),
+                            'line' => $tokens[$stackPtr]['line'],
+                        ];
+                    }
+                }//end if
             }//end if
 
             $stackPtr = $phpcsFile->findNext($findTokens, ($stackPtr + 1));

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class DuplicateClassNameSniff implements Sniff
 {
@@ -68,19 +69,25 @@ class DuplicateClassNameSniff implements Sniff
 
             // Keep track of what namespace we are in.
             if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
-                $nsEnd = $phpcsFile->findNext(
-                    [
-                        T_NS_SEPARATOR,
-                        T_STRING,
-                        T_WHITESPACE,
-                    ],
-                    ($stackPtr + 1),
-                    null,
-                    true
-                );
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+                if ($nextNonEmpty !== false
+                    // Ignore namespace keyword used as operator.
+                    && $tokens[$nextNonEmpty]['code'] !== T_NS_SEPARATOR
+                ) {
+                    $nsEnd = $phpcsFile->findNext(
+                        [
+                            T_NS_SEPARATOR,
+                            T_STRING,
+                            T_WHITESPACE,
+                        ],
+                        ($stackPtr + 1),
+                        null,
+                        true
+                    );
 
-                $namespace = trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($nsEnd - $stackPtr - 1)));
-                $stackPtr  = $nsEnd;
+                    $namespace = trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($nsEnd - $stackPtr - 1)));
+                    $stackPtr  = $nsEnd;
+                }
             } else {
                 $nameToken = $phpcsFile->findNext(T_STRING, $stackPtr);
                 $name      = $tokens[$nameToken]['content'];

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.10.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.10.inc
@@ -1,0 +1,6 @@
+<?php
+namespace Code\IsNamespaced ?>
+
+<?php
+class MyClass {}
+interface MyInterface {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.11.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.11.inc
@@ -1,0 +1,13 @@
+<?php
+namespace Code\IsNamespaced;
+class FooBar {}
+
+namespace Code\AnotherNamespace;
+
+namespace Code\IsNamespaced ?>
+
+<?php
+echo '123';
+?>
+<?php
+class FooBar {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.7.inc
@@ -7,3 +7,7 @@ interface YourInterface {}
 namespace F;
 namespace\functionCall();
 class MyClass {}
+
+namespace /*comment*/ G;
+namespace\functionCall();
+class MyClass {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.7.inc
@@ -1,0 +1,9 @@
+<?php
+namespace E;
+namespace\functionCall();
+class MyClass {}
+interface YourInterface {}
+
+namespace F;
+namespace\functionCall();
+class MyClass {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.8.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.8.inc
@@ -1,0 +1,8 @@
+<?php
+namespace Foo\Bar;
+class MyClass {}
+interface YourInterface {}
+
+namespace Foo /*comment*/ \ /*comment*/ Bar;
+class MyClass {}
+interface YourInterface {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.9.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.9.inc
@@ -1,0 +1,5 @@
+<?php
+namespace {
+	class MyClass {}
+	trait YourTrait {}
+}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.97.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.97.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error/live coding.
+// This should be the only test in this file.
+// This is a two-file test: test case file 97 and 98 belong together.
+// Testing against false positives during live coding and invalid class names being stored in the cache.
+
+class

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.98.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.98.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error/live coding.
+// This should be the only test in this file.
+// This is a two-file test: test case file 97 and 98 belong together.
+// Testing against false positives during live coding and invalid class names being stored in the cache.
+
+class

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.99.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.99.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Intentional parse error/live coding.
+// This should be the only test in this file.
+// Testing that the sniff is *not* triggered.
+
+namespace

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -73,6 +73,18 @@ final class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
         case 'DuplicateClassNameUnitTest.6.inc':
             return [10 => 1];
 
+        case 'DuplicateClassNameUnitTest.8.inc':
+            return [
+                7 => 1,
+                8 => 1,
+            ];
+
+        case 'DuplicateClassNameUnitTest.9.inc':
+            return [
+                3 => 1,
+                4 => 1,
+            ];
+
         default:
             return [];
         }//end switch

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -85,6 +85,9 @@ final class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
                 4 => 1,
             ];
 
+        case 'DuplicateClassNameUnitTest.11.inc':
+            return [13 => 1];
+
         default:
             return [];
         }//end switch


### PR DESCRIPTION
# Description
### Generic/DuplicateClassName: bug fix - ignore namespace operator

The `namespace` keyword can also be used as an operator, in which case, the sniff as it were would throw false positives.

The fix now applied for this incidentally also fixes a nasty bug which could throw the sniff into an eternal loop when an unfinished namespace statement was encountered during live coding.

Includes unit tests.

**Note**: the unit test for the live coding situation has to be the last unit test file for this sniff so as to not influence the other tests. To that end, it has been numbered `99`.

### Generic/DuplicateClassName: bug fix - ignore comments in namespace declarations

A comment in a namespace declaration statement would throw the sniff off, leading to false positives and false negatives.

Fixed now.

Includes unit tests. Additionally, a unit test for classes declared within a scoped global namespace has also been added.

### Generic/DuplicateClassName: bug fix - namespace is reset on PHP open tag

As things were, the sniff listens to the `T_OPEN_TAG` token, processes the file until the first `T_CLOSE_TAG` and then waits again for a new `T_OPEN_TAG`.

However, every time the sniff is called, the namespace is reset, even when still processing the same file, i.e. when the namespace is still in effect.

This led to both false positives as well as false negatives.

Fixed now, by always processing the complete file in one go and not returning on a `T_CLOSE_TAG`.

Includes unit tests.

### Generic/DuplicateClassName: use helper method

Use the `File::getDeclarationName()` method instead of finding the name of an OO structure in the sniff itself.

This also prevents a potential situation where if a class name could not be found, the `findNext()` method would return `false`, which would then be used in the `$tokens[$nameToken]['content']` leading to `false` being juggled to `0` and a class name of `<?php` being stored in the class name cache.

Includes tests.

### Generic/DuplicateClassName: performance fix

As things were, the sniff would unconditionally walk a complete file, making it one of the top 15 slowest sniffs.

However, OO structures in PHP cannot be nested, so once we've found an OO declaration, we can skip to the end of it before continuing the token walking. See: https://3v4l.org/pbSTG

This small tweak makes a significant difference in the sniff performance without any impact on the sniff results.


## Suggested changelog entry
- Fixed Generic.Classes.DuplicateClassName : the sniff did not skip namespace keywords used as operators, which could lead to false positives.
- Fixed Generic.Classes.DuplicateClassName : sniff going into an infinite loop during live coding.
- Fixed Generic.Classes.DuplicateClassName : false positives/negatives when a namespace declaration contained whitespace or comments in unconventional places.
- Fixed Generic.Classes.DuplicateClassName : namespace for a file going in/out of PHP was not be remembered/applied correctly.
- Performance improvement for Generic.Classes.DuplicateClassName


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
