### PR TITLE
GH Actions: change PHAR building to reusable workflow

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -8,6 +8,7 @@ on:
       - master
     paths:
       - '.github/workflows/build-phar.yml'
+      - '.github/workflows/reusable-build-phar.yml'
       - 'scripts/build-phar.php'
       - 'autoload.php'
       - 'src/Config.php'
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build-phar.yml'
+      - '.github/workflows/reusable-build-phar.yml'
       - 'scripts/build-phar.php'
       - 'autoload.php'
       - 'src/Config.php'
@@ -37,35 +39,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         # Deliberately missing PHP 8.0 as that PHAR is build and used in the test workflow.
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.1', '8.2', '8.3', '8.4', 'nightly']
 
     name: "Build Phar on PHP: ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.5' }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          coverage: none
-          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
-
-      - name: Build the phars
-        run: php scripts/build-phar.php
-
-      # Both the below only check a file which is rarely changed and therefore unlikely to have issues.
-      # This test is about testing that the phars are functional, *not* about whether the code style complies.
-      - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
-        run: php phpcs.phar ./scripts
-
-      - name: 'PHPCBF: fix code style using the Phar file to test the Phar is functional'
-        run: php phpcbf.phar ./scripts
+    uses: ./.github/workflows/reusable-build-phar.yml
+    with:
+      phpVersion: ${{ matrix.php }}

--- a/.github/workflows/reusable-build-phar.yml
+++ b/.github/workflows/reusable-build-phar.yml
@@ -1,0 +1,81 @@
+name: Build PHAR files
+
+on:
+  workflow_call:
+    inputs:
+      phpVersion:
+        description: "The PHP version to use. Defaults to PHP 8.0 as used for the releases."
+        type: string
+        required: false
+        default: '8.0'
+      uploadArtifacts:
+        description: "Whether or not to upload the artifacts. Defaults to false."
+        type: boolean
+        required: false
+        default: false
+      retentionDays:
+        description: "How long uploaded artifacts should remain available (in days). Defaults to 1 day."
+        type: string
+        required: false
+        default: 1
+      createAttestations:
+        description: "Whether or not to create attestations for the artifacts. Defaults to false."
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Build Phar on PHP: ${{ inputs.phpVersion }}"
+
+    continue-on-error: ${{ inputs.phpVersion == 'nightly' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.phpVersion }}
+          coverage: none
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
+
+      - name: Build the phar files
+        run: php scripts/build-phar.php
+
+      # Provide provenance for generated binaries.
+      - name: Generate artifact attestations
+        if: ${{ inputs.createAttestations == true }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            ${{ github.workspace }}/phpcs.phar
+            ${{ github.workspace }}/phpcbf.phar
+
+      - name: Upload the PHPCS phar
+        if: ${{ inputs.uploadArtifacts == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpcs-phar
+          path: ./phpcs.phar
+          if-no-files-found: error
+          retention-days: ${{ inputs.retentionDays }}
+
+      - name: Upload the PHPCBF phar
+        if: ${{ inputs.uploadArtifacts == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: phpcbf-phar
+          path: ./phpcbf.phar
+          if-no-files-found: error
+          retention-days: ${{ inputs.retentionDays }}
+
+      # Both the below only check a file which is rarely changed and therefore unlikely to have issues.
+      # This test is about testing that the phars are functional, *not* about whether the code style complies.
+      - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
+        run: php phpcs.phar ./scripts
+
+      - name: 'PHPCBF: fix code style using the Phar file to test the Phar is functional'
+        run: php phpcbf.phar ./scripts

--- a/.github/workflows/reusable-build-phar.yml
+++ b/.github/workflows/reusable-build-phar.yml
@@ -48,7 +48,7 @@ jobs:
       # Provide provenance for generated binaries.
       - name: Generate artifact attestations
         if: ${{ inputs.createAttestations == true }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
             ${{ github.workspace }}/phpcs.phar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
       cancel-in-progress: true
 
-    runs-on: ubuntu-latest
     name: "Build Phar on PHP: 8.0"
 
     permissions:
@@ -30,54 +29,13 @@ jobs:
       contents: read
       attestations: write
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.0'
-          coverage: none
-          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
-
-      - name: Build the phar
-        run: php scripts/build-phar.php
-
-      # Provide provenance for generated binaries.
+    uses: ./.github/workflows/reusable-build-phar.yml
+    with:
+      uploadArtifacts: true
+      retentionDays: 28
       # Only attests the build artifacts which will be used in the published releases as per the guidelines in "what to attest".
       # https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
-      - name: Generate artifact attestations
-        if: ${{ github.ref_type == 'tag' }}
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: |
-            ${{ github.workspace }}/phpcs.phar
-            ${{ github.workspace }}/phpcbf.phar
-
-      - name: Upload the PHPCS phar
-        uses: actions/upload-artifact@v4
-        with:
-          name: phpcs-phar
-          path: ./phpcs.phar
-          if-no-files-found: error
-          retention-days: 28
-
-      - name: Upload the PHPCBF phar
-        uses: actions/upload-artifact@v4
-        with:
-          name: phpcbf-phar
-          path: ./phpcbf.phar
-          if-no-files-found: error
-          retention-days: 28
-
-      # Both the below only check a file which is rarely changed and therefore unlikely to have issues.
-      # This test is about testing that the phars are functional, *not* about whether the code style complies.
-      - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
-        run: php phpcs.phar ./scripts
-
-      - name: 'PHPCBF: fix code style using the Phar file to test the Phar is functional'
-        run: php phpcbf.phar ./scripts
+      createAttestations: ${{ github.ref_type == 'tag' }}
 
   test:
     # Cancels all previous runs of this particular job for the same branch that have not yet completed.


### PR DESCRIPTION
# Description
The workflows currently contain two jobs which build the PHAR files. In PHPCS 4.0, a third job will be added (in relation to 530), which will also need to build the PHAR files.

This means that any changes to the steps in these jobs would then have to be made in three places.

With this in mind, it makes sense to change the PHAR building to a reusable workflow, which can then be used by all three jobs. With this change, any changes to the steps of the job will only need to be made in one place.

This commit makes it so.


## Suggested changelog entry
_N/A_


## Related issues/external references

_Note: this PR should be merged just before the next release to verify that the attestation handling on tagging works correctly. This can't really be tested, other than when an actual tag is being created._

Closes #759 