### PR TITLE
Squiz/FunctionDeclarationArgumentSpacing: handle constructor property promotion

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -370,55 +370,46 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                 }
 
                 if ($checkComma === true) {
-                    if ($param['type_hint_token'] === false) {
-                        $spacesAfter = 0;
-                        if ($tokens[($commaToken + 1)]['code'] === T_WHITESPACE) {
-                            $spacesAfter = $tokens[($commaToken + 1)]['length'];
+                    $typeOfNext      = 'argument';
+                    $typeOfNextShort = 'Arg';
+                    $contentOfNext   = $param['name'];
+
+                    if ($param['type_hint_token'] !== false) {
+                        $typeOfNext      = 'type hint';
+                        $typeOfNextShort = 'Hint';
+                        $contentOfNext   = $param['type_hint'];
+                    }
+
+                    $spacesAfter = 0;
+                    if ($tokens[($commaToken + 1)]['code'] === T_WHITESPACE) {
+                        $spacesAfter = $tokens[($commaToken + 1)]['length'];
+                    }
+
+                    if ($spacesAfter === 0) {
+                        $error     = 'Expected 1 space between comma and %s "%s"; 0 found';
+                        $errorCode = 'NoSpaceBefore'.$typeOfNextShort;
+                        $data      = [
+                            $typeOfNext,
+                            $contentOfNext,
+                        ];
+
+                        $fix = $phpcsFile->addFixableError($error, $commaToken, $errorCode, $data);
+                        if ($fix === true) {
+                            $phpcsFile->fixer->addContent($commaToken, ' ');
                         }
+                    } else if ($spacesAfter !== 1) {
+                        $error     = 'Expected 1 space between comma and %s "%s"; %s found';
+                        $errorCode = 'SpacingBefore'.$typeOfNextShort;
+                        $data      = [
+                            $typeOfNext,
+                            $contentOfNext,
+                            $spacesAfter,
+                        ];
 
-                        if ($spacesAfter === 0) {
-                            $error = 'Expected 1 space between comma and argument "%s"; 0 found';
-                            $data  = [$param['name']];
-                            $fix   = $phpcsFile->addFixableError($error, $commaToken, 'NoSpaceBeforeArg', $data);
-                            if ($fix === true) {
-                                $phpcsFile->fixer->addContent($commaToken, ' ');
-                            }
-                        } else if ($spacesAfter !== 1) {
-                            $error = 'Expected 1 space between comma and argument "%s"; %s found';
-                            $data  = [
-                                $param['name'],
-                                $spacesAfter,
-                            ];
-
-                            $fix = $phpcsFile->addFixableError($error, $commaToken, 'SpacingBeforeArg', $data);
-                            if ($fix === true) {
-                                $phpcsFile->fixer->replaceToken(($commaToken + 1), ' ');
-                            }
-                        }//end if
-                    } else {
-                        $hint = $param['type_hint'];
-
-                        if ($tokens[($commaToken + 1)]['code'] !== T_WHITESPACE) {
-                            $error = 'Expected 1 space between comma and type hint "%s"; 0 found';
-                            $data  = [$hint];
-                            $fix   = $phpcsFile->addFixableError($error, $commaToken, 'NoSpaceBeforeHint', $data);
-                            if ($fix === true) {
-                                $phpcsFile->fixer->addContent($commaToken, ' ');
-                            }
-                        } else {
-                            $gap = $tokens[($commaToken + 1)]['length'];
-                            if ($gap !== 1) {
-                                $error = 'Expected 1 space between comma and type hint "%s"; %s found';
-                                $data  = [
-                                    $hint,
-                                    $gap,
-                                ];
-                                $fix   = $phpcsFile->addFixableError($error, $commaToken, 'SpacingBeforeHint', $data);
-                                if ($fix === true) {
-                                    $phpcsFile->fixer->replaceToken(($commaToken + 1), ' ');
-                                }
-                            }
-                        }//end if
+                        $fix = $phpcsFile->addFixableError($error, $commaToken, $errorCode, $data);
+                        if ($fix === true) {
+                            $phpcsFile->fixer->replaceToken(($commaToken + 1), ' ');
+                        }
                     }//end if
                 }//end if
             }//end if

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -306,6 +306,71 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                 }//end if
             }//end if
 
