### PR TITLE
Generators: don't print standard when it's empty

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -318,7 +318,12 @@ class HTML extends Generator
      */
     protected function getFormattedTextBlock(DOMNode $node)
     {
-        $content = trim($node->nodeValue);
+        $content = $node->nodeValue;
+        if (empty($content) === true) {
+            return '';
+        }
+
+        $content = trim($content);
         $content = htmlspecialchars($content, (ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
 
         // Allow only em tags.

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -178,7 +178,12 @@ class Markdown extends Generator
      */
     protected function getFormattedTextBlock(DOMNode $node)
     {
-        $content = trim($node->nodeValue);
+        $content = $node->nodeValue;
+        if (empty($content) === true) {
+            return '';
+        }
+
+        $content = trim($content);
         $content = htmlspecialchars($content, (ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401));
         $content = str_replace('&lt;em&gt;', '*', $content);
         $content = str_replace('&lt;/em&gt;', '*', $content);

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -124,7 +124,12 @@ class Text extends Generator
      */
     protected function getFormattedTextBlock(DOMNode $node)
     {
-        $text = trim($node->nodeValue);
+        $text = $node->nodeValue;
+        if (empty($text) === true) {
+            return '';
+        }
+
+        $text = trim($text);
         $text = str_replace('<em>', '*', $text);
         $text = str_replace('</em>', '*', $text);
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.html
@@ -72,7 +72,6 @@
   <h1>GeneratorTest Coding Standards</h1>
   <a name="Standard-Element,-no-content" />
   <h2>Standard Element, no content</h2>
-  <p class="text"></p>
   <table class="code-comparison">
    <tr>
     <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.md
@@ -2,7 +2,6 @@
 
 ## Standard Element, no content
 
-
   <table>
    <tr>
     <th>Valid: Lorem ipsum dolor sit amet.</th>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.txt
@@ -3,8 +3,6 @@
 | GENERATORTEST CODING STANDARD: STANDARD ELEMENT, NO CONTENT |
 ---------------------------------------------------------------
 
-
-
 ----------------------------------------- CODE COMPARISON ------------------------------------------
 | Valid: Lorem ipsum dolor sit amet.             | Invalid: Maecenas non rutrum dolor.             |
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Description
No need to do any work on the `standard` text if there is no text. Nor is there a need to print an empty paragraph/extra blank lines in that case.


## Suggested changelog entry
Generators: cleaner output based on the elements available


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.
