### PR TITLE
GH Actions/test: add missing condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
         run: php "vendor/bin/phpunit" tests/AllTests.php --no-coverage
 
       - name: 'PHPUnit: run select tests in CBF mode'
+        if: ${{ matrix.skip_tests != true }}
         run: php "vendor/bin/phpunit" tests/AllTests.php --group CBF --exclude-group nothing --no-coverage
         env:
           PHP_CODESNIFFER_CBF: '1'


### PR DESCRIPTION
# Description
The `skip_tests` matrix condition is used to not duplicate test runs which are run in the code coverage jobs anyway. This condition was missing for the CBF mode test run, while that step is also run in the code coverage job.

Fixed now.

## Suggested changelog entry
_N/A_