### PR TITLE
Generators/HTML: improve code table semantics

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -72,6 +72,11 @@ class HTML extends Generator
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -410,8 +415,8 @@ class HTML extends Generator
         $titleRow = '';
         if ($firstTitle !== '' || $secondTitle !== '') {
             $titleRow .= '   <tr>'.PHP_EOL;
-            $titleRow .= "    <td class=\"code-comparison-title\">$firstTitle</td>".PHP_EOL;
-            $titleRow .= "    <td class=\"code-comparison-title\">$secondTitle</td>".PHP_EOL;
+            $titleRow .= "    <th class=\"code-comparison-title\">$firstTitle</th>".PHP_EOL;
+            $titleRow .= "    <th class=\"code-comparison-title\">$secondTitle</th>".PHP_EOL;
             $titleRow .= '   </tr>'.PHP_EOL;
         }
 

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlankLines.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlankLines.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Checking handling of blank lines.</td>
-    <td class="code-comparison-title">Invalid: Checking handling of blank lines.</td>
+    <th class="code-comparison-title">Valid: Checking handling of blank lines.</th>
+    <th class="code-comparison-title">Invalid: Checking handling of blank lines.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;First&nbsp;line&nbsp;of&nbsp;the&nbsp;code&nbsp;sample&nbsp;is</br>//&nbsp;deliberately&nbsp;empty.</br></br>//&nbsp;We&nbsp;also&nbsp;have&nbsp;a&nbsp;blank&nbsp;line&nbsp;in&nbsp;the&nbsp;middle.</br></br>//&nbsp;And&nbsp;a&nbsp;blank&nbsp;line&nbsp;at&nbsp;the&nbsp;end.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlockLength.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonBlockLength.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: code sample A has more lines than B.</td>
-    <td class="code-comparison-title">Invalid: shorter.</td>
+    <th class="code-comparison-title">Valid: code sample A has more lines than B.</th>
+    <th class="code-comparison-title">Invalid: shorter.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;This&nbsp;code&nbsp;sample&nbsp;has&nbsp;more&nbsp;lines</br>//&nbsp;than&nbsp;the&nbsp;"invalid"&nbsp;one.</br><span class="code-comparison-highlight">$one</span>&nbsp;=&nbsp;10;</td>
@@ -85,8 +90,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: shorter.</td>
-    <td class="code-comparison-title">Invalid: code sample B has more lines than A.</td>
+    <th class="code-comparison-title">Valid: shorter.</th>
+    <th class="code-comparison-title">Invalid: code sample B has more lines than A.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">echo</span>&nbsp;$foo;</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonEncoding.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonEncoding.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Vestibulum et orci condimentum.</td>
-    <td class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</td>
+    <th class="code-comparison-title">Valid: Vestibulum et orci condimentum.</th>
+    <th class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">&lt;?php</br></br>//&nbsp;The&nbsp;above&nbsp;PHP&nbsp;tag&nbsp;is&nbsp;specifically&nbsp;testing</br>//&nbsp;handling&nbsp;of&nbsp;that&nbsp;in&nbsp;generated&nbsp;HTML&nbsp;doc.</br></br>//&nbsp;Now&nbsp;let's&nbsp;also&nbsp;check&nbsp;the&nbsp;handling&nbsp;of</br>//&nbsp;comparison&nbsp;operators&nbsp;in&nbsp;code&nbsp;samples...</br>$a&nbsp;=&nbsp;$b&nbsp;<&nbsp;$c;</br>$d&nbsp;=&nbsp;$e&nbsp;>&nbsp;$f;</br>$g&nbsp;=&nbsp;$h&nbsp;<=&nbsp;$i;</br>$j&nbsp;=&nbsp;$k&nbsp;>=&nbsp;$l;</br>$m&nbsp;=&nbsp;$n&nbsp;<=>&nbsp;$o;</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeComparisonLineLength.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -76,8 +81,8 @@
 Ref: squizlabs/PHP_CodeSniffer#2522</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: contains line which is too long.</td>
