### PR TITLE
Tests: introduce AbstractRunnerTestCase base class and start using it

### DIFF
--- a/tests/Core/Generators/GeneratorTest.php
+++ b/tests/Core/Generators/GeneratorTest.php
@@ -9,7 +9,6 @@
 namespace PHP_CodeSniffer\Tests\Core\Generators;
 
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\MockGenerator;
 use PHPUnit\Framework\TestCase;
@@ -223,56 +222,6 @@ final class GeneratorTest extends TestCase
         $generator->generate();
 
     }//end testGetTitleFallbackToFilename()
-
-
-    /**
-     * Test that the documentation for each standard passed on the command-line is shown separately.
-     *
-     * @covers \PHP_CodeSniffer\Runner::runPHPCS
-     *
-     * @return void
-     */
-    public function testGeneratorWillShowEachStandardSeparately()
-    {
-        if (PHP_CODESNIFFER_CBF === true) {
-            $this->markTestSkipped('This test needs CS mode to run');
-        }
-
-        $standard        = __DIR__.'/OneDocTest.xml';
-        $_SERVER['argv'] = [
-            'phpcs',
-            '--generator=Text',
-            "--standard=$standard,PSR1",
-            '--report-width=80',
-        ];
-
-        $regex = '`^
-            \R*                                                      # Optional blank line at the start.
-            (?:
-                (?P<delimiter>-++\R)                                 # Line with dashes.
-                \|[ ]GENERATORTEST[ ]CODING[ ]STANDARD:[ ][^\|]+\|\R # Doc title line with prefix expected for first standard.
-                (?P>delimiter)                                       # Line with dashes.
-                \R(?:[^\r\n]+\R)+\R{2}                               # Standard description.
-            )                                                        # Only expect this group once.
-            (?:
-                (?P>delimiter)                                       # Line with dashes.
-                \|[ ]PSR1[ ]CODING[ ]STANDARD:[ ][^\|]+\|\R          # Doc title line with prefix expected for second standard.
-                (?P>delimiter)                                       # Line with dashes.
-                \R(?:[^\r\n]+\R)+\R                                  # Standard description.
-                (?:
-                    -+[ ]CODE[ ]COMPARISON[ ]-+\R                    # Code Comparison starter line with dashes.
-                    (?:(?:[^\r\n]+\R)+(?P>delimiter)){2}             # Arbitrary text followed by a delimiter line.
-                )*                                                   # Code comparison is optional and can exist multiple times.
-                \R+
-            ){3,}                                                    # This complete group should occur at least three times.
-            `x';
-
-        $this->expectOutputRegex($regex);
-
-        $runner = new Runner();
-        $runner->runPHPCS();
-
-    }//end testGeneratorWillShowEachStandardSeparately()
 
 
 }//end class

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
@@ -208,57 +207,6 @@ final class ExplainTest extends TestCase
         $ruleset->explain();
 
     }//end testExplainWithDeprecatedSniffs()
-
-
-    /**
-     * Test that each standard passed on the command-line is explained separately.
-     *
-     * @covers \PHP_CodeSniffer\Runner::runPHPCS
-     *
-     * @return void
-     */
-    public function testExplainWillExplainEachStandardSeparately()
-    {
-        if (PHP_CODESNIFFER_CBF === true) {
-            $this->markTestSkipped('This test needs CS mode to run');
-        }
-
-        $standard        = __DIR__.'/ExplainSingleSniffTest.xml';
-        $_SERVER['argv'] = [
-            'phpcs',
-            '-e',
-            "--standard=PSR1,$standard",
-            '--report-width=80',
-        ];
-
-        $expected  = PHP_EOL;
-        $expected .= 'The PSR1 standard contains 8 sniffs'.PHP_EOL.PHP_EOL;
-        $expected .= 'Generic (4 sniffs)'.PHP_EOL;
-        $expected .= '------------------'.PHP_EOL;
-        $expected .= '  Generic.Files.ByteOrderMark'.PHP_EOL;
-        $expected .= '  Generic.NamingConventions.UpperCaseConstantName'.PHP_EOL;
-        $expected .= '  Generic.PHP.DisallowAlternativePHPTags'.PHP_EOL;
-        $expected .= '  Generic.PHP.DisallowShortOpenTag'.PHP_EOL.PHP_EOL;
-        $expected .= 'PSR1 (3 sniffs)'.PHP_EOL;
-        $expected .= '---------------'.PHP_EOL;
-        $expected .= '  PSR1.Classes.ClassDeclaration'.PHP_EOL;
-        $expected .= '  PSR1.Files.SideEffects'.PHP_EOL;
-        $expected .= '  PSR1.Methods.CamelCapsMethodName'.PHP_EOL.PHP_EOL;
-        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
-        $expected .= '---------------'.PHP_EOL;
-        $expected .= '  Squiz.Classes.ValidClassName'.PHP_EOL.PHP_EOL;
-
-        $expected .= 'The ExplainSingleSniffTest standard contains 1 sniff'.PHP_EOL.PHP_EOL;
-        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
-        $expected .= '---------------'.PHP_EOL;
-        $expected .= '  Squiz.Scope.MethodScope'.PHP_EOL;
-
-        $this->expectOutputString($expected);
-
-        $runner = new Runner();
-        $runner->runPHPCS();
-
-    }//end testExplainWillExplainEachStandardSeparately()
 
 
 }//end class

--- a/tests/Core/Runner/AbstractRunnerTestCase.php
+++ b/tests/Core/Runner/AbstractRunnerTestCase.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Base class to use for tests invoking the Runner class.
+ *
+ * As those tests will use the _real_ Config class instead of the ConfigDouble, we need to ensure
+ * this doesn't negatively impact other tests, what with the Config using static properties.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Runner;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+abstract class AbstractRunnerTestCase extends TestCase
+{
+
+
+    /**
+     * Set static properties in the Config class to prevent tests influencing each other.
+     *
+     * @before
+     *
+     * @return void
+     */
+    public function setConfigStatics()
+    {
+        // Set to the property's default value to clear out potentially set values from other tests.
+        self::setStaticConfigProperty('overriddenDefaults', []);
+        self::setStaticConfigProperty('executablePaths', []);
+
+        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
+        // from being read and influencing the tests.
+        self::setStaticConfigProperty('configData', []);
+        self::setStaticConfigProperty('configDataFile', '');
+
+    }//end setConfigStatics()
+
+
+    /**
+     * Clean up after each finished test.
+     *
+     * @after
+     *
+     * @return void
+     */
+    public function clearArgv()
+    {
+        $_SERVER['argv'] = [];
+
+    }//end clearArgv()
+
+
+    /**
+     * Reset the static properties in the Config class to their true defaults to prevent this class
+     * from influencing other tests.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function reset()
+    {
+        self::setStaticConfigProperty('overriddenDefaults', []);
+        self::setStaticConfigProperty('executablePaths', []);
+        self::setStaticConfigProperty('configData', null);
+        self::setStaticConfigProperty('configDataFile', null);
+        $_SERVER['argv'] = [];
+
+    }//end reset()
+
+
+    /**
+     * Helper function to set a static property on the Config class.
+     *
+     * @param string $name  The name of the property to set.
+     * @param mixed  $value The value to set the property to.
+     *
+     * @return void
+     */
+    public static function setStaticConfigProperty($name, $value)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+        $property->setAccessible(false);
+
+    }//end setStaticConfigProperty()
+
+
+}//end class

--- a/tests/Core/Runner/RunPHPCSExplainTest.php
+++ b/tests/Core/Runner/RunPHPCSExplainTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests the wiring in of the explain functionality in the Runner class.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Runner;
+
+use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
+
+/**
+ * Tests the wiring in of the explain functionality in the Runner class.
+ *
+ * @covers \PHP_CodeSniffer\Runner::runPHPCS
+ */
+final class RunPHPCSExplainTest extends AbstractRunnerTestCase
+{
+
+
+    /**
+     * Test that each standard passed on the command-line is explained separately.
+     *
+     * @return void
+     */
+    public function testExplainWillExplainEachStandardSeparately()
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+        $standard        = dirname(__DIR__).'/Ruleset/ExplainSingleSniffTest.xml';
+        $_SERVER['argv'] = [
+            'phpcs',
+            '-e',
+            "--standard=PSR1,$standard",
+            '--report-width=80',
+        ];
+
+        $expected  = PHP_EOL;
+        $expected .= 'The PSR1 standard contains 8 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'Generic (4 sniffs)'.PHP_EOL;
+        $expected .= '------------------'.PHP_EOL;
+        $expected .= '  Generic.Files.ByteOrderMark'.PHP_EOL;
+        $expected .= '  Generic.NamingConventions.UpperCaseConstantName'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowAlternativePHPTags'.PHP_EOL;
+        $expected .= '  Generic.PHP.DisallowShortOpenTag'.PHP_EOL.PHP_EOL;
+        $expected .= 'PSR1 (3 sniffs)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  PSR1.Classes.ClassDeclaration'.PHP_EOL;
+        $expected .= '  PSR1.Files.SideEffects'.PHP_EOL;
+        $expected .= '  PSR1.Methods.CamelCapsMethodName'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Classes.ValidClassName'.PHP_EOL.PHP_EOL;
+
+        $expected .= 'The ExplainSingleSniffTest standard contains 1 sniff'.PHP_EOL.PHP_EOL;
+        $expected .= 'Squiz (1 sniff)'.PHP_EOL;
+        $expected .= '---------------'.PHP_EOL;
+        $expected .= '  Squiz.Scope.MethodScope'.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        $runner = new Runner();
+        $runner->runPHPCS();
+
+    }//end testExplainWillExplainEachStandardSeparately()
+
+
+}//end class

--- a/tests/Core/Runner/RunPHPCSGeneratorTest.php
+++ b/tests/Core/Runner/RunPHPCSGeneratorTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Tests the wiring in of the Generator functionality in the Runner class.
+ *
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Runner;
+
+use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
+
+/**
+ * Tests the wiring in of the Generator functionality in the Runner class.
+ *
+ * @covers \PHP_CodeSniffer\Runner::runPHPCS
+ * @group  Windows
+ */
+final class RunPHPCSGeneratorTest extends AbstractRunnerTestCase
+{
+
+
+    /**
+     * Test that the documentation for each standard passed on the command-line is shown separately.
+     *
+     * @return void
+     */
+    public function testGeneratorWillShowEachStandardSeparately()
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+        $standard        = dirname(__DIR__).'/Generators/OneDocTest.xml';
+        $_SERVER['argv'] = [
+            'phpcs',
+            '--generator=Text',
+            "--standard=$standard,PSR1",
+            '--report-width=80',
+        ];
+
+        $regex = '`^
+            \R*                                                      # Optional blank line at the start.
+            (?:
+                (?P<delimiter>-++\R)                                 # Line with dashes.
+                \|[ ]GENERATORTEST[ ]CODING[ ]STANDARD:[ ][^\|]+\|\R # Doc title line with prefix expected for first standard.
+                (?P>delimiter)                                       # Line with dashes.
+                \R(?:[^\r\n]+\R)+\R{2}                               # Standard description.
+            )                                                        # Only expect this group once.
+            (?:
+                (?P>delimiter)                                       # Line with dashes.
+                \|[ ]PSR1[ ]CODING[ ]STANDARD:[ ][^\|]+\|\R          # Doc title line with prefix expected for second standard.
+                (?P>delimiter)                                       # Line with dashes.
+                \R(?:[^\r\n]+\R)+\R                                  # Standard description.
+                (?:
+                    -+[ ]CODE[ ]COMPARISON[ ]-+\R                    # Code Comparison starter line with dashes.
+                    (?:(?:[^\r\n]+\R)+(?P>delimiter)){2}             # Arbitrary text followed by a delimiter line.
+                )*                                                   # Code comparison is optional and can exist multiple times.
+                \R+
+            ){3,}                                                    # This complete group should occur at least three times.
+            `x';
+
+        $this->expectOutputRegex($regex);
+
+        $runner = new Runner();
+        $runner->runPHPCS();
+
+    }//end testGeneratorWillShowEachStandardSeparately()
+
+
+}//end class


### PR DESCRIPTION
# Description

### Tests: introduce AbstractRunnerTestCase base class 

... for tests which directly invoke the `Runner` class.

### Tests: split off two tests for the Runner class 

... to their own test classes using the new `AbstractRunnerTestCase` base class.

## Suggested changelog entry
_N/A_
