### PR TITLE
Squiz/ValidClassName: bug fix - improve comment handling

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -12,6 +12,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ValidClassNameSniff implements Sniff
 {
@@ -58,8 +59,8 @@ class ValidClassNameSniff implements Sniff
         // simply look for the first T_STRING because a class name
         // starting with the number will be multiple tokens.
         $opener    = $tokens[$stackPtr]['scope_opener'];
-        $nameStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $opener, true);
-        $nameEnd   = $phpcsFile->findNext([T_WHITESPACE, T_COLON], $nameStart, $opener);
+        $nameStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $opener, true);
+        $nameEnd   = $phpcsFile->findNext((Tokens::$emptyTokens + [T_COLON => T_COLON]), $nameStart, $opener);
         if ($nameEnd === false) {
             $name = $tokens[$nameStart]['content'];
         } else {
@@ -75,7 +76,7 @@ class ValidClassNameSniff implements Sniff
                 $type,
                 $name,
             ];
-            $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $data);
+            $phpcsFile->addError($error, $nameStart, 'NotCamelCaps', $data);
             $phpcsFile->recordMetric($stackPtr, 'PascalCase class name', 'no');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PascalCase class name', 'yes');

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
@@ -189,3 +189,13 @@ $foo = new class(
     }
 ) extends DateTime {
 };
+
+class /*comment*/ CommentsShouldBeIgnoredValidName {}
+trait //comment
+    commentsshouldbeignoredInvalidName {}
+interface // phpcs:ignore Stnd.Cat.SniffName -- just testing
+    annotationshouldbeignored_InvalidName {}
+
+class CommentsShouldBeIgnoredValid/*comment*/ {}
+interface annotations_should_be_ignored_InvalidName// phpcs:ignore Stnd.Cat.SniffName -- just testing
+{}

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -57,6 +57,9 @@ final class ValidClassNameUnitTest extends AbstractSniffUnitTest
             150 => 1,
             151 => 1,
             156 => 1,
+            195 => 1,
+            197 => 1,
+            200 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Noticed while working on something else.

If there would be a comment between the OO keyword and the declared name, the sniff could throw false positives with unhelpful error messages, like:
```
193 | ERROR | Class name "/*comment*/" is not in PascalCase format (Squiz.Classes.ValidClassName.NotCamelCaps)
 194 | ERROR | Trait name "//comment" is not in PascalCase format (Squiz.Classes.ValidClassName.NotCamelCaps)
 196 | ERROR | Interface name "// phpcs:ignore Stnd.Cat.SniffName -- just testing" is not in PascalCase format
     |       | (Squiz.Classes.ValidClassName.NotCamelCaps)
 199 | ERROR | Class name "CommentsShouldBeIgnoredValid/*comment*/" is not in PascalCase format (Squiz.Classes.ValidClassName.NotCamelCaps)
 200 | ERROR | Interface name "annotations_should_be_ignored_InvalidName" is not in PascalCase format (Squiz.Classes.ValidClassName.NotCamelCaps)
```

Fixed now by:
1. Ignoring any comments between the OO keyword and the name.
2. Not including comments directly following a name in the name to be evaluated.

Includes tests.

Includes minor error message precision fix - the error will now be thrown on the name which is being flagged as invalid, not on the OO keyword.


## Suggested changelog entry
Squiz.Classes.ValidClassName will now ignore comments when determining the name to be validated.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
