### PR TITLE
Ruleset: improve error handling

### DIFF
--- a/src/Util/MessageCollector.php
+++ b/src/Util/MessageCollector.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Collect messages for display at a later point in the process flow.
+ *
+ * If any message with type "error" is passed in, displaying the errors will result in halting the program
+ * with a non-zero exit code.
+ * If only messages with a lower severity are passed in, displaying the errors will be non-blocking
+ * and will not affect the exit code.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is intended for internal use only and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @internal
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Util;
+
+use InvalidArgumentException;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+final class MessageCollector
+{
+
+    /**
+     * Indicator for a (blocking) error.
+     *
+     * @var int
+     */
+    const ERROR = 1;
+
+    /**
+     * Indicator for a warning.
+     *
+     * @var int
+     */
+    const WARNING = 2;
+
+    /**
+     * Indicator for a notice.
+     *
+     * @var int
+     */
+    const NOTICE = 4;
+
+    /**
+     * Indicator for a deprecation notice.
+     *
+     * @var int
+     */
+    const DEPRECATED = 8;
+
+    /**
+     * Indicator for ordering the messages based on severity first, order received second.
+     *
+     * @var string
+     */
+    const ORDERBY_SEVERITY = 'severity';
+
+    /**
+     * Indicator for ordering the messages based on the order in which they were received.
+     *
+     * @var string
+     */
+    const ORDERBY_RECEIVED = 'received';
+
+    /**
+     * Collected messages.
+     *
+     * @var array<array<string, string|int>> The value for each array entry is an associative array
+     *                                       which holds two keys:
+     *                                       - 'message' string The message text.
+     *                                       - 'type'    int    The type of the message based on the
+     *                                                          above declared error level constants.
+     */
+    private $cache = [];
+
+
+    /**
+     * Add a new message.
+     *
+     * @param string $message The message text.
+     * @param int    $type    The type of message. Should be one of the following constants:
+     *                        MessageCollector::ERROR, MessageCollector::WARNING, MessageCollector::NOTICE
+     *                        or MessageCollector::DEPRECATED.
+     *                        Defaults to MessageCollector::NOTICE.
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException If the message text is not a string.
+     * @throws \InvalidArgumentException If the message type is not one of the accepted types.
+     */
+    public function add($message, $type=self::NOTICE)
+    {
+        if (is_string($message) === false) {
+            throw new InvalidArgumentException('The $message should be of type string. Received: '.gettype($message).'.');
+        }
+
+        if ($type !== self::ERROR
+            && $type !== self::WARNING
+            && $type !== self::NOTICE
+            && $type !== self::DEPRECATED
+        ) {
+            throw new InvalidArgumentException('The message $type should be one of the predefined MessageCollector constants. Received: '.$type.'.');
+        }
+
+        $this->cache[] = [
+            'message' => $message,
+            'type'    => $type,
+        ];
+
+    }//end add()
+
+
+    /**
+     * Determine whether or not the currently cached errors include blocking errors.
+     *
+     * @return bool
+     */
+    public function containsBlockingErrors()
+    {
+        $seenTypes     = $this->arrayColumn($this->cache, 'type');
+        $typeFrequency = array_count_values($seenTypes);
+        return isset($typeFrequency[self::ERROR]);
+
+    }//end containsBlockingErrors()
+
+
+    /**
+     * Display the cached messages.
+     *
+     * Displaying the messages will also clear the message cache.
+     *
+     * @param string $order Optional. The order in which to display the messages.
+     *                      Should be one of the following constants: MessageCollector::ORDERBY_SEVERITY,
+     *                      MessageCollector::ORDERBY_RECEIVED.
+     *                      Defaults to MessageCollector::ORDERBY_SEVERITY.
+     *
+     * @return void
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException When there are blocking errors.
+     */
+    public function display($order=self::ORDERBY_SEVERITY)
+    {
+        if ($this->cache === []) {
+            return;
+        }
+
+        $blocking    = $this->containsBlockingErrors();
+        $messageInfo = $this->prefixAll($this->cache);
+        $this->clearCache();
+
+        if ($order === self::ORDERBY_RECEIVED) {
+            $messages = $this->arrayColumn($messageInfo, 'message');
+        } else {
+            $messages = $this->sortBySeverity($messageInfo);
+        }
+
+        $allMessages = implode(PHP_EOL, $messages).PHP_EOL.PHP_EOL;
+
+        if ($blocking === true) {
+            throw new RuntimeException($allMessages);
+        } else {
+            echo $allMessages;
+        }
+
+    }//end display()
+
+
+    /**
+     * Label all messages based on their type.
+     *
+     * @param array<array<string, string|int>> $messages A multi-dimensional array of messages with their severity.
+     *
+     * @return array<array<string, string|int>>
+     */
+    private function prefixAll($messages)
+    {
+        foreach ($messages as $i => $details) {
+            $messages[$i]['message'] = $this->prefix($details['message'], $details['type']);
+        }
+
+        return $messages;
+
+    }//end prefixAll()
+
+
+    /**
+     * Add a message type prefix to a message.
+     *
+     * @param string $message The message text.
+     * @param int    $type    The type of message.
+     *
+     * @return string
+     */
+    private function prefix($message, $type)
+    {
+        switch ($type) {
+        case self::ERROR:
+            $message = 'ERROR: '.$message;
+            break;
+
+        case self::WARNING:
+            $message = 'WARNING: '.$message;
+            break;
+
+        case self::DEPRECATED:
+            $message = 'DEPRECATED: '.$message;
+            break;
+
+        default:
+            $message = 'NOTICE: '.$message;
+            break;
+        }
+
+        return $message;
+
+    }//end prefix()
+
+
+    /**
+     * Sort an array of messages by severity.
+     *
+     * @param array<array<string, string|int>> $messages A multi-dimensional array of messages with their severity.
+     *
+     * @return array<string> A single dimensional array of only messages, sorted by severity.
+     */
+    private function sortBySeverity($messages)
+    {
+        if (count($messages) === 1) {
+            return [$messages[0]['message']];
+        }
+
+        $errors       = [];
+        $warnings     = [];
+        $notices      = [];
+        $deprecations = [];
+
+        foreach ($messages as $details) {
+            switch ($details['type']) {
+            case self::ERROR:
+                $errors[] = $details['message'];
+                break;
+
+            case self::WARNING:
+                $warnings[] = $details['message'];
+                break;
+
+            case self::DEPRECATED:
+                $deprecations[] = $details['message'];
+                break;
+
+            default:
+                $notices[] = $details['message'];
+                break;
+            }
+        }
+
+        return array_merge($errors, $warnings, $notices, $deprecations);
+
+    }//end sortBySeverity()
+
+
+    /**
+     * Clear the message cache.
+     *
+     * @return void
+     */
+    private function clearCache()
+    {
+        $this->cache = [];
+
+    }//end clearCache()
+
+
+    /**
+     * Return the values from a single column in the input array.
+     *
+     * Polyfill for the PHP 5.5+ native array_column() function (for the functionality needed here).
+     *
+     * @param array<array<string, string|int>> $input     A multi-dimensional array from which to pull a column of values.
+     * @param string                           $columnKey The name of the column of values to return.
+     *
+     * @link https://www.php.net/function.array-column
+     *
+     * @return array<string|int>
+     */
+    private function arrayColumn(array $input, $columnKey)
+    {
+        if (function_exists('array_column') === true) {
+            // PHP 5.5+.
+            return array_column($input, $columnKey);
+        }
+
+        // PHP 5.4.
+        $callback = function ($row) use ($columnKey) {
+            return $row[$columnKey];
+        };
+
+        return array_map($callback, $input);
+
+    }//end arrayColumn()
+
+
+}//end class

