### PR TITLE
Tests/Ruleset: introduce an abstract base TestCase and start using it

### DIFF
--- a/tests/Core/Ruleset/AbstractRulesetTestCase.php
+++ b/tests/Core/Ruleset/AbstractRulesetTestCase.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Test case with helper methods for tests for the Ruleset class.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractRulesetTestCase extends TestCase
+{
+
+    /**
+     * The fully qualified name of the PHPCS runtime exception class.
+     *
+     * @var string
+     */
+    const RUNTIME_EXCEPTION = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+
+
+    /**
+     * Asserts that an object has a specified property in a PHPUnit cross-version compatible manner.
+     *
+     * @param string $propertyName The name of the property.
+     * @param object $object       The object on which to check whether the property exists.
+     * @param string $message      Optional failure message to display.
+     *
+     * @return void
+     */
+    protected function assertXObjectHasProperty($propertyName, $object, $message='')
+    {
+        if (method_exists($this, 'assertObjectHasProperty') === true) {
+            $this->assertObjectHasProperty($propertyName, $object, $message);
+        } else {
+            // PHPUnit < 9.6.11.
+            $this->assertObjectHasAttribute($propertyName, $object, $message);
+        }
+
+    }//end assertXObjectHasProperty()
+
+
+    /**
+     * Asserts that an object does not have a specified property
+     * in a PHPUnit cross-version compatible manner.
+     *
+     * @param string $propertyName The name of the property.
+     * @param object $object       The object on which to check whether the property exists.
+     * @param string $message      Optional failure message to display.
+     *
+     * @return void
+     */
+    protected function assertXObjectNotHasProperty($propertyName, $object, $message='')
+    {
+        if (method_exists($this, 'assertObjectNotHasProperty') === true) {
+            $this->assertObjectNotHasProperty($propertyName, $object, $message);
+        } else {
+            // PHPUnit < 9.6.11.
+            $this->assertObjectNotHasAttribute($propertyName, $object, $message);
+        }
+
+    }//end assertXObjectNotHasProperty()
+
+
+    /**
+     * Helper method to tell PHPUnit to expect a PHPCS RuntimeException with a certain message
+     * in a PHPUnit cross-version compatible manner.
+     *
+     * @param string $message The expected exception message.
+     *
+     * @return void
+     */
+    protected function expectRuntimeExceptionMessage($message)
+    {
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException(self::RUNTIME_EXCEPTION);
+            $this->expectExceptionMessage($message);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException(self::RUNTIME_EXCEPTION, $message);
+        }
+
+    }//end expectRuntimeExceptionMessage()
+
+
+    /**
+     * Helper method to tell PHPUnit to expect a PHPCS RuntimeException which matches a regex patten
+     * in a PHPUnit cross-version compatible manner.
+     *
+     * @param string $regex The regex which should match.
+     *
+     * @return void
+     */
+    protected function expectRuntimeExceptionRegex($regex)
+    {
+        if (method_exists($this, 'expectExceptionMessageMatches') === true) {
+            $this->expectException(self::RUNTIME_EXCEPTION);
+            $this->expectExceptionMessageMatches($regex);
+        } else if (method_exists($this, 'expectExceptionMessageRegExp') === true) {
+            // PHPUnit < 8.4.0.
+            $this->expectException(self::RUNTIME_EXCEPTION);
+            $this->expectExceptionMessageRegExp($regex);
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedExceptionRegExp(self::RUNTIME_EXCEPTION, $regex);
+        }
+
+    }//end expectRuntimeExceptionRegex()
+
+
+}//end class

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -11,15 +11,14 @@ namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
-use PHPUnit\Framework\TestCase;
-use ReflectionObject;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Ruleset class.
  *
  * @covers \PHP_CodeSniffer\Ruleset
  */
