### PR TITLE
Generator::getTitle(): fall back to file name if title is missing

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -83,7 +83,22 @@ abstract class Generator
      */
     protected function getTitle(DOMNode $doc)
     {
-        return $doc->getAttribute('title');
+        $title = $doc->getAttribute('title');
+
+        if (empty($title) === true) {
+            // Fall back to the sniff name if no title was supplied.
+            $fileName  = $doc->ownerDocument->documentURI;
+            $lastSlash = strrpos($fileName, '/');
+            if (is_int($lastSlash) === true) {
+                // Get the sniff name without "Standard.xml".
+                $title = substr($fileName, ($lastSlash + 1), -12);
+
+                // Split the sniff name to individual words.
+                $title = preg_replace('`[-._]|(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])`', '$1 $2', $title);
+            }
+        }
+
+        return $title;
 
     }//end getTitle()
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.html
@@ -70,19 +70,10 @@
  </head>
  <body>
   <h1>GeneratorTest Coding Standards</h1>
-  <a name="Documentation-Title-Empty" />
-  <h2>Documentation Title Empty</h2>
-  <p class="text">The above &quot;documentation&quot; element has an empty title attribute.</p>
-  <table class="code-comparison">
-   <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
-   </tr>
-   <tr>
-    <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>
-    <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Comparison</span>&nbsp;{}</td>
-   </tr>
-  </table>
+  <a name="Documentation-Title-PCRE-Fallback" />
+  <h2>Documentation Title PCRE Fallback</h2>
+  <p class="text">Testing the document title can get determined from the sniff name if missing.</p>
+  <p class="text">This file name contains an acronym on purpose to test the word splitting.</p>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.md
@@ -1,0 +1,9 @@
+# GeneratorTest Coding Standard
+
+## Documentation Title PCRE Fallback
+
+Testing the document title can get determined from the sniff name if missing.
+
+This file name contains an acronym on purpose to test the word splitting.
+
+Documentation generated on *REDACTED* by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.txt
@@ -1,0 +1,9 @@
+
+--------------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: DOCUMENTATION TITLE PCRE FALLBACK |
+--------------------------------------------------------------------
+
+Testing the document title can get determined from the sniff name if missing.
+
+This file name contains an acronym on purpose to test the word splitting.
+

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.md
@@ -1,6 +1,6 @@
 # GeneratorTest Coding Standard
 
-## 
+## Documentation Title Empty
 
 The above &quot;documentation&quot; element has an empty title attribute.
   <table>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.txt
@@ -1,7 +1,7 @@
 
------------------------------------
-| GENERATORTEST CODING STANDARD:  |
------------------------------------
+------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: DOCUMENTATION TITLE EMPTY |
+------------------------------------------------------------
 
 The above "documentation" element has an empty title attribute.
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.html
@@ -70,8 +70,8 @@
  </head>
  <body>
   <h1>GeneratorTest Coding Standards</h1>
-  <a name="" />
-  <h2></h2>
+  <a name="Documentation-Title-Missing" />
+  <h2>Documentation Title Missing</h2>
   <p class="text">The above &quot;documentation&quot; element is missing the title attribute.</p>
   <table class="code-comparison">
    <tr>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.md
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.md
@@ -1,6 +1,6 @@
 # GeneratorTest Coding Standard
 
-## 
+## Documentation Title Missing
 
 The above &quot;documentation&quot; element is missing the title attribute.
   <table>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.txt
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.txt
@@ -1,7 +1,7 @@
 
------------------------------------
-| GENERATORTEST CODING STANDARD:  |
------------------------------------
+--------------------------------------------------------------
+| GENERATORTEST CODING STANDARD: DOCUMENTATION TITLE MISSING |
+--------------------------------------------------------------
 
 The above "documentation" element is missing the title attribute.
 

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/DocumentationTitlePCREFallbackStandard.xml
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Docs/Content/DocumentationTitlePCREFallbackStandard.xml
@@ -1,0 +1,9 @@
+<documentation>
+    <standard>
+    <![CDATA[
+    Testing the document title can get determined from the sniff name if missing.
+    
+    This file name contains an acronym on purpose to test the word splitting.
+    ]]>
+    </standard>
+</documentation>

