### PR TITLE
Tests/Ruleset/fixtures: move existing fixtures to subdirectory

### DIFF
--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -187,17 +187,17 @@ final class ExplainTest extends TestCase
         $expected  = PHP_EOL;
         $expected .= 'The ShowSniffDeprecationsTest standard contains 9 sniffs'.PHP_EOL.PHP_EOL;
 
-        $expected .= 'Fixtures (9 sniffs)'.PHP_EOL;
-        $expected .= '-------------------'.PHP_EOL;
-        $expected .= '  Fixtures.Deprecated.WithLongReplacement *'.PHP_EOL;
-        $expected .= '  Fixtures.Deprecated.WithoutReplacement *'.PHP_EOL;
-        $expected .= '  Fixtures.Deprecated.WithReplacement *'.PHP_EOL;
-        $expected .= '  Fixtures.Deprecated.WithReplacementContainingLinuxNewlines *'.PHP_EOL;
-        $expected .= '  Fixtures.Deprecated.WithReplacementContainingNewlines *'.PHP_EOL;
-        $expected .= '  Fixtures.SetProperty.AllowedAsDeclared'.PHP_EOL;
-        $expected .= '  Fixtures.SetProperty.AllowedViaMagicMethod'.PHP_EOL;
-        $expected .= '  Fixtures.SetProperty.AllowedViaStdClass'.PHP_EOL;
-        $expected .= '  Fixtures.SetProperty.NotAllowedViaAttribute'.PHP_EOL.PHP_EOL;
+        $expected .= 'TestStandard (9 sniffs)'.PHP_EOL;
+        $expected .= '-----------------------'.PHP_EOL;
+        $expected .= '  TestStandard.Deprecated.WithLongReplacement *'.PHP_EOL;
+        $expected .= '  TestStandard.Deprecated.WithoutReplacement *'.PHP_EOL;
+        $expected .= '  TestStandard.Deprecated.WithReplacement *'.PHP_EOL;
+        $expected .= '  TestStandard.Deprecated.WithReplacementContainingLinuxNewlines *'.PHP_EOL;
+        $expected .= '  TestStandard.Deprecated.WithReplacementContainingNewlines *'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.AllowedAsDeclared'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.AllowedViaMagicMethod'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.AllowedViaStdClass'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.NotAllowedViaAttribute'.PHP_EOL.PHP_EOL;
 
         $expected .= '* Sniffs marked with an asterix are deprecated.'.PHP_EOL;
 

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithLongReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithLongReplacementSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\Deprecated;
+namespace Fixtures\TestStandard\Sniffs\Deprecated;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingLinuxNewlinesSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingLinuxNewlinesSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\Deprecated;
+namespace Fixtures\TestStandard\Sniffs\Deprecated;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingNewlinesSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingNewlinesSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\Deprecated;
+namespace Fixtures\TestStandard\Sniffs\Deprecated;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementSniff.php
@@ -5,28 +5,28 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\DeprecatedInvalid;
+namespace Fixtures\TestStandard\Sniffs\Deprecated;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class EmptyDeprecationVersionSniff implements Sniff,DeprecatedSniff
+class WithReplacementSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
     {
-        return '';
+        return 'v3.8.0';
     }
 
     public function getRemovalVersion()
     {
-        return 'dummy';
+        return 'v4.0.0';
     }
 
     public function getDeprecationMessage()
     {
-        return 'dummy';
+        return 'Use the Stnd.Category.OtherSniff sniff instead.';
     }
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithoutReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithoutReplacementSniff.php
@@ -5,29 +5,28 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\DeprecatedInvalid;
+namespace Fixtures\TestStandard\Sniffs\Deprecated;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use stdClass;
 
