### PR TITLE
Ruleset::processRule(): add test for handling of invalid `<type>` directives

### DIFF
--- a/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
+++ b/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test handling of invalid type elements.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+
+/**
+ * Test handling of invalid type elements.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::processRule
+ */
+final class ProcessRuleInvalidTypeTest extends AbstractRulesetTestCase
+{
+
+
+    /**
+     * Test displaying an informative error message when an invalid type is given.
+     *
+     * @return void
+     */
+    public function testInvalidTypeHandling()
+    {
+        $standard = __DIR__.'/ProcessRuleInvalidTypeTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+
+        $message = 'Message type "notice" is invalid; must be "error" or "warning"';
+        $this->expectRuntimeExceptionMessage($message);
+
+        new Ruleset($config);
+
+    }//end testInvalidTypeHandling()
+
+
+}//end class

--- a/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.xml
+++ b/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRuleInvalidTypeTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Generic.Files.ByteOrderMark">
+        <!-- Invalid type will throw an error. -->
+        <type>notice</type>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION

## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs expanding the tests for the `Ruleset` class.