### PR TITLE
Generators/HTML: various minor code simplifications

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -149,15 +149,20 @@ class HTML extends Generator
     protected function getFormattedHeader()
     {
         $standard = $this->ruleset->name;
-        $output   = '<html>'.PHP_EOL;
-        $output  .= ' <head>'.PHP_EOL;
-        $output  .= "  <title>$standard Coding Standards</title>".PHP_EOL;
-        $output  .= '  '.str_replace("\n", PHP_EOL, self::STYLESHEET).PHP_EOL;
-        $output  .= ' </head>'.PHP_EOL;
-        $output  .= ' <body>'.PHP_EOL;
-        $output  .= "  <h1>$standard Coding Standards</h1>".PHP_EOL;
+        $output   = sprintf(
+            '<html>
+ <head>
+  <title>%1$s Coding Standards</title>
+  %2$s
+ </head>
+ <body>
+  <h1>%1$s Coding Standards</h1>',
+            $standard,
+            self::STYLESHEET
+        );
 
-        return $output;
+        // Use the correct line endings based on the OS.
+        return str_replace("\n", PHP_EOL, $output).PHP_EOL;
 
     }//end getFormattedHeader()
 

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -245,16 +245,17 @@ class HTML extends Generator
         // Turn off errors so we don't get timezone warnings if people
         // don't have their timezone set.
         $errorLevel = error_reporting(0);
-        $output     = '  <div class="tag-line">';
-        $output    .= 'Documentation generated on '.date('r');
-        $output    .= ' by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer '.Config::VERSION.'</a>';
-        $output    .= '</div>'.PHP_EOL;
+        $output     = sprintf(
+            '  <div class="tag-line">Documentation generated on %s by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer %s</a></div>
+ </body>
+</html>',
+            date('r'),
+            Config::VERSION
+        );
         error_reporting($errorLevel);
 
-        $output .= ' </body>'.PHP_EOL;
-        $output .= '</html>'.PHP_EOL;
-
-        return $output;
+        // Use the correct line endings based on the OS.
+        return str_replace("\n", PHP_EOL, $output).PHP_EOL;
 
     }//end getFormattedFooter()
 

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -202,12 +202,14 @@ class HTML extends Generator
         $output  = '  <h2>Table of Contents</h2>'.PHP_EOL;
         $output .= '  <ul class="toc">'.PHP_EOL;
 
+        $listItemTemplate = '   <li><a href="#%s">%s</a></li>'.PHP_EOL;
+
         foreach ($this->docFiles as $file) {
             $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
             $title         = $this->getTitle($documentation);
-            $output       .= '   <li><a href="#'.str_replace(' ', '-', $title).'">'.$title.'</a></li>'.PHP_EOL;
+            $output       .= sprintf($listItemTemplate, str_replace(' ', '-', $title), $title);
         }
 
         $output .= '  </ul>'.PHP_EOL;

--- a/tests/Core/Generators/Fixtures/HTMLDouble.php
+++ b/tests/Core/Generators/Fixtures/HTMLDouble.php
@@ -20,14 +20,12 @@ class HTMLDouble extends HTML
      */
     protected function getFormattedFooter()
     {
-        $output     = '  <div class="tag-line">';
-        $output    .= 'Documentation generated on #REDACTED#';
-        $output    .= ' by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a>';
-        $output    .= '</div>'.PHP_EOL;
-        $output .= ' </body>'.PHP_EOL;
-        $output .= '</html>'.PHP_EOL;
+        $output ='  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+ </body>
+</html>';
 
-        return $output;
+        // Use the correct line endings based on the OS.
+        return str_replace("\n", PHP_EOL, $output).PHP_EOL;
     }
 
     /**


### PR DESCRIPTION
# Description
### Generators/HTML::getFormattedHeader(): minor simplification 

Use a single call to `sprintf()` instead of lots of string concatenation.

### Generators/HTML::getFormattedFooter(): minor simplification 

Use a single call to `sprintf()` instead of lots of string concatenation.

### Generators/HTML::getFormattedToc(): minor simplification 

Use `sprintf()` on a template string.


## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.