-class InvalidDeprecationMessageSniff implements Sniff,DeprecatedSniff
+class WithoutReplacementSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
     {
-        return 'dummy';
+        return 'v3.4.0';
     }
 
     public function getRemovalVersion()
     {
-        return 'dummy';
+        return 'v4.0.0';
     }
 
     public function getDeprecationMessage()
     {
-        return new stdClass;
+        return '';
     }
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyDeprecationVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyDeprecationVersionSniff.php
@@ -5,28 +5,28 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\Deprecated;
+namespace Fixtures\TestStandard\Sniffs\DeprecatedInvalid;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithReplacementSniff implements Sniff,DeprecatedSniff
+class EmptyDeprecationVersionSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
     {
-        return 'v3.8.0';
+        return '';
     }
 
     public function getRemovalVersion()
     {
-        return 'v4.0.0';
+        return 'dummy';
     }
 
     public function getDeprecationMessage()
     {
-        return 'Use the Stnd.Category.OtherSniff sniff instead.';
+        return 'dummy';
     }
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyRemovalVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyRemovalVersionSniff.php
@@ -5,28 +5,28 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\Deprecated;
+namespace Fixtures\TestStandard\Sniffs\DeprecatedInvalid;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithoutReplacementSniff implements Sniff,DeprecatedSniff
+class EmptyRemovalVersionSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
     {
-        return 'v3.4.0';
+        return 'dummy';
     }
 
     public function getRemovalVersion()
     {
-        return 'v4.0.0';
+        return '';
     }
 
     public function getDeprecationMessage()
     {
-        return '';
+        return 'dummy';
     }
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationMessageSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationMessageSniff.php
@@ -5,13 +5,14 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\DeprecatedInvalid;
+namespace Fixtures\TestStandard\Sniffs\DeprecatedInvalid;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use stdClass;
 
-class InvalidRemovalVersionSniff implements Sniff,DeprecatedSniff
+class InvalidDeprecationMessageSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
@@ -21,12 +22,12 @@ class InvalidRemovalVersionSniff implements Sniff,DeprecatedSniff
 
     public function getRemovalVersion()
     {
-        return ['4.0'];
+        return 'dummy';
     }
 
     public function getDeprecationMessage()
     {
-        return 'dummy';
+        return new stdClass;
     }
 
     public function register()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationVersionSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\DeprecatedInvalid;
+namespace Fixtures\TestStandard\Sniffs\DeprecatedInvalid;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidRemovalVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidRemovalVersionSniff.php
@@ -5,13 +5,13 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SniffDeprecationTest
  */
 
