### PR TITLE
Generators HTML/Markdown: add extra test around error silencing

### DIFF
--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -129,4 +129,47 @@ final class HTMLTest extends TestCase
     }//end testFooterResetsErrorReportingToOriginalSetting()
 
 
+    /**
+     * Safeguard that users won't see a PHP warning about the timezone not being set when calling date().
+     *
+     * The warning we don't want to see is:
+     *   "date(): It is not safe to rely on the system's timezone settings. You are *required* to use
+     *    the date.timezone setting or the date_default_timezone_set() function. In case you used any of
+     *    those methods and you are still getting this warning, you most likely misspelled the timezone
+     *    identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select
+     *    your timezone."
+     *
+     * JRF: Based on my tests, the warning only occurs on PHP < 7.0, but never a bad thing to safeguard this
+     * on a wider range of PHP versions.
+     *
+     * Note: as of PHP 8.2, PHP no longer accepts an empty string as timezone and will use `UTC` instead,
+     * so the warning on calling date() in the code itself would not display anyway.
+     *
+     * @requires PHP < 8.2
+     *
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testFooterDoesntThrowWarningOnMissingTimezone()
+    {
+        $originalIni = @ini_set('date.timezone', '');
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/OneDocTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // We know there will be output, but we're not interested in the output for this test.
+        ob_start();
+        $generator = new HTMLDouble($ruleset);
+        $generator->printRealFooter();
+        ob_end_clean();
+
+        // Reset the timezone to its original state.
+        ini_set('date.timezone', $originalIni);
+
+    }//end testFooterDoesntThrowWarningOnMissingTimezone()
+
+
 }//end class

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -127,4 +127,47 @@ final class MarkdownTest extends TestCase
     }//end testFooterResetsErrorReportingToOriginalSetting()
 
 
+    /**
+     * Safeguard that users won't see a PHP warning about the timezone not being set when calling date().
+     *
+     * The warning we don't want to see is:
+     *   "date(): It is not safe to rely on the system's timezone settings. You are *required* to use
+     *    the date.timezone setting or the date_default_timezone_set() function. In case you used any of
+     *    those methods and you are still getting this warning, you most likely misspelled the timezone
+     *    identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select
+     *    your timezone."
+     *
+     * JRF: Based on my tests, the warning only occurs on PHP < 7.0, but never a bad thing to safeguard this
+     * on a wider range of PHP versions.
+     *
+     * Note: as of PHP 8.2, PHP no longer accepts an empty string as timezone and will use `UTC` instead,
+     * so the warning on calling date() in the code itself would not display anyway.
+     *
+     * @requires PHP < 8.2
+     *
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testFooterDoesntThrowWarningOnMissingTimezone()
+    {
+        $originalIni = @ini_set('date.timezone', '');
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/OneDocTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // We know there will be output, but we're not interested in the output for this test.
+        ob_start();
+        $generator = new MarkdownDouble($ruleset);
+        $generator->printRealFooter();
+        ob_end_clean();
+
+        // Reset the timezone to its original state.
+        ini_set('date.timezone', $originalIni);
+
+    }//end testFooterDoesntThrowWarningOnMissingTimezone()
+
+
 }//end class


### PR DESCRIPTION
# Description
Follow up on #688, which safeguarded/fixed that the `error_reporting` would be reset to its original value, this commit now adds tests to cover the original situation which caused the error silencing to be introduced in the first place.


## Suggested changelog entry
_N/A_


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests for the Generator feature.

Also see: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/671.

