### PR TITLE
Generators/HTML: move static string to class constant

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -20,6 +20,78 @@ use PHP_CodeSniffer\Config;
 class HTML extends Generator
 {
 
+    /**
+     * Stylesheet for the HTML output.
+     *
+     * @var string
+     */
+    const STYLESHEET = '<style>
+        body {
+            background-color: #FFFFFF;
+            font-size: 14px;
+            font-family: Arial, Helvetica, sans-serif;
+            color: #000000;
+        }
+
+        h1 {
+            color: #666666;
+            font-size: 20px;
+            font-weight: bold;
+            margin-top: 0px;
+            background-color: #E6E7E8;
+            padding: 20px;
+            border: 1px solid #BBBBBB;
+        }
+
+        h2 {
+            color: #00A5E3;
+            font-size: 16px;
+            font-weight: normal;
+            margin-top: 50px;
+        }
+
+        .code-comparison {
+            width: 100%;
+        }
+
+        .code-comparison td {
+            border: 1px solid #CCCCCC;
+        }
+
+        .code-comparison-title, .code-comparison-code {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 12px;
+            color: #000000;
+            vertical-align: top;
+            padding: 4px;
+            width: 50%;
+            background-color: #F1F1F1;
+            line-height: 15px;
+        }
+
+        .code-comparison-code {
+            font-family: Courier;
+            background-color: #F9F9F9;
+        }
+
+        .code-comparison-highlight {
+            background-color: #DDF1F7;
+            border: 1px solid #00A5E3;
+            line-height: 15px;
+        }
+
+        .tag-line {
+            text-align: center;
+            width: 100%;
+            margin-top: 30px;
+            font-size: 12px;
+        }
+
+        .tag-line a {
+            color: #000000;
+        }
+    </style>';
+
 
     /**
      * Generates the documentation for a standard.
@@ -61,72 +133,7 @@ class HTML extends Generator
         echo '<html>'.PHP_EOL;
         echo ' <head>'.PHP_EOL;
         echo "  <title>$standard Coding Standards</title>".PHP_EOL;
-        echo '  <style>
-                    body {
-                        background-color: #FFFFFF;
-                        font-size: 14px;
-                        font-family: Arial, Helvetica, sans-serif;
-                        color: #000000;
-                    }
-
-                    h1 {
-                        color: #666666;
-                        font-size: 20px;
-                        font-weight: bold;
-                        margin-top: 0px;
-                        background-color: #E6E7E8;
-                        padding: 20px;
-                        border: 1px solid #BBBBBB;
-                    }
-
-                    h2 {
-                        color: #00A5E3;
-                        font-size: 16px;
-                        font-weight: normal;
-                        margin-top: 50px;
-                    }
-
-                    .code-comparison {
-                        width: 100%;
-                    }
-
-                    .code-comparison td {
-                        border: 1px solid #CCCCCC;
-                    }
-
-                    .code-comparison-title, .code-comparison-code {
-                        font-family: Arial, Helvetica, sans-serif;
-                        font-size: 12px;
-                        color: #000000;
-                        vertical-align: top;
-                        padding: 4px;
-                        width: 50%;
-                        background-color: #F1F1F1;
-                        line-height: 15px;
-                    }
-
-                    .code-comparison-code {
-                        font-family: Courier;
-                        background-color: #F9F9F9;
-                    }
-
-                    .code-comparison-highlight {
-                        background-color: #DDF1F7;
-                        border: 1px solid #00A5E3;
-                        line-height: 15px;
-                    }
-
-                    .tag-line {
-                        text-align: center;
-                        width: 100%;
-                        margin-top: 30px;
-                        font-size: 12px;
-                    }
-
-                    .tag-line a {
-                        color: #000000;
-                    }
-                </style>'.PHP_EOL;
+        echo '  '.self::STYLESHEET.PHP_EOL;
         echo ' </head>'.PHP_EOL;
         echo ' <body>'.PHP_EOL;
         echo "  <h1>$standard Coding Standards</h1>".PHP_EOL;


### PR DESCRIPTION
# Description

No functional changes, just moving the CSS out of the function to a class constant.

## Suggested changelog entry
_N/A_


## Related issues/external references

This PR is a precursor to a series of PRs which will add a complete set of tests for the Generator feature.