### PR TITLE
Remove some redundant code

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -346,7 +346,6 @@ class File
         $listenerIgnoreTo = [];
         $inTests          = defined('PHP_CODESNIFFER_IN_TESTS');
         $checkAnnotations = $this->config->annotations;
-        $annotationErrors = [];
 
         // Foreach of the listeners that have registered to listen for this
         // token, get them to process it.
@@ -415,15 +414,7 @@ class File
                                 'scope' => 'sniff',
                             ];
                             $listenerClass = $this->ruleset->sniffCodes[$listenerCode];
-                            try {
-                                $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
-                            } catch (RuntimeException $e) {
-                                // Non-existant property being set via an inline annotation.
-                                // This is typically a PHPCS test case file, but we can't throw an error on the annotation
-                                // line as it would get ignored. We also don't want this error to block
-                                // the scan of the current file, so collect these and throw later.
-                                $annotationErrors[] = 'Line '.$token['line'].': '.str_replace('Ruleset invalid. ', '', $e->getMessage());
-                            }
+                            $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
                         }
                     }
                 }//end if
@@ -551,13 +542,6 @@ class File
                 $error = 'No PHP code was found in this file and short open tags are not allowed by this install of PHP. This file may be using short open tags but PHP does not allow them.';
                 $this->addWarning($error, null, 'Internal.NoCodeFound');
             }
-        }
-
-        if ($annotationErrors !== []) {
-            $error  = 'Encountered invalid inline phpcs:set annotations. Found:'.PHP_EOL;
-            $error .= implode(PHP_EOL, $annotationErrors);
-
-            $this->addWarning($error, null, 'Internal.PropertyDoesNotExist');
         }
 
         if (PHP_CODESNIFFER_VERBOSITY > 2) {

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
@@ -1,9 +1,2 @@
 <?php
 $output = `ls -al`;
-
-// Testing an invalid phpcs:set annotations.
-// This test is unrelated to this sniff, but the issue needs a sniff to be tested.
-// phpcs:set Generic.PHP.BacktickOperator unknown 10
-
-// Make sure errors after an incorrect annotation are still being thrown.
-$output = `ls -al`;

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -32,7 +32,6 @@ final class BacktickOperatorUnitTest extends AbstractSniffUnitTest
     {
         return [
             2 => 2,
-            9 => 2,
         ];
 
     }//end getErrorList()
@@ -48,7 +47,6 @@ final class BacktickOperatorUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        // Warning about incorrect annotation will be shown on line 1 once PR #3915 would be merged.
         return [];
 
     }//end getWarningList()


### PR DESCRIPTION
# Description
With the `MessageCollector` being used in the `Ruleset` class since PR #857, some guard code as introduced in #99 is no longer needed.

The guard code was in place to prevent the following situation:
* File under test contained an invalid `// phpcs:set` annotation which tried to set a non-existent property on a sniff.
* The  `File::process()` method would see this annotation and call the `Ruleset::setSniffProperty()` method to set the property.
* The `Ruleset::setSniffProperty()` method would throw an exception for the non-existent property.
* The exception would cause the `File` class to stop scanning the file, potentially leading to missing errors/warnings.

As the error for setting a non-existent property now no longer leads to an exception on a direct call to the `Ruleset::setSniffProperty()` method, we also no longer need to catch the exception and handle it from within the `File::process()` method.

In practice, this means that setting a non-existent property on a sniff via an inline `// phpcs:set` annotation will now be silently ignored (again) and will not affect the scan of the rest of the file.

This commit reverts #99.


## Suggested changelog entry
_N/A_