### PR TITLE
GH Actions: use the xmllint-validate action runner and enhance checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,9 +24,6 @@ jobs:
     # Don't run the cronjob in this workflow on forks.
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
 
-    env:
-      XMLLINT_INDENT: '    '
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,6 +56,38 @@ jobs:
       - name: Validate XSD against schema
         run: xmllint --noout --schema ./XMLSchema.xsd ./phpcs.xsd
 
+      # Validate the basic well-formedness of the Documentation XML files.
+      - name: Validate documentation XML
+        run: xmllint --noout ./src/Standards/*/Docs/*/*Standard.xml
+
+  xml-cs:
+    name: 'XML Code style'
+    runs-on: ubuntu-latest
+
+    # Don't run the cronjob in this workflow on forks.
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show XML violations inline in the file diff.
+      - name: Enable showing XML issues inline
+        uses: korelstar/xmllint-problem-matcher@v1
+
       # Check the code-style consistency of the XML files.
       - name: Check XML code style
         run: |
@@ -71,10 +100,6 @@ jobs:
           diff -B ./src/Standards/PSR12/ruleset.xml <(xmllint --format "./src/Standards/PSR12/ruleset.xml")
           diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml")
           diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml")
-
-      # Validate the basic well-formedness of the Documentation XML files.
-      - name: Validate documentation XML
-        run: xmllint --noout ./src/Standards/*/Docs/*/*Standard.xml
 
   yamllint:
     name: 'Lint Yaml'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,11 +42,24 @@ jobs:
           pattern: "./src/Standards/*/ruleset.xml"
           xsd-file: "phpcs.xsd"
 
-      # Validate the basic well-formedness of the Documentation XML files.
+      # Validate the Documentation XML files.
       - name: Validate documentation XML
         uses: phpcsstandards/xmllint-validate@v1
         with:
           pattern: "./src/Standards/*/Docs/*/*Standard.xml"
+          xsd-url: "https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+
+      # Validate dev tool related XML files.
+      - name: Validate Project PHPCS ruleset against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpcs.xml.dist"
+          xsd-file: "phpcs.xsd"
+
+      - name: "Validate PHPUnit config for well-formedness"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
 
   xml-cs:
     name: 'XML Code style'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,37 +28,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
-      # This should not be blocking for this job, so ignore any errors from this step.
-      # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
-        continue-on-error: true
-        run: sudo apt-get update
-
-      - name: Install xmllint
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
-
-      - name: Retrieve XML Schema
-        run: curl -O https://www.w3.org/2012/04/XMLSchema.xsd
-
-      # Show XML violations inline in the file diff.
-      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - name: Enable showing XML issues inline
-        uses: korelstar/xmllint-problem-matcher@v1
+      # Validate the XSD file.
+      - name: Validate XSD against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpcs.xsd"
+          xsd-url: "https://www.w3.org/2012/04/XMLSchema.xsd"
 
       # Validate the XML ruleset files.
-      # @link http://xmlsoft.org/xmllint.html
       - name: Validate rulesets against schema
-        run: xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml
-
-      # Validate the XSD file.
-      # @link http://xmlsoft.org/xmllint.html
-      - name: Validate XSD against schema
-        run: xmllint --noout --schema ./XMLSchema.xsd ./phpcs.xsd
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "./src/Standards/*/ruleset.xml"
+          xsd-file: "phpcs.xsd"
 
       # Validate the basic well-formedness of the Documentation XML files.
       - name: Validate documentation XML
-        run: xmllint --noout ./src/Standards/*/Docs/*/*Standard.xml
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "./src/Standards/*/Docs/*/*Standard.xml"
 
   xml-cs:
     name: 'XML Code style'


### PR DESCRIPTION
# Description

### GH Actions: split XML code style check off from "Validate XML"check 

The intention is for there to be a dedicated action runner available at some point for XML code style checking, so let's move this to a separate job.

Also see: PHPCSStandards/PHPCSDevTools#145

### GH Actions: use the xmllint-validate action runner 

Instead of doing all the installation steps for xmllint validation in the workflow, use the ✨ new dedicated `phpcsstandards/xmllint-validate` action runner instead.

Ref: https://github.com/marketplace/actions/xmllint-validate

### GH Actions: add some additional XML validation checks 

* Check the docs against the schema from PHPCSDevTools.
* Check dev tool config files.

## Suggested changelog entry
_N/A_

