### PR TITLE
Tests: use more specific assertions

### DIFF
--- a/tests/Core/Tokenizers/PHP/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizers/PHP/AnonClassParenthesisOwnerTest.php
@@ -30,9 +30,9 @@ final class AnonClassParenthesisOwnerTest extends AbstractTokenizerTestCase
         $tokens = $this->phpcsFile->getTokens();
 
         $anonClass = $this->getTargetToken($testMarker, T_ANON_CLASS);
-        $this->assertFalse(array_key_exists('parenthesis_owner', $tokens[$anonClass]));
-        $this->assertFalse(array_key_exists('parenthesis_opener', $tokens[$anonClass]));
-        $this->assertFalse(array_key_exists('parenthesis_closer', $tokens[$anonClass]));
+        $this->assertArrayNotHasKey('parenthesis_owner', $tokens[$anonClass]);
+        $this->assertArrayNotHasKey('parenthesis_opener', $tokens[$anonClass]);
+        $this->assertArrayNotHasKey('parenthesis_closer', $tokens[$anonClass]);
 
     }//end testAnonClassNoParentheses()
 
@@ -54,11 +54,11 @@ final class AnonClassParenthesisOwnerTest extends AbstractTokenizerTestCase
         $function = $this->getTargetToken($testMarker, T_FUNCTION);
 
         $opener = $this->getTargetToken($testMarker, T_OPEN_PARENTHESIS);
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$opener]));
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$opener]);
         $this->assertSame($function, $tokens[$opener]['parenthesis_owner']);
 
         $closer = $this->getTargetToken($testMarker, T_CLOSE_PARENTHESIS);
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$closer]));
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$closer]);
         $this->assertSame($function, $tokens[$closer]['parenthesis_owner']);
 
     }//end testAnonClassNoParenthesesNextOpenClose()
@@ -107,23 +107,23 @@ final class AnonClassParenthesisOwnerTest extends AbstractTokenizerTestCase
         $opener    = $this->getTargetToken($testMarker, T_OPEN_PARENTHESIS);
         $closer    = $this->getTargetToken($testMarker, T_CLOSE_PARENTHESIS);
 
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$anonClass]));
-        $this->assertTrue(array_key_exists('parenthesis_opener', $tokens[$anonClass]));
-        $this->assertTrue(array_key_exists('parenthesis_closer', $tokens[$anonClass]));
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$anonClass]);
+        $this->assertArrayHasKey('parenthesis_opener', $tokens[$anonClass]);
+        $this->assertArrayHasKey('parenthesis_closer', $tokens[$anonClass]);
         $this->assertSame($anonClass, $tokens[$anonClass]['parenthesis_owner']);
         $this->assertSame($opener, $tokens[$anonClass]['parenthesis_opener']);
         $this->assertSame($closer, $tokens[$anonClass]['parenthesis_closer']);
 
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$opener]));
-        $this->assertTrue(array_key_exists('parenthesis_opener', $tokens[$opener]));
-        $this->assertTrue(array_key_exists('parenthesis_closer', $tokens[$opener]));
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$opener]);
+        $this->assertArrayHasKey('parenthesis_opener', $tokens[$opener]);
+        $this->assertArrayHasKey('parenthesis_closer', $tokens[$opener]);
         $this->assertSame($anonClass, $tokens[$opener]['parenthesis_owner']);
         $this->assertSame($opener, $tokens[$opener]['parenthesis_opener']);
         $this->assertSame($closer, $tokens[$opener]['parenthesis_closer']);
 
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$closer]));
-        $this->assertTrue(array_key_exists('parenthesis_opener', $tokens[$closer]));
-        $this->assertTrue(array_key_exists('parenthesis_closer', $tokens[$closer]));
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$closer]);
+        $this->assertArrayHasKey('parenthesis_opener', $tokens[$closer]);
+        $this->assertArrayHasKey('parenthesis_closer', $tokens[$closer]);
         $this->assertSame($anonClass, $tokens[$closer]['parenthesis_owner']);
         $this->assertSame($opener, $tokens[$closer]['parenthesis_opener']);
         $this->assertSame($closer, $tokens[$closer]['parenthesis_closer']);

