### PR TITLE
File::getDeclarationName(): prevent incorrect result during live coding 

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1304,8 +1304,17 @@ class File
             return $this->tokens[$stackPtr]['content'];
         }
 
+        $stopPoint = $this->numTokens;
+        if (isset($this->tokens[$stackPtr]['parenthesis_opener']) === true) {
+            // For functions, stop searching at the parenthesis opener.
+            $stopPoint = $this->tokens[$stackPtr]['parenthesis_opener'];
+        } else if (isset($this->tokens[$stackPtr]['scope_opener']) === true) {
+            // For OO tokens, stop searching at the open curly.
+            $stopPoint = $this->tokens[$stackPtr]['scope_opener'];
+        }
+
         $content = null;
-        for ($i = $stackPtr; $i < $this->numTokens; $i++) {
+        for ($i = $stackPtr; $i < $stopPoint; $i++) {
             if ($this->tokens[$i]['code'] === T_STRING) {
                 $content = $this->tokens[$i]['content'];
                 break;

--- a/tests/Core/File/GetDeclarationNameParseError1Test.inc
+++ b/tests/Core/File/GetDeclarationNameParseError1Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+/* testLiveCoding */
+// Intentional parse error. This must be the only test in the file.
+function // Comment.

--- a/tests/Core/File/GetDeclarationNameParseError1Test.php
+++ b/tests/Core/File/GetDeclarationNameParseError1Test.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getDeclarationName method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getDeclarationName method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
+ */
+final class GetDeclarationNameParseError1Test extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test receiving "null" in case of a parse error.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameNull()
+    {
+        $target = $this->getTargetToken('/* testLiveCoding */', T_FUNCTION);
+        $result = self::$phpcsFile->getDeclarationName($target);
+        $this->assertNull($result);
+
+    }//end testGetDeclarationNameNull()
+
+
+}//end class

--- a/tests/Core/File/GetDeclarationNameParseError2Test.inc
+++ b/tests/Core/File/GetDeclarationNameParseError2Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+/* testLiveCoding */
+// Intentional parse error/live coding. This must be the only test in the file.
+// Safeguarding that the utility method does not confuse the `string` type with a function name.
+$closure = function (string $param) use ($var

--- a/tests/Core/File/GetDeclarationNameParseError2Test.php
+++ b/tests/Core/File/GetDeclarationNameParseError2Test.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getDeclarationName method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getDeclarationName method.
+ *
+ * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
+ */
+final class GetDeclarationNameParseError2Test extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test receiving "null" in case of a parse error.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameNull()
+    {
+        $target = $this->getTargetToken('/* testLiveCoding */', T_FUNCTION);
+        $result = self::$phpcsFile->getDeclarationName($target);
+        $this->assertNull($result);
+
+    }//end testGetDeclarationNameNull()
+
+
+}//end class

--- a/tests/Core/File/GetDeclarationNameTest.inc
+++ b/tests/Core/File/GetDeclarationNameTest.inc
@@ -96,7 +96,3 @@ function &self() {}
 
 /* testFunctionReturnByRefWithReservedKeywordStatic */
 function &static() {}
-
-/* testLiveCoding */
-// Intentional parse error. This has to be the last test in the file.
-function // Comment.

--- a/tests/Core/File/GetDeclarationNameTest.php
+++ b/tests/Core/File/GetDeclarationNameTest.php
@@ -84,10 +84,6 @@ final class GetDeclarationNameTest extends AbstractMethodUnitTest
                 'testMarker' => '/* testAnonClassExtendsWithoutParens */',
                 'targetType' => T_ANON_CLASS,
             ],
-            'live-coding'                            => [
-                'testMarker' => '/* testLiveCoding */',
-                'targetType' => T_FUNCTION,
-            ],
         ];
 
     }//end dataGetDeclarationNameNull()


### PR DESCRIPTION
# Description

### GetDeclarationNameTest: move parse error test to separate file

### File::getDeclarationName(): prevent incorrect result during live coding 

The `function` keyword for a closure is normally tokenized as `T_CLOSURE`, but will be tokenized as `T_FUNCTION` in case of an unfinished closure declaration (no scope opener/closer).

For an unfinished closure with typed parameters, the `File::getDeclarationName()` method would incorrectly return the contents of the first `T_STRING` in the type declaration as if it were the name of the function.

Fixed now.

Includes test.

## Suggested changelog entry
File::getDeclarationName(): prevent incorrect result for unfinished closures during live coding 


## Related issues/external references

Loosely related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

