### PR TITLE
Generators/Markdown: add blank line after title

### DIFF
--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -93,7 +93,7 @@ class Markdown extends Generator
     protected function processSniff(DOMNode $doc)
     {
         $title = $this->getTitle($doc);
-        echo PHP_EOL."## $title".PHP_EOL;
+        echo PHP_EOL."## $title".PHP_EOL.PHP_EOL;
 
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlankLines.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlankLines.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Comparison, blank lines
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlockLength.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlockLength.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Comparison, block length
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonEncoding.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonEncoding.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Comparison, char encoding
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Comparison, line length
+
 Ensure there is no PHP &quot;Warning: str_repeat(): Second argument has to be greater than or equal to 0&quot;.
     Ref: squizlabs/PHP_CodeSniffer#2522
   <table>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleLineWrapping.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleLineWrapping.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Title, line wrapping
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Code Title, whitespace handling
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleCase.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleCase.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## lowercase title
+
 This is a standard block.
 
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleLength.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleLength.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## This is a very very very very very very very very very very very long title
+
 This is a standard block.
 
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## One Standard Block, No Code
+
 Documentation contains one standard block and no code comparison.
 
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Standard Element, blank line handling
+
 There is a blank line at the start of this standard.
 
     And the above blank line is also deliberate to test part of the logic.

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Standard Element, handling of HTML tags
+
 The use of *tags* in standard descriptions is allowed and their handling should be *safeguarded*.
     Other tags, like &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;, &lt;b&gt;bold&lt;/bold&gt;, &lt;script&gt;&lt;/script&gt; are not allowed and will be encoded for display when the HTML or Markdown report is used.
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Standard Element, indentation should be ignored
+
 This line has no indentation.
     This line has 4 spaces indentation.
         This line has 8 spaces indentation.

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Standard Element, line wrapping handling
+
 This line has to be exactly 99 chars to test part of the logic.------------------------------------
     And this line has to be exactly 100 chars.----------------------------------------------------------
     And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.

--- a/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.md
@@ -2,7 +2,9 @@
 
 ## No Content
 
+
 ## Code Comparison Only, Missing Standard Block
+
   <table>
    <tr>
     <th>Valid: Lorem ipsum dolor sit amet.</th>
@@ -23,6 +25,7 @@
   </table>
 
 ## One Standard Block, Code Comparison
+
 Documentation contains one standard block and one code comparison.
   <table>
    <tr>
@@ -44,9 +47,11 @@ Documentation contains one standard block and one code comparison.
   </table>
 
 ## One Standard Block, No Code
+
 Documentation contains one standard block and no code comparison.
 
 ## One Standard Block, Two Code Comparisons
+
 Documentation contains one standard block and two code comparisons.
   <table>
    <tr>
@@ -86,10 +91,12 @@ Documentation contains one standard block and two code comparisons.
   </table>
 
 ## Two Standard Blocks, No Code
+
 This is standard block one.
 This is standard block two.
 
 ## Two Standard Blocks, One Code Comparison
+
 This is standard block one.
   <table>
    <tr>
@@ -112,6 +119,7 @@ This is standard block one.
 This is standard block two.
 
 ## Two Standard Blocks, Three Code Comparisons
+
 This is standard block one.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedElementAtWrongLevel.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedElementAtWrongLevel.md
@@ -2,4 +2,5 @@
 
 ## Code element at wrong level
 
+
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedOneElmAtWrongLevel.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedOneElmAtWrongLevel.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## One element correct, one element wrong level
+
 This is a standard block at the correct level.
 
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedSuperfluousCodeElement.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedSuperfluousCodeElement.md
@@ -1,6 +1,7 @@
 # GeneratorTest Coding Standard
 
 ## Superfluous code element
+
 This is a standard block.
   <table>
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedUnknownElement.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedUnknownElement.md
@@ -2,4 +2,5 @@
 
 ## Unknown element
 
+
 Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)


### PR DESCRIPTION
# Description
As per the guidelines for cross-flavour markdown, it is best to always have a blank line below a header.

Ref:
* https://www.markdownguide.org/basic-syntax/#heading-best-practices

## Suggested changelog entry
* Generators/Markdown: improved compatibility with the variety of available markdown parsers

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and #716.
