### PR TITLE
Tests: Add ugly integration test for Reports\Full

### DIFF
--- a/tests/Core/Reports/FullTest.php
+++ b/tests/Core/Reports/FullTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Reports\Full class.
+ *
+ * @author  Bartosz Dziewoński <dziewonski@fastmail.fm>
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Reports;
+
+use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Reports\Full;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util\Common;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Reports\Full class.
+ *
+ * @covers \PHP_CodeSniffer\Reports\Full
+ */
+final class FullTest extends TestCase
+{
+
+
+    /**
+     * Test generating a full PHPCS report.
+     *
+     * @param string $reportData Prepared report data.
+     * @param string $expected   Expected function output.
+     *
+     * @dataProvider dataGenerateFileReport
+     *
+     * @return void
+     */
+    public function testGenerateFileReport($reportData, $expected)
+    {
+        $reportClass = new Full();
+        $config      = new Config();
+        $phpcsFile   = new File('', new Ruleset($config), $config);
+
+        ob_start();
+        $result = $reportClass->generateFileReport(
+            $reportData,
+            $phpcsFile
+        );
+        $this->assertTrue($result);
+        $generatedReport = ob_get_contents();
+        ob_end_clean();
+
+        // For readability of the output in the test data, omit color codes.
+        // Their behavior is covered by their own unit tests.
+        $generatedReport = Common::stripColors($generatedReport);
+
+        $this->assertSame(
+            str_replace("\n", PHP_EOL, trim($expected)),
+            trim($generatedReport)
+        );
+
+    }//end testGenerateFileReport()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testGenerateFileReport()
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataGenerateFileReport()
+    {
+        return [
+            'Simple output' => [
+                'reportData' => [
+                    'filename' => 'simple.php',
+                    'errors'   => 6,
+                    'warnings' => 0,
+                    'fixable'  => 4,
+                    'messages' => [
+                        1 => [
+                            1 => [
+                                0 => [
+                                    'message'  => 'The PHP open tag does not have a corresponding PHP close tag',
+                                    'source'   => 'Generic.PHP.ClosingPHPTag.NotFound',
+                                    'severity' => 5,
+                                    'fixable'  => false,
+                                    'type'     => 'ERROR',
+                                ],
+                                1 => [
+                                    'message'  => 'Missing required strict_types declaration',
+                                    'source'   => 'Generic.PHP.RequireStrictTypes.MissingDeclaration',
+                                    'severity' => 5,
+                                    'fixable'  => false,
+                                    'type'     => 'ERROR',
+                                ],
+                            ],
+                        ],
+                        3 => [
+                            1 => [
+                                0 => [
+                                    'message'  => 'Tabs must be used to indent lines; spaces are not allowed',
+                                    'source'   => 'Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed',
+                                    'severity' => 5,
+                                    'fixable'  => true,
+                                    'type'     => 'ERROR',
+                                ],
+                            ],
+                        ],
+                        4 => [
+                            1 => [
+                                0 => [
+                                    'message'  => 'Tabs must be used to indent lines; spaces are not allowed',
+                                    'source'   => 'Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed',
+                                    'severity' => 5,
+                                    'fixable'  => true,
+                                    'type'     => 'ERROR',
+                                ],
+                            ],
+                        ],
+                        5 => [
+                            1 => [
+                                0 => [
+                                    'message'  => 'Spaces must be used to indent lines; tabs are not allowed',
+                                    'source'   => 'Generic.WhiteSpace.DisallowTabIndent.TabsUsed',
+                                    'severity' => 5,
+                                    'fixable'  => true,
+                                    'type'     => 'ERROR',
+                                ],
+                            ],
+                            5 => [
+                                0 => [
+                                    'message'  => 'File must not end with a newline character',
+                                    'source'   => 'Generic.Files.EndFileNoNewline.Found',
+                                    'severity' => 5,
+                                    'fixable'  => true,
+                                    'type'     => 'ERROR',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'expected'   => <<<EOF
+FILE: simple.php
+------------------------------------------------------------------------------
+FOUND 6 ERRORS AFFECTING 4 LINES
+------------------------------------------------------------------------------
+ 1 | ERROR | [ ] The PHP open tag does not have a corresponding PHP close tag
+ 1 | ERROR | [ ] Missing required strict_types declaration
+ 3 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
+ 4 | ERROR | [x] Tabs must be used to indent lines; spaces are not allowed
+ 5 | ERROR | [x] Spaces must be used to indent lines; tabs are not allowed
+ 5 | ERROR | [x] File must not end with a newline character
+------------------------------------------------------------------------------
+PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+------------------------------------------------------------------------------
+EOF
+                ,
+            ],
+        ];
+
+    }//end dataGenerateFileReport()
+
+
+}//end class


### PR DESCRIPTION
The class does not really have individually testable components. Provide a big ugly real report data as the input, and a big ugly real generated report as the output. This is not great, but it's something.

The Full report ignores the $phpcsFile argument, so it's easy to mock. Other reports would require a more complicated setup to test.

The test data has been generated from a file `simple.php` as follows:
```
<?php

    // This is a space indented line.
    $a = 10;
	// This is a tab indented line.
```
…using the following command for the output:
```
phpcs simple.php --basepath=. --report=full --tab-width=4 --no-colors --standard=generic
```
…and adding this snippet in generateFileReport() for the input:
```
var_export($report);
```



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
