### PR TITLE
[Docs] Add XML doc for Squiz.Classes.ValidClassName sniff

### DIFF
--- a/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
+++ b/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
@@ -7,14 +7,14 @@
     <code_comparison>
         <code title="Valid: Class name is written in Pascal case.">
         <![CDATA[
-class PascalCaseStandard
+class <em>PascalCaseStandard</em>
 {
 }
         ]]>
         </code>
         <code title="Invalid: Class name does not start with a capital letter.">
         <![CDATA[
-class notPascalCaseStandard
+class <em>notPascalCaseStandard</em>
 {
 }
         ]]>

--- a/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
+++ b/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="Valid Class Name">
+    <standard>
+    <![CDATA[
+    Class names must be written in Pascal case.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Class name is written in Pascal case.">
+        <![CDATA[
+class PascalCaseStandard
+{
+}
+        ]]>
+        </code>
+        <code title="Invalid: Class name does not start with a capital letter.">
+        <![CDATA[
+class notPascalCaseStandard
+{
+}
+        ]]>
+        </code>
+        </code_comparison>
+</documentation>

--- a/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
+++ b/src/Standards/Squiz/Docs/Classes/ValidClassNameStandard.xml
@@ -1,11 +1,11 @@
 <documentation title="Valid Class Name">
     <standard>
     <![CDATA[
-    Class names must be written in Pascal case.
+    Class names must be written in Pascal case. This means that it starts with a capital letter, and the first letter of each word in the class name is capitalized. Only letters and numbers are allowed.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Class name is written in Pascal case.">
+        <code title="Valid: Class name starts with a capital letter.">
         <![CDATA[
 class <em>PascalCaseStandard</em>
 {
@@ -19,5 +19,21 @@ class <em>notPascalCaseStandard</em>
 }
         ]]>
         </code>
-        </code_comparison>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Class name contains only letters and numbers.">
+        <![CDATA[
+class <em>PSR7Response</em>
+{
+}
+        ]]>
+        </code>
+        <code title="Invalid: Class name contains underscores.">
+        <![CDATA[
+class <em>PSR7_Response</em>
+{
+}
+        ]]>
+        </code>
+    </code_comparison>
 </documentation>


### PR DESCRIPTION
# Description
This PR adds documentation for the `Squiz\Classes\ValidClassName` sniff.

## Suggested changelog entry
Add documentation for the Squiz.Classes.ValidClassName sniff

## Related issues/external references

Partial fix for #148 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
