### PR TITLE
Generators: always present docs in alphabetical order

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -60,6 +60,9 @@ abstract class Generator
             }
         }
 
+        // Always present the docs in a consistent alphabetical order.
+        sort($this->docFiles, (SORT_NATURAL | SORT_FLAG_CASE));
+
     }//end __construct()
 
 


### PR DESCRIPTION
# Description
As things were, the order in which sniff documentation was presented was dependent on the file system the sniffs were found on.

Fixed now by making the order logical and consistent.


## Suggested changelog entry
* Documentation generated via the `--generator=...` feature will now be presented in natural order based on the sniff name(s).


## Related issues/external references

This PR is a precursor to a series of PRs which will add a complete set of tests for the `Generator` feature.