### PR TITLE
Squiz/ArrayDeclaration: fixes false positive when handling short lists inside `foreach`

### DIFF
--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -19,7 +19,7 @@ class TestClass
                     'height' => '',
                    );
 
-    private $_bad = Array(
+    private $_bad = ARRAY(
                     'width' => '',
                     'height' => ''
                      );
@@ -547,3 +547,14 @@ $x = array(
       1, static::helloWorld(), $class instanceof static,
       2,
      );
+
+$noSpaceBeforeDoubleArrow = array(
+                             'width'=> '',
+                             'height' => '',
+                            );
+
+$newlineAfterDoubleArrow = array(
+                            'width'  =>
+                            '',
+                            'height' => '',
+                           );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
@@ -586,3 +586,13 @@ $x = array(
       $class instanceof static,
       2,
      );
+
+$noSpaceBeforeDoubleArrow = array(
+                             'width'  => '',
+                             'height' => '',
+                            );
+
+$newlineAfterDoubleArrow = array(
+                            'width'  => '',
+                            'height' => '',
+                           );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -547,3 +547,9 @@ $newlineAfterDoubleArrow = [
                             '',
                             'height' => '',
                            ];
+
+// Sniff should ignore short lists when inside a foreach.
+// https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/527
+foreach ($data as [, , $value]) {}
+foreach ($array as $k => [$v1, , $v3]) {}
+foreach ([$a ,$b] as $c) {} // Not a short list. Sniff should handle it.

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -536,3 +536,14 @@ $x = [
       1, static::helloWorld(), $class instanceof static,
       2,
      ];
+
+$noSpaceBeforeDoubleArrow = [
+                             'width'=> '',
+                             'height' => '',
+                            ];
+
+$newlineAfterDoubleArrow = [
+                            'width'  =>
+                            '',
+                            'height' => '',
+                           ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -573,3 +573,13 @@ $x = [
       $class instanceof static,
       2,
      ];
+
+$noSpaceBeforeDoubleArrow = [
+                             'width'  => '',
+                             'height' => '',
+                            ];
+
+$newlineAfterDoubleArrow = [
+                            'width'  => '',
+                            'height' => '',
+                           ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -583,3 +583,9 @@ $newlineAfterDoubleArrow = [
                             'width'  => '',
                             'height' => '',
                            ];
+
+// Sniff should ignore short lists when inside a foreach.
+// https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/527
+foreach ($data as [, , $value]) {}
+foreach ($array as $k => [$v1, , $v3]) {}
+foreach ([$a, $b] as $c) {} // Not a short list. Sniff should handle it.

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.3.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.3.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Intentional parse error (missing closing parenthesis).
+// This should be the only test in this file.
+// Testing that the sniff is *not* triggered.
+
+$array = array(

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.4.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.4.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error (missing T_AS in foreach).
+// This should be the only test in this file.
+// Testing that the code preventing the sniff to act on short lists inside a foreach doesn't
+// interfere with the rest of sniff when the `as` keyword is missing.
+
+foreach ([$a , $b])

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.4.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.4.inc.fixed
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error (missing T_AS in foreach).
+// This should be the only test in this file.
+// Testing that the code preventing the sniff to act on short lists inside a foreach doesn't
+// interfere with the rest of sniff when the `as` keyword is missing.
+
+foreach ([$a, $b])

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -233,7 +233,10 @@ final class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 536 => 2,
                 541 => 1,
                 546 => 1,
+                555 => 2,
             ];
+        case 'ArrayDeclarationUnitTest.4.inc':
+            return [8 => 1];
         default:
             return [];
         }//end switch

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -136,6 +136,8 @@ final class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 537 => 1,
                 540 => 1,
                 547 => 2,
+                552 => 1,
+                557 => 1,
             ];
         case 'ArrayDeclarationUnitTest.2.inc':
             return [
@@ -229,6 +231,8 @@ final class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 526 => 1,
                 529 => 1,
                 536 => 2,
+                541 => 1,
+                546 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
# Description

This PR fixes a false positive when handling a short list inside a `foreach` as reported in #527. I implemented the solution that @jrfnl described in this comment: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/527#issuecomment-2189958063.

I included a separate commit with some tests that I wrote to improve test coverage for this sniff while I was familiarizing myself with its code. This is not a full code coverage commit. There are still some uncovered lines in this sniff, and those lines might be unreachable, but I have not investigated this at this time. There are also potentially some more relevant tests that could be added for lines that are already covered. This is also not addressed in this commit.

cc @VladaHejda in case you are available to test this PR and confirm if it fixes the problem that you reported. Thanks.

## Suggested changelog entry
`Squiz.Arrays.ArrayDeclaration`: fix false positive when handling short lists inside `foreach`

## Related issues/external references

Fixes #527


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.