--- a/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/DocumentationTitlePCREFallbackSniff.php
+++ b/tests/Core/Generators/Fixtures/StandardWithDocs/Sniffs/Content/DocumentationTitlePCREFallbackSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Generators\GeneratorTest
+ */
+
+namespace Fixtures\StandardWithDocs\Sniffs\Content;
+
+use Fixtures\StandardWithDocs\Sniffs\DummySniff;
+
+final class DocumentationTitlePCREFallbackSniff extends DummySniff {}

--- a/tests/Core/Generators/GeneratorTest.php
+++ b/tests/Core/Generators/GeneratorTest.php
@@ -193,6 +193,39 @@ final class GeneratorTest extends TestCase
 
 
     /**
+     * Verify that if the `<documentation>` title is missing, it will fallback to the file name
+     * and split the CamelCaps name correctly.
+     *
+     * @return void
+     */
+    public function testGetTitleFallbackToFilename()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/AllValidDocsTest.xml';
+        $sniffs   = 'StandardWithDocs.Content.DocumentationTitlePCREFallback';
+        $config   = new ConfigDouble(["--standard=$standard", "--sniffs=$sniffs"]);
+        $ruleset  = new Ruleset($config);
+
+        // In tests, the `--sniffs` setting doesn't work out of the box.
+        $sniffParts = explode('.', $sniffs);
+        $sniffFile  = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$sniffParts[0].DIRECTORY_SEPARATOR;
+        $sniffFile .= 'Sniffs'.DIRECTORY_SEPARATOR.$sniffParts[1].DIRECTORY_SEPARATOR.$sniffParts[2].'Sniff.php';
+
+        $sniffParts   = array_map('strtolower', $sniffParts);
+        $sniffName    = $sniffParts[0].'\sniffs\\'.$sniffParts[1].'\\'.$sniffParts[2].'sniff';
+        $restrictions = [$sniffName => true];
+        $ruleset->registerSniffs([$sniffFile], $restrictions, []);
+
+        // Make the test OS independent.
+        $this->expectOutputString('Documentation Title PCRE Fallback'.PHP_EOL);
+
+        $generator = new MockGenerator($ruleset);
+        $generator->generate();
+
+    }//end testGetTitleFallbackToFilename()
+
+
+    /**
      * Test that the documentation for each standard passed on the command-line is shown separately.
      *
      * @covers \PHP_CodeSniffer\Runner::runPHPCS

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -133,6 +133,10 @@ final class HTMLTest extends TestCase
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.html',
             ],
+            'Documentation title: fallback to file name'        => [
+                'sniffs'         => 'StandardWithDocs.Content.DocumentationTitlePCREFallback',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitlePCREFallback.html',
+            ],
             'Standard Element: blank line handling'             => [
                 'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.html',

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -133,6 +133,10 @@ final class MarkdownTest extends TestCase
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.md',
             ],
+            'Documentation title: fallback to file name'        => [
+                'sniffs'         => 'StandardWithDocs.Content.DocumentationTitlePCREFallback',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitlePCREFallback.md',
+            ],
             'Standard Element: blank line handling'             => [
                 'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.md',

--- a/tests/Core/Generators/TextTest.php
+++ b/tests/Core/Generators/TextTest.php
@@ -133,6 +133,10 @@ final class TextTest extends TestCase
                 'sniffs'         => 'StandardWithDocs.Content.DocumentationTitleLength',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitleLength.txt',
             ],
+            'Documentation title: fallback to file name'        => [
+                'sniffs'         => 'StandardWithDocs.Content.DocumentationTitlePCREFallback',
+                'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputDocumentationTitlePCREFallback.txt',
+            ],
             'Standard Element: blank line handling'             => [
                 'sniffs'         => 'StandardWithDocs.Content.StandardBlankLines',
                 'pathToExpected' => __DIR__.'/Expectations/ExpectedOutputStandardBlankLines.txt',


### PR DESCRIPTION
# Description

When the documentation `title` attribute is missing, a title would still be included in the docs, but not contain any (useful) information.

![8-missing-title-html](https://github.com/user-attachments/assets/cf9eebf1-43f7-4b67-8d2b-7a051f61ef4b)
![8-missing-title-markdown](https://github.com/user-attachments/assets/ed967282-70b5-42b6-b665-3ede22885424)
![8-missing-title-text](https://github.com/user-attachments/assets/436a0655-57cb-4a8f-a131-cc7d52dd6f82)


Fixed now by falling back to the XML document file name and splitting the name into words.

Includes tests.


## Suggested changelog entry
Generators: gracefully handle missing title attribute


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.


## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_