--- a/tests/Core/Ruleset/ConstructorTest.php
+++ b/tests/Core/Ruleset/ConstructorTest.php
@@ -282,7 +282,7 @@ final class ConstructorTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ConstructorNoSniffsTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $message = 'ERROR: No sniffs were registered';
+        $message = 'ERROR: No sniffs were registered.'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/DisplayCachedMessagesTest.php
+++ b/tests/Core/Ruleset/DisplayCachedMessagesTest.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Test error handling for the Ruleset.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+use PHP_CodeSniffer\Util\MessageCollector;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Test error handling for the Ruleset.
+ *
+ * Note: this is purely a unit test of the `displayCachedMessages()` method.
+ * The errors themselves are mocked.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::displayCachedMessages
+ */
+final class DisplayCachedMessagesTest extends AbstractRulesetTestCase
+{
+
+
+    /**
+     * Test that no exception nor output is generated when there are no cached messsages.
+     *
+     * @return void
+     */
+    public function testDisplayCachedMessagesStaysSilentWithoutErrors()
+    {
+        $ruleset = $this->getPlainRuleset();
+
+        $this->expectOutputString('');
+
+        $this->invokeDisplayCachedMessages($ruleset);
+
+    }//end testDisplayCachedMessagesStaysSilentWithoutErrors()
+
+
+    /**
+     * Verify that blocking errors encountered while loading the ruleset(s) result in an exception being thrown.
+     *
+     * @param array<string, int> $messages The messages encountered.
+     * @param string             $expected The expected function output to screen (via an internally handled exception).
+     *
+     * @dataProvider dataBlockingErrorsAreDisplayedViaAnException
+     *
+     * @return void
+     */
+    public function testBlockingErrorsAreDisplayedViaAnException($messages, $expected)
+    {
+        $ruleset = $this->getPlainRuleset();
+        $this->mockCachedMessages($ruleset, $messages);
+
+        $this->expectRuntimeExceptionMessage($expected);
+
+        $this->invokeDisplayCachedMessages($ruleset);
+
+    }//end testBlockingErrorsAreDisplayedViaAnException()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBlockingErrorsAreDisplayedViaAnException()
+     *
+     * @return array<string, array<string, string|array<string, int>>>
+     */
+    public static function dataBlockingErrorsAreDisplayedViaAnException()
+    {
+        return [
+            'One error'                               => [
+                'messages' => ['This is a serious blocking issue' => MessageCollector::ERROR],
+                'expected' => 'ERROR: This is a serious blocking issue'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple blocking errors'                => [
+                'messages' => [
+                    'This is a serious blocking issue'        => MessageCollector::ERROR,
+                    'And here is another one'                 => MessageCollector::ERROR,
+                    'OMG, why do you think that would work ?' => MessageCollector::ERROR,
+                ],
+                // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
+                'expected' => 'ERROR: This is a serious blocking issue'.PHP_EOL
+                    . 'ERROR: And here is another one'.PHP_EOL
+                    . 'ERROR: OMG, why do you think that would work ?'.PHP_EOL.PHP_EOL,
+                // phpcs:enable
+            ],
+            'Mix of blocking and non-blocking errors' => [
+                'messages' => [
+                    'This is a serious blocking issue'                              => MessageCollector::ERROR,
+                    'Something something deprecated and will be removed in v x.x.x' => MessageCollector::DEPRECATED,
+                    'Careful, this may not be correct'                              => MessageCollector::NOTICE,
+                ],
+                // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
+                'expected' => 'ERROR: This is a serious blocking issue'.PHP_EOL
+                    . 'NOTICE: Careful, this may not be correct'.PHP_EOL
+                    . 'DEPRECATED: Something something deprecated and will be removed in v x.x.x'.PHP_EOL.PHP_EOL,
+                // phpcs:enable
+            ],
+        ];
+
+    }//end dataBlockingErrorsAreDisplayedViaAnException()
+
+
+    /**
+     * Test display of non-blocking messages encountered while loading the ruleset(s).
+     *
+     * @param array<string, int> $messages The messages encountered.
+     * @param string             $expected The expected function output to screen.
+     *
+     * @dataProvider dataNonBlockingErrorsGenerateOutput
+     *
+     * @return void
+     */
+    public function testNonBlockingErrorsGenerateOutput($messages, $expected)
+    {
+        $ruleset = $this->getPlainRuleset();
+        $this->mockCachedMessages($ruleset, $messages);
+
+        $this->expectOutputString($expected);
+
+        $this->invokeDisplayCachedMessages($ruleset);
+
+    }//end testNonBlockingErrorsGenerateOutput()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testNonBlockingErrorsGenerateOutput()
+     *
+     * @return array<string, array<string, string|array<string>>>
+     */
+    public static function dataNonBlockingErrorsGenerateOutput()
+    {
+        return [
+            'One deprecation'              => [
+                'messages' => ['My deprecation message' => MessageCollector::DEPRECATED],
+                'expected' => 'DEPRECATED: My deprecation message'.PHP_EOL.PHP_EOL,
+            ],
+            'One notice'                   => [
+                'messages' => ['My notice message' => MessageCollector::NOTICE],
+                'expected' => 'NOTICE: My notice message'.PHP_EOL.PHP_EOL,
+            ],
+            'One warning'                  => [
+                'messages' => ['My warning message' => MessageCollector::WARNING],
+                'expected' => 'WARNING: My warning message'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple non-blocking errors' => [
+                'messages' => [
+                    'Something something deprecated and will be removed in v x.x.x' => MessageCollector::DEPRECATED,
+                    'Something is not supported and support may be removed'         => MessageCollector::WARNING,
+                    'Some other deprecation notice'                                 => MessageCollector::DEPRECATED,
+                    'Careful, this may not be correct'                              => MessageCollector::NOTICE,
+                ],
+                // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
+                'expected' => 'WARNING: Something is not supported and support may be removed'.PHP_EOL
+                    .'NOTICE: Careful, this may not be correct'.PHP_EOL
+                    .'DEPRECATED: Something something deprecated and will be removed in v x.x.x'.PHP_EOL
+                    .'DEPRECATED: Some other deprecation notice'.PHP_EOL.PHP_EOL,
+                // phpcs:enable
+            ],
+        ];
+
+    }//end dataNonBlockingErrorsGenerateOutput()
+
+
+    /**
+     * Test that blocking errors will always show, independently of specific command-line options being used.
+     *
+     * @param array<string> $configArgs Arguments to pass to the Config.
+     *
+     * @dataProvider dataSelectiveDisplayOfMessages
+     *
+     * @return void
+     */
+    public function testBlockingErrorsAlwaysShow($configArgs)
+    {
+        $config  = new ConfigDouble($configArgs);
+        $ruleset = new Ruleset($config);
+
+        $message = 'Some serious error';
+        $errors  = [$message => MessageCollector::ERROR];
+        $this->mockCachedMessages($ruleset, $errors);
+
+        $this->expectRuntimeExceptionMessage('ERROR: '.$message.PHP_EOL);
+
+        $this->invokeDisplayCachedMessages($ruleset);
+
+    }//end testBlockingErrorsAlwaysShow()
+
+
+    /**
+     * Test that non-blocking messsages will not show when specific command-line options are being used.
+     *
+     * @param array<string> $configArgs Arguments to pass to the Config.
+     *
+     * @dataProvider dataSelectiveDisplayOfMessages
+     *
+     * @return void
+     */
+    public function testNonBlockingErrorsDoNotShowUnderSpecificCircumstances($configArgs)
+    {
+        $config  = new ConfigDouble($configArgs);
+        $ruleset = new Ruleset($config);
+        $this->mockCachedMessages($ruleset, ['Deprecation notice' => MessageCollector::DEPRECATED]);
+
+        $this->expectOutputString('');
+
+        $this->invokeDisplayCachedMessages($ruleset);
+
+    }//end testNonBlockingErrorsDoNotShowUnderSpecificCircumstances()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testBlockingErrorsAlwaysShow()
+     * @see testNonBlockingErrorsDoNotShow()
+     *
+     * @return array<string, array<string, string|array<string>>>
+     */
+    public static function dataSelectiveDisplayOfMessages()
+    {
+        return [
+            'Explain mode'               => [
+                'configArgs' => ['-e'],
+            ],
+            'Quiet mode'                 => [
+                'configArgs' => ['-q'],
+            ],
+            'Documentation is requested' => [
+                'configArgs' => ['--generator=text'],
+            ],
+        ];
+
+    }//end dataSelectiveDisplayOfMessages()
+
+
+    /**
+     * Test Helper.
+     *
+     * @return \PHP_CodeSniffer\Ruleset
+     */
+    private function getPlainRuleset()
+    {
+        static $ruleset;
+
+        if (isset($ruleset) === false) {
+            $config  = new ConfigDouble();
+            $ruleset = new Ruleset($config);
+        }
+
+        return $ruleset;
+
+    }//end getPlainRuleset()
+
+
+    /**
+     * Add mock messages to the message cache.
+     *
+     * @param \PHP_CodeSniffer\Ruleset $ruleset  The ruleset object.
+     * @param array<string, int>       $messages The messages to add to the message cache.
+     *
+     * @return void
+     */
+    private function mockCachedMessages(Ruleset $ruleset, $messages)
+    {
+        $reflProperty = new ReflectionProperty($ruleset, 'msgCache');
+        $reflProperty->setAccessible(true);
+
+        $msgCache = $reflProperty->getValue($ruleset);
+        foreach ($messages as $msg => $type) {
+            $msgCache->add($msg, $type);
+        }
+
+        $reflProperty->setAccessible(false);
+
+    }//end mockCachedMessages()
+
+
+    /**
+     * Invoke the display of the cached messages.
+     *
+     * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset object.
+     *
+     * @return void
+     */
+    private function invokeDisplayCachedMessages(Ruleset $ruleset)
+    {
+        $reflMethod = new ReflectionMethod($ruleset, 'displayCachedMessages');
+        $reflMethod->setAccessible(true);
+        $reflMethod->invoke($ruleset);
+        $reflMethod->setAccessible(false);
+
+    }//end invokeDisplayCachedMessages()
+
+
+}//end class

