### PR TITLE
EscapeshellcmdTest: fix up data provider

### DIFF
--- a/tests/Core/Util/Common/EscapeshellcmdTest.php
+++ b/tests/Core/Util/Common/EscapeshellcmdTest.php
@@ -59,27 +59,27 @@ final class EscapeshellcmdTest extends TestCase
     {
         return [
             'Command is empty string'                                        => [
-                'text'     => '',
+                'command'  => '',
                 'expected' => '',
             ],
             'Command is simple string'                                       => [
-                'text'     => 'csslint',
+                'command'  => 'csslint',
                 'expected' => 'csslint',
             ],
             'Command containing characters which PHP escapes'                => [
-                'text'        => '&#;`|*?~<>^()[]{}$\,%!',
+                'command'     => '&#;`|*?~<>^()[]{}$\,%!',
                 'expected'    => '\&\#\;\`\|\*\?\~\<\>\^\(\)\[\]\{\}\$\\\\,%!',
                 'expectedWin' => '^&^#^;^`^|^*^?^~^<^>^^^(^)^[^]^{^}^$^\,^%^!',
             ],
             // @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3214
             'Command containing spaces, which can cause problems on Windows' => [
-                'text'        => 'C:\Program Files\nodejs\csslint.cmd',
+                'command'     => 'C:\Program Files\nodejs\csslint.cmd',
                 'expected'    => 'C:\\\\Program Files\\\\nodejs\\\\csslint.cmd',
                 'expectedWin' => 'C:^\Program^ Files^\nodejs^\csslint.cmd',
             ],
             // @link https://github.com/php/doc-en/pull/511
             'Command containing spaces with additional arguments'            => [
-                'text'        => 'php -f ./~home/path to/file.php',
+                'command'     => 'php -f ./~home/path to/file.php',
                 'expected'    => 'php -f ./\~home/path to/file.php',
                 'expectedWin' => 'php^ -f^ ./^~home/path^ to/file.php',
             ],


### PR DESCRIPTION
# Description
The array keys should match the names of the expected parameters of the test function.


## Suggested changelog entry
_N/A_