### PR TITLE
Generators/Text: trim code titles

### DIFF
--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -133,7 +133,7 @@ class Text extends Generator
     {
         $codeBlocks = $node->getElementsByTagName('code');
         $first      = trim($codeBlocks->item(0)->nodeValue);
-        $firstTitle = $codeBlocks->item(0)->getAttribute('title');
+        $firstTitle = trim($codeBlocks->item(0)->getAttribute('title'));
 
         $firstTitleLines = [];
         $tempTitle       = '';
@@ -168,7 +168,7 @@ class Text extends Generator
         $firstLines = explode("\n", $first);
 
         $second      = trim($codeBlocks->item(1)->nodeValue);
-        $secondTitle = $codeBlocks->item(1)->getAttribute('title');
+        $secondTitle = trim($codeBlocks->item(1)->getAttribute('title'));
 
         $secondTitleLines = [];
         $tempTitle        = '';

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.txt
@@ -6,15 +6,13 @@
 This is a standard block.
 
 ----------------------------------------- CODE COMPARISON ------------------------------------------
-|   Valid: spaces at start of description.       | Invalid: spaces at end making line > 46 chars.  |
-|                                                |                                                 |
+| Valid: spaces at start of description.         | Invalid: spaces at end making line > 46 chars.  |
 ----------------------------------------------------------------------------------------------------
 | // Dummy.                                      | // Dummy.                                       |
 ----------------------------------------------------------------------------------------------------
 
 ----------------------------------------- CODE COMPARISON ------------------------------------------
-|   Valid: spaces at start + end of description. | Invalid: spaces '     ' in description.         |
-|                                                |                                                 |
+| Valid: spaces at start + end of description.   | Invalid: spaces '     ' in description.         |
 ----------------------------------------------------------------------------------------------------
 | // Note: description above without the         | // Dummy.                                       |
 | // trailing whitespace fits in 46 chars.       |                                                 |


### PR DESCRIPTION
# Description
As things were, whitespace at the start/end of a title could cause unnecessary line wrapping of the title.

Fixed now.

Includes updated test expectations.

### Before
![5-code-title-text-whitespace-before](https://github.com/user-attachments/assets/33f2ef28-c94b-464e-9284-3915e441750e)

### After
![5-code-title-text-whitespace-after](https://github.com/user-attachments/assets/157b9e4f-fe72-43b1-ad03-e4155b9451d1)


## Suggested changelog entry
Generators/Text: minor clean up of code title presentation


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and #718.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [ ] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
