### PR TITLE
PHPCS ruleset: make the file level `@author` tag optional

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,6 +22,7 @@
         <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
         <exclude name="PEAR.NamingConventions.ValidVariableName"/>
         <exclude name="PEAR.Commenting.ClassComment"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingAuthorTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>


### PR DESCRIPTION
## Related issues/external references

Related to #155 and #663