### PR TITLE
Tests/Ruleset/XML fixtures: add direct link between fixture and test using the fixture

### DIFF
--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -185,7 +185,7 @@ final class ExplainTest extends TestCase
         $ruleset  = new Ruleset($config);
 
         $expected  = PHP_EOL;
-        $expected .= 'The SniffDeprecationTest standard contains 9 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'The ShowSniffDeprecationsTest standard contains 9 sniffs'.PHP_EOL.PHP_EOL;
 
         $expected .= 'Fixtures (9 sniffs)'.PHP_EOL;
         $expected .= '-------------------'.PHP_EOL;

--- a/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedAsDeclaredSniff.php">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaStdClassSniff.php">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="PEAR.Functions">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml
+++ b/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="Generic.Arrays">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
+++ b/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="Generic">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
+++ b/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php">
         <properties>

--- a/tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml
+++ b/tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="Generic.Arrays.ArrayIndent">
         <properties>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsEmptyDeprecationVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsEmptyDeprecationVersionTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsEmptyRemovalVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsEmptyRemovalVersionTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationMessageTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationMessageTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationVersionTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidRemovalVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidRemovalVersionTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsOrderTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsOrderTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsReportWidthTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsReportWidthTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -234,7 +234,7 @@ final class ShowSniffDeprecationsTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", '--no-colors']);
         $ruleset  = new Ruleset($config);
 
-        $expected  = 'WARNING: The SniffDeprecationTest standard uses 5 deprecated sniffs'.PHP_EOL;
+        $expected  = 'WARNING: The ShowSniffDeprecationsTest standard uses 5 deprecated sniffs'.PHP_EOL;
         $expected .= '--------------------------------------------------------------------------------'.PHP_EOL;
         $expected .= '-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
@@ -321,13 +321,13 @@ final class ShowSniffDeprecationsTest extends TestCase
      */
     public static function dataReportWidthIsRespected()
     {
-        $summaryLine = 'WARNING: The SniffDeprecationTest standard uses 1 deprecated sniff'.PHP_EOL;
+        $summaryLine = 'WARNING: The ShowSniffDeprecationsTest standard uses 1 deprecated sniff'.PHP_EOL;
 
         // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
         return [
             'Report width small: 40; with truncated sniff name and wrapped header and footer lines' => [
                 'reportWidth'    => 40,
-                'expectedOutput' => 'WARNING: The SniffDeprecationTest'.PHP_EOL
+                'expectedOutput' => 'WARNING: The ShowSniffDeprecationsTest'.PHP_EOL
                     .'standard uses 1 deprecated sniff'.PHP_EOL
                     .'----------------------------------------'.PHP_EOL
                     .'-  Fixtures.Deprecated.WithLongRepla...'.PHP_EOL
@@ -409,7 +409,7 @@ final class ShowSniffDeprecationsTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", '--no-colors']);
         $ruleset  = new Ruleset($config);
 
-        $expected  = 'WARNING: The SniffDeprecationTest standard uses 2 deprecated sniffs'.PHP_EOL;
+        $expected  = 'WARNING: The ShowSniffDeprecationsTest standard uses 2 deprecated sniffs'.PHP_EOL;
         $expected .= '--------------------------------------------------------------------------------'.PHP_EOL;
         $expected .= '-  Fixtures.Deprecated.WithoutReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.4.0 and will be removed in v4.0.0.'.PHP_EOL;

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SniffDeprecationTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
 


### PR DESCRIPTION
# Description
Small tweak to make sure the XML rulesets used for specific tests are directly linked to those tests via the XML ruleset name - this should make the tests more self-documenting.


## Suggested changelog entry
_N/A_

## Related issues/external references

This is a preliminary PR for a series of PRs expanding the tests for the `Ruleset` class.
