### PR TITLE
Tests/Tokenizer: improve switch keyword tests

### DIFF
--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.inc
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.inc
@@ -8,11 +8,12 @@ switch ($value) {
     default :
         echo 'other';
         break;
+/* testSwitchNormalSyntaxScopeCloser */
 }
 
 // Test for https://github.com/squizlabs/PHP_CodeSniffer/issues/497
 /* testSwitchAlternativeSyntax */
-switch ($value):
+switch ($value) :
     /* testSwitchAlternativeSyntaxEnsureTestWillNotPickUpWrongColon */
     case 1:
         echo 'one';
@@ -20,7 +21,7 @@ switch ($value):
     default:
         echo 'other';
         break;
-/* testSwitchAlternativeSyntaxEnd */
+/* testSwitchAlternativeSyntaxScopeCloser */
 endswitch;
 
 // Test for https://github.com/squizlabs/PHP_CodeSniffer/issues/543
@@ -30,4 +31,5 @@ switch((function () {
 })()) /* testSwitchClosureWithinConditionScopeOpener */ {
     case 1:
         return 'test';
+/* testSwitchClosureWithinConditionScopeCloser */
 }

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.inc
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.inc
@@ -33,3 +33,28 @@ switch((function () {
         return 'test';
 /* testSwitchClosureWithinConditionScopeCloser */
 }
+
+/* testSwitchClosureWithReturnTypeWithinCondition */
+switch((function (): string {
+    return 'bar';
+})()) /* testSwitchClosureWithReturnTypeWithinConditionScopeOpener */ :
+    /* testSwitchClosureWithReturnTypeWithinConditionEnsureTestWillNotPickUpWrongColon */
+    case 1:
+        return 'test';
+/* testSwitchClosureWithReturnTypeWithinConditionScopeCloser */
+endswitch;
+
+/* testSwitchArrowFunctionWithinCondition */
+switch((fn() => $obj->{$foo . $bar})()) /* testSwitchArrowFunctionWithinConditionScopeOpener */ {
+    case 1:
+        return 'test';
+/* testSwitchArrowFunctionWithinConditionScopeCloser */
+}
+
+/* testSwitchArrowFunctionWithReturnTypeWithinCondition */
+switch((fn(): string => $condition ? 'foo' : 'bar')()) /* testSwitchArrowFunctionWithReturnTypeWithinConditionScopeOpener */ :
+    /* testSwitchArrowFunctionWithReturnTypeWithinConditionEnsureTestWillNotPickUpWrongColon */
+    case 1:
+        return 'test';
+/* testSwitchArrowFunctionWithReturnTypeWithinConditionScopeCloser */
+endswitch;

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
@@ -98,11 +98,13 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
     {
         return [
             'switch normal syntax'                 => [
-                'testMarker'     => '/* testSwitchNormalSyntax */',
-                'expectedTokens' => [
+                'testMarker'       => '/* testSwitchNormalSyntax */',
+                'expectedTokens'   => [
                     'scope_opener' => T_OPEN_CURLY_BRACKET,
                     'scope_closer' => T_CLOSE_CURLY_BRACKET,
                 ],
+                'testOpenerMarker' => null,
+                'testCloserMarker' => '/* testSwitchNormalSyntaxScopeCloser */',
             ],
             'switch alternative syntax'            => [
                 'testMarker'       => '/* testSwitchAlternativeSyntax */',
@@ -111,7 +113,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
                     'scope_closer' => T_ENDSWITCH,
                 ],
                 'testOpenerMarker' => null,
-                'testCloserMarker' => '/* testSwitchAlternativeSyntaxEnd */',
+                'testCloserMarker' => '/* testSwitchAlternativeSyntaxScopeCloser */',
             ],
             'switch with closure in the condition' => [
                 'testMarker'       => '/* testSwitchClosureWithinCondition */',
@@ -120,7 +122,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
                     'scope_closer' => T_CLOSE_CURLY_BRACKET,
                 ],
                 'testOpenerMarker' => '/* testSwitchClosureWithinConditionScopeOpener */',
-                'testCloserMarker' => '/* testSwitchClosureWithinConditionScopeOpener */',
+                'testCloserMarker' => '/* testSwitchClosureWithinConditionScopeCloser */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
@@ -97,7 +97,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
     public static function dataSwitchScope()
     {
         return [
-            'switch normal syntax'                 => [
+            'switch normal syntax'                                                                  => [
                 'testMarker'       => '/* testSwitchNormalSyntax */',
                 'expectedTokens'   => [
                     'scope_opener' => T_OPEN_CURLY_BRACKET,
@@ -106,7 +106,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
                 'testOpenerMarker' => null,
                 'testCloserMarker' => '/* testSwitchNormalSyntaxScopeCloser */',
             ],
-            'switch alternative syntax'            => [
+            'switch alternative syntax'                                                             => [
                 'testMarker'       => '/* testSwitchAlternativeSyntax */',
                 'expectedTokens'   => [
                     'scope_opener' => T_COLON,
@@ -115,7 +115,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
                 'testOpenerMarker' => null,
                 'testCloserMarker' => '/* testSwitchAlternativeSyntaxScopeCloser */',
             ],
-            'switch with closure in the condition' => [
+            'switch with closure in the condition'                                                  => [
                 'testMarker'       => '/* testSwitchClosureWithinCondition */',
                 'expectedTokens'   => [
                     'scope_opener' => T_OPEN_CURLY_BRACKET,
@@ -124,6 +124,34 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
                 'testOpenerMarker' => '/* testSwitchClosureWithinConditionScopeOpener */',
                 'testCloserMarker' => '/* testSwitchClosureWithinConditionScopeCloser */',
             ],
+            'switch alternative syntax with closure containing return type in the condition'        => [
+                'testMarker'       => '/* testSwitchClosureWithReturnTypeWithinCondition */',
+                'expectedTokens'   => [
+                    'scope_opener' => T_COLON,
+                    'scope_closer' => T_ENDSWITCH,
+                ],
+                'testOpenerMarker' => '/* testSwitchClosureWithReturnTypeWithinConditionScopeOpener */',
+                'testCloserMarker' => '/* testSwitchClosureWithReturnTypeWithinConditionScopeCloser */',
+            ],
+            'switch with arrow function in the condition'                                           => [
+                'testMarker'       => '/* testSwitchArrowFunctionWithinCondition */',
+                'expectedTokens'   => [
+                    'scope_opener' => T_OPEN_CURLY_BRACKET,
+                    'scope_closer' => T_CLOSE_CURLY_BRACKET,
+                ],
+                'testOpenerMarker' => '/* testSwitchArrowFunctionWithinConditionScopeOpener */',
+                'testCloserMarker' => '/* testSwitchArrowFunctionWithinConditionScopeCloser */',
+            ],
+            'switch alternative syntax with arrow function containing return type in the condition' => [
+                'testMarker'       => '/* testSwitchArrowFunctionWithReturnTypeWithinCondition */',
+                'expectedTokens'   => [
+                    'scope_opener' => T_COLON,
+                    'scope_closer' => T_ENDSWITCH,
+                ],
+                'testOpenerMarker' => '/* testSwitchArrowFunctionWithReturnTypeWithinConditionScopeOpener */',
+                'testCloserMarker' => '/* testSwitchArrowFunctionWithReturnTypeWithinConditionScopeCloser */',
+            ],
+
         ];
 
     }//end dataSwitchScope()


### PR DESCRIPTION
# Description
This PR improves the switch keyword tokenizer tests by adding the tests suggested in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887087504. It also adds another commit to improve the tests stability by ensuring that a marker is always used to get the scope opener and scope closer.

## Related issues/external references

Part of the changes suggested in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887087504

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.