### PR TITLE
Tests/Tokenizer: fix bug in the `default` keyword tests

### DIFF
--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -112,7 +112,8 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      * @param string   $testMarker    The comment prefacing the target token.
      * @param int      $openerOffset  The expected offset of the scope opener in relation to the testMarker.
      * @param int      $closerOffset  The expected offset of the scope closer in relation to the testMarker.
-     * @param int|null $conditionStop The expected offset at which tokens stop having T_DEFAULT as a scope condition.
+     * @param int|null $conditionStop The expected offset in relation to the testMarker, at which tokens stop
+     *                                having T_DEFAULT as a scope condition.
      * @param string   $testContent   The token content to look for.
      *
      * @dataProvider dataSwitchDefault
@@ -158,7 +159,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStop) === true) {
-                $end = ($opener + $conditionStop);
+                $end = ($token + $conditionStop);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {
@@ -196,7 +197,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                 'testMarker'    => '/* testSimpleSwitchDefaultWithCurlies */',
                 'openerOffset'  => 3,
                 'closerOffset'  => 12,
-                'conditionStop' => 3,
+                'conditionStop' => 6,
             ],
             'switch_default_toplevel'                => [
                 'testMarker'   => '/* testSwitchDefault */',

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -158,7 +158,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStop) === true) {
-                $end = $conditionStop;
+                $end = ($opener + $conditionStop);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {
@@ -196,7 +196,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                 'testMarker'    => '/* testSimpleSwitchDefaultWithCurlies */',
                 'openerOffset'  => 3,
                 'closerOffset'  => 12,
-                'conditionStop' => 6,
+                'conditionStop' => 3,
             ],
             'switch_default_toplevel'                => [
                 'testMarker'   => '/* testSwitchDefault */',


### PR DESCRIPTION
# Description

This PR fixes a bug in `RecurseScopeMapDefaultKeywordConditionsTest ::testSwitchDefault()`. Among other things, this method checks whether tokens within the scope of a `default` have `T_DEFAULT` set as the scope condition.

But the code would never check if the scope condition is set for the tokens within the scope of a `T_DEFAULT` token when `$conditionStop` is not `null`. `$conditionStop` is used when `T_DEFAULT` uses curlies to open and close the scope. In those cases, scope conditions are not set all the way until the scope closer. Instead, they are set only until just before a T_BREAK|T_RETURN|T_CONTINUE.

`simple_switch_default_with_curlies` test case is the only one that currently sets `$conditionStop` to something other than `null`. But it passes an offset value of the condition stop while the code was expecting an absolute value of the index of the token where the scope condition stops being set. Passing an offset meant that when `$end` was set to be equal to `$conditionStop` it would always be less than `$i` and the assertion inside the `for` loop would never run:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/be74da1a2727948c35e8862cc378fcf9e9345b42/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php#L160-L170

Now, the code calculates the correct value for `$end` when `$conditionStop` is not null. It was also necessary to update the value for `$conditionStop` in `simple_switch_default_with_curlies` as it was pointing to the wrong token.

This uncovered an inconsistency in the tokenizer that might need to be addressed in a separate issue. When `T_DEFAULT` doesn't use curlies the tokenizer sets `scope_condition` for all the tokens until the token just before `T_BREAK|T_RETURN|T_CONTINUE`. But when there are curlies, `scope_condition` is set including for `T_BREAK|T_RETURN|T_CONTINUE`. It needs to be determined if this behavior is intentional or not. Let me know if I should create an issue for us to investigate this.

## Related issues/external references

This problem was found while working on #813.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
