### PR TITLE
Tests: fix up some setup/teardown method signatures

### DIFF
--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -29,7 +29,7 @@ final class ReportWidthTest extends TestCase
      *
      * @return void
      */
-    public static function cleanConfig()
+    protected function cleanConfig()
     {
         // Set to the property's default value to clear out potentially set values from other tests.
         self::setStaticProperty('executablePaths', []);
@@ -52,7 +52,7 @@ final class ReportWidthTest extends TestCase
      *
      * @return void
      */
-    public function resetConfig()
+    protected function resetConfig()
     {
         $_SERVER['argv'] = [];
 

--- a/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceHomePathTest.php
@@ -36,9 +36,9 @@ final class ExpandRulesetReferenceHomePathTest extends AbstractRulesetTestCase
      *
      * @return void
      */
-    protected function storeHomePath()
+    public static function storeHomePath()
     {
-        $this->homepath = getenv('HOME');
+        self::$homepath = getenv('HOME');
 
     }//end storeHomePath()
 
@@ -50,10 +50,10 @@ final class ExpandRulesetReferenceHomePathTest extends AbstractRulesetTestCase
      *
      * @return void
      */
-    protected function restoreHomePath()
+    public static function restoreHomePath()
     {
-        if (is_string($this->homepath) === true) {
-            putenv('HOME='.$this->homepath);
+        if (is_string(self::$homepath) === true) {
+            putenv('HOME='.self::$homepath);
         } else {
             // Remove the environment variable as it didn't exist before.
             putenv('HOME');

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -50,7 +50,7 @@ final class RuleInclusionAbsoluteLinuxTest extends TestCase
      *
      * @return void
      */
-    public function initializeConfigAndRuleset()
+    protected function initializeConfigAndRuleset()
     {
         $this->standard = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
         $repoRootDir    = dirname(dirname(dirname(__DIR__)));
@@ -84,7 +84,7 @@ final class RuleInclusionAbsoluteLinuxTest extends TestCase
      *
      * @return void
      */
-    public function resetRuleset()
+    protected function resetRuleset()
     {
         file_put_contents($this->standard, $this->contents);
 

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -52,7 +52,7 @@ final class RuleInclusionAbsoluteWindowsTest extends TestCase
      *
      * @return void
      */
-    public function initializeConfigAndRuleset()
+    protected function initializeConfigAndRuleset()
     {
         $this->standard = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
         $repoRootDir    = dirname(dirname(dirname(__DIR__)));
@@ -81,7 +81,7 @@ final class RuleInclusionAbsoluteWindowsTest extends TestCase
      *
      * @return void
      */
-    public function resetRuleset()
+    protected function resetRuleset()
     {
         file_put_contents($this->standard, $this->contents);
 

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -50,7 +50,7 @@ final class RuleInclusionTest extends AbstractRulesetTestCase
      *
      * @return void
      */
-    public static function initializeConfigAndRuleset()
+    protected function initializeConfigAndRuleset()
     {
         if (self::$standard === '') {
             $standard       = __DIR__.'/'.basename(__FILE__, '.php').'.xml';


### PR DESCRIPTION
# Description

The `setUpBeforeClass()` and `tearDownAfterClass()` type methods should have visibility `public` and should be static methods, even when invoked via the annotations.

To be honest, I'm a bit surprised PHPUnit didn't flag some of these as errors, but either way, it's fixed now.

Ref: https://docs.phpunit.de/en/9.6/fixtures.html#fixtures-examples-templatemethodstest-php


## Suggested changelog entry
_N/A_