### PR TITLE
Tests/Tokenizer: fix `conditions` checking range in `T_DEFAULT` test

### DIFF
--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -159,7 +159,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStop) === true) {
-                $end = ($token + $conditionStop);
+                $end = ($token + $conditionStop + 1);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {


### PR DESCRIPTION
# Description

This PR addresses an issue that I missed when working on #850. Among other things, the `RecurseScopeMapDefaultKeywordConditionsTest ::testSwitchDefault()` method checks if tokens within the scope of a `T_DEFAULT` token have `T_DEFAULT` set as one of its `conditions` array.

The test incorrectly checked token `conditions` due to an off-by-one error in the loop range when the `T_DEFAULT` uses curly braces.

For a `T_DEFAULT` with curly braces, the tokenizer adds `T_DEFAULT` to the `conditions` array of all the tokens within its scope up to the `T_BREAK|T_RETURN|T_CONTINUE`, but the test was checking only until the token before the `T_BREAK|T_RETURN|T_CONTINUE`. While for a `T_DEFAULT` without curly braces, it adds to all the tokens within the scope until the token before the scope closer.

This commit updates the test to ensure that all tokens within a default case scope that should have the `T_DEFAULT` token in their `conditions` array are properly checked. To achieve that, the loop was modified:

- The end point ($end) is now set to `$closer - 1` when curly braces are not used.
- The loop condition uses inclusive comparison (<=) to ensure that the `$end` is also checked.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
