### PR TITLE
Generic/InlineControlStructure: bail early for control structures without body

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -251,102 +251,69 @@ class InlineControlStructureSniff implements Sniff
         }
 
         $nextContent = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
+
         if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
-            // Looks for completely empty statements.
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($closer + 1), ($end + 1), true);
+            // Account for a comment on the end of the line.
+            for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
+                if (isset($tokens[($endLine + 1)]) === false
+                    || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
+                ) {
+                    break;
+                }
+            }
+
+            if (isset(Tokens::COMMENT_TOKENS[$tokens[$endLine]['code']]) === false
+                && ($tokens[$endLine]['code'] !== T_WHITESPACE
+                || isset(Tokens::COMMENT_TOKENS[$tokens[($endLine - 1)]['code']]) === false)
+            ) {
+                $endLine = $end;
+            }
         } else {
-            $next    = ($end + 1);
             $endLine = $end;
         }
 
-        if ($next !== $end) {
-            if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
-                // Account for a comment on the end of the line.
-                for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
-                    if (isset($tokens[($endLine + 1)]) === false
-                        || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
-                    ) {
-                        break;
-                    }
-                }
-
-                if (isset(Tokens::COMMENT_TOKENS[$tokens[$endLine]['code']]) === false
-                    && ($tokens[$endLine]['code'] !== T_WHITESPACE
-                    || isset(Tokens::COMMENT_TOKENS[$tokens[($endLine - 1)]['code']]) === false)
-                ) {
-                    $endLine = $end;
-                }
-            }
-
-            if ($endLine !== $end) {
-                $endToken     = $endLine;
-                $addedContent = '';
-            } else {
-                $endToken     = $end;
-                $addedContent = $phpcsFile->eolChar;
-
-                if ($tokens[$end]['code'] !== T_SEMICOLON
-                    && $tokens[$end]['code'] !== T_CLOSE_CURLY_BRACKET
-                ) {
-                    $phpcsFile->fixer->addContent($end, '; ');
-                }
-            }
-
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($endToken + 1), null, true);
-            if ($next !== false
-                && ($tokens[$next]['code'] === T_ELSE
-                || $tokens[$next]['code'] === T_ELSEIF)
-            ) {
-                $phpcsFile->fixer->addContentBefore($next, '} ');
-            } else {
-                $indent = '';
-                for ($first = $stackPtr; $first > 0; $first--) {
-                    if ($tokens[$first]['column'] === 1) {
-                        break;
-                    }
-                }
-
-                if ($tokens[$first]['code'] === T_WHITESPACE) {
-                    $indent = $tokens[$first]['content'];
-                } else if ($tokens[$first]['code'] === T_INLINE_HTML
-                    || $tokens[$first]['code'] === T_OPEN_TAG
-                ) {
-                    $addedContent = '';
-                }
-
-                $addedContent .= $indent.'}';
-                if ($next !== false && $tokens[$endToken]['code'] === T_COMMENT) {
-                    $addedContent .= $phpcsFile->eolChar;
-                }
-
-                $phpcsFile->fixer->addContent($endToken, $addedContent);
-            }//end if
+        if ($endLine !== $end) {
+            $endToken     = $endLine;
+            $addedContent = '';
         } else {
-            if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
-                // Account for a comment on the end of the line.
-                for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
-                    if (isset($tokens[($endLine + 1)]) === false
-                        || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
-                    ) {
-                        break;
-                    }
-                }
+            $endToken     = $end;
+            $addedContent = $phpcsFile->eolChar;
 
