### PR TITLE
GH Action/Labeller: fix up outdated labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,11 +5,11 @@ labels:
     draft: false
     author-can-merge: false
 
-  - label: "Core Component: Config & Ruleset & CLI options"
+  - label: "Core Component: Config & CLI options"
     draft: false
     files:
       - "src/Config.php$"
-  - label: "Core Component: Config & Ruleset & CLI options"
+  - label: "Core Component: Ruleset"
     draft: false
     files:
       - "src/Ruleset.php$"


### PR DESCRIPTION
# Description
I recently split the `Core Component: Config & Ruleset & CLI options` label into two, but this ruleset wasn't updated yet, so the label was being re-introduced by the workflow which auto-adds labels. Oops.

Fixed now.


## Suggested changelog entry
_N/A_
