### PR TITLE
PSR2/NamespaceDeclaration: do not enforce new line in inline HTML

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -50,6 +50,11 @@ class NamespaceDeclarationSniff implements Sniff
 
         $end = $phpcsFile->findEndOfStatement($stackPtr);
         for ($i = ($end + 1); $i < ($phpcsFile->numTokens - 1); $i++) {
+            if ($tokens[$i]['code'] === T_CLOSE_TAG) {
+                // Don't enforce new line if the next thing after the statement is a PHP close tag.
+                return;
+            }
+
             if ($tokens[$i]['line'] === $tokens[$end]['line']) {
                 continue;
             }

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc
@@ -24,3 +24,10 @@ namespace Vendor\Package;
 $call = namespace\function_name();
 echo namespace\CONSTANT_NAME;
 // Something which is not a blank line.
+
+// When the next thing after a namespace declaration is a PHP close tag, don't enforce a new line as it may impact HTML display.
+namespace Vendor\NoBlankLine\EndsOnCloseTag ?>
+<?php
+namespace Vendor\HasBlankLine\EndsOnSemiColonPlusCloseTag; ?>
+
+<?php

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc.fixed
@@ -26,3 +26,10 @@ namespace Vendor\Package;
 $call = namespace\function_name();
 echo namespace\CONSTANT_NAME;
 // Something which is not a blank line.
+
+// When the next thing after a namespace declaration is a PHP close tag, don't enforce a new line as it may impact HTML display.
+namespace Vendor\NoBlankLine\EndsOnCloseTag ?>
+<?php
+namespace Vendor\HasBlankLine\EndsOnSemiColonPlusCloseTag; ?>
+
+<?php


### PR DESCRIPTION
# Description
If a namespace declaration has a PHP close tag on the same line, the new line would be added as `T_INLINE_HTML` and therefore not be recognized as a blank line as the sniff solely looks for `T_WHITESPACE`. This then leads to a fixer conflict where the sniff just keeps adding new lines until it runs out of loops.

```
        => Fixing file: 0/6 violations remaining [made 46 passes]...
        * fixed 0 violations, starting loop 47 *
        PSR2.Namespaces.NamespaceDeclaration:81 replaced token 118 (T_INLINE_HTML on line 32) "\n\n" => "\n\n\n"
        PSR2.Namespaces.NamespaceDeclaration:81 replaced token 153 (T_INLINE_HTML on line 58) "\n\n" => "\n\n\n"
        => Fixing file: 2/6 violations remaining [made 47 passes]...
        * fixed 2 violations, starting loop 48 *
        **** PSR2.Namespaces.NamespaceDeclaration:81 has possible conflict with another sniff on loop 46; caused by the following change ****
        **** replaced token 118 (T_INLINE_HTML on line 32) "\n\n" => "\n\n\n" ****
        **** ignoring all changes until next loop ****
        => Fixing file: 0/6 violations remaining [made 48 passes]...
        * fixed 0 violations, starting loop 49 *
```

In my opinion, the sniff should bow out in that situation and should not enforce a new line as it may impact HTML display.

This commit implements this.

Includes a test safeguarding the fix.

## Suggested changelog entry
PSR2.Namespaces.NamespaceDeclaration: prevent fixer conflict when the next thing after a namespace declaration is a PHP close tag


## Related issues/external references

Related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
