### PR TITLE
Generators: add tests for handling <standard> element + use consistent encoding cross-PHP 

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -235,7 +235,7 @@ class HTML extends Generator
     protected function printTextBlock(DOMNode $node)
     {
         $content = trim($node->nodeValue);
-        $content = htmlspecialchars($content);
+        $content = htmlspecialchars($content, (ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
 
         // Use the correct line endings based on the OS.
         $content = str_replace("\n", PHP_EOL, $content);

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -116,7 +116,7 @@ class Markdown extends Generator
     protected function printTextBlock(DOMNode $node)
     {
         $content = trim($node->nodeValue);
-        $content = htmlspecialchars($content);
+        $content = htmlspecialchars($content, (ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
 
         // Use the correct line endings based on the OS.
         $content = str_replace("\n", PHP_EOL, $content);

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
@@ -1,0 +1,82 @@
+<html>
+ <head>
+  <title>GeneratorTest Coding Standards</title>
+  <style>
+        body {
+            background-color: #FFFFFF;
+            font-size: 14px;
+            font-family: Arial, Helvetica, sans-serif;
+            color: #000000;
+        }
+
+        h1 {
+            color: #666666;
+            font-size: 20px;
+            font-weight: bold;
+            margin-top: 0px;
+            background-color: #E6E7E8;
+            padding: 20px;
+            border: 1px solid #BBBBBB;
+        }
+
+        h2 {
+            color: #00A5E3;
+            font-size: 16px;
+            font-weight: normal;
+            margin-top: 50px;
+        }
+
+        .code-comparison {
+            width: 100%;
+        }
+
+        .code-comparison td {
+            border: 1px solid #CCCCCC;
+        }
+
+        .code-comparison-title, .code-comparison-code {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 12px;
+            color: #000000;
+            vertical-align: top;
+            padding: 4px;
+            width: 50%;
+            background-color: #F1F1F1;
+            line-height: 15px;
+        }
+
+        .code-comparison-code {
+            font-family: Courier;
+            background-color: #F9F9F9;
+        }
+
+        .code-comparison-highlight {
+            background-color: #DDF1F7;
+            border: 1px solid #00A5E3;
+            line-height: 15px;
+        }
+
+        .tag-line {
+            text-align: center;
+            width: 100%;
+            margin-top: 30px;
+            font-size: 12px;
+        }
+
+        .tag-line a {
+            color: #000000;
+        }
+    </style>
+ </head>
+ <body>
+  <h1>GeneratorTest Coding Standards</h1>
+  <a name="Standard-Element,-blank-line-handling" />
+  <h2>Standard Element, blank line handling</h2>
+  <p class="text">There is a blank line at the start of this standard.
+
+    And the above blank line is also deliberate to test part of the logic.
+
+    Let&#039;s also end on a blank line to test that too.</p>
+  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+ </body>
+</html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.md
@@ -1,0 +1,10 @@
+# GeneratorTest Coding Standard
+
+## Standard Element, blank line handling
+There is a blank line at the start of this standard.
+
+    And the above blank line is also deliberate to test part of the logic.
+
+    Let&#039;s also end on a blank line to test that too.
+
+Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.txt
@@ -1,0 +1,11 @@
+
+------------------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: STANDARD ELEMENT, BLANK LINE HANDLING |
+------------------------------------------------------------------------
+
+There is a blank line at the start of this standard.
+
+And the above blank line is also deliberate to test part of the logic.
+
+Let's also end on a blank line to test that too.
+

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
@@ -1,0 +1,79 @@
+<html>
+ <head>
+  <title>GeneratorTest Coding Standards</title>
+  <style>
+        body {
+            background-color: #FFFFFF;
+            font-size: 14px;
+            font-family: Arial, Helvetica, sans-serif;
+            color: #000000;
+        }
+
+        h1 {
+            color: #666666;
+            font-size: 20px;
+            font-weight: bold;
+            margin-top: 0px;
+            background-color: #E6E7E8;
+            padding: 20px;
+            border: 1px solid #BBBBBB;
+        }
+
+        h2 {
+            color: #00A5E3;
+            font-size: 16px;
+            font-weight: normal;
+            margin-top: 50px;
+        }
+
+        .code-comparison {
+            width: 100%;
+        }
+
+        .code-comparison td {
+            border: 1px solid #CCCCCC;
+        }
+
+        .code-comparison-title, .code-comparison-code {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 12px;
+            color: #000000;
+            vertical-align: top;
+            padding: 4px;
+            width: 50%;
+            background-color: #F1F1F1;
+            line-height: 15px;
+        }
+
+        .code-comparison-code {
+            font-family: Courier;
+            background-color: #F9F9F9;
+        }
+
+        .code-comparison-highlight {
+            background-color: #DDF1F7;
+            border: 1px solid #00A5E3;
+            line-height: 15px;
+        }
+
+        .tag-line {
+            text-align: center;
+            width: 100%;
+            margin-top: 30px;
+            font-size: 12px;
+        }
+
+        .tag-line a {
+            color: #000000;
+        }
+    </style>
+ </head>
+ <body>
+  <h1>GeneratorTest Coding Standards</h1>
+  <a name="Standard-Element,-handling-of-HTML-tags" />
+  <h2>Standard Element, handling of HTML tags</h2>
+  <p class="text">The use of <em>tags</em> in standard descriptions is allowed and their handling should be <em>safeguarded</em>.
+    Other tags, like &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;, &lt;b&gt;bold&lt;/bold&gt;, &lt;script&gt;&lt;/script&gt; are not allowed and will be encoded for display when the HTML or Markdown report is used.</p>
+  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+ </body>
+</html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.md
@@ -1,0 +1,7 @@
+# GeneratorTest Coding Standard
+
+## Standard Element, handling of HTML tags
+The use of *tags* in standard descriptions is allowed and their handling should be *safeguarded*.
+    Other tags, like &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;, &lt;b&gt;bold&lt;/bold&gt;, &lt;script&gt;&lt;/script&gt; are not allowed and will be encoded for display when the HTML or Markdown report is used.
+
+Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.txt
@@ -1,0 +1,9 @@
+
+--------------------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: STANDARD ELEMENT, HANDLING OF HTML TAGS |
+--------------------------------------------------------------------------
+
+The use of *tags* in standard descriptions is allowed and their handling should be *safeguarded*.
+Other tags, like <a href="example.com">link</a>, <b>bold</bold>, <script></script> are not allowed
+and will be encoded for display when the HTML or Markdown report is used.
+

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
@@ -1,0 +1,81 @@
+<html>
+ <head>
+  <title>GeneratorTest Coding Standards</title>
+  <style>
+        body {
+            background-color: #FFFFFF;
+            font-size: 14px;
+            font-family: Arial, Helvetica, sans-serif;
+            color: #000000;
+        }
+
+        h1 {
+            color: #666666;
+            font-size: 20px;
+            font-weight: bold;
+            margin-top: 0px;
+            background-color: #E6E7E8;
+            padding: 20px;
+            border: 1px solid #BBBBBB;
+        }
+
+        h2 {
+            color: #00A5E3;
+            font-size: 16px;
+            font-weight: normal;
+            margin-top: 50px;
+        }
+
+        .code-comparison {
+            width: 100%;
+        }
+
+        .code-comparison td {
+            border: 1px solid #CCCCCC;
+        }
+
+        .code-comparison-title, .code-comparison-code {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 12px;
+            color: #000000;
+            vertical-align: top;
+            padding: 4px;
+            width: 50%;
+            background-color: #F1F1F1;
+            line-height: 15px;
+        }
+
+        .code-comparison-code {
+            font-family: Courier;
+            background-color: #F9F9F9;
+        }
+
+        .code-comparison-highlight {
+            background-color: #DDF1F7;
+            border: 1px solid #00A5E3;
+            line-height: 15px;
+        }
+
+        .tag-line {
+            text-align: center;
+            width: 100%;
+            margin-top: 30px;
+            font-size: 12px;
+        }
+
+        .tag-line a {
+            color: #000000;
+        }
+    </style>
+ </head>
+ <body>
+  <h1>GeneratorTest Coding Standards</h1>
+  <a name="Standard-Element,-indentation-should-be-ignored" />
+  <h2>Standard Element, indentation should be ignored</h2>
+  <p class="text">This line has no indentation.
+    This line has 4 spaces indentation.
+        This line has 8 spaces indentation.
+    This line has 4 spaces indentation.</p>
+  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+ </body>
+</html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.md
@@ -1,0 +1,9 @@
+# GeneratorTest Coding Standard
+
+## Standard Element, indentation should be ignored
+This line has no indentation.
+    This line has 4 spaces indentation.
+        This line has 8 spaces indentation.
+    This line has 4 spaces indentation.
+
+Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.txt
@@ -1,0 +1,10 @@
+
+----------------------------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: STANDARD ELEMENT, INDENTATION SHOULD BE IGNORED |
+----------------------------------------------------------------------------------
+
+This line has no indentation.
+This line has 4 spaces indentation.
+This line has 8 spaces indentation.
+This line has 4 spaces indentation.
+

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
@@ -1,0 +1,80 @@
+<html>
+ <head>
+  <title>GeneratorTest Coding Standards</title>
+  <style>
+        body {
+            background-color: #FFFFFF;
+            font-size: 14px;
+            font-family: Arial, Helvetica, sans-serif;
+            color: #000000;
+        }
+
+        h1 {
+            color: #666666;
+            font-size: 20px;
+            font-weight: bold;
+            margin-top: 0px;
+            background-color: #E6E7E8;
+            padding: 20px;
+            border: 1px solid #BBBBBB;
+        }
+
+        h2 {
+            color: #00A5E3;
+            font-size: 16px;
+            font-weight: normal;
+            margin-top: 50px;
+        }
+
+        .code-comparison {
+            width: 100%;
+        }
+
+        .code-comparison td {
+            border: 1px solid #CCCCCC;
+        }
+
+        .code-comparison-title, .code-comparison-code {
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 12px;
+            color: #000000;
+            vertical-align: top;
+            padding: 4px;
+            width: 50%;
+            background-color: #F1F1F1;
+            line-height: 15px;
+        }
+
+        .code-comparison-code {
+            font-family: Courier;
+            background-color: #F9F9F9;
+        }
+
+        .code-comparison-highlight {
+            background-color: #DDF1F7;
+            border: 1px solid #00A5E3;
+            line-height: 15px;
+        }
+
+        .tag-line {
+            text-align: center;
+            width: 100%;
+            margin-top: 30px;
+            font-size: 12px;
+        }
+
+        .tag-line a {
+            color: #000000;
+        }
+    </style>
+ </head>
+ <body>
+  <h1>GeneratorTest Coding Standards</h1>
+  <a name="Standard-Element,-line-wrapping-handling" />
+  <h2>Standard Element, line wrapping handling</h2>
+  <p class="text">This line has to be exactly 99 chars to test part of the logic.------------------------------------
+    And this line has to be exactly 100 chars.----------------------------------------------------------
+    And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.</p>
+  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+ </body>
+</html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.md
@@ -1,0 +1,8 @@
+# GeneratorTest Coding Standard
+
+## Standard Element, line wrapping handling
+This line has to be exactly 99 chars to test part of the logic.------------------------------------
+    And this line has to be exactly 100 chars.----------------------------------------------------------
+    And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.
+
+Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.txt
@@ -1,0 +1,11 @@
+
+---------------------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: STANDARD ELEMENT, LINE WRAPPING HANDLING |
+---------------------------------------------------------------------------
+
+This line has to be exactly 99 chars to test part of the logic.------------------------------------
+And this line has to be exactly 100 chars.----------------------------------------------------------
+And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum
+dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi
+ultrices in odio pharetra commodo.
+

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardBlankLinesStandard.xml
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardBlankLinesStandard.xml
@@ -1,0 +1,13 @@
+<documentation title="Standard Element, blank line handling">
+    <standard>
+    <![CDATA[
+
+    There is a blank line at the start of this standard.
+
+    And the above blank line is also deliberate to test part of the logic.
+
+    Let's also end on a blank line to test that too.
+
+    ]]>
+    </standard>
+</documentation>

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardEncodingStandard.xml
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardEncodingStandard.xml
@@ -1,0 +1,8 @@
+<documentation title="Standard Element, handling of HTML tags">
+    <standard>
+    <![CDATA[
+    The use of <em>tags</em> in standard descriptions is allowed and their handling should be <em>safeguarded</em>.
+    Other tags, like <a href="example.com">link</a>, <b>bold</bold>, <script></script> are not allowed and will be encoded for display when the HTML or Markdown report is used.
+    ]]>
+    </standard>
+</documentation>

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardIndentStandard.xml
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardIndentStandard.xml
@@ -1,0 +1,10 @@
+<documentation title="Standard Element, indentation should be ignored">
+    <standard>
+    <![CDATA[
+This line has no indentation.
+    This line has 4 spaces indentation.
+        This line has 8 spaces indentation.
+    This line has 4 spaces indentation.
+    ]]>
+    </standard>
+</documentation>

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardLineWrappingStandard.xml
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/StandardLineWrappingStandard.xml
@@ -1,0 +1,9 @@
+<documentation title="Standard Element, line wrapping handling">
+    <standard>
+    <![CDATA[
+    This line has to be exactly 99 chars to test part of the logic.------------------------------------
+    And this line has to be exactly 100 chars.----------------------------------------------------------
+    And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.
+    ]]>
+    </standard>
+</documentation>

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardBlankLinesSniff.php
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardBlankLinesSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Generators\GeneratorTest
+ */
+
+namespace Fixtures\StandardWithDocs\Sniffs\Content;
+
+use Fixtures\StandardWithDocs\Sniffs\DummySniff;
+
+final class StandardBlankLinesSniff extends DummySniff {}

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardEncodingSniff.php
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardEncodingSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Generators\GeneratorTest
+ */
+
+namespace Fixtures\StandardWithDocs\Sniffs\Content;
+
+use Fixtures\StandardWithDocs\Sniffs\DummySniff;
+
+final class StandardEncodingSniff extends DummySniff {}

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardIndentSniff.php
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardIndentSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Generators\GeneratorTest
+ */
+
+namespace Fixtures\StandardWithDocs\Sniffs\Content;
+
+use Fixtures\StandardWithDocs\Sniffs\DummySniff;
+
+final class StandardIndentSniff extends DummySniff {}

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardLineWrappingSniff.php
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/StandardLineWrappingSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Generators\GeneratorTest
+ */
+
+namespace Fixtures\StandardWithDocs\Sniffs\Content;
+
+use Fixtures\StandardWithDocs\Sniffs\DummySniff;
+
+final class StandardLineWrappingSniff extends DummySniff {}

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -125,13 +125,29 @@ final class HTMLTest extends TestCase
     public static function dataDocSpecifics()
     {
         return [
-            'Documentation title: case'   => [
+            'Documentation title: case'                        => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleCase',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleCase.html',
             ],
-            'Documentation title: length' => [
+            'Documentation title: length'                      => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.html',
+            ],
+            'Standard Element: blank line handling'            => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.html',
+            ],
+            'Standard Element: encoding of special characters' => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardEncoding',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardEncoding.html',
+            ],
+            'Standard Element: indent handling'                => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardIndent',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardIndent.html',
+            ],
+            'Standard Element: line wrapping'                  => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardLineWrapping',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardLineWrapping.html',
             ],
         ];
 

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -125,13 +125,29 @@ final class MarkdownTest extends TestCase
     public static function dataDocSpecifics()
     {
         return [
-            'Documentation title: case'   => [
+            'Documentation title: case'                        => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleCase',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleCase.md',
             ],
-            'Documentation title: length' => [
+            'Documentation title: length'                      => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.md',
+            ],
+            'Standard Element: blank line handling'            => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.md',
+            ],
+            'Standard Element: encoding of special characters' => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardEncoding',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardEncoding.md',
+            ],
+            'Standard Element: indent handling'                => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardIndent',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardIndent.md',
+            ],
+            'Standard Element: line wrapping'                  => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardLineWrapping',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardLineWrapping.md',
             ],
         ];
 

