### PR TITLE
Tests/Tokenizer: expand `default` keyword tests

### DIFF
--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.inc
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.inc
@@ -92,6 +92,29 @@ function switchWithDefaultInMatch() {
     };
 }
 
+function switchAndDefaultSharingScopeCloser($i) {
+    switch ($i):
+        /* testSwitchAndDefaultSharingScopeCloser */
+        default:
+            echo 'one';
+    endswitch;
+}
+
+function switchDefaultNestedIfWithAndWithoutBraces($i, $foo, $baz) {
+    switch ($i) {
+        /* testSwitchDefaultNestedIfWithAndWithoutBraces */
+        default:
+            if ($foo) {
+                return true;
+            } elseif ($baz)
+                return true;
+            else {
+                echo 'else';
+            }
+            break;
+    }
+}
+
 function shortArrayWithConstantKey() {
     $arr = [
         /* testClassConstantAsShortArrayKey */

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -109,19 +109,23 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      * Note: Cases and default structures within a switch control structure *do* get case/default scope
      * conditions.
      *
-     * @param string   $testMarker    The comment prefacing the target token.
-     * @param int      $openerOffset  The expected offset of the scope opener in relation to the testMarker.
-     * @param int      $closerOffset  The expected offset of the scope closer in relation to the testMarker.
-     * @param int|null $conditionStop The expected offset in relation to the testMarker, at which tokens stop
-     *                                having T_DEFAULT as a scope condition.
-     * @param string   $testContent   The token content to look for.
+     * @param string   $testMarker        The comment prefacing the target token.
+     * @param int      $openerOffset      The expected offset of the scope opener in relation to the testMarker.
+     * @param int      $closerOffset      The expected offset of the scope closer in relation to the testMarker.
+     * @param int|null $conditionStop     The expected offset in relation to the testMarker, at which tokens stop
+     *                                    having T_DEFAULT as a scope condition.
+     * @param string   $testContent       The token content to look for.
+     * @param bool     $sharedScopeCloser Whether to skip checking for the `scope_condition` of the
+     *                                    scope closer. Needed when the default and switch
+     *                                    structures share a scope closer. See
+     *                                    https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/810.
      *
      * @dataProvider dataSwitchDefault
      * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
      *
      * @return void
      */
-    public function testSwitchDefault($testMarker, $openerOffset, $closerOffset, $conditionStop=null, $testContent='default')
+    public function testSwitchDefault($testMarker, $openerOffset, $closerOffset, $conditionStop=null, $testContent='default', $sharedScopeCloser=false)
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -148,13 +152,17 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         $this->assertSame($expectedScopeOpener, $tokens[$opener]['scope_opener'], 'T_DEFAULT opener scope opener token incorrect');
         $this->assertSame($expectedScopeCloser, $tokens[$opener]['scope_closer'], 'T_DEFAULT opener scope closer token incorrect');
 
-        $closer = $tokenArray['scope_closer'];
-        $this->assertArrayHasKey('scope_condition', $tokens[$closer], 'Closer scope condition is not set');
-        $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Closer scope opener is not set');
-        $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Closer scope closer is not set');
-        $this->assertSame($token, $tokens[$closer]['scope_condition'], 'Closer scope condition is not the T_DEFAULT token');
-        $this->assertSame($expectedScopeOpener, $tokens[$closer]['scope_opener'], 'T_DEFAULT closer scope opener token incorrect');
-        $this->assertSame($expectedScopeCloser, $tokens[$closer]['scope_closer'], 'T_DEFAULT closer scope closer token incorrect');
+        $closer = $expectedScopeCloser;
+
+        if ($sharedScopeCloser === false) {
+            $closer = $tokenArray['scope_closer'];
+            $this->assertArrayHasKey('scope_condition', $tokens[$closer], 'Closer scope condition is not set');
+            $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Closer scope opener is not set');
+            $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Closer scope closer is not set');
+            $this->assertSame($token, $tokens[$closer]['scope_condition'], 'Closer scope condition is not the T_DEFAULT token');
+            $this->assertSame($expectedScopeOpener, $tokens[$closer]['scope_opener'], 'T_DEFAULT closer scope opener token incorrect');
+            $this->assertSame($expectedScopeCloser, $tokens[$closer]['scope_closer'], 'T_DEFAULT closer scope closer token incorrect');
+        }
 
         if (($opener + 1) !== $closer) {
             $end = $closer;
@@ -184,12 +192,12 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
     public static function dataSwitchDefault()
     {
         return [
-            'simple_switch_default'                  => [
+            'simple_switch_default'                                     => [
                 'testMarker'   => '/* testSimpleSwitchDefault */',
                 'openerOffset' => 1,
                 'closerOffset' => 4,
             ],
-            'simple_switch_default_with_curlies'     => [
+            'simple_switch_default_with_curlies'                        => [
                 // For a default structure with curly braces, the scope opener
                 // will be the open curly and the closer the close curly.
                 // However, scope conditions will not be set for open to close,
@@ -199,20 +207,33 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                 'closerOffset'  => 12,
                 'conditionStop' => 6,
             ],
-            'switch_default_toplevel'                => [
+            'switch_default_toplevel'                                   => [
                 'testMarker'   => '/* testSwitchDefault */',
                 'openerOffset' => 1,
                 'closerOffset' => 43,
             ],
-            'switch_default_nested_in_match_case'    => [
+            'switch_default_nested_in_match_case'                       => [
                 'testMarker'   => '/* testSwitchDefaultNestedInMatchCase */',
                 'openerOffset' => 1,
                 'closerOffset' => 20,
             ],
-            'switch_default_nested_in_match_default' => [
+            'switch_default_nested_in_match_default'                    => [
                 'testMarker'   => '/* testSwitchDefaultNestedInMatchDefault */',
                 'openerOffset' => 1,
                 'closerOffset' => 18,
+            ],
+            'switch_and_default_sharing_scope_closer'                   => [
+                'testMarker'        => '/* testSwitchAndDefaultSharingScopeCloser */',
+                'openerOffset'      => 1,
+                'closerOffset'      => 10,
+                'conditionStop'     => null,
+                'testContent'       => 'default',
+                'sharedScopeCloser' => true,
+            ],
+            'switch_and_default_with_nested_if_with_and_without_braces' => [
+                'testMarker'   => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
+                'openerOffset' => 1,
+                'closerOffset' => 48,
             ],
         ];
 


### PR DESCRIPTION
# Description

This PR adds two new tests to the tokenizer tests for the `default` keyword:

- Ensure that the `default` scope is set correctly when the scope closer is shared with a `switch`.
- Ensure that the `default` scope is set correctly when there is an inner if condition with and without braces.

Both tests were copied from similar tests for the `case` keyword that were added to protect against regressions (see b9809c7 and 61b9e9b). They were suggested in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887061197 and https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887142654.

## Related issues/external references

Tests suggested in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887061197 and https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/595#discussion_r1887142654.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.