### PR TITLE
Squiz/ClassFileName: various improvements

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -48,8 +48,9 @@ class ClassFileNameSniff implements Sniff
             return $phpcsFile->numTokens;
         }
 
-        $fullPath = basename($filename);
-        $fileName = substr($fullPath, 0, strrpos($fullPath, '.'));
+        $fullPath  = basename($filename);
+        $fileName  = substr($fullPath, 0, strrpos($fullPath, '.'));
+        $extension = substr($fullPath, (strrpos($fullPath, '.') + 1));
 
         $tokens = $phpcsFile->getTokens();
         $ooName = $phpcsFile->getDeclarationName($stackPtr);
@@ -59,11 +60,10 @@ class ClassFileNameSniff implements Sniff
         }
 
         if ($ooName !== $fileName) {
-            $error = '%s name doesn\'t match filename; expected "%s %s"';
+            $error = 'Filename doesn\'t match %s name; expected file name "%s"';
             $data  = [
-                ucfirst($tokens[$stackPtr]['content']),
                 $tokens[$stackPtr]['content'],
-                $fileName,
+                $ooName.'.'.$extension,
             ];
             $phpcsFile->addError($error, $stackPtr, 'NoMatch', $data);
         }

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ClassFileNameSniff implements Sniff
 {
@@ -23,12 +24,10 @@ class ClassFileNameSniff implements Sniff
      */
     public function register()
     {
-        return [
-            T_CLASS,
-            T_INTERFACE,
-            T_TRAIT,
-            T_ENUM,
-        ];
+        $targets = Tokens::$ooScopeTokens;
+        unset($targets[T_ANON_CLASS]);
+
+        return $targets;
 
     }//end register()
 

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -43,14 +43,14 @@ class ClassFileNameSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $filename = $phpcsFile->getFilename();
-        if ($filename === 'STDIN') {
+        $fullPath = $phpcsFile->getFilename();
+        if ($fullPath === 'STDIN') {
             return $phpcsFile->numTokens;
         }
 
-        $fullPath  = basename($filename);
-        $fileName  = substr($fullPath, 0, strrpos($fullPath, '.'));
-        $extension = substr($fullPath, (strrpos($fullPath, '.') + 1));
+        $fileName  = basename($fullPath);
+        $fileNoExt = substr($fileName, 0, strrpos($fileName, '.'));
+        $extension = substr($fileName, (strrpos($fileName, '.') + 1));
 
         $tokens = $phpcsFile->getTokens();
         $ooName = $phpcsFile->getDeclarationName($stackPtr);
@@ -59,7 +59,7 @@ class ClassFileNameSniff implements Sniff
             return;
         }
 
-        if ($ooName !== $fileName) {
+        if ($ooName !== $fileNoExt) {
             $error = 'Filename doesn\'t match %s name; expected file name "%s"';
             $data  = [
                 $tokens[$stackPtr]['content'],

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -51,10 +51,14 @@ class ClassFileNameSniff implements Sniff
         $fullPath = basename($filename);
         $fileName = substr($fullPath, 0, strrpos($fullPath, '.'));
 
-        $tokens  = $phpcsFile->getTokens();
-        $decName = $phpcsFile->findNext(T_STRING, $stackPtr);
+        $tokens = $phpcsFile->getTokens();
+        $ooName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($ooName === null) {
+            // Probably parse error/live coding.
+            return;
+        }
 
-        if ($tokens[$decName]['content'] !== $fileName) {
+        if ($ooName !== $fileName) {
             $error = '%s name doesn\'t match filename; expected "%s %s"';
             $data  = [
                 ucfirst($tokens[$stackPtr]['content']),

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -43,12 +43,13 @@ class ClassFileNameSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $fullPath = basename($phpcsFile->getFilename());
-        $fileName = substr($fullPath, 0, strrpos($fullPath, '.'));
-        if ($fileName === '') {
-            // No filename probably means STDIN, so we can't do this check.
-            return;
+        $filename = $phpcsFile->getFilename();
+        if ($filename === 'STDIN') {
+            return $phpcsFile->numTokens;
         }
+
+        $fullPath = basename($filename);
+        $fileName = substr($fullPath, 0, strrpos($fullPath, '.'));
 
         $tokens  = $phpcsFile->getTokens();
         $decName = $phpcsFile->findNext(T_STRING, $stackPtr);

--- a/src/Standards/Squiz/Tests/Classes/ClassFileName Spaces In FilenameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileName Spaces In FilenameUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Test to demonstrate that file names should follow class names, not the other way around.
+// Making the class name comply with the file name would result in a parse error for this file,
+// as the file name doesn't comply with the naming conventions for PHP symbol names.
+
+class ClassFileNameSpacesInFilenameUnitTest {}

--- a/src/Standards/Squiz/Tests/Classes/ClassFileName-Dashes-In-FilenameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileName-Dashes-In-FilenameUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Test to demonstrate that file names should follow class names, not the other way around.
+// Making the class name comply with the file name would result in a parse error for this file,
+// as the file name doesn't comply with the naming conventions for PHP symbol names.
+
+class ClassFileNameDashesInFilenameUnitTest

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameLiveCodingFailUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameLiveCodingFailUnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Intentional parse error. This should be the only test in this file.
+// Live coding/missing curlies should not block the sniff from functioning.
+
+class Class_FileName_Live_Coding_Fail_UnitTest

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameLiveCodingPassUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameLiveCodingPassUnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Intentional parse error. This should be the only test in this file.
+// Live coding/missing curlies should not block the sniff from functioning.
+
+class ClassFileNameLiveCodingPassUnitTest

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameParseError1UnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Intentional parse error. This should be the only test in this file.
+// Class missing class name should be ignored.
+
+class

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
@@ -15,7 +15,7 @@ class CLASSFILENAMEUNITTEST {}
 interface classFileNameUnitTest {}
 interface classfilenameunittest {}
 interface CLASSFILENAMEUNITTEST {}
-trait classFileNameUnitTest {}
+trait /*comment*/ classFileNameUnitTest {}
 trait classfilenameunittest {}
 trait CLASSFILENAMEUNITTEST {}
 enum classFileNameUnitTest {}
@@ -39,7 +39,6 @@ trait ExtraClassFileNameUnitTest {}
 enum CompletelyWrongClassName {}
 enum ClassFileNameUnitTestExtra {}
 enum ClassFileNameUnitTestInc {}
-enum ExtraClassFileNameUnitTest {}
-
-
-?>
+enum
+    // Comment
+    ExtraClassFileNameUnitTest {}

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
+use DirectoryIterator;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 /**
@@ -21,45 +22,98 @@ final class ClassFileNameUnitTest extends AbstractSniffUnitTest
 
 
     /**
+     * Get a list of all test files to check.
+     *
+     * These will have the same base as the sniff name but different extensions.
+     * We ignore the .php file as it is the class.
+     *
+     * @param string $testFileBase The base path that the unit tests files will have.
+     *
+     * @return string[]
+     */
+    protected function getTestFiles($testFileBase)
+    {
+        $testFiles = [];
+
+        $dir = substr($testFileBase, 0, strrpos($testFileBase, DIRECTORY_SEPARATOR));
+        $di  = new DirectoryIterator($dir);
+
+        // Strip off the path and the "UnitTest." suffix from the $testFileBase to allow
+        // for some less conventionally named test case files.
+        $fileBase = str_replace($dir, '', $testFileBase);
+        $fileBase = substr($fileBase, 1, -9);
+
+        foreach ($di as $file) {
+            $fileName  = $file->getBasename('UnitTest.inc');
+            $extension = $file->getExtension();
+            if (substr($fileName, 0, strlen($fileBase)) === $fileBase
+                && $extension === 'inc'
+            ) {
+                $testFiles[] = $file->getPathname();
+            }
+        }
+
+        // Put them in order.
+        sort($testFiles, SORT_NATURAL);
+
+        return $testFiles;
+
+    }//end getTestFiles()
+
+
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getErrorList()
+    public function getErrorList($testFile='')
     {
-        return [
-            12 => 1,
-            13 => 1,
-            14 => 1,
-            15 => 1,
-            16 => 1,
-            17 => 1,
-            18 => 1,
-            19 => 1,
-            20 => 1,
-            21 => 1,
-            22 => 1,
-            23 => 1,
-            27 => 1,
-            28 => 1,
-            29 => 1,
-            30 => 1,
-            31 => 1,
-            32 => 1,
-            33 => 1,
-            34 => 1,
-            35 => 1,
-            36 => 1,
-            37 => 1,
-            38 => 1,
-            39 => 1,
-            40 => 1,
-            41 => 1,
-            42 => 1,
-        ];
+        switch ($testFile) {
+        case 'ClassFileNameUnitTest.inc':
+            return [
+                12 => 1,
+                13 => 1,
+                14 => 1,
+                15 => 1,
+                16 => 1,
+                17 => 1,
+                18 => 1,
+                19 => 1,
+                20 => 1,
+                21 => 1,
+                22 => 1,
+                23 => 1,
+                27 => 1,
+                28 => 1,
+                29 => 1,
+                30 => 1,
+                31 => 1,
+                32 => 1,
+                33 => 1,
+                34 => 1,
+                35 => 1,
+                36 => 1,
+                37 => 1,
+                38 => 1,
+                39 => 1,
+                40 => 1,
+                41 => 1,
+                42 => 1,
+            ];
+
+        case 'ClassFileNameLiveCodingFailUnitTest.inc':
+            return [
+                6 => 1,
+            ];
+
+        default:
+            return [];
+        }//end switch
 
     }//end getErrorList()
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -111,6 +111,16 @@ final class ClassFileNameUnitTest extends AbstractSniffUnitTest
                 6 => 1,
             ];
 
+        case 'ClassFileName Spaces In FilenameUnitTest.inc':
+            return [
+                7 => 1,
+            ];
+
+        case 'ClassFileName-Dashes-In-FilenameUnitTest.inc':
+            return [
+                7 => 1,
+            ];
+
         default:
             return [];
         }//end switch


### PR DESCRIPTION
# Description

### Squiz/ClassFileName: expand the tests 

This commit adds some extra tests for the sniff.
* Document handling of unfinished OO declarations (which contain enough info to still action).
* Safeguard that comments in unexpected places doesn't cause problems.

As this sniff looks at the file name of the file containing the tests, we cannot use the _normal_ `SniffNameUnitTest.#.inc` naming conventions for extra tests files, so the `getTestFiles()` method from the `AbstractSniffUnitTest` class needs to be overloaded to retrieve the test case files in a slightly different way.

### Squiz/ClassFileName: minor stability tweak 

Use the predefined `Tokens::$ooScopeTokens` array to automatically benefit from new OO structures being added to that list.

### Squiz/ClassFileName: bow out earlier for STDIN 

As `STDIN` won't contain a usable file name, bow out and don't examine the input again.

_Note: the `process()` method should really end on a `return $this->phpcsFile->numTokens;` as well as a file containing multiple classes should not get multiple contradicting errors, but that would require each test for this sniff to be in their own file, which I currently don't deem worth the effort._

### Squiz/ClassFileName: don't error when there is no class name 

As things were, the sniff would try to find the next `T_STRING`, but didn't take live coding into account, which means it would end up comparing `$tokens[false]['content']` to the filename, which would end up comparing `<?php` to the file name.

This changes the sniff to use the `File::getDeclarationName()` method instead and verifies we have a usable name to compare against before throwing the error.

Includes test.

### Squiz/ClassFileName: inverse the error message 

As things were, the `Squiz.Classes.ClassFileName` sniff would recommend for a class (OO structure) to be called the same as the file.

However, file names can contain characters which are not allowed in PHP class names, so this advise could end up being impossible to action for names not complying with the PHP requirements for symbol names.

This commit changes the error message to advise to change the file name instead of the class name, which should make the error actionable in all cases.

Includes tests.
While the tests would not _fail_ without this change, the tests can be used to verify the difference in the error messages on the command-line.

Before this change, the errors would read like so:
```
FILE: src/Standards/Squiz/Tests/Classes/ClassFileName Spaces In FilenameUnitTest.inc
------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------
 7 | ERROR | Class name doesn't match filename; expected "class ClassFileName Spaces In FilenameUnitTest" (Squiz.Classes.ClassFileName.NoMatch)
------------------------------------------------------------------------------------------------------------------------------------------------

FILE: src/Standards/Squiz/Tests/Classes/ClassFileName-Dashes-In-FilenameUnitTest.inc
------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------
 7 | ERROR | Class name doesn't match filename; expected "class ClassFileName-Dashes-In-FilenameUnitTest" (Squiz.Classes.ClassFileName.NoMatch)
------------------------------------------------------------------------------------------------------------------------------------------------
```

With this change, the errors will read:
```
FILE: src/Standards/Squiz/Tests/Classes/ClassFileName Spaces In FilenameUnitTest.inc
-----------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------
 7 | ERROR | Filename doesn't match class name; expected file name "ClassFileNameSpacesInFilenameUnitTest.inc" (Squiz.Classes.ClassFileName.NoMatch)
-----------------------------------------------------------------------------------------------------------------------------------------------------

FILE: src/Standards/Squiz/Tests/Classes/ClassFileName-Dashes-In-FilenameUnitTest.inc
-----------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------
 7 | ERROR | Filename doesn't match class name; expected file name "ClassFileNameDashesInFilenameUnitTest.inc" (Squiz.Classes.ClassFileName.NoMatch)
-----------------------------------------------------------------------------------------------------------------------------------------------------
```

Side-note: while the `strrpos($fullPath, '.')` _could_ return `false`, this is not something we need to be concerned about in this sniff as PHPCS doesn't examine files without a file extension (at this time), so there should always be a `.` in the file name.

### 🆕  Squiz/ClassFileName: use more meaningful variable names


## Suggested changelog entry
Changed: Squiz.Classes.ClassFileName: recommend changing the file name instead of changing the class name to prevent recommendations which are inactionable due to the file name not translating to a valid PHP symbol name
Fixed: Squiz.Classes.ClassFileName: don't throw an incorrect error for an unfinished OO declaration during live coding



## Related issues/external references

Inspired by #843


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
