### PR TITLE
GH Actions: fiddle the PHP versions and line endings for Windows builds

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -44,6 +44,9 @@ jobs:
     name: "QuickTest: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
 
     steps:
+      - name: Prepare git to leave line endings alone
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -28,7 +28,18 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        php: ['5.4', '7.2', 'latest']
+        php: ['7.2', 'latest']
+
+        include:
+          - php: '5.4'
+            os: 'ubuntu-latest'
+            custom_ini: false
+          # Installing on Windows with PHP 5.4 runs into all sorts of problems with Composer.
+          # See this issue for more context (yes, I've seen this problem before):
+          # @link https://github.com/PHPCSStandards/composer-installer/pull/213
+          - php: '5.5'
+            os: 'windows-latest'
+            custom_ini: false
 
     name: "QuickTest: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,9 @@ jobs:
     continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
+      - name: Prepare git to leave line endings alone
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -229,6 +232,9 @@ jobs:
     name: "Coverage: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
 
     steps:
+      - name: Prepare git to leave line endings alone
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

Follow up on #663

### GH Actions/quicktest: fiddle the PHP versions 

Installing on PHP 5.4 with Composer on Windows runs into issues a lot of the time. Considering PHP 5.4 is ancient, let's just side-step this problem by using PHP 5.5.

Also see PHPCSStandards/composer-installer#213 for a little more context (yes, I've seen this issue before).

### GH Actions: don't convert line endings 

By default the `actions/checkout` runner uses the default git settings for line ending normalization, which is `true`.
For Windows, this means that `lf` line endings in files get converted to `crlf` on checkout.

In the case of PHPCS, this is problematic as this means that the integration test, which runs PHPCS over the code in PHPCS itself, would fail on hundreds of `End of line character is invalid; expected "\n" but found "\r\n"` CS errors.

Now, this line ending normalization can be undone via some config in `.gitattributes`, but that could negatively impact contributors who may prefer to have the line ending conversion when working on files in their local editors.

So instead of that, this commit just turns it off in CI alone. The `core.autocrlf input` setting should leave the line-endings "as-is" when it gets checked out.

Refs:
* https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_formatting_and_whitespace
* actions/checkout#135
* actions/checkout#226


## Suggested changelog entry
_N/A_