### PR TITLE
GH Actions/test: allow concurrency for build against "main" branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,13 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
-# Cancels all previous workflow runs for the same branch that have not yet completed.
+# Cancels all previous workflow runs for the same branch that have not yet completed,
+# but don't cancel when it's one of the "main" branches as that prevents
+# accurate monitoring of code coverage.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'master' && github.ref_name != '4.0' }}
 
 jobs:
   build:


### PR DESCRIPTION
# Description
The `concurrency` setting will cancel running workflows is a new push to the same branch is seen. This is useful to prevent unnecessary workflow runs (as the previous push was superseded, so the outcome is no longer relevant).

However, for the "main" branches (`master` and `4.0`), this workflow cancelling means that if multiple PRs are merged in succession, only the code coverage for the _last_ merge is recorded in Coveralls as the workflow runs on `master` for the previous merges will have been cancelled.

While in practice, it's not a biggie, it does make it more difficult to identify which commit/merge added or decreased code coverage.

With this in mind, I'm making a small change to the `concurrency` setting for the `test` workflow only to allow those to always finish when the workflow is run for the "main" branches.


## Suggested changelog entry
_N/A_