### PR TITLE
Reports: Fix word wrapping edge cases

### DIFF
--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -153,10 +153,6 @@ class Code implements Report
 
         // The maximum amount of space an error message can use.
         $maxErrorSpace = ($width - $errorPaddingLength);
-        if ($showSources === true) {
-            // Account for the chars used to print colors.
-            $maxErrorSpace += 8;
-        }
 
         // Figure out the max report width we need and can use.
         $fileLength = strlen($file);
@@ -291,19 +287,33 @@ class Code implements Report
                         echo '] ';
                     }
 
-                    $message = $error['message'];
-                    $message = str_replace("\n", "\n".$errorPadding, $message);
-                    if ($showSources === true) {
-                        $message = "\033[1m".$message."\033[0m".' ('.$error['source'].')';
+                    $message       = wordwrap($error['message'], $maxErrorSpace, PHP_EOL);
+                    $paddedMessage = '';
+                    // Add padding and colors to each line of the output.
+                    foreach (explode(PHP_EOL, $message) as $i => $msgLine) {
+                        if ($i !== 0) {
+                            $paddedMessage .= PHP_EOL.$errorPadding;
+                        }
+
+                        if ($showSources === true) {
+                            $paddedMessage .= "\033[1m".$msgLine."\033[0m";
+                        } else {
+                            $paddedMessage .= $msgLine;
+                        }
                     }
 
-                    $errorMsg = wordwrap(
-                        $message,
-                        $maxErrorSpace,
-                        PHP_EOL.$errorPadding
-                    );
+                    if ($showSources === true) {
+                        // Add sniff code, taking care to manually wrap the line if needed.
+                        if ((strlen($msgLine) + strlen($error['source']) + 3) > $maxErrorSpace) {
+                            $paddedMessage .= PHP_EOL.$errorPadding;
+                        } else {
+                            $paddedMessage .= ' ';
+                        }
 
-                    echo $errorMsg.PHP_EOL;
+                        $paddedMessage .= '('.$error['source'].')';
+                    }
+
+                    echo $paddedMessage.PHP_EOL;
                 }//end foreach
             }//end foreach
 


### PR DESCRIPTION


# Description

The word wrapping in Code and Full reports did not correctly account for the ANSI color codes (producing differently wrapped text depending on the value of `$showSources`) and for the `PHP_EOL` constant values (producing differently wrapped text on Linux and Windows).

Rewrite the code so that word wrapping is done first, and padding and colors are added afterwards.

Also harmonize the implementation between the two reports.


## Suggested changelog entry
(probably not needed)


## Related issues/external references
(none)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
  (**Not applicable**? I didn't find any tests for the reports classes, I assume this is not meant to be covered)
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
  (**Not applicable**)
