### PR TITLE
Runner: don't prefix Ruleset error notices

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -239,7 +239,7 @@ class Ruleset
         }
 
         if ($numSniffs === 0) {
-            throw new RuntimeException('No sniffs were registered');
+            throw new RuntimeException('ERROR: No sniffs were registered');
         }
 
     }//end __construct()
@@ -366,7 +366,7 @@ class Ruleset
 
         $messages        = [];
         $messageTemplate = 'This sniff has been deprecated since %s and will be removed in %s. %s';
-        $errorTemplate   = 'The %s::%s() method must return a %sstring, received %s';
+        $errorTemplate   = 'ERROR: The %s::%s() method must return a %sstring, received %s';
 
         foreach ($this->deprecatedSniffs as $sniffCode => $className) {
             if (isset($this->sniffs[$className]) === false) {
@@ -486,7 +486,7 @@ class Ruleset
         libxml_use_internal_errors(true);
         $ruleset = simplexml_load_string(file_get_contents($rulesetPath));
         if ($ruleset === false) {
-            $errorMsg = "Ruleset $rulesetPath is not valid".PHP_EOL;
+            $errorMsg = "ERROR: Ruleset $rulesetPath is not valid".PHP_EOL;
             $errors   = libxml_get_errors();
             foreach ($errors as $error) {
                 $errorMsg .= '- On line '.$error->line.', column '.$error->column.': '.$error->message;
@@ -530,7 +530,7 @@ class Ruleset
             if ($relativePath !== false && is_file($relativePath) === true) {
                 $autoloadPath = $relativePath;
             } else if (is_file($autoloadPath) === false) {
-                throw new RuntimeException('The specified autoload file "'.$autoload.'" does not exist');
+                throw new RuntimeException('ERROR: The specified autoload file "'.$autoload.'" does not exist');
             }
 
             include_once $autoloadPath;
@@ -993,7 +993,7 @@ class Ruleset
             }
         } else {
             if (is_file($ref) === false) {
-                $error = "Referenced sniff \"$ref\" does not exist";
+                $error = "ERROR: Referenced sniff \"$ref\" does not exist";
                 throw new RuntimeException($error);
             }
 
@@ -1083,7 +1083,7 @@ class Ruleset
 
                 $type = strtolower((string) $rule->type);
                 if ($type !== 'error' && $type !== 'warning') {
-                    throw new RuntimeException("Message type \"$type\" is invalid; must be \"error\" or \"warning\"");
+                    throw new RuntimeException("ERROR: Message type \"$type\" is invalid; must be \"error\" or \"warning\"");
                 }
 
                 $this->ruleset[$code]['type'] = $type;
@@ -1412,7 +1412,7 @@ class Ruleset
 
             $tokens = $this->sniffs[$sniffClass]->register();
             if (is_array($tokens) === false) {
-                $msg = "Sniff $sniffClass register() method must return an array";
+                $msg = "ERROR: Sniff $sniffClass register() method must return an array";
                 throw new RuntimeException($msg);
             }
 
@@ -1523,7 +1523,7 @@ class Ruleset
 
         if ($isSettable === false) {
             if ($settings['scope'] === 'sniff') {
-                $notice  = "Ruleset invalid. Property \"$propertyName\" does not exist on sniff ";
+                $notice  = "ERROR: Ruleset invalid. Property \"$propertyName\" does not exist on sniff ";
                 $notice .= array_search($sniffClass, $this->sniffCodes, true);
                 throw new RuntimeException($notice);
             }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -351,7 +351,7 @@ class Runner
                 $this->ruleset->showSniffDeprecations();
             }
         } catch (RuntimeException $e) {
-            $error  = 'ERROR: '.$e->getMessage().PHP_EOL.PHP_EOL;
+            $error  = rtrim($e->getMessage(), "\r\n").PHP_EOL.PHP_EOL;
             $error .= $this->config->printShortUsage(true);
             throw new DeepExitException($error, 3);
         }

--- a/tests/Core/Ruleset/ConstructorTest.php
+++ b/tests/Core/Ruleset/ConstructorTest.php
@@ -282,7 +282,7 @@ final class ConstructorTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ConstructorNoSniffsTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $message = 'No sniffs were registered';
+        $message = 'ERROR: No sniffs were registered';
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
@@ -109,7 +109,7 @@ final class ExpandRulesetReferenceHomePathTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ExpandRulesetReferenceHomePathFailTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $exceptionMessage = 'Referenced sniff "~/src/MyStandard/Sniffs/DoesntExist/" does not exist';
+        $exceptionMessage = 'ERROR: Referenced sniff "~/src/MyStandard/Sniffs/DoesntExist/" does not exist';
         $this->expectRuntimeExceptionMessage($exceptionMessage);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
@@ -61,7 +61,7 @@ final class ExpandRulesetReferenceTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/'.$standard;
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $exceptionMessage = 'Referenced sniff "%s" does not exist';
+        $exceptionMessage = 'ERROR: Referenced sniff "%s" does not exist';
         $this->expectRuntimeExceptionMessage(sprintf($exceptionMessage, $replacement));
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.php
@@ -62,7 +62,7 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
         $config   = new ConfigDouble(["--standard=$standard"]);
 
         $sniffClass = 'Fixtures\\TestStandard\\Sniffs\\InvalidSniffs\\RegisterNoArraySniff';
-        $message    = "Sniff $sniffClass register() method must return an array";
+        $message    = "ERROR: Sniff $sniffClass register() method must return an array";
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
+++ b/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
@@ -32,7 +32,7 @@ final class ProcessRuleInvalidTypeTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ProcessRuleInvalidTypeTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $message = 'Message type "notice" is invalid; must be "error" or "warning"';
+        $message = 'ERROR: Message type "notice" is invalid; must be "error" or "warning"';
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/ProcessRulesetAutoloadTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetAutoloadTest.php
@@ -150,7 +150,7 @@ final class ProcessRulesetAutoloadTest extends AbstractRulesetTestCase
      */
     public function testFileNotFoundException()
     {
-        $exceptionMsg = 'The specified autoload file "./tests/Core/Ruleset/Fixtures/ThisFileDoesNotExist.php" does not exist';
+        $exceptionMsg = 'ERROR: The specified autoload file "./tests/Core/Ruleset/Fixtures/ThisFileDoesNotExist.php" does not exist';
         $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.

--- a/tests/Core/Ruleset/ProcessRulesetBrokenRulesetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetBrokenRulesetTest.php
@@ -39,7 +39,7 @@ final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ProcessRulesetBrokenRulesetEmptyFileTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $regex  = '`^Ruleset \S+ProcessRulesetBrokenRulesetEmptyFileTest\.xml is not valid\R';
+        $regex  = '`^ERROR: Ruleset \S+ProcessRulesetBrokenRulesetEmptyFileTest\.xml is not valid\R';
         $regex .= '(- On line 1, column 1: Document is empty\R)?$`';
 
         $this->expectRuntimeExceptionRegex($regex);
@@ -59,7 +59,7 @@ final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ProcessRulesetBrokenRulesetSingleErrorTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $regex  = '`^Ruleset \S+ProcessRulesetBrokenRulesetSingleErrorTest\.xml is not valid\R';
+        $regex  = '`^ERROR: Ruleset \S+ProcessRulesetBrokenRulesetSingleErrorTest\.xml is not valid\R';
         $regex .= '- On line 3, column 1: Premature end of data in tag ruleset line 2\R$`';
 
         $this->expectRuntimeExceptionRegex($regex);
@@ -79,7 +79,7 @@ final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ProcessRulesetBrokenRulesetMultiErrorTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $regex  = '`^Ruleset \S+ProcessRulesetBrokenRulesetMultiErrorTest\.xml is not valid\R';
+        $regex  = '`^ERROR: Ruleset \S+ProcessRulesetBrokenRulesetMultiErrorTest\.xml is not valid\R';
         $regex .= '- On line 8, column 12: Opening and ending tag mismatch: property line 7 and rule\R';
         $regex .= '- On line 10, column 11: Opening and ending tag mismatch: properties line 5 and ruleset\R';
         $regex .= '(- On line 11, column 1: Premature end of data in tag rule line 4\R)?$`';

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -135,7 +135,7 @@ final class SetSniffPropertyTest extends AbstractRulesetTestCase
      */
     public function testSetPropertyThrowsErrorOnInvalidProperty()
     {
-        $exceptionMsg = 'Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
+        $exceptionMsg = 'ERROR: Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
         $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.
@@ -155,7 +155,7 @@ final class SetSniffPropertyTest extends AbstractRulesetTestCase
      */
     public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
     {
-        $exceptionMsg = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
+        $exceptionMsg = 'ERROR: Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
         $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -514,23 +514,23 @@ final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
         return [
             'getDeprecationVersion() does not return a string' => [
                 'standard'         => 'ShowSniffDeprecationsInvalidDeprecationVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received double',
+                'exceptionMessage' => 'ERROR: The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received double',
             ],
             'getRemovalVersion() does not return a string'     => [
                 'standard'         => 'ShowSniffDeprecationsInvalidRemovalVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received array',
+                'exceptionMessage' => 'ERROR: The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received array',
             ],
             'getDeprecationMessage() does not return a string' => [
                 'standard'         => 'ShowSniffDeprecationsInvalidDeprecationMessageTest.xml',
-                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationMessageSniff::getDeprecationMessage() method must return a string, received object',
+                'exceptionMessage' => 'ERROR: The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\InvalidDeprecationMessageSniff::getDeprecationMessage() method must return a string, received object',
             ],
             'getDeprecationVersion() returns an empty string'  => [
                 'standard'         => 'ShowSniffDeprecationsEmptyDeprecationVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received ""',
+                'exceptionMessage' => 'ERROR: The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyDeprecationVersionSniff::getDeprecationVersion() method must return a non-empty string, received ""',
             ],
             'getRemovalVersion() returns an empty string'      => [
                 'standard'         => 'ShowSniffDeprecationsEmptyRemovalVersionTest.xml',
-                'exceptionMessage' => 'The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received ""',
+                'exceptionMessage' => 'ERROR: The Fixtures\TestStandard\Sniffs\DeprecatedInvalid\EmptyRemovalVersionSniff::getRemovalVersion() method must return a non-empty string, received ""',
             ],
         ];
 


### PR DESCRIPTION
# Description
As things are, the `Runner` class catches any exception thrown by the Ruleset, enhances the message with an `ERROR` prefix, adds new lines and short help usage info and then re-throws this as a `DeepExitException`.

In an upcoming PR, a new `MsgCollector` class will be introduced, which will allow for both errors, as well as warnings, notices and deprecations.

This means that the `ERROR` prefix won't always be appropriate anymore.

This commit moves the `ERROR` prefix addition from the `Runner` class to the individual messages for the Exceptions being thrown in the `Ruleset` class.

Additionally, it changes the "trailing new lines" handling as the `MsgCollector` may also add new lines at the end of a message, as messages will not necessarily always be displayed via an exception (think: non-blocking deprecation notices). So to prevent a duplicate set of new lines, any new lines which are included in the exception are trimmed off before adding the new lines desired for the Exception display.

_This is a preliminary step before introducing the `MsgCollector` to the `Ruleset` class._


## Suggested changelog entry
_N/A - This is an internal change only_


## Related issues/external references

Loosely related to #689