--- a/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
@@ -109,7 +109,8 @@ final class ExpandRulesetReferenceHomePathTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ExpandRulesetReferenceHomePathFailTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $exceptionMessage = 'ERROR: Referenced sniff "~/src/MyStandard/Sniffs/DoesntExist/" does not exist';
+        $exceptionMessage  = 'ERROR: Referenced sniff "~/src/MyStandard/Sniffs/DoesntExist/" does not exist.'.PHP_EOL;
+        $exceptionMessage .= 'ERROR: No sniffs were registered.'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($exceptionMessage);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
@@ -61,7 +61,8 @@ final class ExpandRulesetReferenceTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/'.$standard;
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $exceptionMessage = 'ERROR: Referenced sniff "%s" does not exist';
+        $exceptionMessage  = 'ERROR: Referenced sniff "%s" does not exist.'.PHP_EOL;
+        $exceptionMessage .= 'ERROR: No sniffs were registered.'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage(sprintf($exceptionMessage, $replacement));
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/PopulateTokenListenersRegisterNoArrayTest.xml
+++ b/tests/Core/Ruleset/PopulateTokenListenersRegisterNoArrayTest.xml
@@ -5,4 +5,6 @@
 
     <rule ref="TestStandard.InvalidSniffs.RegisterNoArray"/>
 
+    <!-- Prevent a "no sniff were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
 </ruleset>

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.php
@@ -62,10 +62,15 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
         $config   = new ConfigDouble(["--standard=$standard"]);
 
         $sniffClass = 'Fixtures\\TestStandard\\Sniffs\\InvalidSniffs\\RegisterNoArraySniff';
-        $message    = "ERROR: Sniff $sniffClass register() method must return an array";
+        $message    = "ERROR: The sniff {$sniffClass}::register() method must return an array.".PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);
+
+        // Verify that the sniff has not been registered/has been unregistered.
+        // These assertions will only take effect for PHPUnit 10+.
+        $this->assertArrayNotHasKey($sniffClass, self::$ruleset->sniffs, "Sniff class $sniffClass is listed in registered sniffs");
+        $this->assertArrayNotHasKey('TestStandard.InvalidSniffs.RegisterNoArray', self::$ruleset->sniffCodes, 'Sniff code is registered');
 
     }//end testSniffWhereRegisterDoesNotReturnAnArrayThrowsException()
 

--- a/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
+++ b/tests/Core/Ruleset/ProcessRuleInvalidTypeTest.php
@@ -23,7 +23,7 @@ final class ProcessRuleInvalidTypeTest extends AbstractRulesetTestCase
 
 
     /**
-     * Test displaying an informative error message when an invalid type is given.
+     * Test displaying an error when an invalid type is given.
      *
      * @return void
      */
@@ -32,7 +32,7 @@ final class ProcessRuleInvalidTypeTest extends AbstractRulesetTestCase
         $standard = __DIR__.'/ProcessRuleInvalidTypeTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
 
