### PR TITLE
Generators HTML/Markdown: remove some duplicate code

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -108,12 +108,7 @@ class HTML extends Generator
         }
 
         ob_start();
-        foreach ($this->docFiles as $file) {
-            $doc = new DOMDocument();
-            $doc->load($file);
-            $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            $this->processSniff($documentation);
-        }
+        parent::generate();
 
         $content = ob_get_contents();
         ob_end_clean();

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -11,7 +11,6 @@
 
 namespace PHP_CodeSniffer\Generators;
 
-use DOMDocument;
 use DOMNode;
 use PHP_CodeSniffer\Config;
 
@@ -32,12 +31,7 @@ class Markdown extends Generator
         }
 
         ob_start();
-        foreach ($this->docFiles as $file) {
-            $doc = new DOMDocument();
-            $doc->load($file);
-            $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            $this->processSniff($documentation);
-        }
+        parent::generate();
 
         $content = ob_get_contents();
         ob_end_clean();


### PR DESCRIPTION
# Description

The method in the parent class already contains the same code snippet, no need to duplicate.


## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.
