### PR TITLE
Ruleset: add tests for custom property type handling

### DIFF
--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -185,10 +185,10 @@ final class ExplainTest extends TestCase
         $ruleset  = new Ruleset($config);
 
         $expected  = PHP_EOL;
-        $expected .= 'The ShowSniffDeprecationsTest standard contains 9 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'The ShowSniffDeprecationsTest standard contains 10 sniffs'.PHP_EOL.PHP_EOL;
 
-        $expected .= 'TestStandard (9 sniffs)'.PHP_EOL;
-        $expected .= '-----------------------'.PHP_EOL;
+        $expected .= 'TestStandard (10 sniffs)'.PHP_EOL;
+        $expected .= '------------------------'.PHP_EOL;
         $expected .= '  TestStandard.Deprecated.WithLongReplacement *'.PHP_EOL;
         $expected .= '  TestStandard.Deprecated.WithoutReplacement *'.PHP_EOL;
         $expected .= '  TestStandard.Deprecated.WithReplacement *'.PHP_EOL;
@@ -197,7 +197,8 @@ final class ExplainTest extends TestCase
         $expected .= '  TestStandard.SetProperty.AllowedAsDeclared'.PHP_EOL;
         $expected .= '  TestStandard.SetProperty.AllowedViaMagicMethod'.PHP_EOL;
         $expected .= '  TestStandard.SetProperty.AllowedViaStdClass'.PHP_EOL;
-        $expected .= '  TestStandard.SetProperty.NotAllowedViaAttribute'.PHP_EOL.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.NotAllowedViaAttribute'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.PropertyTypeHandling'.PHP_EOL.PHP_EOL;
 
         $expected .= '* Sniffs marked with an asterix are deprecated.'.PHP_EOL;
 

