### PR TITLE
Tests: add `@group Windows` to more tests + mention in CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -339,6 +339,13 @@ Example:
 for
 ```
 
+#### Tests covering code which has OS-specific behaviour
+
+Most code in PHP_CodeSniffer is operating system agnostic.
+However, there are a few places which include OS-specific conditions, most notably for Windows.
+
+Tests which cover code which have Windows specific conditions should be marked with a `@group Windows` annotation to allow for running those tests separately/selectively in CI.
+
 
 ### Submitting Your Pull Request
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,11 @@ jobs:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         custom_ini: [false]
 
+        exclude:
+          # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
+          - php: '5.4'
+            os: 'windows-latest'
+
         include:
           # Skip test runs on builds which are also run in the coverage job.
           # Note: the tests on PHP 7.2 will still be run as the coverage build uses custom_ini settings for that version.

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -16,6 +16,8 @@ use PHP_CodeSniffer\Config;
  * Unit test class for the CSSLint sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Debug\CSSLintSniff
+ * @covers \PHP_CodeSniffer\Config::getExecutablePath
+ * @group  Windows
  */
 final class CSSLintUnitTest extends AbstractSniffUnitTest
 {

--- a/tests/Core/Fixer/GenerateDiffTest.php
+++ b/tests/Core/Fixer/GenerateDiffTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
  * test running the fixer itself, nor generating a diff based on a fixer run.
  *
  * @covers PHP_CodeSniffer\Fixer::generateDiff
+ * @group  Windows
  */
 final class GenerateDiffTest extends TestCase
 {


### PR DESCRIPTION
# Description

Follow up on #663

### Tests: add `@group Windows` to more tests 

As part of PR #663, test runs on the Windows OS where introduced in CI/GH Actions.

While, generally speaking, all tests should run and pass on Windows too (and they do), for the purposes of CI, a specific test group named `Windows` was introduced to allow for selectively only running the tests which _may_ have a different outcome on Windows.
This group is used in the code coverage job to prevent the Windows builds taking forever.

While most PHPCS code is OS agnostic, there are a number of places in the code base where OS-based conditions are used.

This commit adds the `@group Windows` annotation to few more tests which hits these OS-based conditions to make sure those conditions are also hit in the code coverage builds.

### CONTRIBUTING: document use of the `@group Windows` annotation

### GH Actions: exclude PHP 5.4-Windows combi everywhere

This was in part already done in #663 and #677, but there was still one PHP 5.4-Windows build being run.

This last one is now also excluded.


## Suggested changelog entry
_N/A_