### PR TITLE
Util\Timing::getHumanReadableDuration: improve time display

### DIFF
--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -13,6 +13,20 @@ class Timing
 {
 
     /**
+     * Number of milliseconds in a minute.
+     *
+     * @var int
+     */
+    const MINUTE_IN_MS = 60000;
+
+    /**
+     * Number of milliseconds in a second.
+     *
+     * @var int
+     */
+    const SECOND_IN_MS = 1000;
+
+    /**
      * The start time of the run in microseconds.
      *
      * @var float
@@ -67,15 +81,15 @@ class Timing
     public static function getHumanReadableDuration($duration)
     {
         $timeString = '';
-        if ($duration >= 60000) {
-            $mins       = floor($duration / 60000);
-            $secs       = round((fmod($duration, 60000) / 1000), 2);
+        if ($duration >= self::MINUTE_IN_MS) {
+            $mins       = floor($duration / self::MINUTE_IN_MS);
+            $secs       = round((fmod($duration, self::MINUTE_IN_MS) / self::SECOND_IN_MS), 2);
             $timeString = $mins.' mins';
             if ($secs >= 0.01) {
                 $timeString .= ", $secs secs";
             }
-        } else if ($duration >= 1000) {
-            $timeString = round(($duration / 1000), 2).' secs';
+        } else if ($duration >= self::SECOND_IN_MS) {
+            $timeString = round(($duration / self::SECOND_IN_MS), 2).' secs';
         } else {
             $timeString = round($duration).'ms';
         }

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -67,14 +67,14 @@ class Timing
     public static function getHumanReadableDuration($duration)
     {
         $timeString = '';
-        if ($duration > 60000) {
+        if ($duration >= 60000) {
             $mins       = floor($duration / 60000);
             $secs       = round((fmod($duration, 60000) / 1000), 2);
             $timeString = $mins.' mins';
-            if ($secs !== 0) {
+            if ($secs >= 0.01) {
                 $timeString .= ", $secs secs";
             }
-        } else if ($duration > 1000) {
+        } else if ($duration >= 1000) {
             $timeString = round(($duration / 1000), 2).' secs';
         } else {
             $timeString = round($duration).'ms';

--- a/tests/Core/Util/Timing/GetHumanReadableDurationTest.php
+++ b/tests/Core/Util/Timing/GetHumanReadableDurationTest.php
@@ -68,7 +68,7 @@ final class GetHumanReadableDurationTest extends TestCase
             ],
             'Duration: 1 second'                           => [
                 'duration' => 1000,
-                'expected' => '1000ms',
+                'expected' => '1 secs',
             ],
             'Duration: slightly more than 1 second'        => [
                 'duration' => 1001.178215,
@@ -80,11 +80,11 @@ final class GetHumanReadableDurationTest extends TestCase
             ],
             'Duration: exactly 1 minute'                   => [
                 'duration' => 60000,
-                'expected' => '60 secs',
+                'expected' => '1 mins',
             ],
             'Duration: slightly more than 1 minute'        => [
                 'duration' => 60001.7581235,
-                'expected' => '1 mins, 0 secs',
+                'expected' => '1 mins',
             ],
             'Duration: 1 minute, just under half a second' => [
                 'duration' => 60499.83639,
@@ -100,7 +100,7 @@ final class GetHumanReadableDurationTest extends TestCase
             ],
             'Duration: exactly 1 hour'                     => [
                 'duration' => 3600000,
-                'expected' => '60 mins, 0 secs',
+                'expected' => '60 mins',
             ],
             'Duration: 89.4 mins'                          => [
                 'duration' => 5364000,


### PR DESCRIPTION
# Description

### Util\Timing::getHumanReadableDuration: improve time display

This commit makes some tiny changes to how the run time is displayed:
* For "exactly 1 second", display `1 secs` instead of `1000ms`.
* For "exactly 1 minute", display `1 mins` instead of `60 secs`.
* When minutes are displayed, only display seconds when there are seconds to display (so no `# mins, 0 secs`).

Includes updating the tests to match.

### Util\Timing::getHumanReadableDuration: magic numbers to constants

Make the code more self-descriptive and use less "magic numbers" by declaring a couple of constants.

## Suggested changelog entry
Minor improvements to the display of runtime information.