### PR TITLE
Generators/Text: various minor code simplifications

### DIFF
--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -133,42 +133,10 @@ class Text extends Generator
         $text = str_replace(['<em>', '</em>'], '*', $text);
 
         $nodeLines = explode("\n", $text);
-        $lines     = [];
+        $nodeLines = array_map('trim', $nodeLines);
+        $text      = implode(PHP_EOL, $nodeLines);
 
-        foreach ($nodeLines as $currentLine) {
-            $currentLine = trim($currentLine);
-            if ($currentLine === '') {
-                // The text contained a blank line. Respect this.
-                $lines[] = '';
-                continue;
-            }
-
-            $tempLine = '';
-            $words    = explode(' ', $currentLine);
-
-            foreach ($words as $word) {
-                $currentLength = strlen($tempLine.$word);
-                if ($currentLength < 99) {
-                    $tempLine .= $word.' ';
-                    continue;
-                }
-
-                if ($currentLength === 99 || $currentLength === 100) {
-                    // We are already at the edge, so we are done.
-                    $lines[]  = $tempLine.$word;
-                    $tempLine = '';
-                } else {
-                    $lines[]  = rtrim($tempLine);
-                    $tempLine = $word.' ';
-                }
-            }//end foreach
-
-            if ($tempLine !== '') {
-                $lines[] = rtrim($tempLine);
-            }
-        }//end foreach
-
-        return implode(PHP_EOL, $lines).PHP_EOL.PHP_EOL;
+        return wordwrap($text, 100, PHP_EOL).PHP_EOL.PHP_EOL;
 
     }//end getFormattedTextBlock()
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -130,8 +130,7 @@ class Text extends Generator
         }
 
         $text = trim($text);
-        $text = str_replace('<em>', '*', $text);
-        $text = str_replace('</em>', '*', $text);
+        $text = str_replace(['<em>', '</em>'], '*', $text);
 
         $nodeLines = explode("\n", $text);
         $lines     = [];
@@ -243,8 +242,7 @@ class Text extends Generator
             $firstTitleLines[] = $tempTitle;
         }
 
-        $first      = str_replace('<em>', '', $first);
-        $first      = str_replace('</em>', '', $first);
+        $first      = str_replace(['<em>', '</em>'], '', $first);
         $firstLines = explode("\n", $first);
 
         $second      = trim($secondCodeElm->nodeValue);
@@ -278,8 +276,7 @@ class Text extends Generator
             $secondTitleLines[] = $tempTitle;
         }
 
-        $second      = str_replace('<em>', '', $second);
-        $second      = str_replace('</em>', '', $second);
+        $second      = str_replace(['<em>', '</em>'], '', $second);
         $secondLines = explode("\n", $second);
 
         $titleRow = '';


### PR DESCRIPTION
# Description
### Generators/Text: minor simplification 

No need for multiple calls to `str_replace()` when a single call will do.

### Generators/Text::getFormattedTextBlock(): simplify the logic 

There's absolutely no need for custom word-wrapping logic when PHP contains a function which can do this perfectly well.


## Suggested changelog entry
_N/A_

## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.
