### PR TITLE
Use ANSI color codes and Unicode characters on Windows as well

### DIFF
--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -228,7 +228,8 @@ class Code implements Report
                     if (strpos($tokenContent, "\t") !== false) {
                         $token            = $tokens[$i];
                         $token['content'] = $tokenContent;
-                        if (stripos(PHP_OS, 'WIN') === 0) {
+                        if (stripos(PHP_OS, 'WIN') === 0 && PHP_VERSION_ID < 70100) {
+                            // Printing Unicode characters like '»' to Windows console only works since PHP 7.1.
                             $tab = "\000";
                         } else {
                             $tab = "\033[30;1m»\033[0m";

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -516,10 +516,6 @@ class PHP extends Tokenizer
     {
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             echo "\t*** START PHP TOKENIZING ***".PHP_EOL;
-            $isWin = false;
-            if (stripos(PHP_OS, 'WIN') === 0) {
-                $isWin = true;
-            }
         }
 
         $tokens      = @token_get_all($string);
@@ -584,11 +580,7 @@ class PHP extends Tokenizer
                 ) {
                     $token[1] .= "\n";
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                        if ($isWin === true) {
-                            echo '\n';
-                        } else {
-                            echo "\033[30;1m\\n\033[0m";
-                        }
+                        echo "\033[30;1m\\n\033[0m";
                     }
 
                     if ($tokens[($stackPtr + 1)][1] === "\n") {

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -283,8 +283,9 @@ class Common
             "\t" => '\t',
             " "  => '·',
         ];
-        if (stripos(PHP_OS, 'WIN') === 0) {
-            // Do not replace spaces on Windows.
+        if (stripos(PHP_OS, 'WIN') === 0 && PHP_VERSION_ID < 70100) {
+            // Do not replace spaces on old PHP on Windows.
+            // Printing Unicode characters like '·' to Windows console only works since PHP 7.1.
             unset($replacements[" "]);
         }
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -267,8 +267,7 @@ class Common
     /**
      * Prepares token content for output to screen.
      *
-     * Replaces invisible characters so they are visible. On non-Windows
-     * operating systems it will also colour the invisible characters.
+     * Replaces invisible characters so they are visible, and colour them.
      *
      * @param string   $content The content to prepare.
      * @param string[] $exclude A list of characters to leave invisible.
@@ -291,11 +290,9 @@ class Common
 
         $replacements = array_diff_key($replacements, array_fill_keys($exclude, true));
 
-        if (stripos(PHP_OS, 'WIN') !== 0) {
-            // On non-Windows, colour runs of invisible characters.
-            $match   = implode('', array_keys($replacements));
-            $content = preg_replace("/([$match]+)/", "\033[30;1m$1\033[0m", $content);
-        }
+        // Colour runs of invisible characters.
+        $match   = implode('', array_keys($replacements));
+        $content = preg_replace("/([$match]+)/", "\033[30;1m$1\033[0m", $content);
 
         $content = strtr($content, $replacements);
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -278,35 +278,26 @@ class Common
      */
     public static function prepareForOutput($content, $exclude=[])
     {
+        $replacements = [
+            "\r" => '\r',
+            "\n" => '\n',
+            "\t" => '\t',
+            " "  => '·',
+        ];
         if (stripos(PHP_OS, 'WIN') === 0) {
-            if (in_array("\r", $exclude, true) === false) {
-                $content = str_replace("\r", '\r', $content);
-            }
+            // Do not replace spaces on Windows.
+            unset($replacements[" "]);
+        }
 
-            if (in_array("\n", $exclude, true) === false) {
-                $content = str_replace("\n", '\n', $content);
-            }
+        $replacements = array_diff_key($replacements, array_fill_keys($exclude, true));
 
-            if (in_array("\t", $exclude, true) === false) {
-                $content = str_replace("\t", '\t', $content);
-            }
-        } else {
-            if (in_array("\r", $exclude, true) === false) {
-                $content = str_replace("\r", "\033[30;1m\\r\033[0m", $content);
-            }
+        if (stripos(PHP_OS, 'WIN') !== 0) {
+            // On non-Windows, colour runs of invisible characters.
+            $match   = implode('', array_keys($replacements));
+            $content = preg_replace("/([$match]+)/", "\033[30;1m$1\033[0m", $content);
+        }
 
-            if (in_array("\n", $exclude, true) === false) {
-                $content = str_replace("\n", "\033[30;1m\\n\033[0m", $content);
-            }
-
-            if (in_array("\t", $exclude, true) === false) {
-                $content = str_replace("\t", "\033[30;1m\\t\033[0m", $content);
-            }
-
-            if (in_array(' ', $exclude, true) === false) {
-                $content = str_replace(' ', "\033[30;1m·\033[0m", $content);
-            }
-        }//end if
+        $content = strtr($content, $replacements);
 
         return $content;
 

--- a/tests/Core/Util/Common/PrepareForOutputTest.php
+++ b/tests/Core/Util/Common/PrepareForOutputTest.php
@@ -27,14 +27,14 @@ final class PrepareForOutputTest extends TestCase
      * @param string   $content     The content to prepare.
      * @param string[] $exclude     A list of characters to leave invisible.
      * @param string   $expected    Expected function output.
-     * @param string   $expectedWin Expected function output on Windows (unused in this test).
+     * @param string   $expectedOld Expected function output on PHP<7.1 on Windows (unused in this test).
      *
      * @requires     OS ^(?!WIN).*
      * @dataProvider dataPrepareForOutput
      *
      * @return void
      */
-    public function testPrepareForOutput($content, $exclude, $expected, $expectedWin)
+    public function testPrepareForOutput($content, $exclude, $expected, $expectedOld)
     {
         $this->assertSame($expected, Common::prepareForOutput($content, $exclude));
 
@@ -42,23 +42,51 @@ final class PrepareForOutputTest extends TestCase
 
 
     /**
-     * Test formatting whitespace characters, on Windows.
+     * Test formatting whitespace characters, on modern PHP on Windows.
      *
      * @param string   $content     The content to prepare.
      * @param string[] $exclude     A list of characters to leave invisible.
-     * @param string   $expected    Expected function output (unused in this test).
-     * @param string   $expectedWin Expected function output on Windows.
+     * @param string   $expected    Expected function output.
+     * @param string   $expectedOld Expected function output on PHP<7.1 on Windows (unused in this test).
      *
      * @requires     OS ^WIN.*.
+     * @requires     PHP 7.1
      * @dataProvider dataPrepareForOutput
      *
      * @return void
      */
-    public function testPrepareForOutputWindows($content, $exclude, $expected, $expectedWin)
+    public function testPrepareForOutputWindows($content, $exclude, $expected, $expectedOld)
     {
-        $this->assertSame($expectedWin, Common::prepareForOutput($content, $exclude));
+        $this->assertSame($expected, Common::prepareForOutput($content, $exclude));
 
     }//end testPrepareForOutputWindows()
+
+
+    /**
+     * Test formatting whitespace characters, on PHP<7.1 on Windows.
+     *
+     * @param string   $content     The content to prepare.
+     * @param string[] $exclude     A list of characters to leave invisible.
+     * @param string   $expected    Expected function output (unused in this test).
+     * @param string   $expectedOld Expected function output on PHP<7.1 on Windows.
+     *
+     * @requires     OS ^WIN.*.
+     * @requires     PHP < 7.1
+     * @dataProvider dataPrepareForOutput
+     *
+     * @return void
+     */
+    public function testPrepareForOutputOldPHPWindows($content, $exclude, $expected, $expectedOld)
+    {
+        // PHPUnit 4.8 (used on PHP 5.4) does not support the `@requires PHP < 7.1` syntax,
+        // so double-check to avoid test failures.
+        if (PHP_VERSION_ID >= 70100) {
+            $this->markTestSkipped("Only for PHP < 7.1");
+        }
+
+        $this->assertSame($expectedOld, Common::prepareForOutput($content, $exclude));
+
+    }//end testPrepareForOutputOldPHPWindows()
 
 
     /**
@@ -66,6 +94,7 @@ final class PrepareForOutputTest extends TestCase
      *
      * @see testPrepareForOutput()
      * @see testPrepareForOutputWindows()
+     * @see testPrepareForOutputOldPHPWindows()
      *
      * @return array<string, array<string, mixed>>
      */
@@ -76,25 +105,25 @@ final class PrepareForOutputTest extends TestCase
                 'content'     => "\r\n\t",
                 'exclude'     => [],
                 'expected'    => "\033[30;1m\\r\\n\\t\033[0m",
-                'expectedWin' => "\033[30;1m\\r\\n\\t\033[0m",
+                'expectedOld' => "\033[30;1m\\r\\n\\t\033[0m",
             ],
             'Spaces are replaced with a unique mark'             => [
                 'content'     => "    ",
                 'exclude'     => [],
                 'expected'    => "\033[30;1m····\033[0m",
-                'expectedWin' => "    ",
+                'expectedOld' => "    ",
             ],
             'Other characters are unaffected'                    => [
                 'content'     => "{echo 1;}",
                 'exclude'     => [],
                 'expected'    => "{echo\033[30;1m·\033[0m1;}",
-                'expectedWin' => "{echo 1;}",
+                'expectedOld' => "{echo 1;}",
             ],
             'No replacements'                                    => [
                 'content'     => 'nothing-should-be-replaced',
                 'exclude'     => [],
                 'expected'    => 'nothing-should-be-replaced',
-                'expectedWin' => 'nothing-should-be-replaced',
+                'expectedOld' => 'nothing-should-be-replaced',
             ],
             'Excluded whitespace characters are unaffected'      => [
                 'content'     => "\r\n\t ",
@@ -103,7 +132,7 @@ final class PrepareForOutputTest extends TestCase
                     "\n",
                 ],
                 'expected'    => "\r\n\033[30;1m\\t·\033[0m",
-                'expectedWin' => "\r\n\033[30;1m\\t\033[0m ",
+                'expectedOld' => "\r\n\033[30;1m\\t\033[0m ",
             ],
         ];
 

--- a/tests/Core/Util/Common/PrepareForOutputTest.php
+++ b/tests/Core/Util/Common/PrepareForOutputTest.php
@@ -75,13 +75,13 @@ final class PrepareForOutputTest extends TestCase
             'Special characters are replaced with their escapes' => [
                 'content'     => "\r\n\t",
                 'exclude'     => [],
-                'expected'    => "\033[30;1m\\r\033[0m\033[30;1m\\n\033[0m\033[30;1m\\t\033[0m",
+                'expected'    => "\033[30;1m\\r\\n\\t\033[0m",
                 'expectedWin' => "\\r\\n\\t",
             ],
             'Spaces are replaced with a unique mark'             => [
                 'content'     => "    ",
                 'exclude'     => [],
-                'expected'    => "\033[30;1m·\033[0m\033[30;1m·\033[0m\033[30;1m·\033[0m\033[30;1m·\033[0m",
+                'expected'    => "\033[30;1m····\033[0m",
                 'expectedWin' => "    ",
             ],
             'Other characters are unaffected'                    => [
@@ -102,7 +102,7 @@ final class PrepareForOutputTest extends TestCase
                     "\r",
                     "\n",
                 ],
-                'expected'    => "\r\n\033[30;1m\\t\033[0m\033[30;1m·\033[0m",
+                'expected'    => "\r\n\033[30;1m\\t·\033[0m",
                 'expectedWin' => "\r\n\\t ",
             ],
         ];