-        $message = 'ERROR: Message type "notice" is invalid; must be "error" or "warning"';
+        $message = 'ERROR: Message type "notice" for "Generic.Files.ByteOrderMark" is invalid; must be "error" or "warning".'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($message);
 
         new Ruleset($config);

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -135,7 +135,7 @@ final class SetSniffPropertyTest extends AbstractRulesetTestCase
      */
     public function testSetPropertyThrowsErrorOnInvalidProperty()
     {
-        $exceptionMsg = 'ERROR: Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
+        $exceptionMsg = 'ERROR: Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent.'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.
@@ -155,7 +155,7 @@ final class SetSniffPropertyTest extends AbstractRulesetTestCase
      */
     public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
     {
-        $exceptionMsg = 'ERROR: Ruleset invalid. Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute';
+        $exceptionMsg = 'ERROR: Property "arbitrarystring" does not exist on sniff TestStandard.SetProperty.NotAllowedViaAttribute.'.PHP_EOL.PHP_EOL;
         $this->expectRuntimeExceptionMessage($exceptionMsg);
 
         // Set up the ruleset.

--- a/tests/Core/Util/MessageCollector/MessageCollectorTest.php
+++ b/tests/Core/Util/MessageCollector/MessageCollectorTest.php
@@ -1,0 +1,539 @@
+<?php
+/**
+ * Tests the message collecting functionality.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Util\MessageCollector;
+
+use PHP_CodeSniffer\Util\MessageCollector;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the message caching and display functionality.
+ *
+ * @covers \PHP_CodeSniffer\Util\MessageCollector
+ */
+final class MessageCollectorTest extends TestCase
+{
+
+
+    /**
+     * Verify that non-string "messages" are rejected with an exception.
+     *
+     * @param mixed $message The invalid "message" to add.
+     *
+     * @dataProvider dataAddingNonStringMessageResultsInException
+     *
+     * @return void
+     */
+    public function testAddingNonStringMessageResultsInException($message)
+    {
+        $exception    = 'InvalidArgumentException';
+        $exceptionMsg = 'The $message should be of type string. Received: ';
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($exceptionMsg);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $exceptionMsg);
+        }
+
+        $msgCollector = new MessageCollector();
+        $msgCollector->add($message);
+
+    }//end testAddingNonStringMessageResultsInException()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testAddingNonStringMessageResultsInException()
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function dataAddingNonStringMessageResultsInException()
+    {
+        return [
+            'null'    => [null],
+            'boolean' => [true],
+            'integer' => [10],
+            'array'   => [['something' => 'incorrect']],
+        ];
+
+    }//end dataAddingNonStringMessageResultsInException()
+
+
+    /**
+     * Verify that passing a message type which is not one of the predefined types is rejected with an exception.
+     *
+     * @param mixed $type The invalid "type" to pass.
+     *
+     * @dataProvider dataAddingMessageWithUnsupportedMessageTypeResultsInException
+     *
+     * @return void
+     */
+    public function testAddingMessageWithUnsupportedMessageTypeResultsInException($type)
+    {
+        $exception    = 'InvalidArgumentException';
+        $exceptionMsg = 'The message $type should be one of the predefined MessageCollector constants. Received: ';
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($exceptionMsg);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $exceptionMsg);
+        }
+
+        $msgCollector = new MessageCollector();
+        $msgCollector->add('Message', $type);
+
+    }//end testAddingMessageWithUnsupportedMessageTypeResultsInException()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testAddingMessageWithUnsupportedMessageTypeResultsInException()
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function dataAddingMessageWithUnsupportedMessageTypeResultsInException()
+    {
+        return [
+            'null'                                                                        => [null],
+            'boolean'                                                                     => [true],
+            'string'                                                                      => ['DEPRECATED'],
+            'integer which doesn\'t match any of the message type constants: -235'        => [-235],
+            'integer which doesn\'t match any of the message type constants: 0'           => [0],
+            'integer which doesn\'t match any of the message type constants: 3'           => [3],
+            'integer which doesn\'t match any of the message type constants: 6'           => [6],
+            'integer which doesn\'t match any of the message type constants: 123'         => [123],
+            'integer which doesn\'t match any of the message type constants: PHP_INT_MAX' => [PHP_INT_MAX],
+        ];
+
+    }//end dataAddingMessageWithUnsupportedMessageTypeResultsInException()
+
+
+    /**
+     * Verify that the `containsBlockingErrors()` method correctly identifies whether the collected messages
+     * include messages which are blocking (errors), or only include non-blocking (warnings, notices,
+     * deprecations) messages.
+     *
+     * @param array<string, int> $messages The messages to display.
+     *                                     Key is the message, value is the error level.
+     * @param bool               $expected The expected function output.
+     *
+     * @dataProvider dataContainsBlockingErrors
+     *
+     * @return void
+     */
+    public function testContainsBlockingErrors($messages, $expected)
+    {
+        $msgCollector = new MessageCollector();
+        $this->createErrorCache($msgCollector, $messages);
+
+        $this->assertSame($expected, $msgCollector->containsBlockingErrors());
+
+    }//end testContainsBlockingErrors()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testContainsBlockingErrors()
+     *
+     * @return array<string, array<string, array<string, int>|bool>>
+     */
+    public function dataContainsBlockingErrors()
+    {
+        return [
+            'No messages'                               => [
+                'messages' => [],
+                'expected' => false,
+            ],
+            'Only non-blocking messages'                => [
+                'messages' => [
+                    'First message'  => MessageCollector::WARNING,
+                    'Second message' => MessageCollector::NOTICE,
+                    'Third message'  => MessageCollector::DEPRECATED,
+                ],
+                'expected' => false,
+            ],
+            'Only blocking messages'                    => [
+                'messages' => [
+                    'First message'  => MessageCollector::ERROR,
+                    'Second message' => MessageCollector::ERROR,
+                    'Third message'  => MessageCollector::ERROR,
+                ],
+                'expected' => true,
+            ],
+            'Mix of blocking and non-blocking messages' => [
+                'messages' => [
+                    'First message'  => MessageCollector::DEPRECATED,
+                    'Second message' => MessageCollector::ERROR,
+                    'Third message'  => MessageCollector::WARNING,
+                ],
+                'expected' => true,
+            ],
+        ];
+
+    }//end dataContainsBlockingErrors()
+
+
+    /**
+     * Test displaying non-blocking messages only.
+     *
+     * Verifies that:
+     * - Each message is prefixed with the appropriate prefix.
+     * - The default message order is observed.
+     * - The messages use the appropriate OS-specific EOL character.
+     *
+     * @param array<string, int> $messages The messages to display.
+     *                                     Key is the message, value is the error level.
+     * @param string             $expected The expected exception message.
+     *
+     * @dataProvider dataDisplayingNonBlockingMessages
+     *
+     * @return void
+     */
+    public function testDisplayingNonBlockingMessages($messages, $expected)
+    {
+        $msgCollector = new MessageCollector();
+        $this->createErrorCache($msgCollector, $messages);
+
+        $this->expectOutputString($expected);
+
+        $msgCollector->display();
+
+    }//end testDisplayingNonBlockingMessages()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDisplayingNonBlockingMessages()
+     *
+     * @return array<string, array<string, array<string, int>|string>>
+     */
+    public function dataDisplayingNonBlockingMessages()
+    {
+        // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
+        return [
+            'No messages'           => [
+                'messages' => [],
+                'expected' => '',
+            ],
+            'One warning'           => [
+                'messages' => [
+                    'This is a warning' => MessageCollector::WARNING,
+                ],
+                'expected' => 'WARNING: This is a warning'.PHP_EOL.PHP_EOL,
+            ],
+            'One notice'            => [
+                'messages' => [
+                    'This is a notice' => MessageCollector::NOTICE,
+                ],
+                'expected' => 'NOTICE: This is a notice'.PHP_EOL.PHP_EOL,
+            ],
+            'One deprecation'       => [
+                'messages' => [
+                    'This is a deprecation' => MessageCollector::DEPRECATED,
+                ],
+                'expected' => 'DEPRECATED: This is a deprecation'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple warnings'     => [
+                'messages' => [
+                    'First warning'  => MessageCollector::WARNING,
+                    'Second warning' => MessageCollector::WARNING,
+                ],
+                'expected' => 'WARNING: First warning'.PHP_EOL
+                    .'WARNING: Second warning'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple notices'      => [
+                'messages' => [
+                    'First notice'  => MessageCollector::NOTICE,
+                    'Second notice' => MessageCollector::NOTICE,
+                    'Third notice'  => MessageCollector::NOTICE,
+                ],
+                'expected' => 'NOTICE: First notice'.PHP_EOL
+                    .'NOTICE: Second notice'.PHP_EOL
+                    .'NOTICE: Third notice'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple deprecations' => [
+                'messages' => [
+                    'First deprecation'  => MessageCollector::DEPRECATED,
+                    'Second deprecation' => MessageCollector::DEPRECATED,
+                ],
+                'expected' => 'DEPRECATED: First deprecation'.PHP_EOL
+                    .'DEPRECATED: Second deprecation'.PHP_EOL.PHP_EOL,
+            ],
+            'All together now'      => [
+                'messages' => [
+                    'First deprecation' => MessageCollector::DEPRECATED,
+                    'Second warning'    => MessageCollector::WARNING,
+                    'Third notice'      => MessageCollector::NOTICE,
+                    'Fourth warning'    => MessageCollector::WARNING,
+                ],
+                'expected' => 'WARNING: Second warning'.PHP_EOL
+                    .'WARNING: Fourth warning'.PHP_EOL
+                    .'NOTICE: Third notice'.PHP_EOL
+                    .'DEPRECATED: First deprecation'.PHP_EOL.PHP_EOL,
+            ],
+        ];
+        // phpcs:enable
+
+    }//end dataDisplayingNonBlockingMessages()
+
+
+    /**
+     * Test displaying message collections containing blocking messages.
+     *
+     * Verifies that:
+     * - Each message is prefixed with the appropriate prefix.
+     * - The default message order is observed.
+     * - The messages use the appropriate OS-specific EOL character.
+     *
+     * @param array<string, int> $messages The messages to display.
+     *                                     Key is the message, value is the error level.
+     * @param string             $expected The expected exception message.
+     *
+     * @dataProvider dataDisplayingBlockingErrors
+     *
+     * @return void
+     */
+    public function testDisplayingBlockingErrors($messages, $expected)
+    {
+        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+        if (method_exists($this, 'expectException') === true) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($expected);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $expected);
+        }
+
+        $msgCollector = new MessageCollector();
+        $this->createErrorCache($msgCollector, $messages);
+        $msgCollector->display();
+
+    }//end testDisplayingBlockingErrors()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDisplayingBlockingErrors()
+     *
+     * @return array<string, array<string, array<string, int>|string>>
+     */
+    public function dataDisplayingBlockingErrors()
+    {
+        // phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- Test readability is more important.
+        return [
+            'Single error'                            => [
+                'messages' => [
+                    'This is an error' => MessageCollector::ERROR,
+                ],
+                'expected' => 'ERROR: This is an error'.PHP_EOL.PHP_EOL,
+            ],
+            'Multiple errors'                         => [
+                'messages' => [
+                    'First error'  => MessageCollector::ERROR,
+                    'Second error' => MessageCollector::ERROR,
+                ],
+                'expected' => 'ERROR: First error'.PHP_EOL
+                    .'ERROR: Second error'.PHP_EOL.PHP_EOL,
+            ],
+            'Errors mixed with non-blocking messages' => [
+                'messages' => [
+                    'First deprecation'   => MessageCollector::DEPRECATED,
+                    'Second warning'      => MessageCollector::WARNING,
+                    'Third notice'        => MessageCollector::NOTICE,
+                    'Fourth error'        => MessageCollector::ERROR,
+                    'Fifth warning'       => MessageCollector::WARNING,
+                    'Sixth error'         => MessageCollector::ERROR,
+                    'Seventh deprecation' => MessageCollector::DEPRECATED,
+                ],
+                'expected' => 'ERROR: Fourth error'.PHP_EOL
+                    .'ERROR: Sixth error'.PHP_EOL
+                    .'WARNING: Second warning'.PHP_EOL
+                    .'WARNING: Fifth warning'.PHP_EOL
+                    .'NOTICE: Third notice'.PHP_EOL
+                    .'DEPRECATED: First deprecation'.PHP_EOL
+                    .'DEPRECATED: Seventh deprecation'.PHP_EOL.PHP_EOL,
+            ],
+        ];
+        // phpcs:enable
+
+    }//end dataDisplayingBlockingErrors()
+
+
+    /**
+     * Verify and safeguard that adding the same message twice is accepted when messages have different error levels.
+     *
+     * Note: have multiple messages with the exact same text is not great for conveying information
+     * to the end-user, but that's not the concern of the MessageCollector class.
+     *
+     * @return void
+     */
+    public function testNonUniqueMessagesWithDifferentErrorLevelAreAccepted()
+    {
+        $message      = 'Trying to add the same message twice';
+        $msgCollector = new MessageCollector();
+        $msgCollector->add($message, MessageCollector::NOTICE);
+        $msgCollector->add($message, MessageCollector::WARNING);
+
+        $expected  = 'WARNING: Trying to add the same message twice'.PHP_EOL;
+        $expected .= 'NOTICE: Trying to add the same message twice'.PHP_EOL.PHP_EOL;
+        $this->expectOutputString($expected);
+
+        $msgCollector->display();
+
+    }//end testNonUniqueMessagesWithDifferentErrorLevelAreAccepted()
+
+
+    /**
+     * Verify and safeguard that adding the same message twice is accepted when messages have the same error level.
+     *
+     * Note: have multiple messages with the exact same text is not great for conveying information
+     * to the end-user, but that's not the concern of the MessageCollector class.
+     *
+     * @return void
+     */
+    public function testNonUniqueMessagesWithSameErrorLevelAreAccepted()
+    {
+        $message      = 'Trying to add the same message twice';
+        $msgCollector = new MessageCollector();
+        $msgCollector->add($message, MessageCollector::NOTICE);
+        $msgCollector->add($message, MessageCollector::NOTICE);
+
+        $expected  = 'NOTICE: Trying to add the same message twice'.PHP_EOL;
+        $expected .= 'NOTICE: Trying to add the same message twice'.PHP_EOL.PHP_EOL;
+        $this->expectOutputString($expected);
+
+        $msgCollector->display();
+
+    }//end testNonUniqueMessagesWithSameErrorLevelAreAccepted()
+
+
+    /**
+     * Ensure that the message cache is cleared when the collected messages are displayed.
+     *
+     * @return void
+     */
+    public function testCallingDisplayTwiceWillNotShowMessagesTwice()
+    {
+        $messages = [
+            'First notice'       => MessageCollector::NOTICE,
+            'Second deprecation' => MessageCollector::DEPRECATED,
+            'Third notice'       => MessageCollector::NOTICE,
+            'Fourth warning'     => MessageCollector::WARNING,
+        ];
+
+        $msgCollector = new MessageCollector();
+        $this->createErrorCache($msgCollector, $messages);
+
+        $expected  = 'WARNING: Fourth warning'.PHP_EOL;
+        $expected .= 'NOTICE: First notice'.PHP_EOL;
+        $expected .= 'NOTICE: Third notice'.PHP_EOL;
+        $expected .= 'DEPRECATED: Second deprecation'.PHP_EOL.PHP_EOL;
+        $this->expectOutputString($expected);
+
+        $msgCollector->display();
+        $msgCollector->display();
+
+    }//end testCallingDisplayTwiceWillNotShowMessagesTwice()
+
+
+    /**
+     * Test that messages are ordered correctly.
+     *
+     * @param string $order    The display order.
+     * @param string $expected The expected output.
+     *
+     * @dataProvider dataDisplayOrderHandling
+     *
+     * @return void
+     */
+    public function testDisplayOrderHandling($order, $expected)
+    {
+        $messages = [
+            'First notice'       => MessageCollector::NOTICE,
+            'Second deprecation' => MessageCollector::DEPRECATED,
+            'Third notice'       => MessageCollector::NOTICE,
+            'Fourth warning'     => MessageCollector::WARNING,
+        ];
+
+        $msgCollector = new MessageCollector();
+        $this->createErrorCache($msgCollector, $messages);
+
+        $this->expectOutputString($expected);
+
+        $msgCollector->display($order);
+
+    }//end testDisplayOrderHandling()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDisplayOrderHandling()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function dataDisplayOrderHandling()
+    {
+        $expectedForSeverity  = 'WARNING: Fourth warning'.PHP_EOL;
+        $expectedForSeverity .= 'NOTICE: First notice'.PHP_EOL;
+        $expectedForSeverity .= 'NOTICE: Third notice'.PHP_EOL;
+        $expectedForSeverity .= 'DEPRECATED: Second deprecation'.PHP_EOL.PHP_EOL;
+
+        $expectedForReceived  = 'NOTICE: First notice'.PHP_EOL;
+        $expectedForReceived .= 'DEPRECATED: Second deprecation'.PHP_EOL;
+        $expectedForReceived .= 'NOTICE: Third notice'.PHP_EOL;
+        $expectedForReceived .= 'WARNING: Fourth warning'.PHP_EOL.PHP_EOL;
+
+        return [
+            'Order by severity'                  => [
+                'order'    => MessageCollector::ORDERBY_SEVERITY,
+                'expected' => $expectedForSeverity,
+            ],
+            'Order by received'                  => [
+                'order'    => MessageCollector::ORDERBY_RECEIVED,
+                'expected' => $expectedForReceived,
+            ],
+            'Invalid order defaults to severity' => [
+                'order'    => 'unknown order',
+                'expected' => $expectedForSeverity,
+            ],
+        ];
+
+    }//end dataDisplayOrderHandling()
+
+
+    /**
+     * Test helper.
+     *
+     * @param \PHP_CodeSniffer\Util\MessageCollector $collector The error cache object.
+     * @param array<string, int>                     $messages  The error messages to add to the cache.
+     *                                                          Key is the message, value is the error level.
+     *
+     * @return void
+     */
+    private function createErrorCache(MessageCollector $collector, $messages)
+    {
+        foreach ($messages as $msg => $type) {
+            $collector->add($msg, $type);
+        }
+
+    }//end createErrorCache()
+
+
+}//end class