--- a/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
@@ -896,37 +896,37 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $this->assertTrue(array_key_exists('scope_condition', $tokens[$token]), 'Scope condition is not set');
-        $this->assertTrue(array_key_exists('scope_opener', $tokens[$token]), 'Scope opener is not set');
-        $this->assertTrue(array_key_exists('scope_closer', $tokens[$token]), 'Scope closer is not set');
+        $this->assertArrayHasKey('scope_condition', $tokens[$token], 'Scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$token], 'Scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$token], 'Scope closer is not set');
         $this->assertSame($tokens[$token]['scope_condition'], $token, 'Scope condition is not the T_FN token');
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$token]), 'Parenthesis owner is not set');
-        $this->assertTrue(array_key_exists('parenthesis_opener', $tokens[$token]), 'Parenthesis opener is not set');
-        $this->assertTrue(array_key_exists('parenthesis_closer', $tokens[$token]), 'Parenthesis closer is not set');
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$token], 'Parenthesis owner is not set');
+        $this->assertArrayHasKey('parenthesis_opener', $tokens[$token], 'Parenthesis opener is not set');
+        $this->assertArrayHasKey('parenthesis_closer', $tokens[$token], 'Parenthesis closer is not set');
         $this->assertSame($tokens[$token]['parenthesis_owner'], $token, 'Parenthesis owner is not the T_FN token');
 
         $opener = $tokens[$token]['scope_opener'];
-        $this->assertTrue(array_key_exists('scope_condition', $tokens[$opener]), 'Opener scope condition is not set');
-        $this->assertTrue(array_key_exists('scope_opener', $tokens[$opener]), 'Opener scope opener is not set');
-        $this->assertTrue(array_key_exists('scope_closer', $tokens[$opener]), 'Opener scope closer is not set');
+        $this->assertArrayHasKey('scope_condition', $tokens[$opener], 'Opener scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$opener], 'Opener scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$opener], 'Opener scope closer is not set');
         $this->assertSame($tokens[$opener]['scope_condition'], $token, 'Opener scope condition is not the T_FN token');
         $this->assertSame(T_FN_ARROW, $tokens[$opener]['code'], 'Arrow scope opener not tokenized as T_FN_ARROW (code)');
         $this->assertSame('T_FN_ARROW', $tokens[$opener]['type'], 'Arrow scope opener not tokenized as T_FN_ARROW (type)');
 
         $closer = $tokens[$token]['scope_closer'];
-        $this->assertTrue(array_key_exists('scope_condition', $tokens[$closer]), 'Closer scope condition is not set');
-        $this->assertTrue(array_key_exists('scope_opener', $tokens[$closer]), 'Closer scope opener is not set');
-        $this->assertTrue(array_key_exists('scope_closer', $tokens[$closer]), 'Closer scope closer is not set');
+        $this->assertArrayHasKey('scope_condition', $tokens[$closer], 'Closer scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Closer scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Closer scope closer is not set');
         if ($skipScopeCloserCheck === false) {
             $this->assertSame($tokens[$closer]['scope_condition'], $token, 'Closer scope condition is not the T_FN token');
         }
 
         $opener = $tokens[$token]['parenthesis_opener'];
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$opener]), 'Opening parenthesis owner is not set');
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$opener], 'Opening parenthesis owner is not set');
         $this->assertSame($tokens[$opener]['parenthesis_owner'], $token, 'Opening parenthesis owner is not the T_FN token');
 
         $closer = $tokens[$token]['parenthesis_closer'];
-        $this->assertTrue(array_key_exists('parenthesis_owner', $tokens[$closer]), 'Closing parenthesis owner is not set');
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$closer], 'Closing parenthesis owner is not set');
         $this->assertSame($tokens[$closer]['parenthesis_owner'], $token, 'Closing parenthesis owner is not the T_FN token');
 
     }//end backfillHelper()


### PR DESCRIPTION
# Description
The `assertArrayHasKey()` and `assertArrayNotHasKey()` method can be used instead of "manually" doing an `array_key_exists()` with `assert[True|False]()`.

These methods were already available in PHPUnit 4.x and are already in use in other places in the test suite, so there is no reason not to use them in these tests too.


## Suggested changelog entry
_N/A_