### PR TITLE
Config: add tests for setting `--extensions`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1141,21 +1141,24 @@ class Config
                     break;
                 }
 
-                $extensions    = explode(',', substr($arg, 11));
-                $newExtensions = [];
-                foreach ($extensions as $ext) {
-                    $slash = strpos($ext, '/');
-                    if ($slash !== false) {
-                        // They specified the tokenizer too.
-                        list($ext, $tokenizer) = explode('/', $ext);
-                        $newExtensions[$ext]   = strtoupper($tokenizer);
-                        continue;
-                    }
+                $extensionsString = substr($arg, 11);
+                $newExtensions    = [];
+                if (empty($extensionsString) === false) {
+                    $extensions = explode(',', $extensionsString);
+                    foreach ($extensions as $ext) {
+                        $slash = strpos($ext, '/');
+                        if ($slash !== false) {
+                            // They specified the tokenizer too.
+                            list($ext, $tokenizer) = explode('/', $ext);
+                            $newExtensions[$ext]   = strtoupper($tokenizer);
+                            continue;
+                        }
 
-                    if (isset($this->extensions[$ext]) === true) {
-                        $newExtensions[$ext] = $this->extensions[$ext];
-                    } else {
-                        $newExtensions[$ext] = 'PHP';
+                        if (isset($this->extensions[$ext]) === true) {
+                            $newExtensions[$ext] = $this->extensions[$ext];
+                        } else {
+                            $newExtensions[$ext] = 'PHP';
+                        }
                     }
                 }
 

--- a/tests/Core/Config/ExtensionsArgTest.php
+++ b/tests/Core/Config/ExtensionsArgTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Config --extensions argument.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Config --extensions argument.
+ *
+ * @covers \PHP_CodeSniffer\Config::processLongArgument
+ */
+final class ExtensionsArgTest extends TestCase
+{
+
+
+    /**
+     * Ensure that the extension property is set when the parameter is passed a valid value.
+     *
+     * @param string $passedValue Extensions as passed on the command line.
+     * @param string $expected    Expected value for the extensions property.
+     *
+     * @dataProvider dataValidExtensions
+     *
+     * @return void
+     */
+    public function testValidExtensions($passedValue, $expected)
+    {
+        $config = new ConfigDouble(["--extensions=$passedValue"]);
+
+        $this->assertSame($expected, $config->extensions);
+
+    }//end testValidExtensions()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testValidExtensions()
+     *
+     * @return array<int, array<string>>
+     */
+    public static function dataValidExtensions()
+    {
+        return [
+            // Passing an empty extensions list is not useful, as it will result in no files being scanned,
+            // but that's the responsibility of the user.
+            'Empty extensions list'                                                          => [
+                'passedValue' => '',
+                'expected'    => [],
+            ],
+            'Single extension passed: php'                                                   => [
+                'passedValue' => 'php',
+                'expected'    => [
+                    'php' => 'PHP',
+                ],
+            ],
+            // This would cause PHPCS to scan python files as PHP, which will probably cause very weird scan results,
+            // but that's the responsibility of the user.
+            'Single extension passed: py'                                                    => [
+                'passedValue' => 'py',
+                'expected'    => [
+                    'py' => 'PHP',
+                ],
+            ],
+            // This would likely result in a problem when PHPCS can't find a "PY" tokenizer class,
+            // but that's not our concern at this moment. Support for non-PHP tokenizers is being dropped soon anyway.
+            'Single extension passed with language: py/py'                                   => [
+                'passedValue' => 'py/py',
+                'expected'    => [
+                    'py' => 'PY',
+                ],
+            ],
+            'Multiple extensions passed: php,js,css'                                         => [
+                'passedValue' => 'php,js,css',
+                'expected'    => [
+                    'php' => 'PHP',
+                    'js'  => 'JS',
+                    'css' => 'CSS',
+                ],
+            ],
+            'Multiple extensions passed, some with language: php,inc/php,phpt/php,js'        => [
+                'passedValue' => 'php,inc/php,phpt/php,js',
+                'expected'    => [
+                    'php'  => 'PHP',
+                    'inc'  => 'PHP',
+                    'phpt' => 'PHP',
+                    'js'   => 'JS',
+                ],
+            ],
+            'File extensions are set case sensitively (and filtering is case sensitive too)' => [
+                'passedValue' => 'PHP,php',
+                'expected'    => [
+                    'PHP' => 'PHP',
+                    'php' => 'PHP',
+                ],
+            ],
+        ];
+
+    }//end dataValidExtensions()
+
+
+    /**
+     * Ensure that only the first argument is processed and others are ignored.
+     *
+     * @return void
+     */
+    public function testOnlySetOnce()
+    {
+        $config = new ConfigDouble(
+            [
+                '--extensions=php',
+                '--extensions=inc,module',
+            ]
+        );
+
+        $this->assertSame(['php' => 'PHP'], $config->extensions);
+
+    }//end testOnlySetOnce()
+
+
+}//end class


### PR DESCRIPTION
# Description
Includes minor bug fix to treat an empty value correctly.

Previously, passing `--extensions=` (without value) would result in the `Config::$extensions` property being set to:
```php
public $extensions = [
    '' => 'PHP'
];
```
Now, an empty value will set the extensions array to an empty array.
```php
public $extensions = [];
```

Note: in practice, the above change will not make a difference in how files are filtered/scanned.

:point_right: The change to the `Config` class will be most straight-forward to review while ignoring whitespace changes.


## Suggested changelog entry
_N/A_

