### PR TITLE
Help: update list of config options

### DIFF
--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -573,7 +573,7 @@ final class Help
 
             'config-explain' => [
                 'text' => 'Default values for a selection of options can be stored in a user-specific CodeSniffer.conf configuration file.'."\n"
-                    .'This applies to the following options: "default_standard", "report_format", "tab_width", "encoding", "severity", "error_severity", "warning_severity", "show_warnings", "report_width", "show_progress", "quiet", "colors", "cache", "parallel".',
+                    .'This applies to the following options: "default_standard", "report_format", "tab_width", "encoding", "severity", "error_severity", "warning_severity", "show_warnings", "report_width", "show_progress", "quiet", "colors", "cache", "parallel", "installed_paths", "php_version", "ignore_errors_on_exit", "ignore_warnings_on_exit".',
             ],
             'config-show'    => [
                 'argument'    => '--config-show',


### PR DESCRIPTION
# Description

Follow up on #447

I noticed while working on something else that some typical config options were missing from the list in the help text.

The difference between the previously listed ones and the additional options I'm now adding to the list, is that the original set of options are options which the `Config` class manages and for which it has a default value, while the additional options I'm now adding are used at runtime in various places by PHPCS, but do not have default value management in the `Config` class.

Whether default value handling of these options should be added to the `Config` class is up for debate, however, making it more discoverable that these options _exist_ and can be used, seems like an easy win for usability.

* `installed_paths` is probably the best known one and is used to register external standards with PHPCS. It is used in the `Util\Standards` class.
* `php_version` is a way to tell PHPCS what PHP version the code is supposed to run on. It is used by select sniffs.
* `ignore_errors_on_exit` and `ignore_warnings_on_exit` influence the exit code used by PHPCS and is used in the `Runner` class.

These additional options are all mentioned and described in more detail in the wiki: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options


## Suggested changelog entry
The `-h` option now contains a more extensive list of "config" options which can be set.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2412
/cc @aik099

