### PR TITLE
Config: add tests for the `--generator=` argument

### DIFF
--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -2,7 +2,8 @@
 /**
  * Tests for the \PHP_CodeSniffer\Config --generator argument.
  *
- * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHP_CodeSniffer\Tests\Core\Config;
@@ -20,7 +21,7 @@ final class GeneratorArgTest extends TestCase
 
 
     /**
-     * Ensure that the generator property is set when the parameter is passed.
+     * Ensure that the generator property is set when the parameter is passed a valid value.
      *
      * @param string $generatorName Generator name.
      *
@@ -62,9 +63,9 @@ final class GeneratorArgTest extends TestCase
     {
         $config = new ConfigDouble(
             [
-                "--generator=Text",
-                "--generator=HTML",
-                "--generator=InvalidGenerator",
+                '--generator=Text',
+                '--generator=HTML',
+                '--generator=InvalidGenerator',
             ]
         );
 

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Config --generator argument.
+ *
+ * @license https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Config --generator argument.
+ *
+ * @covers \PHP_CodeSniffer\Config::processLongArgument
+ */
+final class GeneratorArgTest extends TestCase
+{
+
+
+    /**
+     * Ensure that the generator property is set when the parameter is passed.
+     *
+     * @param string $generatorName Generator name.
+     *
+     * @return       void
+     * @dataProvider dataGeneratorNames
+     */
+    public function testGenerators($generatorName)
+    {
+        $config = new ConfigDouble(["--generator=$generatorName"]);
+
+        $this->assertSame($generatorName, $config->generator);
+
+    }//end testGenerators()
+
+
+    /**
+     * Data provider for testGenerators().
+     *
+     * @return array<int, array<string>>
+     * @see    self::testGenerators()
+     */
+    public static function dataGeneratorNames()
+    {
+        return [
+            ['Text'],
+            ['HTML'],
+            ['Markdown'],
+        ];
+
+    }//end dataGeneratorNames()
+
+
+    /**
+     * Ensure that only the first argument is processed and others are ignored.
+     *
+     * @return void
+     */
+    public function testOnlySetOnce()
+    {
+        $config = new ConfigDouble(
+            [
+                "--generator=Text",
+                "--generator=HTML",
+                "--generator=InvalidGenerator",
+            ]
+        );
+
+        $this->assertSame('Text', $config->generator);
+
+    }//end testOnlySetOnce()
+
+
+}//end class

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -25,8 +25,9 @@ final class GeneratorArgTest extends TestCase
      *
      * @param string $generatorName Generator name.
      *
-     * @return       void
      * @dataProvider dataGeneratorNames
+     *
+     * @return void
      */
     public function testGenerators($generatorName)
     {
@@ -40,8 +41,9 @@ final class GeneratorArgTest extends TestCase
     /**
      * Data provider for testGenerators().
      *
+     * @see self::testGenerators()
+     *
      * @return array<int, array<string>>
-     * @see    self::testGenerators()
      */
     public static function dataGeneratorNames()
     {


### PR DESCRIPTION
# Description

In preparation for a PR to address #709, this PR adds tests to cover the current behavior of the code in the `Config` class that handles setting the `generator` property when the `--generator=` argument is passed in the command line.

## Related issues/external references

Related to #709


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.