### PR TITLE
Ruleset: add tests to document trimming behaviour

### DIFF
--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -4,6 +4,7 @@
  * Testing handling of properties set inline.
  */
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsString arbitraryvalue
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsTrimmedString   some value
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling emptyStringBecomesNull
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsIntButAcceptsString 12345
@@ -14,8 +15,10 @@
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrue true
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrueCase True
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrueTrimmed    true
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanFalse false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanFalseCase fALSe
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanFalseTrimmed      false
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -23,6 +23,15 @@ final class PropertyTypeHandlingSniff implements Sniff
     public $expectsString;
 
     /**
+     * Used to verify that string properties are set as string, with surrounding whitespace trimmed.
+     *
+     * This is the default behaviour.
+     *
+     * @var string
+     */
+    public $expectsTrimmedString;
+
+    /**
      * Used to verify that a string value with only whitespace will end up being set as null.
      *
      * @var string|null
@@ -44,14 +53,14 @@ final class PropertyTypeHandlingSniff implements Sniff
     public $expectsFloatButAcceptsString;
 
     /**
-     * Used to verify that null gets set as a proper null value.
+     * Used to verify that null gets set as a string.
      *
      * @var null
      */
     public $expectsNull;
 
     /**
-     * Used to verify that null gets set as a proper null value.
+     * Used to verify that null gets set as a string.
      *
      * @var null
      */
@@ -76,6 +85,13 @@ final class PropertyTypeHandlingSniff implements Sniff
      *
      * @var bool
      */
+    public $expectsBooleanTrueTrimmed;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
     public $expectsBooleanFalse;
 
     /**
@@ -84,6 +100,13 @@ final class PropertyTypeHandlingSniff implements Sniff
      * @var bool
      */
     public $expectsBooleanFalseCase;
+
+    /**
+     * Used to verify that booleans get set as proper boolean values.
+     *
+     * @var bool
+     */
+    public $expectsBooleanFalseTrimmed;
 
     /**
      * Used to verify that array properties get parsed to a proper array.

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -119,6 +119,10 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsString',
                 'expected'     => 'arbitraryvalue',
             ],
+            'String value with whitespace gets trimmed'       => [
+                'propertyName' => 'expectsTrimmedString',
+                'expected'     => 'some value',
+            ],
             'String with whitespace only value becomes null'  => [
                 'propertyName' => 'emptyStringBecomesNull',
                 'expected'     => null,
@@ -147,6 +151,10 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsBooleanTrueCase',
                 'expected'     => 'True',
             ],
+            'True (with spaces) value gets set as boolean'    => [
+                'propertyName' => 'expectsBooleanTrueTrimmed',
+                'expected'     => true,
+            ],
             'False value gets set as boolean'                 => [
                 'propertyName' => 'expectsBooleanFalse',
                 'expected'     => false,
@@ -154,6 +162,10 @@ final class PropertyTypeHandlingTest extends TestCase
             'False (mixed case) value gets set as string'     => [
                 'propertyName' => 'expectsBooleanFalseCase',
                 'expected'     => 'fALSe',
+            ],
+            'False (with spaces) value gets set as boolean'   => [
+                'propertyName' => 'expectsBooleanFalseTrimmed',
+                'expected'     => false,
             ],
             'Array with only values (new style)'              => [
                 'propertyName' => 'expectsArrayWithOnlyValues',

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -4,6 +4,7 @@
     <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php">
         <properties>
             <property name="expectsString" value="arbitraryvalue"/>
+            <property name="expectsTrimmedString" value="   some value    "/>
             <property name="emptyStringBecomesNull" value="   	"/>
 
             <property name="expectsIntButAcceptsString" value="12345"/>
@@ -12,10 +13,13 @@
             <property name="expectsNull" value="null"/>
             <property name="expectsNullCase" value="NULL"/>
 
-            <property name="expectsBooleanTrue" value="true"/>
+            <!-- Also tests that property names get cleaned of surrounding whitespace. -->
+            <property name="  expectsBooleanTrue " value="true"/>
             <property name="expectsBooleanTrueCase" value="True"/>
+            <property name="expectsBooleanTrueTrimmed" value="true   "/>
             <property name="expectsBooleanFalse" value="false"/>
             <property name="expectsBooleanFalseCase" value="fALSe"/>
+            <property name="expectsBooleanFalseTrimmed" value="  false  "/>
 
             <property name="expectsArrayWithOnlyValues" type="array">
                 <element value="string"/>


### PR DESCRIPTION
# Description
Document that both the property names as well as the value get trimmed off surrounding whitespace before being passed to the sniff object.

Includes fixing two incorrect property docs in the test sniff.


## Suggested changelog entry
_N/A_
