### PR TITLE
GH Actions: speed up slow jobs by using Linux Arm64

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -27,12 +27,12 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-24.04-arm', 'windows-latest']
         php: ['7.2', 'latest']
 
         include:
           - php: '5.4'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-24.04-arm'
             custom_ini: false
           # Installing on Windows with PHP 5.4 runs into all sorts of problems with Composer.
           # See this issue for more context (yes, I've seen this problem before):
@@ -41,7 +41,7 @@ jobs:
             os: 'windows-latest'
             custom_ini: false
 
-    name: "QuickTest: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
+    name: "QuickTest: PHP ${{ matrix.php }} (${{ matrix.os == 'windows-latest' && 'Win' || 'Linux ARM' }})"
 
     steps:
       - name: Prepare git to leave line endings alone


### PR DESCRIPTION
# Description

ℹ️ **PR title and description has been updated to reflect the latest state of the PR.**

--- 

GitHub has made Linux arm64 runners generally available and running tasks on these images instead of the traditional images can deliver up to a 40% performance boost.

Based on our testing with this, the performance benefit is minimal to non-existent in our test setup and as the code base contains no `arm64` specific code/conditions, there is also no _functional_ benefit to running the tests on `arm64`.

Having said that, having some test runs on `arm64` can serve as an early detection system in case code changes would be needed in the future.

With this in mind and after some discussion about this, this commit ONLY introduces `arm64` in the `quicktest` workflow which is run for branch pushes (with the exception of pushes to `master`).

That means that in practice, it will run:
* When contributors with `push` rights push a branch directly to this server.
* When contributors without `push` rights, but who have enabled workflow runs on their own fork of the repo, push a branch to their fork.

The "normal" (PR) `test` runs will not use `arm64` at this time.

This does mean that a test run failure against `arm64` for a PR contribution via a fork _could_ go unnoticed, but as stated above: as the code contains no `arm64` specific conditions, this is deemed unlikely and is seen as an acceptable risk.

If needs be, this can be revisited in a later iteration.

Refs:
* https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/
* https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
* https://fraudmarc.com/post/arm64-vs-x86-64-for-php

## Suggested changelog entry
_N/A_