### PR TITLE
Generators/HTML: only display a TOC when there is more than one doc

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -156,6 +156,11 @@ class HTML extends Generator
      */
     protected function printToc()
     {
+        // Only show a TOC when there are two or more docs to display.
+        if (count($this->docFiles) < 2) {
+            return;
+        }
+
         echo '  <h2>Table of Contents</h2>'.PHP_EOL;
         echo '  <ul class="toc">'.PHP_EOL;
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.html
@@ -70,10 +70,6 @@
  </head>
  <body>
   <h1>GeneratorTest Coding Standards</h1>
-  <h2>Table of Contents</h2>
-  <ul class="toc">
-   <li><a href="#One-Standard-Block,-No-Code">One Standard Block, No Code</a></li>
-  </ul>
   <a name="One-Standard-Block,-No-Code" />
   <h2>One Standard Block, No Code</h2>
   <p class="text">Documentation contains one standard block and no code comparison.</p>


### PR DESCRIPTION
# Description

Makes no sense to me to have a "Table of Contents" in the HTML output when there is only one sniff with documentation.

## Suggested changelog entry
- Changed: The Generator HTML output will now only contain a Table of Contents when there is more than one sniff with documentation.

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/671.