-                if ($tokens[$endLine]['code'] !== T_COMMENT
-                    && ($tokens[$endLine]['code'] !== T_WHITESPACE
-                    || $tokens[($endLine - 1)]['code'] !== T_COMMENT)
-                ) {
-                    $endLine = $end;
+            if ($tokens[$end]['code'] !== T_SEMICOLON
+                && $tokens[$end]['code'] !== T_CLOSE_CURLY_BRACKET
+            ) {
+                $phpcsFile->fixer->addContent($end, '; ');
+            }
+        }
+
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($endToken + 1), null, true);
+        if ($next !== false
+            && ($tokens[$next]['code'] === T_ELSE
+            || $tokens[$next]['code'] === T_ELSEIF)
+        ) {
+            $phpcsFile->fixer->addContentBefore($next, '} ');
+        } else {
+            $indent = '';
+            for ($first = $stackPtr; $first > 0; $first--) {
+                if ($tokens[$first]['column'] === 1) {
+                    break;
                 }
             }
 
-            if ($endLine !== $end) {
-                $phpcsFile->fixer->replaceToken($end, '');
-                $phpcsFile->fixer->addNewlineBefore($endLine);
-                $phpcsFile->fixer->addContent($endLine, '}');
-            } else {
-                $phpcsFile->fixer->replaceToken($end, '}');
+            if ($tokens[$first]['code'] === T_WHITESPACE) {
+                $indent = $tokens[$first]['content'];
+            } else if ($tokens[$first]['code'] === T_INLINE_HTML
+                || $tokens[$first]['code'] === T_OPEN_TAG
+            ) {
+                $addedContent = '';
             }
+
+            $addedContent .= $indent.'}';
+            if ($next !== false && $tokens[$endToken]['code'] === T_COMMENT) {
+                $addedContent .= $phpcsFile->eolChar;
+            }
+
+            $phpcsFile->fixer->addContent($endToken, $addedContent);
         }//end if
 
         $phpcsFile->fixer->endChangeset();

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -155,9 +155,7 @@ class InlineControlStructureSniff implements Sniff
             $closer = $stackPtr;
         }
 
