### PR TITLE
Generators/Markdown: fix footer not parsing

### DIFF
--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -74,7 +74,7 @@ class Markdown extends Generator
         // Turn off errors so we don't get timezone warnings if people
         // don't have their timezone set.
         $errorLevel = error_reporting(0);
-        echo 'Documentation generated on '.date('r');
+        echo PHP_EOL.'Documentation generated on '.date('r');
         echo ' by [PHP_CodeSniffer '.Config::VERSION.'](https://github.com/PHPCSStandards/PHP_CodeSniffer)'.PHP_EOL;
         error_reporting($errorLevel);
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.md
@@ -2,4 +2,5 @@
 
 ## One Standard Block, No Code
 Documentation contains one standard block and no code comparison.
+
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.md
@@ -168,4 +168,5 @@ This is standard block two.
 </td>
    </tr>
   </table>
+
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Fixtures/MarkdownDouble.php
+++ b/tests/Core/Generators/Fixtures/MarkdownDouble.php
@@ -20,7 +20,7 @@ class MarkdownDouble extends Markdown
      */
     protected function printFooter()
     {
-        echo 'Documentation generated on *REDACTED*';
+        echo PHP_EOL.'Documentation generated on *REDACTED*';
         echo ' by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)'.PHP_EOL;
     }
 

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -89,7 +89,7 @@ final class MarkdownTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
-        $regex  = '`^Documentation generated on [A-Z][a-z]{2}, [0-9]{2} [A-Z][a-z]{2} 20[0-9]{2} [0-2][0-9](?::[0-5][0-9]){2} [+-][0-9]{4}';
+        $regex  = '`^\RDocumentation generated on [A-Z][a-z]{2}, [0-9]{2} [A-Z][a-z]{2} 20[0-9]{2} [0-2][0-9](?::[0-5][0-9]){2} [+-][0-9]{4}';
         $regex .= ' by \[PHP_CodeSniffer [3-9]\.[0-9]+.[0-9]+\]\(https://github\.com/PHPCSStandards/PHP_CodeSniffer\)\R$`';
         $this->expectOutputRegex($regex);
 


### PR DESCRIPTION
# Description

As things were, if the output of the Markdown doc generation would be used in a Markdown-friendly environment, the footer would not be interpreted as markdown and would not display correctly.

Fixed now by adding a blank line at the start of the footer.

Includes updated test expectations.

### Before
![1-fix-footer-not-parsing-before](https://github.com/user-attachments/assets/63f336dc-3369-4e9a-b4a4-4661e7dfea22)

### After
![1-fix-footer-not-parsing-after](https://github.com/user-attachments/assets/87b2bf95-616f-4852-bdd7-348470875d73)



## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/671.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