-    <td class="code-comparison-title">Invalid: contains line which is too long.</td>
+    <th class="code-comparison-title">Valid: contains line which is too long.</th>
+    <th class="code-comparison-title">Invalid: contains line which is too long.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">class&nbsp;Foo&nbsp;extends&nbsp;Bar&nbsp;implements&nbsp;<span class="code-comparison-highlight">Countable</span>,&nbsp;Serializable</br>{</br>}</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleLineWrapping.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleLineWrapping.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: exactly 45 character long description.</td>
-    <td class="code-comparison-title">Invalid: exactly 45 char long description---.</td>
+    <th class="code-comparison-title">Valid: exactly 45 character long description.</th>
+    <th class="code-comparison-title">Invalid: exactly 45 char long description---.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>
@@ -85,8 +90,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: exactly 46 character long description-.</td>
-    <td class="code-comparison-title">Invalid: exactly 46 character long description</td>
+    <th class="code-comparison-title">Valid: exactly 46 character long description-.</th>
+    <th class="code-comparison-title">Invalid: exactly 46 character long description</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>
@@ -95,8 +100,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: exactly 47 character long description--.</td>
-    <td class="code-comparison-title">Invalid: exactly 47 character long description.</td>
+    <th class="code-comparison-title">Valid: exactly 47 character long description--.</th>
+    <th class="code-comparison-title">Invalid: exactly 47 character long description.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>
@@ -105,8 +110,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: this description is longer than 46 characters and will wrap.</td>
-    <td class="code-comparison-title">Invalid: this description is longer than 46 characters and will wrap.</td>
+    <th class="code-comparison-title">Valid: this description is longer than 46 characters and will wrap.</th>
+    <th class="code-comparison-title">Invalid: this description is longer than 46 characters and will wrap.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputCodeTitleWhitespace.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: spaces at start of description.</td>
-    <td class="code-comparison-title">Invalid: spaces at end making line > 46 chars.</td>
+    <th class="code-comparison-title">Valid: spaces at start of description.</th>
+    <th class="code-comparison-title">Invalid: spaces at end making line > 46 chars.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Dummy.</td>
@@ -85,8 +90,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: spaces at start + end of description.</td>
-    <td class="code-comparison-title">Invalid: spaces '&nbsp;&nbsp;&nbsp;&nbsp; ' in description.</td>
+    <th class="code-comparison-title">Valid: spaces at start + end of description.</th>
+    <th class="code-comparison-title">Invalid: spaces '&nbsp;&nbsp;&nbsp;&nbsp; ' in description.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">//&nbsp;Note:&nbsp;description&nbsp;above&nbsp;without&nbsp;the</br>//&nbsp;trailing&nbsp;whitespace&nbsp;fits&nbsp;in&nbsp;46&nbsp;chars.</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleCase.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleCase.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleLength.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitleLength.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputDocumentationTitlePCREFallback.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonMismatchedCodeElms.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonMismatchedCodeElms.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This doc has two code elements, one only has a title, one has actual code. Unbalanced</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Code title</td>
-    <td class="code-comparison-title"></td>
+    <th class="code-comparison-title">Code title</th>
+    <th class="code-comparison-title"></th>
    </tr>
    <tr>
     <td class="code-comparison-code"></td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonMissingCodeElm.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonMissingCodeElm.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonNoCode.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonNoCode.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: no code.</td>
-    <td class="code-comparison-title">Invalid: no code.</td>
+    <th class="code-comparison-title">Valid: no code.</th>
+    <th class="code-comparison-title">Invalid: no code.</th>
    </tr>
   </table>
   <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonNoContent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonNoContent.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonOneEmptyCodeElm.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonOneEmptyCodeElm.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This doc has two code elements, but only one of them has a title and actual code.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Code title</td>
-    <td class="code-comparison-title"></td>
+    <th class="code-comparison-title">Code title</th>
+    <th class="code-comparison-title"></th>
    </tr>
    <tr>
     <td class="code-comparison-code">$a&nbsp;=&nbsp;'Example&nbsp;code';</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonTwoEmptyCodeElms.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeComparisonTwoEmptyCodeElms.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeTitleEmpty.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeTitleEmpty.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeTitleMissing.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidCodeTitleMissing.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleEmpty.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">The above &quot;documentation&quot; element has an empty title attribute.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
+    <th class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</th>
+    <th class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidDocumentationTitleMissing.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">The above &quot;documentation&quot; element is missing the title attribute.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
+    <th class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</th>
+    <th class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputInvalidStandardNoContent.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -74,8 +79,8 @@
   <h2>Standard Element, no content</h2>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
+    <th class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</th>
+    <th class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputOneDoc.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardBlankLines.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardEncoding.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardIndent.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStandardLineWrapping.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputStructureDocs.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -85,8 +90,8 @@
   <h2>Code Comparison Only, Missing Standard Block</h2>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
+    <th class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</th>
+    <th class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>
@@ -98,8 +103,8 @@
   <p class="text">Documentation contains one standard block and one code comparison.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</td>