-final class RuleInclusionTest extends TestCase
+final class RuleInclusionTest extends AbstractRulesetTestCase
 {
 
     /**
@@ -352,10 +351,7 @@ final class RuleInclusionTest extends TestCase
     public function testSettingProperties($sniffClass, $propertyName, $expectedValue)
     {
         $this->assertArrayHasKey($sniffClass, self::$ruleset->sniffs);
-
-        $hasProperty = (new ReflectionObject(self::$ruleset->sniffs[$sniffClass]))->hasProperty($propertyName);
-        $errorMsg    = sprintf('Property %s does not exist on sniff class %s', $propertyName, $sniffClass);
-        $this->assertTrue($hasProperty, $errorMsg);
+        $this->assertXObjectHasProperty($propertyName, self::$ruleset->sniffs[$sniffClass]);
 
         $actualValue = self::$ruleset->sniffs[$sniffClass]->$propertyName;
         $this->assertSame($expectedValue, $actualValue);
@@ -444,10 +440,7 @@ final class RuleInclusionTest extends TestCase
     public function testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails($sniffClass, $propertyName)
     {
         $this->assertArrayHasKey($sniffClass, self::$ruleset->sniffs, 'Sniff class '.$sniffClass.' not listed in registered sniffs');
-
-        $hasProperty = (new ReflectionObject(self::$ruleset->sniffs[$sniffClass]))->hasProperty($propertyName);
-        $errorMsg    = sprintf('Property %s registered for sniff %s which does not support it', $propertyName, $sniffClass);
-        $this->assertFalse($hasProperty, $errorMsg);
+        $this->assertXObjectNotHasProperty($propertyName, self::$ruleset->sniffs[$sniffClass]);
 
     }//end testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
 

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
 use ReflectionObject;
 
 /**
@@ -19,7 +19,7 @@ use ReflectionObject;
  *
  * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
  */
-final class SetSniffPropertyTest extends TestCase
+final class SetSniffPropertyTest extends AbstractRulesetTestCase
 {
 
 
@@ -135,15 +135,8 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testSetPropertyThrowsErrorOnInvalidProperty()
     {
-        $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-        $exceptionMsg   = 'Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
-        if (method_exists($this, 'expectException') === true) {
-            $this->expectException($exceptionClass);
-            $this->expectExceptionMessage($exceptionMsg);
-        } else {
-            // PHPUnit < 5.2.0.
-            $this->setExpectedException($exceptionClass, $exceptionMsg);
-        }
+        $exceptionMsg = 'Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
+        $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyThrowsErrorOnInvalidPropertyTest.xml';
@@ -162,15 +155,8 @@ final class SetSniffPropertyTest extends TestCase
      */
     public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
     {
-        $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
-        if (method_exists($this, 'expectException') === true) {
-            $this->expectException($exceptionClass);
-            $this->expectExceptionMessage($exceptionMsg);
-        } else {
-            // PHPUnit < 5.2.0.
-            $this->setExpectedException($exceptionClass, $exceptionMsg);
-        }
+        $exceptionMsg = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
+        $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.
         $standard = __DIR__.'/SetPropertyNotAllowedViaAttributeTest.xml';

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
 
 /**
  * Tests PHPCS native handling of sniff deprecations.
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \PHP_CodeSniffer\Ruleset::hasSniffDeprecations
  * @covers \PHP_CodeSniffer\Ruleset::showSniffDeprecations
  */
-final class ShowSniffDeprecationsTest extends TestCase
+final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
 {
 
 
@@ -452,15 +452,7 @@ final class ShowSniffDeprecationsTest extends TestCase
      */
     public function testExceptionIsThrownOnIncorrectlyImplementedInterface($standard, $exceptionMessage)
     {
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-        if (method_exists($this, 'expectException') === true) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($exceptionMessage);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $exceptionMessage);
-        }
+        $this->expectRuntimeExceptionMessage($exceptionMessage);
 
         // Set up the ruleset.
         $standard = __DIR__.'/'.$standard;


### PR DESCRIPTION
# Description

### Tests/Ruleset: introduce an abstract base TestCase 

Introduce an abstract base TestCase with some helper methods specifically for tests testing aspects of the `Ruleset` class.

### Tests/Ruleset: start using the new AbstractRulesetTestCase 

Start using the new `AbstractRulesetTestCase` in pre-existing `Ruleset` tests.


## Suggested changelog entry
_N/A_


## Related issues/external references

This is a preliminary PR for a series of PRs expanding the tests for the `Ruleset` class.