### PR TITLE
Ruleset/PropertyTypeHandlingTest: add tests with extended arrays

### DIFF
--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -19,8 +19,12 @@
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedValues[] string, 15, another string
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedValues[] string, 15, another string
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
 
 echo 'hello!';

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -100,6 +100,20 @@ final class PropertyTypeHandlingSniff implements Sniff
     public $expectsArrayWithKeysAndValues;
 
     /**
+     * Used to verify that array properties can get extended.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithExtendedValues;
+
+    /**
+     * Used to verify that array properties can get extended.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithExtendedKeysAndValues;
+
+    /**
      * Used to verify that array properties passed as a string get parsed to a proper array.
      *
      * @var array<mixed>
@@ -112,6 +126,20 @@ final class PropertyTypeHandlingSniff implements Sniff
      * @var array<string, mixed>
      */
     public $expectsOldSchoolArrayWithKeysAndValues;
+
+    /**
+     * Used to verify that array properties passed as a string can get extended.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithExtendedValues;
+
+    /**
+     * Used to verify that array properties passed as a string can get extended.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithExtendedKeysAndValues;
 
     public function register()
     {

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -102,62 +102,90 @@ final class PropertyTypeHandlingTest extends TestCase
             'false'  => 'false',
         ];
 
+        $expectedArrayOnlyValuesExtended    = [
+            'string',
+            '15',
+            'another string',
+        ];
+        $expectedArrayKeysAndValuesExtended = [
+            10               => '10',
+            'string'         => 'string',
+            15               => '15',
+            'another string' => 'another string',
+        ];
+
         return [
-            'String value (default)'                         => [
+            'String value (default)'                          => [
                 'propertyName' => 'expectsString',
                 'expected'     => 'arbitraryvalue',
             ],
-            'String with whitespace only value becomes null' => [
+            'String with whitespace only value becomes null'  => [
                 'propertyName' => 'emptyStringBecomesNull',
                 'expected'     => null,
             ],
-            'Integer value gets set as string'               => [
+            'Integer value gets set as string'                => [
                 'propertyName' => 'expectsIntButAcceptsString',
                 'expected'     => '12345',
             ],
-            'Float value gets set as string'                 => [
+            'Float value gets set as string'                  => [
                 'propertyName' => 'expectsFloatButAcceptsString',
                 'expected'     => '12.345',
             ],
-            'Null value gets set as string'                  => [
+            'Null value gets set as string'                   => [
                 'propertyName' => 'expectsNull',
                 'expected'     => 'null',
             ],
-            'Null (uppercase) value gets set as string'      => [
+            'Null (uppercase) value gets set as string'       => [
                 'propertyName' => 'expectsNullCase',
                 'expected'     => 'NULL',
             ],
-            'True value gets set as boolean'                 => [
+            'True value gets set as boolean'                  => [
                 'propertyName' => 'expectsBooleanTrue',
                 'expected'     => true,
             ],
-            'True (mixed case) value gets set as string'     => [
+            'True (mixed case) value gets set as string'      => [
                 'propertyName' => 'expectsBooleanTrueCase',
                 'expected'     => 'True',
             ],
-            'False value gets set as boolean'                => [
+            'False value gets set as boolean'                 => [
                 'propertyName' => 'expectsBooleanFalse',
                 'expected'     => false,
             ],
-            'False (mixed case) value gets set as string'    => [
+            'False (mixed case) value gets set as string'     => [
                 'propertyName' => 'expectsBooleanFalseCase',
                 'expected'     => 'fALSe',
             ],
-            'Array with only values (new style)'             => [
+            'Array with only values (new style)'              => [
                 'propertyName' => 'expectsArrayWithOnlyValues',
                 'expected'     => $expectedArrayOnlyValues,
             ],
-            'Array with keys and values (new style)'         => [
+            'Array with keys and values (new style)'          => [
                 'propertyName' => 'expectsArrayWithKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValues,
             ],
-            'Array with only values (old style)'             => [
+            'Array with only values extended (new style)'     => [
+                'propertyName' => 'expectsArrayWithExtendedValues',
+                'expected'     => $expectedArrayOnlyValuesExtended,
+            ],
+            'Array with keys and values extended (new style)' => [
+                'propertyName' => 'expectsArrayWithExtendedKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValuesExtended,
+            ],
+            'Array with only values (old style)'              => [
                 'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
                 'expected'     => $expectedArrayOnlyValues,
             ],
-            'Array with keys and values (old style)'         => [
+            'Array with keys and values (old style)'          => [
                 'propertyName' => 'expectsOldSchoolArrayWithKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValues,
+            ],
+            'Array with only values extended (old style)'     => [
+                'propertyName' => 'expectsOldSchoolArrayWithExtendedValues',
+                'expected'     => $expectedArrayOnlyValuesExtended,
+            ],
+            'Array with keys and values extended (old style)' => [
+                'propertyName' => 'expectsOldSchoolArrayWithExtendedKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValuesExtended,
             ],
         ];
 

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -35,9 +35,34 @@
                 <element key="false" value="false"/>
             </property>
 
+            <property name="expectsArrayWithExtendedValues" type="array">
+                <element value="string"/>
+            </property>
+
+            <property name="expectsArrayWithExtendedValues" type="array" extend="true">
+                <element value="15"/>
+                <element value="another string"/>
+            </property>
+
+            <property name="expectsArrayWithExtendedKeysAndValues" type="array">
+                <element key="10" value="10"/>
+                <element key="string" value="string"/>
+            </property>
+
+            <property name="expectsArrayWithExtendedKeysAndValues" type="array" extend="true">
+                <element key="15" value="15"/>
+                <element key="another string" value="another string"/>
+            </property>
+
             <property name="expectsOldSchoolArrayWithOnlyValues" type="array" value="string, 10, 1.5, null, true, false" />
 
             <property name="expectsOldSchoolArrayWithKeysAndValues" type="array" value="string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false" />
+
+            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" value="string" />
+            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" extend="true" value="15,another string" />
+
+            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" value="10=>10,string=>string" />
+            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" extend="true" value="15=>15,another string=>another string" />
         </properties>
     </rule>
 


### PR DESCRIPTION
# Description
Add some extra tests to verify that extending a (new style) array property declaration works as expected.

While this is also tested via the `ProcessRuleShouldProcessElementTest`, some extra tests seemed warranted.


## Suggested changelog entry
_N/A_
