### PR TITLE
GH Actions/verify-release: show output for release attestations

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -92,6 +92,7 @@ jobs:
         run: gh attestation verify ${{ steps.source.outputs.FILE }} -o PHPCSStandards
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_FORCE_TTY: true
 
       - name: Download public key
         env:
@@ -183,6 +184,7 @@ jobs:
         run: gh attestation verify ./tools/${{ matrix.pharfile }} -o PHPCSStandards
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_FORCE_TTY: true
 
       # Note: the `.` is in the command to make it work for both PHPCS as well PHPCBF.
       - name: Verify the PHAR is nominally functional


### PR DESCRIPTION
# Description
Apparently, by default, the GH CLI doesn't show any output when run from a GH Actions step.

This can be confusing and it makes debugging the workflow harder as, in case of failure, it is unclear what the step failed on.

The `GH_FORCE_TTY` environment variable (set to any value) should enable the normal output for the GH CLI command, which should fix this.

Refs:
* https://github.com/cli/cli/issues/10047
* https://cli.github.com/manual/gh_help_environment


## Suggested changelog entry
_N/A_

