### PR TITLE
Config: display user-friendly message when invalid generator is passed

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1215,7 +1215,20 @@ class Config
                     break;
                 }
 
-                $this->generator = substr($arg, 10);
+                $generatorName   = substr($arg, 10);
+                $validGenerators = [
+                    'Text',
+                    'HTML',
+                    'Markdown',
+                ];
+
+                if (in_array($generatorName, $validGenerators, true) === false) {
+                    $error  = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, and Markdown.'.PHP_EOL.PHP_EOL;
+                    $error .= $this->printShortUsage(true);
+                    throw new DeepExitException($error, 3);
+                }
+
+                $this->generator = $generatorName;
                 self::$overriddenDefaults['generator'] = true;
             } else if (substr($arg, 0, 9) === 'encoding=') {
                 if (isset(self::$overriddenDefaults['encoding']) === true) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -171,6 +171,21 @@ class Config
     private $cliArgs = [];
 
     /**
+     * A list of valid generators.
+     *
+     * {@internal Once support for PHP < 5.6 is dropped, this property should be refactored into a
+     * class constant.}
+     *
+     * @var array<string, string> Keys are the lowercase version of the generator name, while values
+     *                            are the associated PHP generator class.
+     */
+    private $validGenerators = [
+        'text'     => 'Text',
+        'html'     => 'HTML',
+        'markdown' => 'Markdown',
+    ];
+
+    /**
      * Command line values that the user has supplied directly.
      *
      * @var array<string, true|array<string, true>>
@@ -197,23 +212,6 @@ class Config
      * @var array<string, string>
      */
     private static $executablePaths = [];
-
-    /**
-     * A list of valid generators.
-     *
-     * - Keys: lowercase version of the generator name.
-     * - Values: name of the generator PHP class.
-     *
-     * Note: once support for PHP < 5.6 is dropped, this property should be refactored into a class
-     * constant.
-     *
-     * @var array<string, string>
-     */
-    private static $validGenerators = [
-        'text'     => 'Text',
-        'html'     => 'HTML',
-        'markdown' => 'Markdown',
-    ];
 
 
     /**
@@ -1235,18 +1233,20 @@ class Config
                 $generatorName          = substr($arg, 10);
                 $lowerCaseGeneratorName = strtolower($generatorName);
 
-                if (isset(self::$validGenerators[$lowerCaseGeneratorName]) === false) {
-                    $validOptions = implode(', ', array_values(self::$validGenerators));
-                    $error        = sprintf(
-                        'ERROR: "%s" is not a valid generator. Valid options are: %s.'.PHP_EOL.PHP_EOL,
+                if (isset($this->validGenerators[$lowerCaseGeneratorName]) === false) {
+                    $lastOption    = array_pop($this->validGenerators);
+                    $validOptions  = implode(', ', $this->validGenerators);
+                    $validOptions .= ' and '.$lastOption;
+                    $error         = sprintf(
+                        'ERROR: "%s" is not a valid generator. The following generators are supported: %s.'.PHP_EOL.PHP_EOL,
                         $generatorName,
                         $validOptions
                     );
-                    $error       .= $this->printShortUsage(true);
+                    $error        .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
 
-                $this->generator = self::$validGenerators[$lowerCaseGeneratorName];
+                $this->generator = $this->validGenerators[$lowerCaseGeneratorName];
                 self::$overriddenDefaults['generator'] = true;
             } else if (substr($arg, 0, 9) === 'encoding=') {
                 if (isset(self::$overriddenDefaults['encoding']) === true) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1234,15 +1234,14 @@ class Config
                 $lowerCaseGeneratorName = strtolower($generatorName);
 
                 if (isset($this->validGenerators[$lowerCaseGeneratorName]) === false) {
-                    $lastOption    = array_pop($this->validGenerators);
-                    $validOptions  = implode(', ', $this->validGenerators);
-                    $validOptions .= ' and '.$lastOption;
-                    $error         = sprintf(
+                    $validOptions = implode(', ', $this->validGenerators);
+                    $validOptions = substr_replace($validOptions, ' and', strrpos($validOptions, ','), 1);
+                    $error        = sprintf(
                         'ERROR: "%s" is not a valid generator. The following generators are supported: %s.'.PHP_EOL.PHP_EOL,
                         $generatorName,
                         $validOptions
                     );
-                    $error        .= $this->printShortUsage(true);
+                    $error       .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -198,6 +198,23 @@ class Config
      */
     private static $executablePaths = [];
 
+    /**
+     * A list of valid generators.
+     *
+     * - Keys: lowercase version of the generator name.
+     * - Values: name of the generator PHP class.
+     *
+     * Note: once support for PHP < 5.6 is dropped, this property should be refactored into a class
+     * constant.
+     *
+     * @var array<string, string>
+     */
+    private static $validGenerators = [
+        'text'     => 'Text',
+        'html'     => 'HTML',
+        'markdown' => 'Markdown',
+    ];
+
 
     /**
      * Get the value of an inaccessible property.
@@ -1215,20 +1232,21 @@ class Config
                     break;
                 }
 
-                $generatorName   = substr($arg, 10);
-                $validGenerators = [
-                    'Text',
-                    'HTML',
-                    'Markdown',
-                ];
+                $generatorName          = substr($arg, 10);
+                $lowerCaseGeneratorName = strtolower($generatorName);
 
-                if (in_array($generatorName, $validGenerators, true) === false) {
-                    $error  = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, and Markdown.'.PHP_EOL.PHP_EOL;
-                    $error .= $this->printShortUsage(true);
+                if (isset(self::$validGenerators[$lowerCaseGeneratorName]) === false) {
+                    $validOptions = implode(', ', array_values(self::$validGenerators));
+                    $error        = sprintf(
+                        'ERROR: "%s" is not a valid generator. Valid options are: %s.'.PHP_EOL.PHP_EOL,
+                        $generatorName,
+                        $validOptions
+                    );
+                    $error       .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
 
-                $this->generator = $generatorName;
+                $this->generator = self::$validGenerators[$lowerCaseGeneratorName];
                 self::$overriddenDefaults['generator'] = true;
             } else if (substr($arg, 0, 9) === 'encoding=') {
                 if (isset(self::$overriddenDefaults['encoding']) === true) {

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -25,27 +25,27 @@ final class GeneratorArgTest extends TestCase
      *
      * @param string $generatorName Generator name.
      *
-     * @dataProvider dataGeneratorNames
+     * @dataProvider dataValidGeneratorNames
      *
      * @return void
      */
-    public function testGenerators($generatorName)
+    public function testValidGenerators($generatorName)
     {
         $config = new ConfigDouble(["--generator=$generatorName"]);
 
         $this->assertSame($generatorName, $config->generator);
 
-    }//end testGenerators()
+    }//end testValidGenerators()
 
 
     /**
-     * Data provider for testGenerators().
+     * Data provider for testValidGenerators().
      *
-     * @see self::testGenerators()
+     * @see self::testValidGenerators()
      *
      * @return array<int, array<string>>
      */
