### PR TITLE
Generators/[HTML|Markdown|Text]::getFormattedCodeComparisonBlock(): minor refactor 

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -16,6 +16,7 @@
 namespace PHP_CodeSniffer\Generators;
 
 use DOMDocument;
+use DOMElement;
 use DOMNode;
 use PHP_CodeSniffer\Config;
 
@@ -400,23 +401,11 @@ class HTML extends Generator
             return '';
         }
 
-        $firstTitle = trim($firstCodeElm->getAttribute('title'));
-        $firstTitle = str_replace('  ', '&nbsp;&nbsp;', $firstTitle);
-        $first      = trim($firstCodeElm->nodeValue);
-        $first      = str_replace('<?php', '&lt;?php', $first);
-        $first      = str_replace("\n", '</br>', $first);
-        $first      = str_replace(' ', '&nbsp;', $first);
-        $first      = str_replace('<em>', '<span class="code-comparison-highlight">', $first);
-        $first      = str_replace('</em>', '</span>', $first);
+        $firstTitle = $this->formatCodeTitle($firstCodeElm);
+        $first      = $this->formatCodeSample($firstCodeElm);
 
-        $secondTitle = trim($secondCodeElm->getAttribute('title'));
-        $secondTitle = str_replace('  ', '&nbsp;&nbsp;', $secondTitle);
-        $second      = trim($secondCodeElm->nodeValue);
-        $second      = str_replace('<?php', '&lt;?php', $second);
-        $second      = str_replace("\n", '</br>', $second);
-        $second      = str_replace(' ', '&nbsp;', $second);
-        $second      = str_replace('<em>', '<span class="code-comparison-highlight">', $second);
-        $second      = str_replace('</em>', '</span>', $second);
+        $secondTitle = $this->formatCodeTitle($secondCodeElm);
+        $second      = $this->formatCodeSample($secondCodeElm);
 
         $titleRow = '';
         if ($firstTitle !== '' || $secondTitle !== '') {
@@ -445,6 +434,45 @@ class HTML extends Generator
         return $output;
 
     }//end getFormattedCodeComparisonBlock()
+
+
+    /**
+     * Retrieve a code block title and prepare it for output as HTML.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return string
+     */
+    private function formatCodeTitle(DOMElement $codeElm)
+    {
+        $title = trim($codeElm->getAttribute('title'));
+        return str_replace('  ', '&nbsp;&nbsp;', $title);
+
+    }//end formatCodeTitle()
+
+
+    /**
+     * Retrieve a code block contents and prepare it for output as HTML.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return string
+     */
+    private function formatCodeSample(DOMElement $codeElm)
+    {
+        $code = (string) $codeElm->nodeValue;
+        $code = trim($code);
+        $code = str_replace('<?php', '&lt;?php', $code);
+        $code = str_replace(["\n", ' '], ['</br>', '&nbsp;'], $code);
+        $code = str_replace(['<em>', '</em>'], ['<span class="code-comparison-highlight">', '</span>'], $code);
+
+        return $code;
+
+    }//end formatCodeSample()
 
 
 }//end class

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -11,6 +11,7 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMElement;
 use DOMNode;
 use PHP_CodeSniffer\Config;
 
@@ -249,19 +250,11 @@ class Markdown extends Generator
             return '';
         }
 
-        $firstTitle = trim($firstCodeElm->getAttribute('title'));
-        $firstTitle = str_replace('  ', '&nbsp;&nbsp;', $firstTitle);
-        $first      = trim($firstCodeElm->nodeValue);
-        $first      = str_replace("\n", PHP_EOL.'    ', $first);
-        $first      = str_replace('<em>', '', $first);
-        $first      = str_replace('</em>', '', $first);
+        $firstTitle = $this->formatCodeTitle($firstCodeElm);
+        $first      = $this->formatCodeSample($firstCodeElm);
 
-        $secondTitle = trim($secondCodeElm->getAttribute('title'));
-        $secondTitle = str_replace('  ', '&nbsp;&nbsp;', $secondTitle);
-        $second      = trim($secondCodeElm->nodeValue);
-        $second      = str_replace("\n", PHP_EOL.'    ', $second);
-        $second      = str_replace('<em>', '', $second);
-        $second      = str_replace('</em>', '', $second);
+        $secondTitle = $this->formatCodeTitle($secondCodeElm);
+        $second      = $this->formatCodeSample($secondCodeElm);
 
         $titleRow = '';
         if ($firstTitle !== '' || $secondTitle !== '') {
@@ -294,6 +287,44 @@ class Markdown extends Generator
         return $output;
 
     }//end getFormattedCodeComparisonBlock()