--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Testing handling of properties set inline.
+ */
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsString arbitraryvalue
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling emptyStringBecomesNull
+
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsIntButAcceptsString 12345
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsFloatButAcceptsString 12.345
+
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsNull null
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsNullCase NULL
+
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrue true
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrueCase True
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanFalse false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanFalseCase fALSe
+
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithOnlyValues[] string, 10, 1.5, null, true, false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
+
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithOnlyValues[] string, 10, 1.5, null, true, false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
+
+echo 'hello!';

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+final class PropertyTypeHandlingSniff implements Sniff
+{
+
+    /**
+     * Used to verify that string properties are set as string.
+     *
+     * This is the default behaviour.
+     *
+     * @var string
+     */
+    public $expectsString;
+
+    /**
+     * Used to verify that a string value with only whitespace will end up being set as null.
+     *
+     * @var string|null
+     */
+    public $emptyStringBecomesNull;
+
+    /**
+     * Used to verify that integer properties do not have special handling and will be set as a string.
+     *
+     * @var int
+     */
+    public $expectsIntButAcceptsString;
+
+    /**
+     * Used to verify that floating point properties do not have special handling and will be set as a string.
+     *
+     * @var float
+     */
+    public $expectsFloatButAcceptsString;
+
+    /**
+     * Used to verify that null gets set as a proper null value.
+     *
+     * @var null
+     */
+    public $expectsNull;
+
+    /**
+     * Used to verify that null gets set as a proper null value.
+     *
+     * @var null
+     */
+    public $expectsNullCase;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
+    public $expectsBooleanTrue;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
+    public $expectsBooleanTrueCase;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
+    public $expectsBooleanFalse;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
+    public $expectsBooleanFalseCase;
+
+    /**
+     * Used to verify that array properties get parsed to a proper array.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithOnlyValues;
+
+    /**
+     * Used to verify that array properties with keys get parsed to a proper array.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsArrayWithKeysAndValues;
+
+    /**
+     * Used to verify that array properties passed as a string get parsed to a proper array.
+     *
+     * @var array<mixed>
+     */
+    public $expectsOldSchoolArrayWithOnlyValues;
+
+    /**
+     * Used to verify that array properties passed as a string with keys get parsed to a proper array.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithKeysAndValues;
+
+    public function register()
+    {
+        return [T_ECHO];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/PropertyTypeHandlingInlineTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingInlineTest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PropertyTypeHandlingTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Tests for the handling of properties being set via the ruleset.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the handling of property value types for properties set via the ruleset and inline.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::processRule
+ * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
+ */
+final class PropertyTypeHandlingTest extends TestCase
+{
+
+    /**
+     * Sniff code for the sniff used in these tests.
+     *
+     * @var string
+     */
+    const SNIFF_CODE = 'TestStandard.SetProperty.PropertyTypeHandling';
+
+    /**
+     * Class name of the sniff used in these tests.
+     *
+     * @var string
+     */
+    const SNIFF_CLASS = 'Fixtures\\TestStandard\\Sniffs\\SetProperty\\PropertyTypeHandlingSniff';
+
+
+    /**
+     * Test the value type handling for properties set via a ruleset.
+     *
+     * @param string $propertyName Property name.
+     * @param mixed  $expected     Expected property value.
+     *
+     * @dataProvider dataTypeHandling
+     *
+     * @return void
+     */
+    public function testTypeHandlingWhenSetViaRuleset($propertyName, $expected)
+    {
+        $sniffObject = $this->getSniffObjectForRuleset();
+
+        $this->assertSame($expected, $sniffObject->$propertyName);
+
+    }//end testTypeHandlingWhenSetViaRuleset()
+
+
+    /**
+     * Test the value type handling for properties set inline in a test case file.
+     *
+     * @param string $propertyName Property name.
+     * @param mixed  $expected     Expected property value.
+     *
+     * @dataProvider dataTypeHandling
+     *
+     * @return void
+     */
+    public function testTypeHandlingWhenSetInline($propertyName, $expected)
+    {
+        $sniffObject = $this->getSniffObjectAfterProcessingFile();
+
+        $this->assertSame($expected, $sniffObject->$propertyName);
+
+    }//end testTypeHandlingWhenSetInline()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testTypeHandlingWhenSetViaRuleset()
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataTypeHandling()
+    {
+        $expectedArrayOnlyValues    = [
+            'string',
+            '10',
+            '1.5',
+            'null',
+            'true',
+            'false',
+        ];
+        $expectedArrayKeysAndValues = [
+            'string' => 'string',
+            10       => '10',
+            'float'  => '1.5',
+            'null'   => 'null',
+            'true'   => 'true',
+            'false'  => 'false',
+        ];
+
+        return [
+            'String value (default)'                         => [
+                'propertyName' => 'expectsString',
+                'expected'     => 'arbitraryvalue',
+            ],
+            'String with whitespace only value becomes null' => [
+                'propertyName' => 'emptyStringBecomesNull',
+                'expected'     => null,
+            ],
+            'Integer value gets set as string'               => [
+                'propertyName' => 'expectsIntButAcceptsString',
+                'expected'     => '12345',
+            ],
+            'Float value gets set as string'                 => [
+                'propertyName' => 'expectsFloatButAcceptsString',
+                'expected'     => '12.345',
+            ],
+            'Null value gets set as string'                  => [
+                'propertyName' => 'expectsNull',
+                'expected'     => 'null',
+            ],
+            'Null (uppercase) value gets set as string'      => [
+                'propertyName' => 'expectsNullCase',
+                'expected'     => 'NULL',
+            ],
+            'True value gets set as boolean'                 => [
+                'propertyName' => 'expectsBooleanTrue',
+                'expected'     => true,
+            ],
+            'True (mixed case) value gets set as string'     => [
+                'propertyName' => 'expectsBooleanTrueCase',
+                'expected'     => 'True',
+            ],
+            'False value gets set as boolean'                => [
+                'propertyName' => 'expectsBooleanFalse',
+                'expected'     => false,
+            ],
+            'False (mixed case) value gets set as string'    => [
+                'propertyName' => 'expectsBooleanFalseCase',
+                'expected'     => 'fALSe',
+            ],
+            'Array with only values (new style)'             => [
+                'propertyName' => 'expectsArrayWithOnlyValues',
+                'expected'     => $expectedArrayOnlyValues,
+            ],
+            'Array with keys and values (new style)'         => [
+                'propertyName' => 'expectsArrayWithKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValues,
+            ],
+            'Array with only values (old style)'             => [
+                'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
+                'expected'     => $expectedArrayOnlyValues,
+            ],
+            'Array with keys and values (old style)'         => [
+                'propertyName' => 'expectsOldSchoolArrayWithKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValues,
+            ],
+        ];
+
+    }//end dataTypeHandling()
+
+
+    /**
+     * Test Helper.
+     *
+     * @see self::testTypeHandlingWhenSetViaRuleset()
+     *
+     * @return \PHP_CodeSniffer\Sniffs\Sniff
+     */
+    private function getSniffObjectForRuleset()
+    {
+        static $sniffObject;
+
+        if (isset($sniffObject) === false) {
+            // Set up the ruleset.
+            $standard = __DIR__."/PropertyTypeHandlingTest.xml";
+            $config   = new ConfigDouble(["--standard=$standard"]);
+            $ruleset  = new Ruleset($config);
+
+            // Verify that our target sniff has been registered.
+            $this->assertArrayHasKey(self::SNIFF_CODE, $ruleset->sniffCodes, 'Target sniff not registered');
+            $this->assertSame(self::SNIFF_CLASS, $ruleset->sniffCodes[self::SNIFF_CODE], 'Target sniff not registered with the correct class');
+            $this->assertArrayHasKey(self::SNIFF_CLASS, $ruleset->sniffs, 'Sniff class not listed in registered sniffs');
+
+            $sniffObject = $ruleset->sniffs[self::SNIFF_CLASS];
+        }
+
+        return $sniffObject;
+
+    }//end getSniffObjectForRuleset()
+
+
+    /**
+     * Test Helper
+     *
+     * @see self::testTypeHandlingWhenSetInline()
+     *
+     * @return \PHP_CodeSniffer\Sniffs\Sniff
+     */
+    private function getSniffObjectAfterProcessingFile()
+    {
+        static $sniffObject;
+
+        if (isset($sniffObject) === false) {
+            // Set up the ruleset.
+            $standard = __DIR__."/PropertyTypeHandlingInlineTest.xml";
+            $config   = new ConfigDouble(["--standard=$standard"]);
+            $ruleset  = new Ruleset($config);
+
+            // Verify that our target sniff has been registered.
+            $this->assertArrayHasKey(self::SNIFF_CODE, $ruleset->sniffCodes, 'Target sniff not registered');
+            $this->assertSame(self::SNIFF_CLASS, $ruleset->sniffCodes[self::SNIFF_CODE], 'Target sniff not registered with the correct class');
+            $this->assertArrayHasKey(self::SNIFF_CLASS, $ruleset->sniffs, 'Sniff class not listed in registered sniffs');
+
+            $sniffObject = $ruleset->sniffs[self::SNIFF_CLASS];
+
+            // Process the file with inline phpcs:set annotations.
+            $testFile = realpath(__DIR__.'/Fixtures/PropertyTypeHandlingInline.inc');
+            $this->assertNotFalse($testFile);
+
+            $phpcsFile = new LocalFile($testFile, $ruleset, $config);
+            $phpcsFile->process();
+        }
+
+        return $sniffObject;
+
+    }//end getSniffObjectAfterProcessingFile()
+
+
+}//end class

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PropertyTypeHandlingTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php">
+        <properties>
+            <property name="expectsString" value="arbitraryvalue"/>
+            <property name="emptyStringBecomesNull" value="   	"/>
+
+            <property name="expectsIntButAcceptsString" value="12345"/>
+            <property name="expectsFloatButAcceptsString" value="12.345"/>
+
+            <property name="expectsNull" value="null"/>
+            <property name="expectsNullCase" value="NULL"/>
+
+            <property name="expectsBooleanTrue" value="true"/>
+            <property name="expectsBooleanTrueCase" value="True"/>
+            <property name="expectsBooleanFalse" value="false"/>
+            <property name="expectsBooleanFalseCase" value="fALSe"/>
+
+            <property name="expectsArrayWithOnlyValues" type="array">
+                <element value="string"/>
+                <element value="10"/>
+                <element value="1.5"/>
+                <element value="null"/>
+                <element value="true"/>
+                <element value="false"/>
+            </property>
+
+            <property name="expectsArrayWithKeysAndValues" type="array">
+                <element key="string" value="string"/>
+                <element key="10" value="10"/>
+                <element key="float" value="1.5"/>
+                <element key="null" value="null"/>
+                <element key="true" value="true"/>
+                <element key="false" value="false"/>
+            </property>
+
+            <property name="expectsOldSchoolArrayWithOnlyValues" type="array" value="string, 10, 1.5, null, true, false" />
+
+            <property name="expectsOldSchoolArrayWithKeysAndValues" type="array" value="string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false" />
+        </properties>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
# Description
Add tests specifically aimed at testing the type handling of sniff properties set via a ruleset and via inline annotations.

The current tests document the existing behaviour, which contains some oddities, but fixing these could be considered a breaking change, so should wait until PHPCS 4.0.


## Suggested changelog entry
_N/A_


## Related issues/external references

This PR is part of a series of PRs expanding the tests for the `Ruleset` class.