### PR TITLE
Squiz/EmbeddedPhp: bug fix - prevent fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -292,8 +292,9 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         // Check for a blank line at the bottom.
-        if ((isset($tokens[$lastContent]['scope_closer']) === false
-            || $tokens[$lastContent]['scope_closer'] !== $lastContent)
+        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closingTag - 1), ($stackPtr + 1), true);
+        if ((isset($tokens[$lastNonEmpty]['scope_closer']) === false
+            || $tokens[$lastNonEmpty]['scope_closer'] !== $lastNonEmpty)
             && $tokens[$lastContent]['line'] < ($tokens[$closingTag]['line'] - 1)
         ) {
             // Find a token on the blank line to throw the error on.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc
@@ -284,6 +284,13 @@ echo $j;
     ?>
 
 <?php
+enum BlankLineBeforeCloseShouldBeIgnoredWhenLastBeforeIsCloseCurlyForScope
+{
+}//trailing comment
+
+?>
+
+<?php
 // This test case file MUST always end with an unclosed long open PHP tag (with this comment) to prevent
 // the tests running into the "last PHP closing tag excepted" condition breaking tests.
 // Tests related to that "last PHP closing tag excepted" condition should go in separate files.

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.1.inc.fixed
@@ -302,6 +302,13 @@ echo $j;
     ?>
 
 <?php
+enum BlankLineBeforeCloseShouldBeIgnoredWhenLastBeforeIsCloseCurlyForScope
+{
+}//trailing comment
+
+?>
+
+<?php
 // This test case file MUST always end with an unclosed long open PHP tag (with this comment) to prevent
 // the tests running into the "last PHP closing tag excepted" condition breaking tests.
 // Tests related to that "last PHP closing tag excepted" condition should go in separate files.


### PR DESCRIPTION
# Description
The `Squiz.PHP.EmbeddedPhp` sniff expects no blank lines before the PHP close tag.
This rule can, however, conflict with sniffs enforcing blank lines after a class or function.

The sniff already contains protection against this conflict, but that protection did not take potential trailing comments after the close curly, like `//end class`, into account.

Fixed now.

Includes test.

## Suggested changelog entry
Squiz.PHP.EmbeddedPhp: no new line before close tag was incorrectly enforced when a preceding OO construct or function had a trailing comment after the close curly


## Related issues/external references

Related to #152


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