+
+
+    /**
+     * Retrieve a code block title and prepare it for output as HTML.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return string
+     */
+    private function formatCodeTitle(DOMElement $codeElm)
+    {
+        $title = trim($codeElm->getAttribute('title'));
+        return str_replace('  ', '&nbsp;&nbsp;', $title);
+
+    }//end formatCodeTitle()
+
+
+    /**
+     * Retrieve a code block contents and prepare it for output as HTML.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return string
+     */
+    private function formatCodeSample(DOMElement $codeElm)
+    {
+        $code = (string) $codeElm->nodeValue;
+        $code = trim($code);
+        $code = str_replace("\n", PHP_EOL.'    ', $code);
+        $code = str_replace(['<em>', '</em>'], '', $code);
+
+        return $code;
+
+    }//end formatCodeSample()
 
 
 }//end class

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -268,35 +268,9 @@ class Text extends Generator
             return [];
         }
 
-        $titleLines = [];
-        $tempTitle  = '';
-        $words      = explode(' ', $title);
+        $title = wordwrap($title, 46, "\n");
 
-        foreach ($words as $word) {
-            if (strlen($tempTitle.$word) >= 45) {
-                if (strlen($tempTitle.$word) === 45) {
-                    // Adding the extra space will push us to the edge
-                    // so we are done.
-                    $titleLines[] = $tempTitle.$word;
-                    $tempTitle    = '';
-                } else if (strlen($tempTitle.$word) === 46) {
-                    // We are already at the edge, so we are done.
-                    $titleLines[] = $tempTitle.$word;
-                    $tempTitle    = '';
-                } else {
-                    $titleLines[] = $tempTitle;
-                    $tempTitle    = $word.' ';
-                }
-            } else {
-                $tempTitle .= $word.' ';
-            }
-        }//end foreach
-
-        if ($tempTitle !== '') {
-            $titleLines[] = $tempTitle;
-        }
-
-        return $titleLines;
+        return explode("\n", $title);
 
     }//end codeTitleToLines()
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -188,53 +188,13 @@ class Text extends Generator
 
         $titleRow = '';
         if ($firstTitleLines !== [] || $secondTitleLines !== []) {
-            $maxTitleLines = max(count($firstTitleLines), count($secondTitleLines));
-            for ($i = 0; $i < $maxTitleLines; $i++) {
-                if (isset($firstTitleLines[$i]) === true) {
-                    $firstLineText = $firstTitleLines[$i];
-                } else {
-                    $firstLineText = '';
-                }
-
-                if (isset($secondTitleLines[$i]) === true) {
-                    $secondLineText = $secondTitleLines[$i];
-                } else {
-                    $secondLineText = '';
-                }
-
-                $titleRow .= '| ';
-                $titleRow .= $firstLineText.str_repeat(' ', (46 - strlen($firstLineText)));
-                $titleRow .= ' | ';
-                $titleRow .= $secondLineText.str_repeat(' ', (47 - strlen($secondLineText)));
-                $titleRow .= ' |'.PHP_EOL;
-            }//end for
-
+            $titleRow  = $this->linesToTableRows($firstTitleLines, $secondTitleLines);
             $titleRow .= str_repeat('-', 100).PHP_EOL;
         }//end if
 
         $codeRow = '';
         if ($firstLines !== [] || $secondLines !== []) {
-            $maxCodeLines = max(count($firstLines), count($secondLines));
-            for ($i = 0; $i < $maxCodeLines; $i++) {
-                if (isset($firstLines[$i]) === true) {
-                    $firstLineText = $firstLines[$i];
-                } else {
-                    $firstLineText = '';
-                }
-
-                if (isset($secondLines[$i]) === true) {
-                    $secondLineText = $secondLines[$i];
-                } else {
-                    $secondLineText = '';
-                }
-
-                $codeRow .= '| ';
-                $codeRow .= $firstLineText.str_repeat(' ', max(0, (47 - strlen($firstLineText))));
-                $codeRow .= '| ';
-                $codeRow .= $secondLineText.str_repeat(' ', max(0, (48 - strlen($secondLineText))));
-                $codeRow .= '|'.PHP_EOL;
-            }//end for
-
+            $codeRow  = $this->linesToTableRows($firstLines, $secondLines);
             $codeRow .= str_repeat('-', 100).PHP_EOL.PHP_EOL;
         }//end if
 
