### PR TITLE
Squiz/ScopeKeywordSpacing: add additional tests

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -44,7 +44,9 @@ class ScopeKeywordSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[($stackPtr + 1)]) === false) {
+        $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($nextNonWhitespace === false) {
+            // Parse error/live coding. Bow out.
             return;
         }
 
@@ -126,9 +128,6 @@ class ScopeKeywordSpacingSniff implements Sniff
 
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             $spacing = 0;
-        } else if (isset($tokens[($stackPtr + 2)]) === false) {
-            // Parse error/live coding. Bow out.
-            return;
         } else {
             if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
                 $spacing = 'newline';

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -77,10 +77,10 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 
-    // Intentionally missing a semicolon for testing.
     public
         $varS,
-        $varT
+        $varT,
+        $varU;
 }
 
 // Issue #3188 - static as return type.

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -174,3 +174,16 @@ final class FinalSpacingCorrect {
 abstract class AbstractSpacingCorrect {
     public abstract function spacingCorrect() {}
 }
+
+$closure = static function() { return 'spacing correct'; };
+$closure =   static     function() { return 'spacing incorrect'; };
+
+class ConstantVisibility {
+    public const PUBLIC_SPACING_CORRECT = true;
+    protected const PROTECTED_SPACING_CORRECT = true;
+    private const PRIVATE_SPACING_CORRECT = true;
+
+    public     const PUBLIC_SPACING_INCORRECT = true;
+    protected  const PROTECTED_SPACING_INCORRECT = true;
+    private    const PRIVATE_SPACING_INCORRECT = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -81,23 +81,23 @@ class MyOtherClass
         $varS,
         $varT,
         $varU;
-}
 
-// Issue #3188 - static as return type.
-public static function fCreate($attributes = []): static
-{
-    return static::factory()->create($attributes);
-}
+    // Issue #3188 - static as return type.
+    public static function staticAsReturnType($attributes = []): static
+    {
+        return static::factory()->create($attributes);
+    }
 
-public static function fCreate($attributes = []): ?static
-{
-    return static::factory()->create($attributes);
-}
+    public static function nullableStaticReturnType($attributes = []): ?static
+    {
+        return static::factory()->create($attributes);
+    }
 
-// Also account for static used within union types.
-public function staticLast($attributes = []): object|static {}
-public function staticMiddle(): string|static|object {}
-public function staticFirst(): static|object {}
+    // Also account for static used within union types.
+    public function staticLast($attributes = []): object|static {}
+    public function staticMiddle(): string|static|object {}
+    public function staticFirst(): static|object {}
+}
 
 // Ensure that static as a scope keyword when preceeded by a colon which is not for a type declaration is still handled.
 $callback = $cond ? get_fn_name() : static  function ($a) { return $a * 10; };

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -72,10 +72,10 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 
-    // Intentionally missing a semicolon for testing.
     public
         $varS,
-        $varT
+        $varT,
+        $varU;
 }
 
 // Issue #3188 - static as return type.

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -76,23 +76,23 @@ class MyOtherClass
         $varS,
         $varT,
         $varU;
-}
 
-// Issue #3188 - static as return type.
-public static function fCreate($attributes = []): static
-{
-    return static::factory()->create($attributes);
-}
+    // Issue #3188 - static as return type.
+    public static function staticAsReturnType($attributes = []): static
+    {
+        return static::factory()->create($attributes);
+    }
 
-public static function fCreate($attributes = []): ?static
-{
-    return static::factory()->create($attributes);
-}
+    public static function nullableStaticReturnType($attributes = []): ?static
+    {
+        return static::factory()->create($attributes);
+    }
 
-// Also account for static used within union types.
-public function staticLast($attributes = []): object|static {}
-public function staticMiddle(): string|static|object {}
-public function staticFirst(): static|object {}
+    // Also account for static used within union types.
+    public function staticLast($attributes = []): object|static {}
+    public function staticMiddle(): string|static|object {}
+    public function staticFirst(): static|object {}
+}
 
 // Ensure that static as a scope keyword when preceeded by a colon which is not for a type declaration is still handled.
 $callback = $cond ? get_fn_name() : static function ($a) { return $a * 10; };

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -167,3 +167,16 @@ final class FinalSpacingCorrect {
 abstract class AbstractSpacingCorrect {
     public abstract function spacingCorrect() {}
 }
+
+$closure = static function() { return 'spacing correct'; };
+$closure =   static function() { return 'spacing incorrect'; };
+
+class ConstantVisibility {
+    public const PUBLIC_SPACING_CORRECT = true;
+    protected const PROTECTED_SPACING_CORRECT = true;
+    private const PRIVATE_SPACING_CORRECT = true;
+
+    public const PUBLIC_SPACING_INCORRECT = true;
+    protected const PROTECTED_SPACING_INCORRECT = true;
+    private const PRIVATE_SPACING_INCORRECT = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.4.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.4.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Intentional parse error.
+// Testing handling of multi-property statements during live coding (missing semicolon after statement).
+// This must be the only test in this file.
+class MyOtherClass
+{
+    public
+        $varS,
+        $varT
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -65,6 +65,10 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
                 163 => 1,
                 166 => 1,
                 167 => 1,
+                179 => 1,
+                186 => 1,
+                187 => 1,
+                188 => 1,
             ];
 
         case 'ScopeKeywordSpacingUnitTest.3.inc':


### PR DESCRIPTION
# Description

### Squiz/ScopeKeywordSpacing: move parse error test to separate file 

Done in a way to maintain the error line numbers for the rest of the file.

### Squiz/ScopeKeywordSpacing: move some method tests into a class 

... as otherwise the test methods would be _unintentional_ parse errors.

Includes making the method names unique.

### Squiz/ScopeKeywordSpacing: add additional tests 

This commit adds a few of tests for syntaxes in which the target keywords could be used, which were so far not covered by tests:
* Tests with the `static` modifier keyword being used for closures.
* Tests with visibility keyword applied to class constants.

### Squiz/ScopeKeywordSpacing: minor efficiency tweak 

Bow out earlier when the sniff won't be able to action anything anyway (live coding/parse errors).

## Suggested changelog entry
Squiz.WhiteSpace.ScopeKeywordSpacing: minor efficiency improvement


## Related issues/external references

Follow up on https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/604#pullrequestreview-2274455160

