### PR TITLE
Ruleset: handle invalid sniffs more graciously

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -1409,6 +1409,24 @@ class Ruleset
                 continue;
             }
 
+            if ($reflection->implementsInterface('PHP_CodeSniffer\Sniffs\Sniff') === false) {
+                // Skip classes which don't implement the register() or process() methods.
+                if (method_exists($className, 'register') === false
+                    || method_exists($className, 'process') === false
+                ) {
+                    $errorMsg = 'Sniff class %s is missing required method %s().';
+                    if (method_exists($className, 'register') === false) {
+                        $this->msgCache->add(sprintf($errorMsg, $className, 'register'), MessageCollector::ERROR);
+                    }
+
+                    if (method_exists($className, 'process') === false) {
+                        $this->msgCache->add(sprintf($errorMsg, $className, 'process'), MessageCollector::ERROR);
+                    }
+
+                    continue;
+                }
+            }//end if
+
             $listeners[$className] = $className;
 
             if (PHP_CODESNIFFER_VERBOSITY > 2) {

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoProcessSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoProcessSniff.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsRejectsInvalidSniffTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\InvalidSniffError;
+
+final class NoImplementsNoProcessSniff
+{
+
+    public function register()
+    {
+        return [T_OPEN_TAG];
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterOrProcessSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterOrProcessSniff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsRejectsInvalidSniffTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\InvalidSniffError;
+
+final class NoImplementsNoRegisterOrProcessSniff
+{
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterSniff.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsRejectsInvalidSniffTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\InvalidSniffError;
+
+use PHP_CodeSniffer\Files\File;
+
+final class NoImplementsNoRegisterSniff
+{
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
+++ b/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
@@ -5,6 +5,7 @@
 
     <rule ref="TestStandard">
         <exclude name="TestStandard.InvalidSniffs"/>
+        <exclude name="TestStandard.InvalidSniffError"/>
     </rule>
 
 </ruleset>

--- a/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoProcessTest.xml
+++ b/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoProcessTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RegisterSniffsRejectsInvalidSniffTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoProcessSniff.php"/>
+
+    <!-- Prevent a "no sniff were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+</ruleset>

--- a/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml
+++ b/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RegisterSniffsRejectsInvalidSniffTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterOrProcessSniff.php"/>
+
+    <!-- Prevent a "no sniff were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+</ruleset>

--- a/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterTest.xml
+++ b/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RegisterSniffsRejectsInvalidSniffTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/InvalidSniffError/NoImplementsNoRegisterSniff.php"/>
+
+    <!-- Prevent a "no sniff were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+</ruleset>

--- a/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffTest.php
+++ b/tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests that invalid sniffs will be rejected with an informative error message.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+
+/**
+ * Tests that invalid sniffs will be rejected with an informative error message.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::registerSniffs
+ */
+final class RegisterSniffsRejectsInvalidSniffTest extends AbstractRulesetTestCase
+{
+
+
+    /**
+     * Verify that an error is thrown if an invalid sniff class is loaded.
+     *
+     * @param string $standard   The standard to use for the test.
+     * @param string $methodName The name of the missing method.
+     *
+     * @dataProvider dataExceptionIsThrownOnMissingInterfaceMethod
+     *
+     * @return void
+     */
+    public function testExceptionIsThrownOnMissingInterfaceMethod($standard, $methodName)
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/'.$standard;
+        $config   = new ConfigDouble(["--standard=$standard"]);
+
+        $regex = "`(^|\R)ERROR: Sniff class \S+Sniff is missing required method $methodName\(\)\.\R`";
+        $this->expectRuntimeExceptionRegex($regex);
+
+        new Ruleset($config);
+
+    }//end testExceptionIsThrownOnMissingInterfaceMethod()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testExceptionIsThrownOnMissingInterfaceMethod()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataExceptionIsThrownOnMissingInterfaceMethod()
+    {
+        return [
+            'Missing register() method'                => [
+                'standard'   => 'RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterTest.xml',
+                'methodName' => 'register',
+            ],
+            'Missing process() method'                 => [
+                'standard'   => 'RegisterSniffsRejectsInvalidSniffNoImplementsNoProcessTest.xml',
+                'methodName' => 'process',
+            ],
+            'Missing both, checking register() method' => [
+                'standard'   => 'RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml',
+                'methodName' => 'register',
+            ],
+            'Missing both, checking process() method'  => [
+                'standard'   => 'RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml',
+                'methodName' => 'process',
+            ],
+        ];
+
+    }//end dataExceptionIsThrownOnMissingInterfaceMethod()
+
+
+}//end class

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
@@ -6,6 +6,7 @@
     <rule ref="TestStandard">
         <exclude name="TestStandard.DeprecatedInvalid"/>
         <exclude name="TestStandard.InvalidSniffs"/>
+        <exclude name="TestStandard.InvalidSniffError"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
# Description
As things were, a ruleset loading an invalid sniff - a sniff which doesn't implement the `Sniff` interface and is missing either the `register()` or `process()` method, or both -, would result in fatal errors which are unfriendly to the end-user.

Now, while this will hopefully be a very rare occurrence and should no longer be possible as of PHPCS 4.0, which intends to remove support for sniffs not implementing the `Sniff` interface, I still believe it prudent to show more user-friendly and more informative error messages to the end-user until that time.

This commit implements this and executes step 2 to address issue #694.

Includes tests.

Output of commands involving various invalid sniffs **before** this PR:

```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterTest.xml

Fatal error: Uncaught Error: Call to undefined method TestStandard\Sniffs\InvalidSniffError\NoImplementsNoRegisterSniff::register() in path/to/PHP_CodeSniffer/src/Ruleset.php:1505
Stack trace:
  thrown in path/to/PHP_CodeSniffer/src/Ruleset.php on line 1505
```

```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoProcessTest.xml

PHP_CodeSniffer version 3.11.1 (stable) by Squiz and PHPCSStandards

Fatal error: Uncaught Error: Call to undefined method TestStandard\Sniffs\InvalidSniffError\NoImplementsNoProcessSniff::process() in path/to/PHP_CodeSniffer/src/Files/File.php:519
Stack trace:
  thrown in path/to/PHP_CodeSniffer/src/Files/File.php on line 519
```

```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml

PHP_CodeSniffer version 3.11.1 (stable) by Squiz and PHPCSStandards

Fatal error: Uncaught Error: Call to undefined method TestStandard\Sniffs\InvalidSniffError\NoImplementsNoRegisterOrProcessSniff::register() in path/to/PHP_CodeSniffer/src/Ruleset.php:1505
Stack trace:
  thrown in path/to/PHP_CodeSniffer/src/Ruleset.php on line 1505
```

Output of commands involving various invalid sniffs **after** this PR:
```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterTest.xml

ERROR: Sniff class TestStandard\Sniffs\InvalidSniffError\NoImplementsNoRegisterSniff is missing required method register().
```

```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoProcessTest.xml

ERROR: Sniff class TestStandard\Sniffs\InvalidSniffError\NoImplementsNoProcessSniff is missing required method process().
```

```
$ phpcs -ps . --standard=./tests/Core/Ruleset/RegisterSniffsRejectsInvalidSniffNoImplementsNoRegisterOrProcessTest.xml

ERROR: Sniff class TestStandard\Sniffs\InvalidSniffError\NoImplementsNoRegisterOrProcessSniff is missing required method register().
ERROR: Sniff class TestStandard\Sniffs\InvalidSniffError\NoImplementsNoRegisterOrProcessSniff is missing required method process().
```


## Suggested changelog entry
The user will be shown an informative error message for sniffs are missing one of the required methods.
Previously this would result in a fatal error.


## Related issues/external references

Related to #694