@@ -295,6 +255,44 @@ class Text extends Generator
         return explode("\n", $code);
 
     }//end codeToLines()
+
+
+    /**
+     * Transform two sets of text lines into rows for use in an ASCII table.
+     *
+     * The sets may not contains an equal amount of lines, while the resulting rows should.
+     *
+     * @param array<string> $column1Lines Lines of text to place in column 1.
+     * @param array<string> $column2Lines Lines of text to place in column 2.
+     *
+     * @return string
+     */
+    private function linesToTableRows(array $column1Lines, array $column2Lines)
+    {
+        $maxLines = max(count($column1Lines), count($column2Lines));
+
+        $rows = '';
+        for ($i = 0; $i < $maxLines; $i++) {
+            $column1Text = '';
+            if (isset($column1Lines[$i]) === true) {
+                $column1Text = $column1Lines[$i];
+            }
+
+            $column2Text = '';
+            if (isset($column2Lines[$i]) === true) {
+                $column2Text = $column2Lines[$i];
+            }
+
+            $rows .= '| ';
+            $rows .= $column1Text.str_repeat(' ', max(0, (47 - strlen($column1Text))));
+            $rows .= '| ';
+            $rows .= $column2Text.str_repeat(' ', max(0, (48 - strlen($column2Text))));
+            $rows .= '|'.PHP_EOL;
+        }//end for
+
+        return $rows;
+
+    }//end linesToTableRows()
 
 
 }//end class

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -13,6 +13,7 @@
 
 namespace PHP_CodeSniffer\Generators;
 
+use DOMElement;
 use DOMNode;
 
 class Text extends Generator
@@ -179,76 +180,14 @@ class Text extends Generator
             return '';
         }
 
-        $first      = trim($firstCodeElm->nodeValue);
-        $firstTitle = trim($firstCodeElm->getAttribute('title'));
+        $firstTitleLines = $this->codeTitleToLines($firstCodeElm);
+        $firstLines      = $this->codeToLines($firstCodeElm);
 
-        $firstTitleLines = [];
-        $tempTitle       = '';
-        $words           = explode(' ', $firstTitle);
-
-        foreach ($words as $word) {
-            if (strlen($tempTitle.$word) >= 45) {
-                if (strlen($tempTitle.$word) === 45) {
-                    // Adding the extra space will push us to the edge
-                    // so we are done.
-                    $firstTitleLines[] = $tempTitle.$word;
-                    $tempTitle         = '';
-                } else if (strlen($tempTitle.$word) === 46) {
-                    // We are already at the edge, so we are done.
-                    $firstTitleLines[] = $tempTitle.$word;
-                    $tempTitle         = '';
-                } else {
-                    $firstTitleLines[] = $tempTitle;
-                    $tempTitle         = $word.' ';
-                }
-            } else {
-                $tempTitle .= $word.' ';
-            }
-        }//end foreach
-
-        if ($tempTitle !== '') {
-            $firstTitleLines[] = $tempTitle;
-        }
-
-        $first      = str_replace(['<em>', '</em>'], '', $first);
-        $firstLines = explode("\n", $first);
-
-        $second      = trim($secondCodeElm->nodeValue);
-        $secondTitle = trim($secondCodeElm->getAttribute('title'));
-
-        $secondTitleLines = [];
-        $tempTitle        = '';
-        $words            = explode(' ', $secondTitle);
-
-        foreach ($words as $word) {
-            if (strlen($tempTitle.$word) >= 45) {
-                if (strlen($tempTitle.$word) === 45) {
-                    // Adding the extra space will push us to the edge
-                    // so we are done.
-                    $secondTitleLines[] = $tempTitle.$word;
-                    $tempTitle          = '';
-                } else if (strlen($tempTitle.$word) === 46) {
-                    // We are already at the edge, so we are done.
-                    $secondTitleLines[] = $tempTitle.$word;
-                    $tempTitle          = '';
-                } else {
-                    $secondTitleLines[] = $tempTitle;
-                    $tempTitle          = $word.' ';
-                }
-            } else {
-                $tempTitle .= $word.' ';
-            }
-        }//end foreach
-
-        if ($tempTitle !== '') {
-            $secondTitleLines[] = $tempTitle;
-        }
-
-        $second      = str_replace(['<em>', '</em>'], '', $second);
-        $secondLines = explode("\n", $second);
+        $secondTitleLines = $this->codeTitleToLines($secondCodeElm);
+        $secondLines      = $this->codeToLines($secondCodeElm);
 
         $titleRow = '';