--- a/tests/Core/Util/Common/PrepareForOutputTest.php
+++ b/tests/Core/Util/Common/PrepareForOutputTest.php
@@ -76,7 +76,7 @@ final class PrepareForOutputTest extends TestCase
                 'content'     => "\r\n\t",
                 'exclude'     => [],
                 'expected'    => "\033[30;1m\\r\\n\\t\033[0m",
-                'expectedWin' => "\\r\\n\\t",
+                'expectedWin' => "\033[30;1m\\r\\n\\t\033[0m",
             ],
             'Spaces are replaced with a unique mark'             => [
                 'content'     => "    ",
@@ -103,7 +103,7 @@ final class PrepareForOutputTest extends TestCase
                     "\n",
                 ],
                 'expected'    => "\r\n\033[30;1m\\t·\033[0m",
-                'expectedWin' => "\r\n\\t ",
+                'expectedWin' => "\r\n\033[30;1m\\t\033[0m ",
             ],
         ];
 


### PR DESCRIPTION
# Description

Use ANSI color codes and Unicode characters on Windows as well, when possible. See commit messages for details.


## Suggested changelog entry
* Output now has fewer redundant ANSI color codes.
* On Windows, when using the `--colors` option, the output now has more colors.
* On Windows, when using PHP 7.1+, the output now has more Unicode characters.


## Related issues/external references
(none)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
