### PR TITLE
Add StandardRulesetsQATest

### DIFF
--- a/tests/Core/Standards/StandardRulesetsQATest.php
+++ b/tests/Core/Standards/StandardRulesetsQATest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests that pre-defined standards do not throw errors.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Standards;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+
+/**
+ * Tests that pre-defined standards do not throw errors.
+ *
+ * @coversNothing
+ */
+final class StandardRulesetsQATest extends AbstractRulesetTestCase
+{
+
+
+    /**
+     * QA check: verify that the PHPCS native rulesets do not throw any errors or other messages.
+     *
+     * This QA check will prevent issues like:
+     * - a sniff being removed, but still being referenced from within a PHPCS native ruleset.
+     * - a supported feature being removed, but still being used from within a PHPCS native ruleset.
+     *
+     * @param string $standard The name of the build-in standard to test.
+     *
+     * @dataProvider dataBuildInStandards
+     *
+     * @return void
+     */
+    public function testBuildInStandardsDoNotContainErrors($standard)
+    {
+        ob_start();
+        $config  = new ConfigDouble(["--standard=$standard"]);
+        $ruleset = new Ruleset($config);
+
+        $seenOutput = ob_get_contents();
+        ob_end_clean();
+
+        // Make sure no messages were thrown.
+        $this->assertSame('', $seenOutput);
+
+        // Make sure sniffs were registered.
+        $this->assertGreaterThanOrEqual(1, count($ruleset->sniffCodes));
+
+    }//end testBuildInStandardsDoNotContainErrors()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testBuildInStandardsDoNotContainErrors()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataBuildInStandards()
+    {
+        // Get a list of all build-in, PHPCS native standards.
+        $sep          = DIRECTORY_SEPARATOR;
+        $targetDir    = dirname(dirname(dirname(__DIR__))).$sep.'src'.$sep.'Standards'.$sep;
+        $rulesetFiles = glob($targetDir.'*'.$sep.'ruleset.xml');
+
+        $data = [];
+        foreach ($rulesetFiles as $file) {
+            $standardName        = basename(dirname($file));
+            $data[$standardName] = [
+                'standard' => $standardName,
+            ];
+        }
+
+        return $data;
+
+    }//end dataBuildInStandards()
+
+
+}//end class


### PR DESCRIPTION
# Description

This adds a QA test to verify that the build-in rulesets do not throw any errors to prevent a change in the sniffs, which needs an update to a ruleset, from going unnoticed.

Ref:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/58#issuecomment-2709028260

## Suggested changelog entry
_N/A_

## Related issues/external references

Fixes #58

