### PR TITLE
RuleInclusionTest: record code coverage + one more test case

### DIFF
--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -47,35 +47,37 @@ final class RuleInclusionTest extends TestCase
     /**
      * Initialize the config and ruleset objects based on the `RuleInclusionTest.xml` ruleset file.
      *
-     * @beforeClass
+     * @before
      *
      * @return void
      */
     public static function initializeConfigAndRuleset()
     {
-        $standard       = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
-        self::$standard = $standard;
+        if (self::$standard === '') {
+            $standard       = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
+            self::$standard = $standard;
 
-        // On-the-fly adjust the ruleset test file to be able to test
-        // sniffs included with relative paths.
-        $contents       = file_get_contents($standard);
-        self::$contents = $contents;
+            // On-the-fly adjust the ruleset test file to be able to test
+            // sniffs included with relative paths.
+            $contents       = file_get_contents($standard);
+            self::$contents = $contents;
 
-        $repoRootDir = basename(dirname(dirname(dirname(__DIR__))));
+            $repoRootDir = basename(dirname(dirname(dirname(__DIR__))));
 
-        $newPath = $repoRootDir;
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $newPath = str_replace('\\', '/', $repoRootDir);
-        }
+            $newPath = $repoRootDir;
+            if (DIRECTORY_SEPARATOR === '\\') {
+                $newPath = str_replace('\\', '/', $repoRootDir);
+            }
 
-        $adjusted = str_replace('%path_root_dir%', $newPath, $contents);
+            $adjusted = str_replace('%path_root_dir%', $newPath, $contents);
 
-        if (file_put_contents($standard, $adjusted) === false) {
-            self::markTestSkipped('On the fly ruleset adjustment failed');
-        }
+            if (file_put_contents($standard, $adjusted) === false) {
+                self::markTestSkipped('On the fly ruleset adjustment failed');
+            }
 
-        $config        = new ConfigDouble(["--standard=$standard"]);
-        self::$ruleset = new Ruleset($config);
+            $config        = new ConfigDouble(["--standard=$standard"]);
+            self::$ruleset = new Ruleset($config);
+        }//end if
 
     }//end initializeConfigAndRuleset()
 

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -103,7 +103,7 @@ final class RuleInclusionTest extends TestCase
      */
     public function testHasSniffCodes()
     {
-        $this->assertCount(48, self::$ruleset->sniffCodes);
+        $this->assertCount(49, self::$ruleset->sniffCodes);
 
     }//end testHasSniffCodes()
 
@@ -321,6 +321,10 @@ final class RuleInclusionTest extends TestCase
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff',
             ],
             [
+                'Squiz.Files.FileExtension',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Files\FileExtensionSniff',
+            ],
+            [
                 'Generic.NamingConventions.CamelCapsFunctionName',
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff',
             ],
@@ -469,6 +473,10 @@ final class RuleInclusionTest extends TestCase
             'Set property for complete category: PSR12 OperatorSpacing'      => [
                 'sniffClass'   => 'PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff',
                 'propertyName' => 'setforallincategory',
+            ],
+            'Set property for all sniffs in included category directory'     => [
+                'sniffClass'   => 'PHP_CodeSniffer\Standards\Squiz\Sniffs\Files\FileExtensionSniff',
+                'propertyName' => 'setforsquizfilessniffs',
             ],
         ];
 

--- a/tests/Core/Ruleset/RuleInclusionTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionTest.xml
@@ -27,6 +27,14 @@
         </properties>
     </rule>
 
+    <!-- Sniff directory include. -->
+    <rule ref="./src/Standards/Squiz/Sniffs/Files/">
+        <properties>
+            <property name="setforsquizfilessniffs" value="true" />
+        </properties>
+    </rule>
+
+    <!-- Sniff file include. -->
     <rule ref="./src/Standards/Generic/Sniffs/Files/LineLengthSniff.php">
         <properties>
             <property name="lineLimit" value="10" />
@@ -39,6 +47,7 @@
         </properties>
     </rule>
 
+    <!-- Ruleset file include. -->
     <rule ref="./RuleInclusionTest-include.xml">
         <!-- Property being set for all sniffs included in this ruleset. -->
         <properties>


### PR DESCRIPTION

# Description

### RuleInclusionTest: record code coverage 

Code executed during "before class" methods is not recorded for code coverage, while code executed in "before" methods is, but the "before" method is executed before _every_ test in the class, not just once before the tests in the class run.

So, to record code coverage, while still maintaining the performance benefits of only creating the Config and Ruleset objects once, the code still sets a static property and will only run if that static property has not been filled yet.

### RuleInclusionTest: add test with directory include


## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #146