-        if ($firstTitle !== '' || $secondTitle !== '') {
+        if ($firstTitleLines !== [] || $secondTitleLines !== []) {
             $maxTitleLines = max(count($firstTitleLines), count($secondTitleLines));
             for ($i = 0; $i < $maxTitleLines; $i++) {
                 if (isset($firstTitleLines[$i]) === true) {
@@ -274,7 +213,7 @@ class Text extends Generator
         }//end if
 
         $codeRow = '';
-        if ($first !== '' || $second !== '') {
+        if ($firstLines !== [] || $secondLines !== []) {
             $maxCodeLines = max(count($firstLines), count($secondLines));
             for ($i = 0; $i < $maxCodeLines; $i++) {
                 if (isset($firstLines[$i]) === true) {
@@ -311,6 +250,77 @@ class Text extends Generator
         return $output;
 
     }//end getFormattedCodeComparisonBlock()
+
+
+    /**
+     * Retrieve a code block title and split it into lines for use in an ASCII table.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return array<string>
+     */
+    private function codeTitleToLines(DOMElement $codeElm)
+    {
+        $title = trim($codeElm->getAttribute('title'));
+        if ($title === '') {
+            return [];
+        }
+
+        $titleLines = [];
+        $tempTitle  = '';
+        $words      = explode(' ', $title);
+
+        foreach ($words as $word) {
+            if (strlen($tempTitle.$word) >= 45) {
+                if (strlen($tempTitle.$word) === 45) {
+                    // Adding the extra space will push us to the edge
+                    // so we are done.
+                    $titleLines[] = $tempTitle.$word;
+                    $tempTitle    = '';
+                } else if (strlen($tempTitle.$word) === 46) {
+                    // We are already at the edge, so we are done.
+                    $titleLines[] = $tempTitle.$word;
+                    $tempTitle    = '';
+                } else {
+                    $titleLines[] = $tempTitle;
+                    $tempTitle    = $word.' ';
+                }
+            } else {
+                $tempTitle .= $word.' ';
+            }
+        }//end foreach
+
+        if ($tempTitle !== '') {
+            $titleLines[] = $tempTitle;
+        }
+
+        return $titleLines;
+
+    }//end codeTitleToLines()
+
+
+    /**
+     * Retrieve a code block contents and split it into lines for use in an ASCII table.
+     *
+     * @param \DOMElement $codeElm The DOMElement object for a code block.
+     *
+     * @since 3.12.0
+     *
+     * @return array<string>
+     */
+    private function codeToLines(DOMElement $codeElm)
+    {
+        $code = trim($codeElm->nodeValue);
+        if ($code === '') {
+            return [];
+        }
+
+        $code = str_replace(['<em>', '</em>'], '', $code);
+        return explode("\n", $code);
+
+    }//end codeToLines()
 
 
 }//end class


### PR DESCRIPTION
# Description

These five commits basically apply the same changes to all three Generator classes (reduce code duplication), which is why I've combined them in one PR.

---

### Generators/HTML::getFormattedCodeComparisonBlock(): minor refactor 

Move some duplicate code to dedicated `private` methods.

### Generators/Markdown::getFormattedCodeComparisonBlock(): minor refactor 

Move some duplicate code to dedicated `private` methods.

### Generators/Text::getFormattedCodeComparisonBlock(): minor refactor [1] 

Move some duplicate code to dedicated `private` methods.

### Generators/Text::codeTitleToLines(): simplify the logic 

There's absolutely no need for custom word-wrapping logic when PHP contains a function which can do this perfectly well.

### Generators/Text::getFormattedCodeComparisonBlock(): minor refactor [2] 

Move yet more duplicate code to a dedicated `private` method.


## Suggested changelog entry
_N/A_


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PR with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.

