### PR TITLE
ProcessRuleShouldProcessElementTest: test changing `Internal` codes

### DIFF
--- a/tests/Core/Ruleset/ProcessRuleShouldProcessElementTest.php
+++ b/tests/Core/Ruleset/ProcessRuleShouldProcessElementTest.php
@@ -64,6 +64,9 @@ final class ProcessRuleShouldProcessElementTest extends AbstractRulesetTestCase
         $key = 'severity';
 
         // Verify that the non-selective severity directive IS applied.
+        $sniffCode = 'Internal.NoCodeFound';
+        $this->assertRulesetPropertySame(0, $sniffCode, $key);
+
         $sniffCode = 'PSR1.Files.SideEffects';
         $this->assertRulesetPropertySame(3, $sniffCode, $key);
 
@@ -215,6 +218,9 @@ final class ProcessRuleShouldProcessElementTest extends AbstractRulesetTestCase
         $key = 'message';
 
         // Verify that the non-selective message directive IS applied.
+        $sniffCode = 'Internal.NoCodeFound';
+        $this->assertRulesetPropertySame("We don't to be notified if files don't contain code", $sniffCode, $key);
+
         $sniffCode = 'PSR1.Files.SideEffects';
         $this->assertRulesetPropertySame('A different warning message', $sniffCode, $key);
 

--- a/tests/Core/Ruleset/ProcessRuleShouldProcessElementTest.xml
+++ b/tests/Core/Ruleset/ProcessRuleShouldProcessElementTest.xml
@@ -6,6 +6,11 @@
     # Neither set. #
     ################
     -->
+    <rule ref="Internal.NoCodeFound">
+        <severity>0</severity>
+        <message>We don't to be notified if files don't contain code</message>
+    </rule>
+
     <rule ref="PSR1.Files.SideEffects">
         <severity>3</severity>
         <type>warning</type>


### PR DESCRIPTION
# Description
Safeguard that aspects of how `Internal` codes are processed can be changed and that these changes are applied correctly.



## Suggested changelog entry
_N/A_

## Related issues/external references

As requested via https://github.com/PHPCSStandards/PHP_CodeSniffer#801#discussion_r1954701449

