### PR TITLE
Squiz/MemberVarSpacing: allow for PHP 8.1+ readonly properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -47,6 +47,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $validPrefixes   = Tokens::$methodPrefixes;
         $validPrefixes[] = T_VAR;
+        $validPrefixes[] = T_READONLY;
 
         $startOfStatement = $phpcsFile->findPrevious($validPrefixes, ($stackPtr - 1), null, false, null, true);
         if ($startOfStatement === false) {

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -372,3 +372,10 @@ enum SomeEnum
 
     case ONE = 'one';
 }
+
+class SupportReadonlyProperties {
+    readonly int $readonlyA;
+    public readonly string $publicReadonly;
+    readonly bool $readonlyB;
+    readonly private bool $readonlyPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -357,3 +357,14 @@ enum SomeEnum
 
     case ONE = 'one';
 }
+
+class SupportReadonlyProperties {
+
+    readonly int $readonlyA;
+
+    public readonly string $publicReadonly;
+
+    readonly bool $readonlyB;
+
+    readonly private bool $readonlyPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -67,6 +67,10 @@ final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             353 => 1,
             357 => 1,
             366 => 1,
+            377 => 1,
+            378 => 1,
+            379 => 1,
+            380 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Readonly properties can be declared without visibility: https://3v4l.org/OS9hE The sniff did not take this into account.

Fixed now.

Includes tests.

## Suggested changelog entry
Squiz.WhiteSpace.MemberVarSpacing: allow for `readonly` properties


## Related issues/external references

Loosely related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
