### PR TITLE
GH Actions/coverage: join some steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,37 +349,26 @@ jobs:
         if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
         run: php "vendor/bin/phpunit" --coverage-cache ./build/phpunit-cache --warm-coverage-cache
 
-      - name: "Run the unit tests with code coverage (PHPUnit < 9.3)"
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit_version.outputs.VERSION < '9.3' }}
-        run: php "vendor/bin/phpunit" tests/AllTests.php
-
-      - name: "Run the unit tests with code coverage (PHPUnit 9.3+)"
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit_version.outputs.VERSION >= '9.3' }}
-        run: php "vendor/bin/phpunit" tests/AllTests.php --coverage-cache ./build/phpunit-cache
-
-      - name: "Run select tests in CBF mode with code coverage (PHPUnit < 9.3)"
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit_version.outputs.VERSION < '9.3' }}
+      - name: "Run the unit tests with code coverage"
+        if: ${{ matrix.os != 'windows-latest' }}
         run: >
           php "vendor/bin/phpunit" tests/AllTests.php
-          --group CBF --exclude-group nothing --coverage-clover build/logs/clover-cbf.xml
-        env:
-          PHP_CODESNIFFER_CBF: '1'
+          ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
 
-      - name: "Run select tests in CBF mode with code coverage (PHPUnit 9.3+)"
-        if: ${{ matrix.os != 'windows-latest' && steps.phpunit_version.outputs.VERSION >= '9.3' }}
+      - name: "Run select tests in CBF mode with code coverage"
+        if: ${{ matrix.os != 'windows-latest' }}
         run: >
-          php "vendor/bin/phpunit" tests/AllTests.php --coverage-cache ./build/phpunit-cache
+          php "vendor/bin/phpunit" tests/AllTests.php
+          ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
           --group CBF --exclude-group nothing --coverage-clover build/logs/clover-cbf.xml
         env:
           PHP_CODESNIFFER_CBF: '1'
 
-      - name: "Run the unit tests which may have different outcomes on Windows with code coverage (PHPUnit < 9.3)"
-        if: ${{ matrix.os == 'windows-latest' && steps.phpunit_version.outputs.VERSION < '9.3' }}
-        run: php "vendor/bin/phpunit" tests/AllTests.php --group Windows
-
-      - name: "Run the unit tests which may have different outcomes on Windows with code coverage (PHPUnit 9.3+)"
-        if: ${{ matrix.os == 'windows-latest' && steps.phpunit_version.outputs.VERSION >= '9.3' }}
-        run: php "vendor/bin/phpunit" tests/AllTests.php --group Windows --coverage-cache ./build/phpunit-cache
+      - name: "Run the unit tests which may have different outcomes on Windows with code coverage"
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: >
+          php "vendor/bin/phpunit" tests/AllTests.php --group Windows
+          ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
 
       - name: "Upload coverage results to Coveralls (normal run)"
         if: ${{ success() }}


### PR DESCRIPTION
# Description
The "coverage" job basically runs the tests in three different ways:
1. Normal test run on Linux.
2. CBF specific tests in CBF mode on Linux.
3. Windows specific tests on Windows.

For these three test runs, the script contained 6 steps as whether or not the coverage cache should be used depends on the PHPUnit version.

This commit condenses the 6 steps to 3 steps by using a command inline expression instead of step conditions.


## Suggested changelog entry
_N/A_