### PR TITLE
Squiz/PropertyDeclaration: add fixer for 'var' keyword

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -53,7 +53,10 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
 
         if ($tokens[$prev]['code'] === T_VAR) {
             $error = 'The var keyword must not be used to declare a property';
-            $phpcsFile->addError($error, $stackPtr, 'VarUsed');
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'VarUsed');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($prev, 'public');
+            }
         }
 
         $next = $phpcsFile->findNext([T_VARIABLE, T_SEMICOLON], ($stackPtr + 1));

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -6,9 +6,9 @@ class MyClass
     private $var = null;
     $var = null;
 
-    var $var = null;
+    public $var = null;
     static $var = null;
-    public var $var = null; // Parse error.
+    public public $var = null; // Parse error.
 
     public $_var = null;
     protected $_var = null;
@@ -46,7 +46,7 @@ class MyClass
     public string $var = null;
     protected ?Folder\ClassName $var = null;
 
-    var int $var = null;
+    public int $var = null;
     static int $var = null;
 
     private int $_var = null;


### PR DESCRIPTION
This pull request adds a fixer for the `var` keyword on class properties.


# Description
We have been running this fixer for many years in Drupal's Coder https://github.com/pfrenssen/coder/blob/8.3.x/coder_sniffer/Drupal/Sniffs/Classes/PropertyDeclarationSniff.php#L59 .

The `var` keyword is equivalent to `public`, so we can replace it with that.

## Suggested changelog entry
PSR2.Classes.PropertyDeclaration.VarUsed: Added a fixer that converts the `var` keyword into `public`.


## Related issues/external references
https://github.com/pfrenssen/coder/blob/8.3.x/coder_sniffer/Drupal/Sniffs/Classes/PropertyDeclarationSniff.php


## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.