-        if ($tokens[($closer + 1)]['code'] === T_WHITESPACE
-            || $tokens[($closer + 1)]['code'] === T_SEMICOLON
-        ) {
+        if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
             $phpcsFile->fixer->addContent($closer, ' {');
         } else {
             $phpcsFile->fixer->addContent($closer, ' { ');

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
@@ -276,3 +276,24 @@ function testFinally()
 if ($something) {
     echo 'hello';
 } else /* comment */ if ($somethingElse) echo 'hi';
+
+if ($sniffShouldBailEarly);
+
+if (false) {
+} elseif ($sniffShouldBailEarly);
+
+if (false) {
+} else if ($sniffShouldBailEarly);
+
+if (false) {
+} else ($sniffShouldGenerateError);
+
+if (false) {
+} else; // Sniff should bail early.
+
+foreach ($array as $sniffShouldBailEarly);
+
+foreach ($array as $sniffShouldBailEarly)
+	/* some comment */;
+
+do ; while ($sniffShouldBailEarly > 5);

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
@@ -314,3 +314,25 @@ if ($something) {
     echo 'hello';
 } else /* comment */ if ($somethingElse) { echo 'hi';
 }
+
+if ($sniffShouldBailEarly);
+
+if (false) {
+} elseif ($sniffShouldBailEarly);
+
+if (false) {
+} else if ($sniffShouldBailEarly);
+
+if (false) {
+} else { ($sniffShouldGenerateError);
+}
+
+if (false) {
+} else; // Sniff should bail early.
+
+foreach ($array as $sniffShouldBailEarly);
+
+foreach ($array as $sniffShouldBailEarly)
+	/* some comment */;
+
+do ; while ($sniffShouldBailEarly > 5);

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -81,6 +81,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffTestCase
                 260 => 1,
                 269 => 1,
                 278 => 1,
+                289 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

As discussed in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/482#pullrequestreview-2062765716 (see "Commit 6" and "Commit 7" sections), `Generic.ControlStructures.InlineControlStructure` now consistently handles all control structures without a body by bailing early. This PR extends the existing behavior for `while` and `for` to also include `do while`, `else`, `elseif`, `if`, and `foreach`. Note that in #482, I did not include `do while`, but I believe it should be included, and it is now part of this PR.

Previously, the sniff would incorrectly flag these empty control structures as inline control structures that needed curly braces. This change makes the behavior consistent across all control structures. For `else`, `elseif`, `if`, and `foreach`, the fixer would remove the semicolon and add the curly braces. For `do while`, the fixer would add the curly braces and keep the semicolon in between the braces. In all the cases, the resulting code was syntactically correct.

Consider the following example:

```
do ; while ($foo < 5);
```

Previously, PHPCS would flag this as an inline control structure, and PHPCBF would fix it to:

```
do { ;
} while ($foo < 5);
```

Now, an empty `do while` is ignored by the sniff (no warnings and no fixes).

Here is a link showing that control structures without a body are valid in PHP:

https://3v4l.org/slnYL

And here is a link showing that the way that PHPCBF was fixing them was resulting in valid code (`while` and `for` are not included below as they were already ignored before this commit):

https://3v4l.org/8k1N3

Additionally, this PR removes two code blocks from the fixer that became unnecessary. They are removed in separate commits to hopefully make it easier to review this PR. I suggest combining all the commits in this PR into a single commit before merging.

### First removed block

The sniff now bails early for all control structures without body, so the code will never reach the fixer if `$closer + 1` is `T_SEMICOLON`.

### Second removed block

The original version of this now removed condition was added in the early days by the commit that enabled this sniff to fix errors:

https://github.com/squizlabs/PHP_CodeSniffer/commit/a54c619#diff-4b3945c2100b0a92a56509de1b797bf58ad804cf36233c95c492479b665655dcR148-R154

The only two tests that were added with the commit mentioned above that trigger the removed condition are tests using `while` loops without body:

https://github.com/squizlabs/PHP_CodeSniffer/commit/a54c619#diff-116c49a7b0b31f724fc25409e31ba119d7f023146818bcb63edbe8f4071422e2R42-R43

Control structures without a body are the only cases where `$next` would be equal to `$end`. Thus, these are the only cases where the removed condition would be executed. But two previous commits, changed the sniff to bail early and not get to the fixer part when handling control structures without a body:
- 13c803b changed the sniff to ignore `while`/`for` without a body and updated the existing tests (https://github.com/squizlabs/PHP_CodeSniffer/commit/13c803b#diff-2f069f3fe33bacdfc80485b97303aec66c98c451d07e6d86e41982b81ab1a294L49-R50).
- 29d0be3e expanded the same approach for `do while`/`else`/`elseif`/`if`/`foreach` control structures.

After the removal of the `$next !== $end` check, the `$next` variable became unused, allowing for further simplification of the code by removing the place where it was being defined.

Regarding what was commented in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/482#pullrequestreview-2062765716:

> Looking at this more closely, I think this needs further investigation before this commit could be considered.
> While looking at this in combination with the review for commit 3, I started wondering about [line 280](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/72b50b9aa22b65fd41be21a5de272d53a327d125/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php#L280). I have a niggly feeling that that findNext() could return false and needs a test + safeguard.
> As things are, without digging deeper into the potentially problematic result of line 280, the code snippet you are proposing to remove, cannot be removed, as if line 280 would return false, the if ($next !== $end) condition could be a false !== $end, which means that the code snippet being removed would be hit and the fixer would end up creating a parse error in the file under scan.

I was not able to create a test case that would make `findNext()` return `false` on that particular line. Please let me know if you can. Despite that, after further checking the changes I proposed on the original commit back in #482, I noticed that the variable `$next` was not used anymore and could be removed. So, in the changes I'm proposing here, the `findNext()` call has also been removed.

Note for reviewers: the third commit is easier to evaluate when ignoring whitespace.

## Suggested changelog entry
Generic.ControlStructures.InlineControlStructure: bail early when encountering `do while`, `else`, `elseif`, `if`, and `foreach`  control structures without a body.


## Related issues/external references

Initially suggested in #482.


## Types of changes

I'm not sure if this should be considered a bug fix or an enhancement. So, I'm not selecting the type of change.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