-namespace Fixtures\Sniffs\DeprecatedInvalid;
+namespace Fixtures\TestStandard\Sniffs\DeprecatedInvalid;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class EmptyRemovalVersionSniff implements Sniff,DeprecatedSniff
+class InvalidRemovalVersionSniff implements Sniff,DeprecatedSniff
 {
 
     public function getDeprecationVersion()
@@ -21,7 +21,7 @@ class EmptyRemovalVersionSniff implements Sniff,DeprecatedSniff
 
     public function getRemovalVersion()
     {
-        return '';
+        return ['4.0'];
     }
 
     public function getDeprecationMessage()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedAsDeclaredSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedAsDeclaredSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\SetProperty;
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\SetProperty;
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaStdClassSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaStdClassSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\SetProperty;
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php
@@ -5,7 +5,7 @@
  * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
  */
 
-namespace Fixtures\Sniffs\SetProperty;
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
 
 use AllowDynamicProperties;
 use PHP_CodeSniffer\Files\File;

--- a/tests/Core/Ruleset/Fixtures/TestStandard/ruleset.xml
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="TestStandard" namespace="Fixtures\TestStandard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ruleset.xml
+++ b/tests/Core/Ruleset/Fixtures/ruleset.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
-
-</ruleset>

--- a/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedAsDeclaredSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedAsDeclaredSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaMagicMethodSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/AllowedViaStdClassSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/AllowedViaStdClassSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
             <property name="arbitraryarray" type="array">

--- a/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
+++ b/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php">
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/NotAllowedViaAttributeSniff.php">
         <properties>
             <property name="arbitrarystring" value="arbitraryvalue"/>
         </properties>

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -34,8 +34,8 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testSniffPropertiesGetSetWhenAllowed($name)
     {
-        $sniffCode  = "Fixtures.SetProperty.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
+        $sniffCode  = "TestStandard.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\TestStandard\Sniffs\SetProperty\\'.$name.'Sniff';
         $properties = [
             'arbitrarystring' => 'arbitraryvalue',
             'arbitraryarray'  => [
@@ -163,7 +163,7 @@ final class SetSniffPropertyTest extends TestCase
     public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
     {
         $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff Fixtures.SetProperty.NotAllowedViaAttribute';
+        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
         if (method_exists($this, 'expectException') === true) {
             $this->expectException($exceptionClass);
             $this->expectExceptionMessage($exceptionMsg);
@@ -225,8 +225,8 @@ final class SetSniffPropertyTest extends TestCase
     public function testDirectCallWithNewArrayFormatSetsProperty()
     {
         $name       = 'AllowedAsDeclared';
-        $sniffCode  = "Fixtures.SetProperty.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
+        $sniffCode  = "TestStandard.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\TestStandard\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
@@ -276,8 +276,8 @@ final class SetSniffPropertyTest extends TestCase
     public function testDirectCallWithOldArrayFormatSetsProperty($propertyValue)
     {
         $name       = 'AllowedAsDeclared';
-        $sniffCode  = "Fixtures.SetProperty.{$name}";
-        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
+        $sniffCode  = "TestStandard.SetProperty.{$name}";
+        $sniffClass = 'Fixtures\TestStandard\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";
@@ -383,7 +383,7 @@ final class SetSniffPropertyTest extends TestCase
         }
 
         $name       = 'AllowedAsDeclared';
-        $sniffClass = 'Fixtures\Sniffs\SetProperty\\'.$name.'Sniff';
+        $sniffClass = 'Fixtures\TestStandard\Sniffs\SetProperty\\'.$name.'Sniff';
 
         // Set up the ruleset.
         $standard = __DIR__."/SetProperty{$name}Test.xml";

--- a/tests/Core/Ruleset/ShowSniffDeprecationsEmptyDeprecationVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsEmptyDeprecationVersionTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.DeprecatedInvalid.EmptyDeprecationVersion"/>
+    <rule ref="TestStandard.DeprecatedInvalid.EmptyDeprecationVersion"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsEmptyRemovalVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsEmptyRemovalVersionTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.DeprecatedInvalid.EmptyRemovalVersion"/>
+    <rule ref="TestStandard.DeprecatedInvalid.EmptyRemovalVersion"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationMessageTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationMessageTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.DeprecatedInvalid.InvalidDeprecationMessage"/>
+    <rule ref="TestStandard.DeprecatedInvalid.InvalidDeprecationMessage"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidDeprecationVersionTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.DeprecatedInvalid.InvalidDeprecationVersion"/>
+    <rule ref="TestStandard.DeprecatedInvalid.InvalidDeprecationVersion"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsInvalidRemovalVersionTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsInvalidRemovalVersionTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.DeprecatedInvalid.InvalidRemovalVersion"/>
+    <rule ref="TestStandard.DeprecatedInvalid.InvalidRemovalVersion"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsOrderTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsOrderTest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
     <!-- This list is non-alphabetic on purpose. The display order is what is being tested. -->
-    <rule ref="Fixtures.Deprecated.WithReplacement"/>
-    <rule ref="Fixtures.Deprecated.WithoutReplacement"/>
+    <rule ref="TestStandard.Deprecated.WithReplacement"/>
+    <rule ref="TestStandard.Deprecated.WithoutReplacement"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsReportWidthTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsReportWidthTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures.Deprecated.WithLongReplacement"/>
+    <rule ref="TestStandard.Deprecated.WithLongReplacement"/>
 
 </ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -141,8 +141,8 @@ final class ShowSniffDeprecationsTest extends TestCase
 
         $restrictions = [];
         $sniffs       = [
-            'Fixtures.SetProperty.AllowedAsDeclared',
-            'Fixtures.SetProperty.AllowedViaStdClass',
+            'TestStandard.SetProperty.AllowedAsDeclared',
+            'TestStandard.SetProperty.AllowedViaStdClass',
         ];
         foreach ($sniffs as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
@@ -187,11 +187,11 @@ final class ShowSniffDeprecationsTest extends TestCase
 
         $exclusions = [];
         $exclude    = [
-            'Fixtures.Deprecated.WithLongReplacement',
-            'Fixtures.Deprecated.WithoutReplacement',
-            'Fixtures.Deprecated.WithReplacement',
-            'Fixtures.Deprecated.WithReplacementContainingLinuxNewlines',
-            'Fixtures.Deprecated.WithReplacementContainingNewlines',
+            'TestStandard.Deprecated.WithLongReplacement',
+            'TestStandard.Deprecated.WithoutReplacement',
+            'TestStandard.Deprecated.WithReplacement',
+            'TestStandard.Deprecated.WithReplacementContainingLinuxNewlines',
+            'TestStandard.Deprecated.WithReplacementContainingNewlines',
         ];
         foreach ($exclude as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
@@ -236,7 +236,7 @@ final class ShowSniffDeprecationsTest extends TestCase
 
         $expected  = 'WARNING: The ShowSniffDeprecationsTest standard uses 5 deprecated sniffs'.PHP_EOL;
         $expected .= '--------------------------------------------------------------------------------'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithLongReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
         $expected .= '   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel'.PHP_EOL;
         $expected .= '   vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium sed.'.PHP_EOL;
@@ -247,12 +247,12 @@ final class ShowSniffDeprecationsTest extends TestCase
         $expected .= '   dictum. Suspendisse dictum egestas sapien, eget ullamcorper metus elementum'.PHP_EOL;
         $expected .= '   semper. Vestibulum sem justo, consectetur ac tincidunt et, finibus eget'.PHP_EOL;
         $expected .= '   libero.'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithoutReplacement'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithoutReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.4.0 and will be removed in v4.0.0.'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithReplacement'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
         $expected .= '   Use the Stnd.Category.OtherSniff sniff instead.'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithReplacementContainingLinuxNewlines'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithReplacementContainingLinuxNewlines'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
         $expected .= '   Lorem ipsum dolor sit amet, consectetur adipiscing elit.'.PHP_EOL;
         $expected .= '   Fusce vel vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium'.PHP_EOL;
@@ -262,7 +262,7 @@ final class ShowSniffDeprecationsTest extends TestCase
         $expected .= '   eros sapien at sem.'.PHP_EOL;
         $expected .= '   Sed pulvinar aliquam malesuada. Aliquam erat volutpat. Mauris gravida rutrum'.PHP_EOL;
         $expected .= '   lectus at egestas.'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithReplacementContainingNewlines'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithReplacementContainingNewlines'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
         $expected .= '   Lorem ipsum dolor sit amet, consectetur adipiscing elit.'.PHP_EOL;
         $expected .= '   Fusce vel vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium'.PHP_EOL;
@@ -330,7 +330,7 @@ final class ShowSniffDeprecationsTest extends TestCase
                 'expectedOutput' => 'WARNING: The ShowSniffDeprecationsTest'.PHP_EOL
                     .'standard uses 1 deprecated sniff'.PHP_EOL
                     .'----------------------------------------'.PHP_EOL
-                    .'-  Fixtures.Deprecated.WithLongRepla...'.PHP_EOL
+                    .'-  TestStandard.Deprecated.WithLongR...'.PHP_EOL
                     .'   This sniff has been deprecated since'.PHP_EOL
                     .'   v3.8.0 and will be removed in'.PHP_EOL
                     .'   v4.0.0. Lorem ipsum dolor sit amet,'.PHP_EOL
@@ -358,7 +358,7 @@ final class ShowSniffDeprecationsTest extends TestCase
             'Report width default: 80'                                                              => [
                 'reportWidth'    => 80,
                 'expectedOutput' => $summaryLine.str_repeat('-', 80).PHP_EOL
-                    .'-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL
+                    .'-  TestStandard.Deprecated.WithLongReplacement'.PHP_EOL
                     .'   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL
                     .'   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel'.PHP_EOL
                     .'   vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium sed.'.PHP_EOL
@@ -376,7 +376,7 @@ final class ShowSniffDeprecationsTest extends TestCase
                 // Length = 4 padding + 75 base line + 587 custom message.
                 'reportWidth'    => 666,
                 'expectedOutput' => $summaryLine.str_repeat('-', 666).PHP_EOL
-                    .'-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL
+                    .'-  TestStandard.Deprecated.WithLongReplacement'.PHP_EOL
                     .'   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium sed. Fusce egestas congue massa semper cursus. Donec quis pretium tellus. In lacinia, augue ut ornare porttitor, diam nunc faucibus purus, et accumsan eros sapien at sem. Sed pulvinar aliquam malesuada. Aliquam erat volutpat. Mauris gravida rutrum lectus at egestas. Fusce tempus elit in tincidunt dictum. Suspendisse dictum egestas sapien, eget ullamcorper metus elementum semper. Vestibulum sem justo, consectetur ac tincidunt et, finibus eget libero.'
                     .PHP_EOL.PHP_EOL
                     .'Deprecated sniffs are still run, but will stop working at some point in the future.'.PHP_EOL.PHP_EOL,
@@ -384,7 +384,7 @@ final class ShowSniffDeprecationsTest extends TestCase
             'Report width wide: 1000; delimiter line length should match longest line'              => [
                 'reportWidth'    => 1000,
                 'expectedOutput' => $summaryLine.str_repeat('-', 666).PHP_EOL
-                    .'-  Fixtures.Deprecated.WithLongReplacement'.PHP_EOL
+                    .'-  TestStandard.Deprecated.WithLongReplacement'.PHP_EOL
                     .'   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vel vestibulum nunc. Sed luctus dolor tortor, eu euismod purus pretium sed. Fusce egestas congue massa semper cursus. Donec quis pretium tellus. In lacinia, augue ut ornare porttitor, diam nunc faucibus purus, et accumsan eros sapien at sem. Sed pulvinar aliquam malesuada. Aliquam erat volutpat. Mauris gravida rutrum lectus at egestas. Fusce tempus elit in tincidunt dictum. Suspendisse dictum egestas sapien, eget ullamcorper metus elementum semper. Vestibulum sem justo, consectetur ac tincidunt et, finibus eget libero.'
                     .PHP_EOL.PHP_EOL
                     .'Deprecated sniffs are still run, but will stop working at some point in the future.'.PHP_EOL.PHP_EOL,
@@ -411,9 +411,9 @@ final class ShowSniffDeprecationsTest extends TestCase
 
         $expected  = 'WARNING: The ShowSniffDeprecationsTest standard uses 2 deprecated sniffs'.PHP_EOL;
         $expected .= '--------------------------------------------------------------------------------'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithoutReplacement'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithoutReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.4.0 and will be removed in v4.0.0.'.PHP_EOL;
-        $expected .= '-  Fixtures.Deprecated.WithReplacement'.PHP_EOL;
+        $expected .= '-  TestStandard.Deprecated.WithReplacement'.PHP_EOL;
         $expected .= '   This sniff has been deprecated since v3.8.0 and will be removed in v4.0.0.'.PHP_EOL;
         $expected .= '   Use the Stnd.Category.OtherSniff sniff instead.'.PHP_EOL.PHP_EOL;
         $expected .= 'Deprecated sniffs are still run, but will stop working at some point in the'.PHP_EOL;
@@ -426,12 +426,12 @@ final class ShowSniffDeprecationsTest extends TestCase
         // Verify that the sniffs have been registered to run.
         $this->assertCount(2, $ruleset->sniffCodes, 'Incorrect number of sniff codes registered');
         $this->assertArrayHasKey(
-            'Fixtures.Deprecated.WithoutReplacement',
+            'TestStandard.Deprecated.WithoutReplacement',
             $ruleset->sniffCodes,
             'WithoutReplacement sniff not registered'
         );
         $this->assertArrayHasKey(
-            'Fixtures.Deprecated.WithReplacement',
+            'TestStandard.Deprecated.WithReplacement',
             $ruleset->sniffCodes,
             'WithReplacement sniff not registered'
         );
@@ -484,23 +484,23 @@ final class ShowSniffDeprecationsTest extends TestCase
         return [
             'getDeprecationVersion() does not return a string' => [
                 'standard'         => 'ShowSniffDeprecationsInvalidDeprecationVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\Sniffs\DeprecatedInvalid\InvalidDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received double',
+                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received double',
             ],
             'getRemovalVersion() does not return a string'     => [
                 'standard'         => 'ShowSniffDeprecationsInvalidRemovalVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\Sniffs\DeprecatedInvalid\InvalidRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received array',
+                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received array',
             ],
             'getDeprecationMessage() does not return a string' => [
                 'standard'         => 'ShowSniffDeprecationsInvalidDeprecationMessageTest.xml',
-                'exceptionMessage' => 'The Fixtures\Sniffs\DeprecatedInvalid\InvalidDeprecationMessageSniff::getDeprecationMessage() method must return a string, received object',
+                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationMessageSniff::getDeprecationMessage() method must return a string, received object',
             ],
             'getDeprecationVersion() returns an empty string'  => [
                 'standard'         => 'ShowSniffDeprecationsEmptyDeprecationVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\Sniffs\DeprecatedInvalid\EmptyDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received ""',
+                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received ""',
             ],
             'getRemovalVersion() returns an empty string'      => [
                 'standard'         => 'ShowSniffDeprecationsEmptyRemovalVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\Sniffs\DeprecatedInvalid\EmptyRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received ""',
+                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received ""',
             ],
         ];
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ShowSniffDeprecationsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/"/>
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
-    <rule ref="Fixtures">
-        <exclude name="Fixtures.DeprecatedInvalid"/>
+    <rule ref="TestStandard">
+        <exclude name="TestStandard.DeprecatedInvalid"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
# Description
For some new tests, some test fixtures outside a standard directory structure and/or in a seperate standard directory structure are needed.

This commit moves the pre-existing sniff test fixtures to a subdirectory to allow for the upcoming additional test fixtures.

Includes updating the standard/ruleset to have a namespace prefix ("Fixtures"), so that aspect of things can now also be tested.


## Suggested changelog entry
_N/A_


## Suggested changelog entry
_N/A_

## Related issues/external references

This is a preliminary PR for a series of PRs expanding the tests for the `Ruleset` class.