### PR TITLE
Generic/DisallowShortOpenTag: prevent fixer conflict

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -74,18 +74,20 @@ class DisallowShortOpenTagSniff implements Sniff
 
         if ($token['code'] === T_OPEN_TAG_WITH_ECHO) {
             $nextVar = $tokens[$phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true)];
-            $error   = 'Short PHP opening tag used with echo; expected "<?php echo %s ..." but found "%s %s ..."';
-            $data    = [
-                $nextVar['content'],
-                $token['content'],
-                $nextVar['content'],
-            ];
-            $fix     = $phpcsFile->addFixableError($error, $stackPtr, 'EchoFound', $data);
-            if ($fix === true) {
-                if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-                    $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo ');
-                } else {
-                    $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo');
+            if ($nextVar['code'] !== T_CLOSE_TAG) {
+                $error = 'Short PHP opening tag used with echo; expected "<?php echo %s ..." but found "%s %s ..."';
+                $data  = [
+                    $nextVar['content'],
+                    $token['content'],
+                    $nextVar['content'],
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'EchoFound', $data);
+                if ($fix === true) {
+                    if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo');
+                    }
                 }
             }
         }

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.5.inc
@@ -1,0 +1,4 @@
+// Intentional parse error. This should be the only test in this file.
+// Making sure that the sniff does not act on this particular parse error (to not things worse).
+
+<?= ?>


### PR DESCRIPTION
# Description
The original fixer conflict which inspired this fix can be reproduced via:
```bash
phpcbf -ps ./src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.19.inc --report=full,source --suffix=.fixed --standard=Squiz
```

What it basically comes down to is that this sniff would replace the `<?=` with `<?php echo`, even in case of a parse error, which would then cause problems for other sniffs.

Fixed now by ignoring this particular parse error.

Includes test.

Note: this PR will be most straight-forward to review while ignoring whitespace changes.

## Suggested changelog entry
Generic.PHP.DisallowShortOpenTag: don't act on parse errors

## Related issues/external references

Related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

