### PR TITLE
GH Actions: fix snafu with code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,8 +256,8 @@ jobs:
         shell: bash
         run: |
           # Set the "short_open_tag" ini to make sure specific conditions are tested.
-          if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '5.4' ]]; then
-            echo 'PHP_INI=, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On' >> "$GITHUB_OUTPUT"
+          if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '7.2' ]]; then
+            echo 'PHP_INI=, date.timezone=Australia/Sydney, short_open_tag=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP


### PR DESCRIPTION
# Description
Follow up on commit 755f0bc35a466e063f55fa7e7697a05e1289c644, which simplified the `custom_ini` setting for the code coverage builds, but did so incorrectly, meaning that code which needs the `short_open_tag=On` setting was no longer being recorded as covered.

Fixed now.


## Suggested changelog entry
_N/A_