### PR TITLE
Generics: Add support for generic type hints in comments

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -435,6 +435,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $suggestedTypeHint = 'callable';
                 } else if (strpos($suggestedName, 'callback') !== false) {
                     $suggestedTypeHint = 'callable';
+                } else if (preg_match('/^([^<]+)<[^>]+>$/', $suggestedName, $matches) === 1) {
+                    $suggestedTypeHint = $matches[1];
                 } else if (in_array($suggestedName, Common::$allowedTypes, true) === false) {
                     $suggestedTypeHint = $suggestedName;
                 }

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1048,6 +1048,18 @@ public function ignored() {
 function throwCommentOneLine() {}
 
 /**
+ * Using generic as a type hint should satisfy a specified object parameter type.
+ * @see https://phpstan.org/blog/generics-in-php-using-phpdocs
+ *
+ * @param Collection<int, string> $values An object with int, string pairs.
+ *
+ * @return void
+ */
+public function genericType(Collection $values) {
+
+}// end genericType()
+
+/**
  * When two adjacent pipe symbols are used (by mistake), the sniff should not throw a PHP Fatal error
  *
  * @param stdClass||null $object While invalid, this should not throw a PHP Fatal error.

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1048,6 +1048,18 @@ public function ignored() {
 function throwCommentOneLine() {}
 
 /**
+ * Using generic as a type hint should satisfy a specified object parameter type.
+ * @see https://phpstan.org/blog/generics-in-php-using-phpdocs
+ *
+ * @param Collection<int, string> $values An object with int, string pairs.
+ *
+ * @return void
+ */
+public function genericType(Collection $values) {
+
+}// end genericType()
+
+/**
  * When two adjacent pipe symbols are used (by mistake), the sniff should not throw a PHP Fatal error
  *
  * @param stdClass|null $object While invalid, this should not throw a PHP Fatal error.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

# Description
Enhanced the FunctionCommentSniff to recognize and correctly suggest generic type hints by extracting the main type from parameter annotations. Added corresponding unit tests to verify this functionality, ensuring better adherence to modern PHPDoc standards with generic collections.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->


## Related issues/external references

Fixes [#746](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/746)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