+            if (isset($param['visibility_token']) === true && $param['visibility_token'] !== false) {
+                $visibilityToken      = $param['visibility_token'];
+                $afterVisibilityToken = $phpcsFile->findNext(T_WHITESPACE, ($visibilityToken + 1), $param['token'], true);
+
+                $spacesAfter = 0;
+                if ($afterVisibilityToken !== false
+                    && $tokens[$visibilityToken]['line'] !== $tokens[$afterVisibilityToken]['line']
+                ) {
+                    $spacesAfter = 'newline';
+                } else if ($tokens[($visibilityToken + 1)]['code'] === T_WHITESPACE) {
+                    $spacesAfter = $tokens[($visibilityToken + 1)]['length'];
+                }
+
+                if ($spacesAfter !== 1) {
+                    $error = 'Expected 1 space after visibility modifier "%s"; %s found';
+                    $data  = [
+                        $tokens[$visibilityToken]['content'],
+                        $spacesAfter,
+                    ];
+
+                    $fix = $phpcsFile->addFixableError($error, $visibilityToken, 'SpacingAfterVisbility', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+                        $phpcsFile->fixer->addContent($visibilityToken, ' ');
+
+                        for ($i = ($visibilityToken + 1); $tokens[$i]['code'] === T_WHITESPACE; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }//end if
+            }//end if
+
+            if (isset($param['readonly_token']) === true) {
+                $readonlyToken      = $param['readonly_token'];
+                $afterReadonlyToken = $phpcsFile->findNext(T_WHITESPACE, ($readonlyToken + 1), $param['token'], true);
+
+                $spacesAfter = 0;
+                if ($afterReadonlyToken !== false
+                    && $tokens[$readonlyToken]['line'] !== $tokens[$afterReadonlyToken]['line']
+                ) {
+                    $spacesAfter = 'newline';
+                } else if ($tokens[($readonlyToken + 1)]['code'] === T_WHITESPACE) {
+                    $spacesAfter = $tokens[($readonlyToken + 1)]['length'];
+                }
+
+                if ($spacesAfter !== 1) {
+                    $error = 'Expected 1 space after readonly modifier; %s found';
+                    $data  = [$spacesAfter];
+
+                    $fix = $phpcsFile->addFixableError($error, $readonlyToken, 'SpacingAfterReadonly', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+                        $phpcsFile->fixer->addContent($readonlyToken, ' ');
+
+                        for ($i = ($readonlyToken + 1); $tokens[$i]['code'] === T_WHITESPACE; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }//end if
+            }//end if
+
             $commaToken = false;
             if ($paramNumber > 0 && $params[($paramNumber - 1)]['comma_token'] !== false) {
                 $commaToken = $params[($paramNumber - 1)]['comma_token'];

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -374,7 +374,12 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                     $typeOfNextShort = 'Arg';
                     $contentOfNext   = $param['name'];
 
-                    if ($param['type_hint_token'] !== false) {
+                    if (isset($param['property_visibility']) === true) {
+                        $typeOfNext      = 'property modifier';
+                        $typeOfNextShort = 'PropertyModifier';
+                        $modifier        = $phpcsFile->findNext(Tokens::$emptyTokens, ($commaToken + 1), $param['token'], true);
+                        $contentOfNext   = $tokens[$modifier]['content'];
+                    } else if ($param['type_hint_token'] !== false) {
                         $typeOfNext      = 'type hint';
                         $typeOfNextShort = 'Hint';
                         $contentOfNext   = $param['type_hint'];

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
@@ -195,3 +195,7 @@ function newlineBeforeCommaFixerRespectsComments(
     , $paramC=30
     , string $paramC='foo'
 ) {}
+
+class PropertyPromotionSpacingAfterComma {
+    public function __construct(private string|int $propA, protected bool $correctSpace,  public MyClass $tooMuchSpace,readonly string $noSpace) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
@@ -199,3 +199,14 @@ function newlineBeforeCommaFixerRespectsComments(
 class PropertyPromotionSpacingAfterComma {
     public function __construct(private string|int $propA, protected bool $correctSpace,  public MyClass $tooMuchSpace,readonly string $noSpace) {}
 }
+
+class PropertyPromotionSpacingAfterModifier {
+    public function __construct(
+        private$noSpace,
+        public    MyClass $tooMuchSpace,
+        protected   readonly   string $tooMuchSpaceX2,
+        readonly
+        public
+        string $tooMuchSpaceNewLines,
+    ) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
@@ -171,3 +171,7 @@ function newlineBeforeCommaFixerRespectsComments(
     $paramC=30,
     string $paramC='foo'
 ) {}
+
+class PropertyPromotionSpacingAfterComma {
+    public function __construct(private string|int $propA, protected bool $correctSpace, public MyClass $tooMuchSpace, readonly string $noSpace) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
@@ -175,3 +175,12 @@ function newlineBeforeCommaFixerRespectsComments(
 class PropertyPromotionSpacingAfterComma {
     public function __construct(private string|int $propA, protected bool $correctSpace, public MyClass $tooMuchSpace, readonly string $noSpace) {}
 }
+
+class PropertyPromotionSpacingAfterModifier {
+    public function __construct(
+        private $noSpace,
+        public MyClass $tooMuchSpace,
+        protected readonly string $tooMuchSpaceX2,
+        readonly public string $tooMuchSpaceNewLines,
+    ) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -89,6 +89,7 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnit
                 193 => 1,
                 195 => 1,
                 196 => 1,
+                200 => 2,
             ];
 
         default:

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -90,6 +90,11 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnit
                 195 => 1,
                 196 => 1,
                 200 => 2,
+                205 => 1,
+                206 => 1,
+                207 => 2,
+                208 => 1,
+                209 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

### Squiz/FunctionDeclarationArgumentSpacing: refactor logic for for "spacing after comma" check

This refactor has two purposes:
* Reduce code duplication.
* Prevent introducing even more code duplication when a new error code will be introduced in the next commit.

### Squiz/FunctionDeclarationArgumentSpacing: special case "spacing after comma" vs constructor property promotion

While incorrect spacing after a comma for constructor property promotion parameters would already be flagged and fixed by the sniff, the error message and code were incorrect/unclear.

Given the following test code:
```php
class PropertyPromotionSpacingAfterComma {
    public function __construct(private string|int $propA, protected bool $correctSpace,  public MyClass $tooMuchSpace,readonly string $noSpace) {}
}
```

Previously the following would be reported:
```
 198 | ERROR | [x] Expected 1 space between comma and type hint "MyClass"; 2 found
     |       |     (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeHint)
 198 | ERROR | [x] Expected 1 space between comma and type hint "string"; 0 found
     |       |     (Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeHint)
```

Take note of the "type hint" in the message and the "Hint" suffix for the error codes.

With the fix from this commit in place, this will now be reported as follows:
```
 198 | ERROR | [x] Expected 1 space between comma and property modifier "public"; 2 found
     |       |     (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforePropertyModifier)
 198 | ERROR | [x] Expected 1 space between comma and property modifier "readonly"; 0 found
     |       |     (Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforePropertyModifier)
```

Includes tests.

### Squiz/FunctionDeclarationArgumentSpacing: handle modifiers for constructor property promotion

The spacing after visibility/`readonly` modifiers for constructor property promotion were so far not checked by this sniff.

While the `Squiz.WhiteSpace.ScopeKeywordSpacing` sniff will already handle this, that sniff may not be in use in all standards using this sniff. As things were, this sniff was just no longer feature complete for the task this sniff is supposed to handle: spacing of function declaration arguments.

This commit adds handling the spacing after modifiers used for constructor property promotion to this sniff.

The spacing requirements are aligned with the spacing expectations of the `Squiz.WhiteSpace.ScopeKeywordSpacing` sniff, so the sniffs should not conflict with each other.

Additionally, the new checks in this sniff have dedicated error codes, which means that - if there would be a conflict anywhere - the modifier spacing checks within this sniff can easily be turned off.

Includes tests.

## Suggested changelog entry

### Changed
* Squiz.Functions.FunctionDeclarationArgumentSpacing: incorrect spacing after a comma followed by a promoted property has an improved error message and will now be flagged with the `SpacingBeforePropertyModifier` or `NoSpaceBeforePropertyModifier` error codes.
* The Squiz.Functions.FunctionDeclarationArgumentSpacing sniff will now also check the spacing around property modifiers for promoted properties in the function signature of constructors


## Related issues/external references

Loosely related to/ follow up on #620 and #783 


## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
