### PR TITLE
GH Actions/basics: add check for valid XML docs + fix two docs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,6 +72,10 @@ jobs:
           diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml")
           diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml")
 
+      # Validate the basic well-formedness of the Documentation XML files.
+      - name: Validate documentation XML
+        run: xmllint --noout ./src/Standards/*/Docs/*/*Standard.xml
+
   yamllint:
     name: 'Lint Yaml'
     # Don't run the cronjob in this workflow on forks.

--- a/src/Standards/Generic/Docs/WhiteSpace/HereNowdocIdentifierSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/HereNowdocIdentifierSpacingStandard.xml
@@ -5,14 +5,14 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: No space between the <<< and the identifier string.">
+        <code title="Valid: No space between the &lt;&lt;&lt; and the identifier string.">
         <![CDATA[
 $heredoc = <em><<<EOD</em>
 some text
 EOD;
         ]]>
         </code>
-        <code title="Invalid: Whitespace between the <<< and the identifier string.">
+        <code title="Invalid: Whitespace between the &lt;&lt;&lt; and the identifier string.">
         <![CDATA[
 $heredoc = <em><<<   END</em>
 some text

--- a/src/Standards/Generic/Docs/WhiteSpace/SpreadOperatorSpacingAfterStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/SpreadOperatorSpacingAfterStandard.xml
@@ -25,7 +25,7 @@ function bar(<em>... </em>$spread) {
     );
 
     bar(
-        [<em>...  </em>$foo ],<em>.../*comment*/</em>array_values($keyedArray)
+        [<em>... </em>$foo ],<em>.../*@*/</em>array_values($keyed)
     );
 }
         ]]>


### PR DESCRIPTION
# Description

_Of course, found this issue when I'd already tagged the 3.11.0 release... oh well, guess I'll do another release later this week. At least with the new CI check, this won't be able to happen again._

### GH Actions/basics: add check for valid XML docs

Verify basic well-formedness of the XML docs.

### Docs: fix up two XML docs

* The `HereNowdocIdentifierSpacing` one contained unescaped special chars in an attribute (oops).
* The `SpreadOperatorSpacingAfter` line length did not conform (not found via the new CI check, but even so).

## Suggested changelog entry
* Generic.WhiteSpace.HereNowdocIdentifierSpacing: fixed broken XML documentation 


## Related issues/external references

Introduced in #586


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_