### PR TITLE
Config: can use custom LocalFile object

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -52,6 +52,7 @@ use PHP_CodeSniffer\Util\Standards;
  * @property string     $generator       The documentation generator to use.
  * @property string     $filter          The filter to use for the run.
  * @property string[]   $bootstrap       One of more files to include before the run begins.
+ * @property string     $localFile       The LocalFile object to use in FileList.
  * @property int|string $reportWidth     The maximum number of columns that reports should use for output.
  *                                       Set to "auto" for have this value changed to the width of the terminal.
  * @property int        $errorSeverity   The minimum severity an error must have to be displayed.
@@ -138,6 +139,7 @@ class Config
         'generator'       => null,
         'filter'          => null,
         'bootstrap'       => null,
+        'localFile'       => null,
         'reports'         => null,
         'basepath'        => null,
         'reportWidth'     => null,
@@ -540,6 +542,7 @@ class Config
         $this->generator       = null;
         $this->filter          = null;
         $this->bootstrap       = [];
+        $this->localFile       = null;
         $this->basepath        = null;
         $this->reports         = ['full' => null];
         $this->reportWidth     = 'auto';


### PR DESCRIPTION
## Description
I'm the author of package [PHPCS-Ignores](https://github.com/forrest79/phpcs-ignores) that allows to ignore PHPCS errors/warning in the similar way as PHPStan - you have a file with listed ignores.

To make this happen, I need some extra logic in `LocalFile` class. I'm using my own `LocalFile` that extends the original one.

`LocalFile` is hardcoded in `FileList`. To force PHP_CodeSniffer to use my own class, I do some magic via stream wrapper that update `FileList.php` on the fly. I was thinking if it would be possible to allow this without a hacking through `Config` class.

I prepared a small example that works for me. I'm able to update config entry in bootstrap file, that you must use if you want to use my package.

This is just proof of work, I will add tests later if this change will be approved.

### Suggested changelog entry
Internals: can use own LocalFile class.


## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.
