### PR TITLE
Generators HTML/Markdown: fix whitespace handling in code title

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -281,7 +281,8 @@ class HTML extends Generator
     {
         $codeBlocks = $node->getElementsByTagName('code');
 
-        $firstTitle = $codeBlocks->item(0)->getAttribute('title');
+        $firstTitle = trim($codeBlocks->item(0)->getAttribute('title'));
+        $firstTitle = str_replace('  ', '&nbsp;&nbsp;', $firstTitle);
         $first      = trim($codeBlocks->item(0)->nodeValue);
         $first      = str_replace('<?php', '&lt;?php', $first);
         $first      = str_replace("\n", '</br>', $first);
@@ -289,7 +290,8 @@ class HTML extends Generator
         $first      = str_replace('<em>', '<span class="code-comparison-highlight">', $first);
         $first      = str_replace('</em>', '</span>', $first);
 
-        $secondTitle = $codeBlocks->item(1)->getAttribute('title');
+        $secondTitle = trim($codeBlocks->item(1)->getAttribute('title'));
+        $secondTitle = str_replace('  ', '&nbsp;&nbsp;', $secondTitle);
         $second      = trim($codeBlocks->item(1)->nodeValue);
         $second      = str_replace('<?php', '&lt;?php', $second);
         $second      = str_replace("\n", '</br>', $second);

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -140,13 +140,15 @@ class Markdown extends Generator
     {
         $codeBlocks = $node->getElementsByTagName('code');
 
-        $firstTitle = $codeBlocks->item(0)->getAttribute('title');
+        $firstTitle = trim($codeBlocks->item(0)->getAttribute('title'));
+        $firstTitle = str_replace('  ', '&nbsp;&nbsp;', $firstTitle);
         $first      = trim($codeBlocks->item(0)->nodeValue);
         $first      = str_replace("\n", PHP_EOL.'    ', $first);
         $first      = str_replace('<em>', '', $first);
         $first      = str_replace('</em>', '', $first);
 
-        $secondTitle = $codeBlocks->item(1)->getAttribute('title');
+        $secondTitle = trim($codeBlocks->item(1)->getAttribute('title'));
+        $secondTitle = str_replace('  ', '&nbsp;&nbsp;', $secondTitle);
         $second      = trim($codeBlocks->item(1)->nodeValue);
         $second      = str_replace("\n", PHP_EOL.'    ', $second);
         $second      = str_replace('<em>', '', $second);

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.html
@@ -75,8 +75,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">  Valid: spaces at start of description.</td>
-    <td class="code-comparison-title">Invalid: spaces at end making line > 46 chars.   </td>
+    <td class="code-comparison-title">Valid: spaces at start of description.</td>
+    <td class="code-comparison-title">Invalid: spaces at end making line > 46 chars.</td>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>
@@ -85,8 +85,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">  Valid: spaces at start + end of description.   </td>
-    <td class="code-comparison-title">Invalid: spaces '     ' in description.</td>
+    <td class="code-comparison-title">Valid: spaces at start + end of description.</td>
+    <td class="code-comparison-title">Invalid: spaces '&nbsp;&nbsp;&nbsp;&nbsp; ' in description.</td>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Note:&nbsp;description&nbsp;above&nbsp;without&nbsp;the</br>//&nbsp;trailing&nbsp;whitespace&nbsp;fits&nbsp;in&nbsp;46&nbsp;chars.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.md
@@ -5,8 +5,8 @@
 This is a standard block.
   <table>
    <tr>
-    <th>  Valid: spaces at start of description.</th>
-    <th>Invalid: spaces at end making line > 46 chars.   </th>
+    <th>Valid: spaces at start of description.</th>
+    <th>Invalid: spaces at end making line > 46 chars.</th>
    </tr>
    <tr>
 <td>
@@ -23,8 +23,8 @@ This is a standard block.
   </table>
   <table>
    <tr>
-    <th>  Valid: spaces at start + end of description.   </th>
-    <th>Invalid: spaces '     ' in description.</th>
+    <th>Valid: spaces at start + end of description.</th>
+    <th>Invalid: spaces '&nbsp;&nbsp;&nbsp;&nbsp; ' in description.</th>
    </tr>
    <tr>
 <td>


### PR DESCRIPTION
# Description
If there were multiple spaces next to each other in the title, this would be folded into one space for the display in HTML and Markdown.

This could mangle the code title, so fixed now.

Includes updated test expectations.

### Before
![6-code-title-html-whitespace-within-before](https://github.com/user-attachments/assets/a9f40ca2-75aa-48c5-b039-76daadc04507)
![6-code-title-markdown-whitespace-within-before](https://github.com/user-attachments/assets/e4a86ed6-0fa0-491a-962a-350fb1e5ca9b)


### After
![6-code-title-html-whitespace-within-after](https://github.com/user-attachments/assets/36d6ac5a-e9e2-47a7-8bcc-012a28d0d9b4)
![6-code-title-markdown-whitespace-within-after](https://github.com/user-attachments/assets/f67c3ab4-57b0-47cf-8862-bd99d605f5a5)



## Suggested changelog entry
Generators/HTML + Markdown: now better respect whitespace within a code sample title


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and #718.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
