### PR TITLE
Generators/Markdown: reset error_reporting to original value

### DIFF
--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -69,9 +69,10 @@ class Markdown extends Generator
     {
         // Turn off errors so we don't get timezone warnings if people
         // don't have their timezone set.
-        error_reporting(0);
+        $errorLevel = error_reporting(0);
         echo 'Documentation generated on '.date('r');
         echo ' by [PHP_CodeSniffer '.Config::VERSION.'](https://github.com/PHPCSStandards/PHP_CodeSniffer)'.PHP_EOL;
+        error_reporting($errorLevel);
 
     }//end printFooter()
 

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -101,4 +101,32 @@ final class HTMLTest extends TestCase
     }//end testFooter()
 
 
+    /**
+     * Safeguard that the footer logic doesn't permanently change the error level.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     *
+     * @return void
+     */
+    public function testFooterResetsErrorReportingToOriginalSetting()
+    {
+        $expected = error_reporting();
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/OneDocTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // We know there will be output, but we're not interested in the output for this test.
+        ob_start();
+        $generator = new HTMLDouble($ruleset);
+        $generator->printRealFooter();
+        ob_end_clean();
+
+        $this->assertSame($expected, error_reporting());
+
+    }//end testFooterResetsErrorReportingToOriginalSetting()
+
+
 }//end class

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -99,4 +99,32 @@ final class MarkdownTest extends TestCase
     }//end testFooter()
 
 
+    /**
+     * Safeguard that the footer logic doesn't permanently change the error level.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     *
+     * @return void
+     */
+    public function testFooterResetsErrorReportingToOriginalSetting()
+    {
+        $expected = error_reporting();
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/OneDocTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // We know there will be output, but we're not interested in the output for this test.
+        ob_start();
+        $generator = new MarkdownDouble($ruleset);
+        $generator->printRealFooter();
+        ob_end_clean();
+
+        $this->assertSame($expected, error_reporting());
+
+    }//end testFooterResetsErrorReportingToOriginalSetting()
+
+
 }//end class


### PR DESCRIPTION
# Description

As things were, the `Markdown` class changes the PHP error level (to prevent potentially getting a warning about the timezone not being set), but doesn't reset the error level back to the original error level once the "risky" code has been executed.

Fixed now.

This was previously already fixed for the `HTML` class in PR squizlabs/PHP_CodeSniffer#488

Includes adding a test to safeguard this for both classes. These tests need to be run in isolation so as not to get interference from the fact that the code is run in a test environment. I.e. without the `@runInSeparateProcess`, the test wouldn't fail when it should.


## Suggested changelog entry
- Fixed: Markdown Generator could leave `error_reporting` in an incorrect state.


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests for the Generator feature.

Also see: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/671.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