-    <td class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</td>
+    <th class="code-comparison-title">Valid: Lorem ipsum dolor sit amet.</th>
+    <th class="code-comparison-title">Invalid: Maecenas non rutrum dolor.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>
@@ -114,8 +119,8 @@
   <p class="text">Documentation contains one standard block and two code comparisons.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Etiam commodo magna at vestibulum blandit.</td>
-    <td class="code-comparison-title">Invalid: Vivamus lacinia ante velit.</td>
+    <th class="code-comparison-title">Valid: Etiam commodo magna at vestibulum blandit.</th>
+    <th class="code-comparison-title">Invalid: Vivamus lacinia ante velit.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>
@@ -124,8 +129,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Pellentesque nisi neque.</td>
-    <td class="code-comparison-title">Invalid: Mauris dictum metus quis maximus pharetra.</td>
+    <th class="code-comparison-title">Valid: Pellentesque nisi neque.</th>
+    <th class="code-comparison-title">Invalid: Mauris dictum metus quis maximus pharetra.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">$one</span>&nbsp;=&nbsp;10;</td>
@@ -141,8 +146,8 @@
   <p class="text">This is standard block one.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Vestibulum et orci condimentum.</td>
-    <td class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</td>
+    <th class="code-comparison-title">Valid: Vestibulum et orci condimentum.</th>
+    <th class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">class&nbsp;<span class="code-comparison-highlight">Code</span>&nbsp;{}</td>
@@ -155,8 +160,8 @@
   <p class="text">This is standard block one.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Vestibulum et orci condimentum.</td>
-    <td class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</td>
+    <th class="code-comparison-title">Valid: Vestibulum et orci condimentum.</th>
+    <th class="code-comparison-title">Invalid: Donec in nisl ut tortor convallis interdum.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">class&nbsp;Code</span>&nbsp;{}</td>
@@ -166,8 +171,8 @@
   <p class="text">This is standard block two.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Pellentesque nisi neque.</td>
-    <td class="code-comparison-title">Invalid: Mauris dictum metus quis maximus pharetra.</td>
+    <th class="code-comparison-title">Valid: Pellentesque nisi neque.</th>
+    <th class="code-comparison-title">Invalid: Mauris dictum metus quis maximus pharetra.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">$one</span>&nbsp;=&nbsp;10;</td>
@@ -176,8 +181,8 @@
   </table>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Quisque sagittis nisi vitae.</td>
-    <td class="code-comparison-title">Invalid: Morbi ac libero vitae lorem.</td>
+    <th class="code-comparison-title">Valid: Quisque sagittis nisi vitae.</th>
+    <th class="code-comparison-title">Invalid: Morbi ac libero vitae lorem.</th>
    </tr>
    <tr>
     <td class="code-comparison-code"><span class="code-comparison-highlight">echo</span>&nbsp;$foo;</td>

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedOneElmAtWrongLevel.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedOneElmAtWrongLevel.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;

--- a/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedSuperfluousCodeElement.html
+++ b/tests/Core/Generators/Expectations/ExpectedOutputUnsupportedSuperfluousCodeElement.html
@@ -45,6 +45,11 @@
             line-height: 15px;
         }
 
+        .code-comparison-title {
+            text-align: left;
+            font-weight: 600;
+        }
+
         .code-comparison-code {
             font-family: Courier;
             background-color: #F9F9F9;
@@ -75,8 +80,8 @@
   <p class="text">This is a standard block.</p>
   <table class="code-comparison">
    <tr>
-    <td class="code-comparison-title">Valid: Checking handling of blank lines.</td>
-    <td class="code-comparison-title">Invalid: Checking handling of blank lines.</td>
+    <th class="code-comparison-title">Valid: Checking handling of blank lines.</th>
+    <th class="code-comparison-title">Invalid: Checking handling of blank lines.</th>
    </tr>
    <tr>
     <td class="code-comparison-code">$valid&nbsp;=&nbsp;true;</td>


### PR DESCRIPTION
# Description
Mark the table headers as headers (and tweak the CSS a little for correct display).

Includes updated test expectations.

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/e7fecc12-e032-4a32-abd6-140465805e85)

#### After
![image](https://github.com/user-attachments/assets/23036362-c2fc-4919-a3d1-c28472629448)


## Suggested changelog entry
Generators/HTML: improved display of code tables via semantic HTML


## Related issues/external references

This PR is part of a series of PRs which will add a complete set of tests (and improvements) for the Generator feature.

Also see: #671 and other PRs with the [Core Component: Generators](https://github.com/PHPCSStandards/PHP_CodeSniffer/labels/Core%20Component%3A%20Generators) label.