### PR TITLE
Common::getSniffCode(): be more lenient about sniffs not following naming conventions

### DIFF
--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -542,13 +542,7 @@ class Common
 
         $parts      = explode('\\', $sniffClass);
         $partsCount = count($parts);
-        if ($partsCount < 4) {
-            throw new InvalidArgumentException(
-                'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received: '.$sniffClass
-            );
-        }
-
-        $sniff = $parts[($partsCount - 1)];
+        $sniff      = $parts[($partsCount - 1)];
 
         if (substr($sniff, -5) === 'Sniff') {
             // Sniff class name.
@@ -562,8 +556,16 @@ class Common
             );
         }
 
-        $standard = $parts[($partsCount - 4)];
-        $category = $parts[($partsCount - 2)];
+        $standard = '';
+        if (isset($parts[($partsCount - 4)]) === true) {
+            $standard = $parts[($partsCount - 4)];
+        }
+
+        $category = '';
+        if (isset($parts[($partsCount - 2)]) === true) {
+            $category = $parts[($partsCount - 2)];
+        }
+
         return $standard.'.'.$category.'.'.$sniff;
 
     }//end getSniffCode()

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -108,7 +108,6 @@ final class GetSniffCodeTest extends TestCase
             'Unqualified class name'                                        => ['ClassName'],
             'Fully qualified class name, not enough parts'                  => ['Fully\\Qualified\\ClassName'],
             'Fully qualified class name, doesn\'t end on Sniff or UnitTest' => ['Fully\\Sniffs\\Qualified\\ClassName'],
-            'Fully qualified class name, ends on Sniff, but isn\'t'         => ['Fully\\Sniffs\\AbstractSomethingSniff'],
         ];
 
     }//end dataGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass()
@@ -141,29 +140,57 @@ final class GetSniffCodeTest extends TestCase
     public static function dataGetSniffCode()
     {
         return [
-            'PHPCS native sniff'                                  => [
+            'PHPCS native sniff'                                                              => [
                 'fqnClass' => 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\Arrays\\ArrayIndentSniff',
                 'expected' => 'Generic.Arrays.ArrayIndent',
             ],
-            'Class is a PHPCS native test class'                  => [
+            'Class is a PHPCS native test class'                                              => [
                 'fqnClass' => 'PHP_CodeSniffer\\Standards\\Generic\\Tests\\Arrays\\ArrayIndentUnitTest',
                 'expected' => 'Generic.Arrays.ArrayIndent',
             ],
-            'Sniff in external standard without namespace prefix' => [
+            'Sniff in external standard without namespace prefix'                             => [
                 'fqnClass' => 'MyStandard\\Sniffs\\PHP\\MyNameSniff',
                 'expected' => 'MyStandard.PHP.MyName',
             ],
-            'Test in external standard without namespace prefix'  => [
+            'Test in external standard without namespace prefix'                              => [
                 'fqnClass' => 'MyStandard\\Tests\\PHP\\MyNameSniff',
                 'expected' => 'MyStandard.PHP.MyName',
             ],
-            'Sniff in external standard with namespace prefix'    => [
+            'Sniff in external standard with namespace prefix'                                => [
                 'fqnClass' => 'Vendor\\Package\\MyStandard\\Sniffs\\Category\\AnalyzeMeSniff',
                 'expected' => 'MyStandard.Category.AnalyzeMe',
             ],
-            'Test in external standard with namespace prefix'     => [
+            'Test in external standard with namespace prefix'                                 => [
                 'fqnClass' => 'Vendor\\Package\\MyStandard\\Tests\\Category\\AnalyzeMeUnitTest',
                 'expected' => 'MyStandard.Category.AnalyzeMe',
+            ],
+
+            /*
+             * These are not valid sniff codes and is an undesirable result, but can't be helped
+             * as changing this would be a BC-break.
+             * Supporting these to allow for <rule> tags directly including sniff files.
+             * See: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/675
+             */
+
+            'Fully qualified class name, ends on Sniff, but isn\'t'                           => [
+                'fqnClass' => 'Fully\\Sniffs\\AbstractSomethingSniff',
+                'expected' => '.Sniffs.AbstractSomething',
+            ],
+            'Sniff provided via file include and doesn\'t comply with naming conventions [1]' => [
+                'fqnClass' => 'CheckMeSniff',
+                'expected' => '..CheckMe',
+            ],
+            'Sniff provided via file include and doesn\'t comply with naming conventions [2]' => [
+                'fqnClass' => 'CompanyName\\CheckMeSniff',
+                'expected' => '.CompanyName.CheckMe',
+            ],
+            'Sniff provided via file include and doesn\'t comply with naming conventions [3]' => [
+                'fqnClass' => 'CompanyName\\Sniffs\\CheckMeSniff',
+                'expected' => '.Sniffs.CheckMe',
+            ],
+            'Sniff provided via file include and doesn\'t comply with naming conventions [4]' => [
+                'fqnClass' => 'CompanyName\\CustomSniffs\\Whatever\\CheckMeSniff',
+                'expected' => 'CompanyName.Whatever.CheckMe',
             ],
         ];
 


### PR DESCRIPTION
# Description
Sniff classes _should_ always follow the directory layout and naming conventions for sniffs as per the [Tutorial](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial).

However, before the change made in #524, when given a sniff class name for a sniff not following the naming conventions, the `Common::getSniffCode()` method would return a "sniff code" anyway. And even though the sniff code would be unconventional and not really valid, it would still _work_.

Since #524 this is no longer the case.

Given the above, the change from #524 breaks custom rulesets which use `<rule>` includes for individual sniff files not complying with the naming conventions. Breaking changes can only be made in majors, so this commit reverts the problematic part of the change from #524.

Includes additional tests safeguarding the (broken) behaviour which needs to be maintained (at least until the next major).


## Suggested changelog entry
* Fixed `InvalidArgumentException` when a ruleset includes a sniff by file name and the included sniff does not comply with the PHPCS naming conventions.
    - Notwithstanding this fix, it is _strongly_ recommended to ensure custom sniff classes comply with the [PHPCS naming conventions](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial)

## Related issues/external references

Fixes #675


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
