### PR TITLE
Ruleset: bug fix - correctly handle empty array property setting

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -1174,12 +1174,14 @@ class Ruleset
                         } else {
                             $value      = (string) $prop['value'];
                             $printValue = $value;
-                            foreach (explode(',', $value) as $val) {
-                                list($k, $v) = explode('=>', $val.'=>');
-                                if ($v !== '') {
-                                    $values[trim($k)] = trim($v);
-                                } else {
-                                    $values[] = trim($k);
+                            if ($value !== '') {
+                                foreach (explode(',', $value) as $val) {
+                                    list($k, $v) = explode('=>', $val.'=>');
+                                    if ($v !== '') {
+                                        $values[trim($k)] = trim($v);
+                                    } else {
+                                        $values[] = trim($k);
+                                    }
                                 }
                             }
                         }//end if

--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -21,10 +21,12 @@
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedValues[] string, 15, another string
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsEmptyArray[]
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedValues[] string, 15, another string
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolEmptyArray[]
 
 echo 'hello!';

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -114,6 +114,13 @@ final class PropertyTypeHandlingSniff implements Sniff
     public $expectsArrayWithExtendedKeysAndValues;
 
     /**
+     * Used to verify that array properties allow for setting a property to an empty array.
+     *
+     * @var array<mixed>
+     */
+    public $expectsEmptyArray;
+
+    /**
      * Used to verify that array properties passed as a string get parsed to a proper array.
      *
      * @var array<mixed>
@@ -140,6 +147,13 @@ final class PropertyTypeHandlingSniff implements Sniff
      * @var array<string, mixed>
      */
     public $expectsOldSchoolArrayWithExtendedKeysAndValues;
+
+    /**
+     * Used to verify that array properties passed as a string allow for setting a property to an empty array.
+     *
+     * @var array<mixed>
+     */
+    public $expectsOldSchoolEmptyArray;
 
     public function register()
     {

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -171,6 +171,10 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsArrayWithExtendedKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValuesExtended,
             ],
+            'Empty array (new style)'                         => [
+                'propertyName' => 'expectsEmptyArray',
+                'expected'     => [],
+            ],
             'Array with only values (old style)'              => [
                 'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
                 'expected'     => $expectedArrayOnlyValues,
@@ -186,6 +190,10 @@ final class PropertyTypeHandlingTest extends TestCase
             'Array with keys and values extended (old style)' => [
                 'propertyName' => 'expectsOldSchoolArrayWithExtendedKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValuesExtended,
+            ],
+            'Empty array (old style)'                         => [
+                'propertyName' => 'expectsOldSchoolEmptyArray',
+                'expected'     => [],
             ],
         ];
 

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -54,6 +54,8 @@
                 <element key="another string" value="another string"/>
             </property>
 
+            <property name="expectsEmptyArray" type="array"/>
+
             <property name="expectsOldSchoolArrayWithOnlyValues" type="array" value="string, 10, 1.5, null, true, false" />
 
             <property name="expectsOldSchoolArrayWithKeysAndValues" type="array" value="string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false" />
@@ -63,6 +65,8 @@
 
             <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" value="10=>10,string=>string" />
             <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" extend="true" value="15=>15,another string=>another string" />
+
+            <property name="expectsOldSchoolEmptyArray" type="array" value=""/>
         </properties>
     </rule>
 


### PR DESCRIPTION
# Description
While already handled correctly for inline properties set via `phpcs:set`, setting a property to an empty array from a ruleset file was not handled correctly until now.

As things were, when setting an array property from the ruleset to an empty array like so:
```xml
    <rule ref="Standard.Category.SniffName">
        <properties>
            <property name="arrayProperty" type="array"/>
        </properties>
    </rule>
```

 the property value would be set to:
```php
public $arrayProperty = [
    0 => '',
];
```
... while the expected behaviour would be:
```php
public $arrayProperty = [];
```

While it is not expected that this type of property setting is encountered a lot in the wild, it should still work correctly.

Fixed now.

Includes test safeguarding the fix.

## Suggested changelog entry
Setting an array property to an empty array from an XML ruleset now works correctly.
Previously, the property value would be set to `[0 => '']`.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_