-    public static function dataGeneratorNames()
+    public static function dataValidGeneratorNames()
     {
         return [
             ['Text'],
@@ -53,7 +53,7 @@ final class GeneratorArgTest extends TestCase
             ['Markdown'],
         ];
 
-    }//end dataGeneratorNames()
+    }//end dataValidGeneratorNames()
 
 
     /**
@@ -74,6 +74,53 @@ final class GeneratorArgTest extends TestCase
         $this->assertSame('Text', $config->generator);
 
     }//end testOnlySetOnce()
+
+
+    /**
+     * Ensure that an exception is thrown for an invalid generator.
+     *
+     * @param string $generatorName Generator name.
+     *
+     * @dataProvider dataInvalidGeneratorNames
+     *
+     * @return void
+     */
+    public function testInvalidGenerator($generatorName)
+    {
+        $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
+        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, and Markdown.';
+
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $message);
+        }
+
+        new ConfigDouble(["--generator={$generatorName}"]);
+
+    }//end testInvalidGenerator()
+
+
+    /**
+     * Data provider for testInvalidGenerator().
+     *
+     * @see self::testInvalidGenerator()
+     *
+     * @return array<int, array<string>>
+     */
+    public static function dataInvalidGeneratorNames()
+    {
+        return [
+            ['InvalidGenerator'],
+            ['Text,HTML'],
+            ['TEXT'],
+            [''],
+        ];
+
+    }//end dataInvalidGeneratorNames()
 
 
 }//end class

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -23,17 +23,18 @@ final class GeneratorArgTest extends TestCase
     /**
      * Ensure that the generator property is set when the parameter is passed a valid value.
      *
-     * @param string $generatorName Generator name.
+     * @param string $argumentValue         Generator name passed in the command line.
+     * @param string $expectedPropertyValue Expected value of the generator property.
      *
      * @dataProvider dataValidGeneratorNames
      *
      * @return void
      */
