### PR TITLE
GH Actions/tests: run tests against multiple libxml versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,17 @@ jobs:
           - php: '8.4'
             skip_tests: true
 
+          # The default libxml library on Ubuntu images is a little out of date.
+          # To safeguard support for the latest libxml we need to update the library on the fly.
+          # This only needs to be tested with one PHP version for each libxml minor to verify support.
+          # Testing against multiple PHP versions would not yield a difference in results.
+          - php: '8.0'
+            os: 'ubuntu-latest'
+            libxml_minor: '2.11'
+          - php: '8.3'
+            os: 'ubuntu-latest'
+            libxml_minor: '2.13'
+
           # Extra builds running only the unit tests with different PHP ini settings.
           - php: '5.5'
             os: 'ubuntu-latest'
@@ -82,7 +93,7 @@ jobs:
             custom_ini: true
 
     # yamllint disable-line rule:line-length
-    name: "PHP: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
+    name: "PHP: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }}${{ matrix.libxml_minor && format( ' with libxml {0}', matrix.libxml_minor ) || '' }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
 
     continue-on-error: ${{ matrix.php == '8.5' }}
 
@@ -93,18 +104,67 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # This is a temporary solution.
-      # Once ubuntu-latest includes the latest libxml2 version, this step can be removed.
-      - name: Install latest libxml2 on PHP 8.4 (linux only)
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php == '8.4' }}
+      - name: "libxml2: find the latest relevant tag"
+        if: ${{ matrix.libxml_minor }}
+        id: libxml_version
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: GNOME/libxml2
+          releases-only: false  # The libxml2 repository doesn't use GitHub's "release" feature.
+          prefix: 'v${{ matrix.libxml_minor }}.' # Limit the result to the minor we're interested in.
+          sort-tags: true # Find the "greatest" version for that minor based on semver.
+
+      # To put it simply: we need to remove the 'v' prefix from the version number.
+      - name: "libxml2: parse the version to a patch version"
+        if: ${{ matrix.libxml_minor }}
+        id: libxml_patch_version
+        shell: bash
+        env:
+          TAG: ${{ steps.libxml_version.outputs.tag }}
+        run: echo "PATCH=$( echo "$TAG" | cut -b 2- )" >> "$GITHUB_OUTPUT"
+
+      - name: "libxml2: restore cache"
+        if: ${{ matrix.libxml_minor }}
+        id: libxml_cache_restore
+        uses: actions/cache/restore@v4
+        with:
+          path: "libxml2-${{ steps.libxml_patch_version.outputs.PATCH }}"
+          key: "${{ matrix.os }}-libxml-${{ matrix.libxml_minor }}-${{ steps.libxml_patch_version.outputs.PATCH }}"
+
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: "libxml2: Update the available packages list"
+        if: ${{ matrix.libxml_minor && steps.libxml_cache_restore.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: "libxml2: Download and build package (linux only)"
+        if: ${{ matrix.libxml_minor && steps.libxml_cache_restore.outputs.cache-hit != 'true' }}
+        env:
+          PATCH: ${{ steps.libxml_patch_version.outputs.PATCH }}
         run: |
-          sudo apt-get update
           sudo apt-get install -y wget build-essential
-          wget https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz
-          tar -xf libxml2-2.12.9.tar.xz
-          cd libxml2-2.12.9
+          wget "https://download.gnome.org/sources/libxml2/${{ matrix.libxml_minor }}/libxml2-$PATCH.tar.xz"
+          tar -xf "libxml2-$PATCH.tar.xz"
+          cd "libxml2-$PATCH"
           ./configure --prefix=/usr/local
           make
+
+      - name: "libxml2: save cache"
+        if: ${{ matrix.libxml_minor && steps.libxml_cache_restore.outputs.cache-hit != 'true' }}
+        id: libxml_cache_save
+        uses: actions/cache/save@v4
+        with:
+          path: "libxml2-${{ steps.libxml_patch_version.outputs.PATCH }}"
+          key: ${{ steps.libxml_cache_restore.outputs.cache-primary-key }}
+
+      - name: "libxml2: Install package (linux only)"
+        if: ${{ matrix.libxml_minor }}
+        env:
+          PATCH: ${{ steps.libxml_patch_version.outputs.PATCH }}
+        run: |
+          cd "libxml2-$PATCH"
           sudo make install
           sudo ldconfig
 
@@ -129,6 +189,9 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
           tools: cs2pr
+
+      - name: "DEBUG: show libxml loaded version (php)"
+        run: php -r 'echo "libxml loaded version = ", LIBXML_LOADED_VERSION, PHP_EOL;'
 
       # This action also handles the caching of the dependencies.
       - name: Set up node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # This is a temporary solution.
+      # Once ubuntu-latest includes the latest libxml2 version, this step can be removed.
+      - name: Install latest libxml2 on PHP 8.4 (linux only)
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.php == '8.4' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget build-essential
+          wget https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz
+          tar -xf libxml2-2.12.9.tar.xz
+          cd libxml2-2.12.9
+          ./configure --prefix=/usr/local
+          make
+          sudo make install
+          sudo ldconfig
+
       - name: Setup ini config
         id: set_ini
         shell: bash


### PR DESCRIPTION
# Description

## Background/Context

As @asispts hasn't been responding to the open feedback on PR #798 anymore **AND** the change proposed in #798 should go into the same release as PR #797 was merged in (to safeguard the changes from that PR) **AND** I haven't got permission to update the PR branch, I'm opening a new PR which supersedes PR #798.

## Commits


### GH Actions/tests: run tests against libxml >= 2.12

I've cherrypicked and squashed the pertinent changes from #798. Props @asispts.

### GH Actions/test: iterate on libxml installation steps 

This commit updates the initial implementation for updating `libxml2` on the fly for select PHP versions.

Compared to the original implementation, the following changes were made:
* Use a `libxml_minor` flag in the matrix to indicate whether `libxml` should be updated for a particular job or not.
    This `libxml_minor` flag also allows for specifying a specific minor to use for the update.
    This flag is now set on the linux PHP 8.0 and PHP 8.3 builds.
    _Take note: PHP 8.4 is explicitly not used, as the tests are not run in this job for that version (they are run in the `coverage` job instead)._
    _In effect that meant that installing `libxml` on PHP 8.4 in the workflow, as per the original PR, wasn't safeguarding anything as without tests running, the tests couldn't fail._
* Based on the `libxml_minor` flag, update the job name to make it clear when a particular job uses a non-default `libxml` version.
* On the fly figure out what the latest relevant tag is for a certain `libxml` minor.
    This makes the workflow more flexible by:
    - Allowing for different minors.
    - Prevents having a specific patch version hard-coded in the workflow (maintenance issue).
* Splits the `sudo apt-get update` command off to its own step as it is prone to intermittent failures.
* Splits the "Install" step into two steps: one to download and compile, one to install the newly compiled `libxml` version.
    Doing this allows for caching the result of the compile step, diminishing the impact on the actions run time of compiling `libxml`.
* Adds an (unconditional) "debug" step to allow for verifying which `libxml` version is being used in each job.

## Suggested changelog entry
_N/A_


## Related issues/external references

Follow up on #797 which fixed #767

Closes #798

