### PR TITLE
GH Actions: run phar building test more selectively

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -1,14 +1,31 @@
 name: Build PHARs
 
 on:
-  # Run on pushes to master and on all pull requests.
+  # Run on pushes to master and on pull requests which touch files used when building the PHARs.
   # Prevent the build from running when there are only irrelevant changes.
   push:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '.github/workflows/build-phar.yml'
+      - 'scripts/build-phar.php'
+      - 'autoload.php'
+      - 'src/Config.php'
+      - 'src/Exceptions/RuntimeException.php'
+      - 'src/Exceptions/TokenizerException.php'
+      - 'src/Tokenizers/PHP.php'
+      - 'src/Util/Tokens.php'
   pull_request:
+    paths:
+      - '.github/workflows/build-phar.yml'
+      - 'scripts/build-phar.php'
+      - 'autoload.php'
+      - 'src/Config.php'
+      - 'src/Exceptions/RuntimeException.php'
+      - 'src/Exceptions/TokenizerException.php'
+      - 'src/Tokenizers/PHP.php'
+      - 'src/Util/Tokens.php'
+
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
# Description
This workflow is a safeguard to ensure that the PHAR files can be build against any of the supported PHP versions.

There are only a few files involved in building the PHAR files, so there isn't really any need to run this workflow for every PR and every merge. It only really needs to run when any of the involved files have changed.

Also, keep in mind that the PHAR which is distributed for releases is build on PHP 8.0 and will still be build in the `test` workflow for every PR and every merge, so the functionality of the distribution PHARs is still guaranteed either way.


## Suggested changelog entry
_N/A_