-    public function testValidGenerators($generatorName)
+    public function testValidGenerators($argumentValue, $expectedPropertyValue)
     {
-        $config = new ConfigDouble(["--generator=$generatorName"]);
+        $config = new ConfigDouble(["--generator=$argumentValue"]);
 
-        $this->assertSame($generatorName, $config->generator);
+        $this->assertSame($expectedPropertyValue, $config->generator);
 
     }//end testValidGenerators()
 
@@ -48,9 +49,30 @@ final class GeneratorArgTest extends TestCase
     public static function dataValidGeneratorNames()
     {
         return [
-            ['Text'],
-            ['HTML'],
-            ['Markdown'],
+            [
+                'Text',
+                'Text',
+            ],
+            [
+                'HTML',
+                'HTML',
+            ],
+            [
+                'Markdown',
+                'Markdown',
+            ],
+            [
+                'TEXT',
+                'Text',
+            ],
+            [
+                'tEXt',
+                'Text',
+            ],
+            [
+                'html',
+                'HTML',
+            ],
         ];
 
     }//end dataValidGeneratorNames()
@@ -88,7 +110,7 @@ final class GeneratorArgTest extends TestCase
     public function testInvalidGenerator($generatorName)
     {
         $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
-        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, and Markdown.';
+        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, Markdown.';
 
         if (method_exists($this, 'expectException') === true) {
             // PHPUnit 5+.
@@ -116,7 +138,6 @@ final class GeneratorArgTest extends TestCase
         return [
             ['InvalidGenerator'],
             ['Text,HTML'],
-            ['TEXT'],
             [''],
         ];
 

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -23,7 +23,7 @@ final class GeneratorArgTest extends TestCase
     /**
      * Ensure that the generator property is set when the parameter is passed a valid value.
      *
-     * @param string $argumentValue         Generator name passed in the command line.
+     * @param string $argumentValue         Generator name passed on the command line.
      * @param string $expectedPropertyValue Expected value of the generator property.
      *
      * @dataProvider dataValidGeneratorNames
@@ -49,29 +49,29 @@ final class GeneratorArgTest extends TestCase
     public static function dataValidGeneratorNames()
     {
         return [
-            [
-                'Text',
-                'Text',
+            'Text generator passed'            => [
+                'argumentValue'         => 'Text',
+                'expectedPropertyValue' => 'Text',
             ],
-            [
-                'HTML',
-                'HTML',
+            'HTML generator passed'            => [
+                'argumentValue'         => 'HTML',
+                'expectedPropertyValue' => 'HTML',
             ],
-            [
-                'Markdown',
-                'Markdown',
+            'Markdown generator passed'        => [
+                'argumentValue'         => 'Markdown',
+                'expectedPropertyValue' => 'Markdown',
             ],
-            [
-                'TEXT',
-                'Text',
+            'Uppercase Text generator passed'  => [
+                'argumentValue'         => 'TEXT',
+                'expectedPropertyValue' => 'Text',
             ],
-            [
-                'tEXt',
-                'Text',
+            'Mixed case Text generator passed' => [
+                'argumentValue'         => 'tEXt',
+                'expectedPropertyValue' => 'Text',
             ],
-            [
-                'html',
-                'HTML',
+            'Lowercase HTML generator passed'  => [
+                'argumentValue'         => 'html',
+                'expectedPropertyValue' => 'HTML',
             ],
         ];
 
@@ -110,7 +110,7 @@ final class GeneratorArgTest extends TestCase
     public function testInvalidGenerator($generatorName)
     {
         $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
-        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. Valid options are: Text, HTML, Markdown.';
+        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. The following generators are supported: Text, HTML and Markdown.';
 
         if (method_exists($this, 'expectException') === true) {
             // PHPUnit 5+.


### PR DESCRIPTION
# Description

This PR improves how `Config::processLongArgument()` handles the `--generator` parameter to display a user-friendly message if an invalid generator name is passed. Before, an invalid generator name caused a fatal error.

I have checked, and it is not possible to add custom generators using third-party code (at least not without adding files to the PHPCS directory). This is because the `Runner` class only loads generators found in the `src/Generator/` directory:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/3d14d004265ac6e38f3e161316cf51b7b4812414/src/Runner.php#L97-L98

So, it should be fine to limit the list of valid generators added in this PR to only the three generators provided by PHPCS.

## Suggested changelog entry
Config: display a user-friendly message if an invalid generator name is passed in the command line

## Related issues/external references

Fixes #709 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.