### PR TITLE
Generators/HTML: fix line break handling

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -237,14 +237,35 @@ class HTML extends Generator
         $content = trim($node->nodeValue);
         $content = htmlspecialchars($content, (ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
 
-        // Use the correct line endings based on the OS.
-        $content = str_replace("\n", PHP_EOL, $content);
-
-        // Allow em tags only.
+        // Allow only em tags.
         $content = str_replace('&lt;em&gt;', '<em>', $content);
         $content = str_replace('&lt;/em&gt;', '</em>', $content);
 
-        echo "  <p class=\"text\">$content</p>".PHP_EOL;
+        $nodeLines = explode("\n", $content);
+        $lineCount = count($nodeLines);
+        $lines     = [];
+
+        for ($i = 0; $i < $lineCount; $i++) {
+            $currentLine = trim($nodeLines[$i]);
+
+            if (isset($nodeLines[($i + 1)]) === false) {
+                // We're at the end of the text, just add the line.
+                $lines[] = $currentLine;
+            } else {
+                $nextLine = trim($nodeLines[($i + 1)]);
+                if ($nextLine === '') {
+                    // Next line is a blank line, end the paragraph and start a new one.
+                    // Also skip over the blank line.
+                    $lines[] = $currentLine.'</p>'.PHP_EOL.'  <p class="text">';
+                    ++$i;
+                } else {
+                    // Next line is not blank, so just add a line break.
+                    $lines[] = $currentLine.'<br/>'.PHP_EOL;
+                }
+            }
+        }
+
+        echo '  <p class="text">'.implode('', $lines).'</p>'.PHP_EOL;
 
     }//end printTextBlock()
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.html
@@ -72,8 +72,8 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Code-Comparison,-line-length" />
   <h2>Code Comparison, line length</h2>
-  <p class="text">Ensure there is no PHP &quot;Warning: str_repeat(): Second argument has to be greater than or equal to 0&quot;.
-    Ref: squizlabs/PHP_CodeSniffer#2522</p>
+  <p class="text">Ensure there is no PHP &quot;Warning: str_repeat(): Second argument has to be greater than or equal to 0&quot;.<br/>
+Ref: squizlabs/PHP_CodeSniffer#2522</p>
   <table class="code-comparison">
    <tr>
     <td class="code-comparison-title">Valid: contains line which is too long.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
@@ -72,11 +72,9 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Standard-Element,-blank-line-handling" />
   <h2>Standard Element, blank line handling</h2>
-  <p class="text">There is a blank line at the start of this standard.
-
-    And the above blank line is also deliberate to test part of the logic.
-
-    Let&#039;s also end on a blank line to test that too.</p>
+  <p class="text">There is a blank line at the start of this standard.</p>
+  <p class="text">And the above blank line is also deliberate to test part of the logic.</p>
+  <p class="text">Let&#039;s also end on a blank line to test that too.</p>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
@@ -72,8 +72,8 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Standard-Element,-handling-of-HTML-tags" />
   <h2>Standard Element, handling of HTML tags</h2>
-  <p class="text">The use of <em>tags</em> in standard descriptions is allowed and their handling should be <em>safeguarded</em>.
-    Other tags, like &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;, &lt;b&gt;bold&lt;/bold&gt;, &lt;script&gt;&lt;/script&gt; are not allowed and will be encoded for display when the HTML or Markdown report is used.</p>
+  <p class="text">The use of <em>tags</em> in standard descriptions is allowed and their handling should be <em>safeguarded</em>.<br/>
+Other tags, like &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;, &lt;b&gt;bold&lt;/bold&gt;, &lt;script&gt;&lt;/script&gt; are not allowed and will be encoded for display when the HTML or Markdown report is used.</p>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
@@ -72,10 +72,10 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Standard-Element,-indentation-should-be-ignored" />
   <h2>Standard Element, indentation should be ignored</h2>
-  <p class="text">This line has no indentation.
-    This line has 4 spaces indentation.
-        This line has 8 spaces indentation.
-    This line has 4 spaces indentation.</p>
+  <p class="text">This line has no indentation.<br/>
+This line has 4 spaces indentation.<br/>
+This line has 8 spaces indentation.<br/>
+This line has 4 spaces indentation.</p>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
@@ -72,9 +72,9 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Standard-Element,-line-wrapping-handling" />
   <h2>Standard Element, line wrapping handling</h2>
-  <p class="text">This line has to be exactly 99 chars to test part of the logic.------------------------------------
-    And this line has to be exactly 100 chars.----------------------------------------------------------
-    And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.</p>
+  <p class="text">This line has to be exactly 99 chars to test part of the logic.------------------------------------<br/>
+And this line has to be exactly 100 chars.----------------------------------------------------------<br/>
+And here we have a line which should start wrapping as it is longer than 100 chars. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean pellentesque iaculis enim quis hendrerit. Morbi ultrices in odio pharetra commodo.</p>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>


### PR DESCRIPTION
# Description
As things were, line breaks in a `<standard>` block were not respected for proper display in HTML.

This has now been fixed by:
* Recognizing a blank line after a text line as an indicator that the next line should be a new paragraph.
* In all other cases, a line break will be translated to an HTML line break.

Includes updated test expectations.

### Before

![image](https://github.com/user-attachments/assets/861f7b17-3778-4ada-86d9-ccf978d25024)
![image](https://github.com/user-attachments/assets/389915ed-fb2b-4e2f-97fc-8bd24fb821d2)


### After

![image](https://github.com/user-attachments/assets/4b072fde-ad28-43a5-92a8-871cfdaf73d1)

![image](https://github.com/user-attachments/assets/6c96882c-c910-457d-9cfe-a502e29d47af)



## Suggested changelog entry
* Generators/HTML: line breaks in `<standard>` blocks will now be respected when generating the HTML documentation.


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and #717.
