### PR TITLE
Generators/Generator: minor tweak

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -6,7 +6,9 @@
  * in a standard.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2024 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
@@ -46,14 +48,18 @@ abstract class Generator
     {
         $this->ruleset = $ruleset;
 
+        $find    = [
+            DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR,
+            'Sniff.php',
+        ];
+        $replace = [
+            DIRECTORY_SEPARATOR.'Docs'.DIRECTORY_SEPARATOR,
+            'Standard.xml',
+        ];
+
         foreach ($ruleset->sniffs as $className => $sniffClass) {
             $file    = Autoload::getLoadedFileName($className);
-            $docFile = str_replace(
-                DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR,
-                DIRECTORY_SEPARATOR.'Docs'.DIRECTORY_SEPARATOR,
-                $file
-            );
-            $docFile = str_replace('Sniff.php', 'Standard.xml', $docFile);
+            $docFile = str_replace($find, $replace, $file);
 
             if (is_file($docFile) === true) {
                 $this->docFiles[] = $docFile;


### PR DESCRIPTION
# Description

* Predefine the find/replace values as these don't change within the loop.
* Only call `str_replace()` once with arrays for find/replace.


## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests for the Generator feature.

In this case, the code in this PR is covered by the tests added in #671.