### PR TITLE
RuleInclusionAbsoluteWindowsTest: minor tweaks

### DIFF
--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for the \PHP_CodeSniffer\Ruleset class using a Windows-style absolute path to include a sniff.
  *
- * @covers \PHP_CodeSniffer\Ruleset
+ * @covers   \PHP_CodeSniffer\Ruleset
+ * @requires OS ^WIN.*.
+ * @group    Windows
  */
 final class RuleInclusionAbsoluteWindowsTest extends TestCase
 {
@@ -52,10 +54,6 @@ final class RuleInclusionAbsoluteWindowsTest extends TestCase
      */
     public function initializeConfigAndRuleset()
     {
-        if (DIRECTORY_SEPARATOR === '/') {
-            $this->markTestSkipped('Windows specific test');
-        }
-
         $this->standard = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
         $repoRootDir    = dirname(dirname(dirname(__DIR__)));
 
@@ -85,9 +83,7 @@ final class RuleInclusionAbsoluteWindowsTest extends TestCase
      */
     public function resetRuleset()
     {
-        if (DIRECTORY_SEPARATOR !== '/') {
-            file_put_contents($this->standard, $this->contents);
-        }
+        file_put_contents($this->standard, $this->contents);
 
     }//end resetRuleset()
 


### PR DESCRIPTION
# Description

Another follow up on #663

* Switching the test skipping from an inline condition to a PHPUnit annotation.
* Adding the `@group Windows` annotation to ensure this test will run for code coverage on Windows in CI.


## Suggested changelog entry
_N/A_