### PR TITLE
Squiz/FunctionSpacing: fixer is broken with doc comment on closing brace line

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -149,6 +149,11 @@ class FunctionSpacingSniff implements Sniff
 
         // Allow for comments on the same line as the closer.
         for ($nextLineToken = ($closer + 1); $nextLineToken < $phpcsFile->numTokens; $nextLineToken++) {
+            // A doc comment belongs to the next statement and must not be on
+            // this line.
+            if ($tokens[$nextLineToken]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                break;
+            }
             if ($tokens[$nextLineToken]['line'] !== $tokens[$closer]['line']) {
                 break;
             }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -154,6 +154,7 @@ class FunctionSpacingSniff implements Sniff
             if ($tokens[$nextLineToken]['code'] === T_DOC_COMMENT_OPEN_TAG) {
                 break;
             }
+
             if ($tokens[$nextLineToken]['line'] !== $tokens[$closer]['line']) {
                 break;
             }

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc
@@ -582,3 +582,14 @@ echo 'this line belongs with the #3904 test';
 
 function Foo() {} function bar($name){}
 echo 'this line belongs with the #3904 test';
+
+
+/**
+ * foo.
+ */
+function a() {
+}/**
+ * foo.
+ */
+function b() {
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc.fixed
@@ -671,3 +671,17 @@ function Foo() {} function bar($name){}
 
 
 echo 'this line belongs with the #3904 test';
+
+
+/**
+ * foo.
+ */
+function a() {
+}
+
+
+/**
+ * foo.
+ */
+function b() {
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -102,6 +102,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffUnitTest
                 566 => 1,
                 580 => 2,
                 583 => 3,
+                591 => 1,
             ];
 
         case 'FunctionSpacingUnitTest.2.inc':


### PR DESCRIPTION
The fixer in Squiz.WhiteSpace.FunctionSpacing gets confused when there is a doc comment on the closing brace line:

# Description
Solves this fixer infinite loop
```php
/**
 * foo.
 */
function a() {
}/**
 * foo.
 */
function b() {
}
```

## Suggested changelog entry
Squiz.WhiteSpace.FunctionSpacing: Fix the fixer when there is a doc comment on the function closing line.

## Related issues/external references

https://www.drupal.org/project/coder/issues/3461139


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.