### PR DESCRIPTION
# Description

👉🏻  _This PR has been a while in the making. While I'm confident about the principle of it, I've been struggling to write up the implementation choices made, which normally means there is still something not completely "right".
So under the guise of "Perfect is the enemy of good", here goes anyway (as this PR is blocking everything else I'm working on, as well as blocking the 3.12.0 release)._

_So please consider this a first iteration. The actual implementation details can be iterated on both in this PR, as well as via future PRs._

---

This PR is intended to solve two problems for the `Ruleset` class and to allow for implementing the same kind of solution in other parts of the codebase at a later point in time.


## Current Situation

Up to now, the `Ruleset` class only allowed for hard errors which would exit the run immediately with a non-zero exit code.

### Problem 1: The Ruleset class only allows for hard errors

In [issue 689](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/689#issuecomment-2478754671), the need to be able to display deprecation notices when processing rulesets was identified.
These deprecation notices should be displayed in a user-friendly manner and should not affect the exit code of PHPCS, nor stop PHPCS from continuing its run.

### Problem 2: The Ruleset class provides errors to the user one by one

If a Ruleset contains multiple errors, running PHPCS would only display one error at a time, which means the user would have to:
* run PHPCS
* see error 1, fix error 1
* run PHPCS again
* find out there is a second error, fix error 2
* run PHPCS again... etc

This pattern of showing errors piecemeal (one-by-one) is not terribly user-friendly, so the intention is to change this behaviour.


## What this PR changes

This PR introduces a new ~~`MsgCollector`~~ ++`MessageCollector`++ class which is intended to fix both problems. Errors and notices are "written to" the ~~`MsgCollector`~~ ++`MessageCollector`++ while processing the `Ruleset` and only displayed when the `Ruleset` has finished its processing.

If there are errors amongst the collected messages, PHPCS will still stop and exit with a non-zero exit code at that point.
If only warnings/notices/deprecations were collected, PHPCS will display these and then continue onto the next step in the PHPCS process.

:point_right: Note: At this time, no changes are being made to the error "level" of the pre-existing errors coming from the `Ruleset` class.

_Also note that the new ~~`MsgCollector`~~ ++`MessageCollector`++ class is marked as a PHPCS `internal` class and has no BC-promise to allow for iterating on the solution._

### Future Scope

At a later point in time, this same principle can be applied in more places.

In particular I'm thinking of:
* The `Config` class (in conjunction with #448). This would then also allow for deprecation of CLI args if/when needed.
* The `Fixer` class to fix issue https://github.com/squizlabs/PHP_CodeSniffer/issues/2871 (PHP errors encountered during fixing are not reported leading to potentially incomplete results without the user being informed).

Both of these improvements are currently blocked by the lack of tests for those parts of the codebase.


## Implementation choices made for this PR

A this time, the `Ruleset` class throws the following errors:
```php
// Errors in the ruleset.
throw new RuntimeException('ERROR: No sniffs were registered');
throw new RuntimeException("ERROR: Ruleset $rulesetPath is not valid ...[XML error details]");
throw new RuntimeException('ERROR: The specified autoload file "'.$autoload.'" does not exist');
throw new RuntimeException("ERROR: Referenced sniff \"$ref\" does not exist");
throw new RuntimeException("ERROR: Message type \"$type\" is invalid; must be \"error\" or \"warning\"");
throw new RuntimeException("ERROR: Sniff $sniffClass register() method must return an array");
throw new RuntimeException("ERROR: Ruleset invalid. Property \"$propertyName\" does not exist on sniff ...");

// Sniff developer errors (mostly type checks related to the `DeprecatedSniff` interface).
throw new RuntimeException(sprintf($errorTemplate, $className, 'getDeprecationVersion', 'non-empty ', gettype($deprecatedSince)));
throw new RuntimeException(sprintf($errorTemplate, $className, 'getDeprecationVersion', 'non-empty ', '""'));
throw new RuntimeException(sprintf($errorTemplate, $className, 'getRemovalVersion', 'non-empty ', gettype($removedIn)));
throw new RuntimeException(sprintf($errorTemplate, $className, 'getRemovalVersion', 'non-empty ', '""'));
throw new RuntimeException(sprintf($errorTemplate, $className, 'getDeprecationMessage', '', gettype($customMessage)));
trigger_error(__FUNCTION__.': the format of the $settings parameter has changed from (mixed) $value to array(\'scope\' => \'sniff|standard\', \'value\' => $value). Please update your integration code. See PR #3629 for more information.', E_USER_DEPRECATED);
```

<details>
  <summary><b>Details about the errors thrown from the `Ruleset` class (with context)</b></summary>

```
241:         if ($numSniffs === 0) {
242:             throw new RuntimeException('ERROR: No sniffs were registered');
243:         }

377:             // Verify the interface was implemented correctly.
378:             // Unfortunately can't be safeguarded via type declarations yet.
379:             $deprecatedSince = $this->sniffs[$className]->getDeprecationVersion();
380:             if (is_string($deprecatedSince) === false) {
381:                 throw new RuntimeException(
382:                     sprintf($errorTemplate, $className, 'getDeprecationVersion', 'non-empty ', gettype($deprecatedSince))
383:                 );
384:             }
385:
386:             if ($deprecatedSince === '') {
387:                 throw new RuntimeException(
388:                     sprintf($errorTemplate, $className, 'getDeprecationVersion', 'non-empty ', '""')
389:                 );
390:             }
391:
392:             $removedIn = $this->sniffs[$className]->getRemovalVersion();
393:             if (is_string($removedIn) === false) {
394:                 throw new RuntimeException(
395:                     sprintf($errorTemplate, $className, 'getRemovalVersion', 'non-empty ', gettype($removedIn))
396:                 );
397:             }
398:
399:             if ($removedIn === '') {
400:                 throw new RuntimeException(
401:                     sprintf($errorTemplate, $className, 'getRemovalVersion', 'non-empty ', '""')
402:                 );
403:             }
404:
405:             $customMessage = $this->sniffs[$className]->getDeprecationMessage();
406:             if (is_string($customMessage) === false) {
407:                 throw new RuntimeException(
408:                     sprintf($errorTemplate, $className, 'getDeprecationMessage', '', gettype($customMessage))
409:                 );
410:             }
411:

487:         $ruleset = simplexml_load_string(file_get_contents($rulesetPath));
488:         if ($ruleset === false) {
489:             $errorMsg = "ERROR: Ruleset $rulesetPath is not valid".PHP_EOL;
490:             $errors   = libxml_get_errors();
491:             foreach ($errors as $error) {
492:                 $errorMsg .= '- On line '.$error->line.', column '.$error->column.': '.$error->message;
493:             }
494:
495:             libxml_clear_errors();
496:             throw new RuntimeException($errorMsg);
497:         }

532:             } else if (is_file($autoloadPath) === false) {
533:                 throw new RuntimeException('ERROR: The specified autoload file "'.$autoload.'" does not exist');
534:             }

995:             if (is_file($ref) === false) {
996:                 $error = "ERROR: Referenced sniff \"$ref\" does not exist";
997:                 throw new RuntimeException($error);
998:             }

1085:                 if ($type !== 'error' && $type !== 'warning') {
1086:                     throw new RuntimeException("ERROR: Message type \"$type\" is invalid; must be \"error\" or \"warning\"");
1087:                 }

1414:             if (is_array($tokens) === false) {
1415:                 $msg = "ERROR: Sniff $sniffClass register() method must return an array";
1416:                 throw new RuntimeException($msg);
1417:             }

1509:             trigger_error(
1510:                 __FUNCTION__.': the format of the $settings parameter has changed from (mixed) $value to array(\'scope\' => \'sniff|standard\', \'value\' => $value). Please update your integration code. See PR #3629 for more information.',
1511:                 E_USER_DEPRECATED
1512:             );

1525:             if ($settings['scope'] === 'sniff') {
1526:                 $notice  = "ERROR: Ruleset invalid. Property \"$propertyName\" does not exist on sniff ";
1527:                 $notice .= array_search($sniffClass, $this->sniffCodes, true);
1528:                 throw new RuntimeException($notice);
1529:             }
```

</details>


I've categorized these errors in the above list as "ruleset errors" and "sniff developer errors".

For now, I'm going to leave the sniff developer errors alone. An end-user should never run into these and we may want to have a think about how to ensure that even better, but for now, in my opinion, that is outside of the scope of this ticket.


So that leaves us with the following errors:
```php
throw new RuntimeException('ERROR: No sniffs were registered');
throw new RuntimeException("ERROR: Ruleset $rulesetPath is not valid ...[XML error details]");
throw new RuntimeException('ERROR: The specified autoload file "'.$autoload.'" does not exist');
throw new RuntimeException("ERROR: Referenced sniff \"$ref\" does not exist");
throw new RuntimeException("ERROR: Message type \"$type\" is invalid; must be \"error\" or \"warning\"");
throw new RuntimeException("ERROR: Sniff $sniffClass register() method must return an array");
throw new RuntimeException("ERROR: Ruleset invalid. Property \"$propertyName\" does not exist on sniff ...");
```

While I'd like to collect ALL of these errors, these is one for which an exception MUST be made:
```php
throw new RuntimeException('ERROR: The specified autoload file "'.$autoload.'" does not exist');
```

A missing autoload file _may_ or _may not_ be problematic in the context of the ~~`MsgCollector`~~ ++`MessageCollector`++, depending on whether whichever classes are supposed to be loaded via the custom autoloader are actually used by the sniffs being loaded in the ruleset and when.

Let me explain. There are basically three possible situations:
1. The autoload file is requested by a (sub-)ruleset, but the sniffs in use by the ruleset do not use any classes which need to be loaded by the custom autoload file. In that case, the missing autoload file is not problematic (at all).
2. The autoload file is requested by a (sub-)ruleset and there are sniffs in use by the ruleset which use classes which need to be loaded by the custom autoload file, but these are only used within a `process()` method and the sniff may bow out before ever reaching the code which calls the class which needs autoloading. In that case, it depends on the "code under scan" whether the missing autoload file would be problematic.
3. The autoload file is requested by a (sub-)ruleset and there are sniffs in use by the ruleset which use classes which need to be loaded by the custom autoload file and these classes are in the class signature of the sniff class, like `extends Something` or `implements Something`.
    In that case, loading the sniff file while reading the ruleset (as done in Ruleset::registerSniffs() line 1337 - `$className = Autoload::loadFile($file);`), would lead to a "Class not found" error and [this error can only be caught since PHP 7.3](https://3v4l.org/TZ9Aj), which means there is no way we can catch this error in a PHP cross-version compatible manner for all currently supported PHP versions.

So, it is this last case which is the blocker. If the "autoload file missing" error would be collected via the ~~`MsgCollector`~~ ++`MessageCollector`++, any subsequent "Class not found" errors, encountered while processing the rulesets, would need to be handled and passed off to the ~~`MsgCollector`~~ ++`MessageCollector`++ as well, but we can't currently do that for all supported PHP versions, which means we can't "collect" the "autoload file missing" error.


And if we're going to make exceptions anyway, I'm inclined to not "collect" the "ruleset XML parse error" error either.
While we could "collect" it, ignore the problematic (sub-)ruleset and continue processing other rulesets, I kind of consider an XML parse error serious enough to error straight away.
:point_right: _Note: I'm open to being persuaded to "collect" this error anyway._


### Alternative to not "collecting" these errors

As an alternative, I considered "collecting" those errors anyway and adding an extra severity level (`CRITICAL`) to the ~~`MsgCollector`~~ ++`MessageCollector`++.
In that case, if a message with severity `CRITICAL` would be `add`ed, the ~~`MsgCollector`~~ ++`MessageCollector`++ would `display()` whatever had been collected straight away.
 
The upside of this is that any messages collected prior to the `CRITICAL` error would also be displayed (instead of getting lost/displayed only in the next run after the critical error was fixed).
The downside of this is that the ~~`MsgCollector`~~ ++`MessageCollector`++ would be less context agnostic (less "clean") and would contain logic deciding when to display the messages instead of leaving that to the class using the ~~`MsgCollector`~~ ++`MessageCollector`++.

For this first iteration, I've decided against this alternative solution, but as the ~~`MsgCollector`~~ ++`MessageCollector`++ is marked as "internal" and has no BC promise, this change could still be made at a later time.



## Commits

**_Note_**: _the last five (six) commits should be squashed into a single commit before merging. They are currently separate commits only to make it more straight-forward to review this PR._


### :sparkles: New ~~`MsgCollector`~~ ++`MessageCollector`++ utility class

This _internal-use only_ `PHP_CodeSniffer\Util\MessageCollector` class can be used to collect various type of "error" messages, including notices, warnings and deprecations for display at a later point in time.

This class is intended to be used by various steps in the PHPCS process flow to improve the error handling and prevent the "one error hiding another" pattern.

#### Design choices:
* This class does not have a constructor and has no awareness of the applicable `Config` or other aspects of a PHPCS run.
    If notices should be displayed conditionally, like only when not in `-q` quite mode, this should be handled by the class _using_ the ~~`MsgCollector`~~ ++`MessageCollector`++.
* While duplicate error messages are not a great user experience, this class allows for them.
    It is the responsibility of the class _using_ the ~~`MsgCollector`~~ ++`MessageCollector`++ to ensure that the messages cached are informative for the end-user.
* The class provides a number of (`public`) class constants to indicate the error level when adding messages.
    It is _strongly_ recommended to only ever use these class constants for the error levels.
    The default error level for messages will be `NOTICE`.
    Note: yes, these class constants should basically be an Enum, however, enums are a PHP 8.1+ feature, so can't be used at this time.
* The class provides two (`public`) "orderby" class constants to indicate the display order of the messages.
    It is _strongly_ recommended to only ever use these class constants for the display order.
    By default, messages will be ordered by severity (with "order received" being the secondary ordering for messages of the same severity).
    Note: again, yes, these class constants should basically be an Enum.
* When display of the messages is requested and the message cache includes messages with severity `ERROR`, the class will throw a RuntimeException, which will cause the PHPCS run to exit with a non-zero exit code (currently `3`).
* In all other cases, the messages will be displayed, but the PHPCS run will continue without affecting the exit code.
* It was suggested by @fredden to consider implementing [PSR-3: Logger Interface](https://www.php-fig.org/psr/psr-3/) for the ~~`MsgCollector`~~ ++`MessageCollector`++.
    While we discussed this, I don't consider this necessary at this time, though as the class has no BC-promise, this can be reconsidered in the future.
    Arguments against implementing PSR-3 at this time:
    - Placeholder handling is required in the PSR-3 implementation to allow for logging to different contexts and using appropriate variable escaping based on the context.
        For PHPCS, messages will only ever be displayed on the command-line, so there is no need to take escaping for different contexts into account.
    - PSR-3 expects handling of eight different severity levels - emergency, alert, critical, error, warning, notice, info, debug -.
        For PHPCS, the `emergency`, `alert` and `critical` levels, as defined in PSR-3, are redundant as these will never occur.
        Along the same line, PHPCS does not log `info`.
        However, we do want to be able to display deprecation notices, but that is a severity level not supported under PSR-3.

The new functionality is fully covered by tests.

#### Potential future scope:
* Add a constructor and inject the `Config` class to allow for colorizing the messages/message prefixes if color support is enabled.
    This would be most effective after issue #448 has been addressed first.
* Add a new `CRITICAL` level for errors which prohibit the current task from finishing. When an error with such level would be received, it would cause the class to display all messages collected up to that point straight away via an exception.
* If the conditional displaying of the messages, like only when not in `-q` mode, would lead to undue duplicate code, potentially move display conditions handling into the ~~`MsgCollector`~~ ++`MessageCollector`++ class.
    This would also need the aforementioned constructor with `Config` injection.

### Ruleset: wire in ~~MsgCollector~~ ++MessageCollector++

This commit adds a mechanism to handle errors encountered while loading a ruleset in a more user-friendly manner.

* Errors and notices aimed at end-users and ruleset maintainers will be collected while processing the ruleset.
* Only once the complete processing of the ruleset is finished, will all errors/notices be displayed.
    This prevents "one error hiding behind another".
* If there are only notices (deprecations/notices/warnings), these will not display when running `-e` (explain), `-q` (quiet mode) or `--generator=...` (documentation).
* Errors will always display and will hard exit out of the run with a non-zero exit code.

This implementation should be seen as an interim - "good enough for now" - solution, which can be iterated on in the future.
I can imagine a more code-base wide solution at some later point in time, but that should not block this initial improvement.
As the current implementation doesn't change the public API (the only new methods are `private`), it should be feasible to transform the current solution to whatever form a future solution will take without breaking changes.

Includes tests covering the new functionality.

### Ruleset: use ~~MsgCollector~~ ++MessageCollector++ for "no sniffs registered" error

### Ruleset: use ~~MsgCollector~~ ++MessageCollector++ for "referenced sniff not found" error

### Ruleset: use ~~MsgCollector~~ ++MessageCollector++ for "invalid type" message

Includes updating the message to mention the reference for which the `type` was (incorrectly) being changed.
This should make it more straight forward for ruleset maintainers to find the problem in their ruleset.
It also makes the message more unique, as this message could occur in multiple places in a ruleset and there was no indication of that in the message previously.

👉🏻  _This commit will be easiest to review while ignoring whitespace differences._

#### Potential future scope

It could be considered to downgrade this message from an `ERROR` to a `NOTICE` as an invalid type is not blocking for running the sniffs, though this could lead to results not being as expected if, for instance, the `-n` flag is being used, which is why I've not changed this at this time.

### Ruleset: use ~~MsgCollector~~ ++MessageCollector++ for "register() method must return an array" error

Includes some new assertions which won't run until the test suite supports PHPUnit 10+ (PHPCS 4.0). These tests belong with this commit though, so adding them now anyway.

### Ruleset: use ~~MsgCollector~~ ++MessageCollector++ for "setting non-existent property" error

Includes minor adjustment to the error message (removal of "Ruleset invalid" and punctuation).


## Suggested changelog entry
Whenever possible, the ruleset processing will be allowed to run to its conclusion before displaying all ruleset errors in one go.
Previously an error in a ruleset would cause PHPCS to exit immediately.


## Related issues/external references

Related to https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/689#issuecomment-2482992507


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature _(non-breaking change which adds functionality)_