--- a/tests/Core/Generators/TextTest.php
+++ b/tests/Core/Generators/TextTest.php
@@ -125,13 +125,29 @@ final class TextTest extends TestCase
     public static function dataDocSpecifics()
     {
         return [
-            'Documentation title: case'   => [
+            'Documentation title: case'                        => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleCase',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleCase.txt',
             ],
-            'Documentation title: length' => [
+            'Documentation title: length'                      => [
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.txt',
+            ],
+            'Standard Element: blank line handling'            => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.txt',
+            ],
+            'Standard Element: encoding of special characters' => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardEncoding',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardEncoding.txt',
+            ],
+            'Standard Element: indent handling'                => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardIndent',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardIndent.txt',
+            ],
+            'Standard Element: line wrapping'                  => [
+                'sniffs'         => 'StandardWithDocs.Content.StandardLineWrapping',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardLineWrapping.txt',
             ],
         ];
 


### PR DESCRIPTION
# Description

### Generators: add tests for handling <standard> element 

This adds dedicated tests for specific issues which can be encountered in a `<standard>` XML element.

This initial set of tests for this documents the current behaviour. This behaviour may not always be the desired behaviour, in which case, this will be fixed in follow-up commits.

### Generators HTML/Markdown: consistent encoding cross-PHP 

The default value for the `$flags` parameter of the `htmlspecialchars()` function changed in PHP 8.1.0.
Previously, the default was `ENT_COMPAT`. Now the default is `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`.

The most notable differences are:
* Single quotes will be encoded.
* Invalid code unit sequences will be replace by a Unicode Replacement Character.

For consistent output cross-version PHP, it is advised to always explicitly pass the `$flags` parameter` and not rely on the default value.

Fixed now and using the _new_ `$flags` default value as the parameter value.

This commit allows for the tests to have the same output expectations cross-version PHP. For end-users, the differences shouldn't have been noticeable.


## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests for the Generator feature.

Related to #146