### PR TITLE
Squiz/FunctionClosingBraceSpace: add some more tests

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.inc
@@ -37,3 +37,54 @@ function foo()
 
 
 }
+
+// Nested functions - okay.
+function hasNestedOkay() {
+    function nestedFunction() {
+        echo 'hello';
+    }
+
+}
+
+$cl = function() {
+    function nestedFunction() {
+        echo 'hello';
+    }
+
+};
+
+mycallback(
+    'name',
+    function() {
+        echo 'hello';
+    }
+
+);
+
+// Nested functions - not okay.
+function hasNestedNotOkay() {
+    function nestedFunction() {}
+
+}
+
+$cl = function() {
+    function nestedFunction() {
+        echo 'hello'; }
+
+};
+
+mycallback('name', function() {
+    echo 'hello';
+
+
+
+    }
+
+);
+
+mycallback('name', function() {
+    // Comment
+
+    }
+
+);

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.inc.fixed
@@ -43,3 +43,52 @@ function foo()
     }//end for
 
 }
+
+// Nested functions - okay.
+function hasNestedOkay() {
+    function nestedFunction() {
+        echo 'hello';
+    }
+
+}
+
+$cl = function() {
+    function nestedFunction() {
+        echo 'hello';
+    }
+
+};
+
+mycallback(
+    'name',
+    function() {
+        echo 'hello';
+    }
+
+);
+
+// Nested functions - not okay.
+function hasNestedNotOkay() {
+    function nestedFunction() {
+}
+
+}
+
+$cl = function() {
+    function nestedFunction() {
+        echo 'hello'; 
+}
+
+};
+
+mycallback('name', function() {
+    echo 'hello';
+    }
+
+);
+
+mycallback('name', function() {
+    // Comment
+    }
+
+);

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -41,6 +41,10 @@ final class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
                 29 => 1,
                 31 => 1,
                 39 => 1,
+                66 => 1,
+                72 => 1,
+                81 => 1,
+                88 => 1,
             ];
 
         case 'FunctionClosingBraceSpaceUnitTest.js':


### PR DESCRIPTION
# Description
A significant part of this sniff (handling of nested functions) is only covered by JS tests, so let's make sure this functionality also has tests for PHP.


## Suggested changelog entry
_N/A_

## Related issues/external references

Loosely related to #146
