### PR TITLE
PHPBCF: Show `no errors were found` when there are no errors to fix.

### DIFF
--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -149,7 +149,12 @@ class Cbf implements Report
         array_pop($lines);
 
         if (empty($lines) === true) {
-            echo PHP_EOL.'No fixable errors were found'.PHP_EOL;
+            if (($totalErrors + $totalWarnings) === 0) {
+                echo PHP_EOL.'No errors were found'.PHP_EOL;
+            } else {
+                echo PHP_EOL.'No fixable errors were found'.PHP_EOL;
+            }
+
             return;
         }
 

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -150,7 +150,7 @@ class Cbf implements Report
 
         if (empty($lines) === true) {
             if (($totalErrors + $totalWarnings) === 0) {
-                echo PHP_EOL.'No errors were found'.PHP_EOL;
+                echo PHP_EOL.'No violations were found'.PHP_EOL;
             } else {
                 echo PHP_EOL.'No fixable errors were found'.PHP_EOL;
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Modifies the output of `phpcbf` when the exiting without fixing any errors to show a message indicating that the reasons was due to no coding standards violations in the code base.

The purpose is to make it clearer to developers running `phpcbf` that the reason no errors were fixed is because there were none to fix. 

I haven't been able to find tests for the `phpcbf` exit messages (searching for the phrase "No fixable errors were found") so I haven't added tests for this change. Please do point me to the relevant location if I have missed something.

_Edit: I've pushed a change to the message based on a discussion on the ticket. As/if further input arrives, I'll make any changes as required._

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

PHPCBF exits with the message `[INSERT FINAL MESSAGE HERE]` when no CS violations exist in the project.

## Related issues/external references

Fixes #806


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
