### PR TITLE
Hard deprecate all sniffs which will be removed in PHPCS 4.0

### DIFF
--- a/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -13,10 +13,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class CSSLintSniff implements Sniff
+class CSSLintSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -93,6 +94,42 @@ class CSSLintSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -13,10 +13,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class ClosureLinterSniff implements Sniff
+class ClosureLinterSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -114,6 +115,42 @@ class ClosureLinterSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
@@ -13,10 +13,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class ESLintSniff implements Sniff
+class ESLintSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -110,6 +111,42 @@ class ESLintSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -14,10 +14,11 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Debug;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class JSHintSniff implements Sniff
+class JSHintSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -92,6 +93,42 @@ class JSHintSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
@@ -13,10 +13,11 @@
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class NoSpaceAfterCastSniff implements Sniff
+class NoSpaceAfterCastSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -56,6 +57,42 @@ class NoSpaceAfterCastSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.4.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Use the Generic.Formatting.SpaceAfterCast sniff with the $spacing property set to 0 instead.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Functions;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class CallTimePassByReferenceSniff implements Sniff
+class CallTimePassByReferenceSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -138,6 +139,42 @@ class CallTimePassByReferenceSniff implements Sniff
         }//end while
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.12.1';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return '';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
+++ b/src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\CSS;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class BrowserSpecificStylesSniff implements Sniff
+class BrowserSpecificStylesSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -84,6 +85,42 @@ class BrowserSpecificStylesSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php
@@ -11,11 +11,12 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class DisallowSelfActionsSniff implements Sniff
+class DisallowSelfActionsSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -122,6 +123,42 @@ class DisallowSelfActionsSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class IncludeOwnSystemSniff implements Sniff
+class IncludeOwnSystemSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -95,6 +96,42 @@ class IncludeOwnSystemSniff implements Sniff
         return false;
 
     }//end getIncludedClassFromToken()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;
 
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class IncludeSystemSniff extends AbstractScopeSniff
+class IncludeSystemSniff extends AbstractScopeSniff implements DeprecatedSniff
 {
 
     /**
@@ -311,6 +312,42 @@ class IncludeSystemSniff extends AbstractScopeSniff
         return false;
 
     }//end getIncludedClassFromToken()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Channels;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class UnusedSystemSniff implements Sniff
+class UnusedSystemSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -138,6 +139,42 @@ class UnusedSystemSniff implements Sniff
         $phpcsFile->addError($error, $stackPtr, 'Found', $data);
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/MySource/Sniffs/Commenting/FunctionCommentSniff.php
@@ -13,11 +13,12 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Commenting;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff as SquizFunctionCommentSniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHP_CodeSniffer\Files\File;
 
-class FunctionCommentSniff extends SquizFunctionCommentSniff
+class FunctionCommentSniff extends SquizFunctionCommentSniff implements DeprecatedSniff
 {
 
 
@@ -81,6 +82,42 @@ class FunctionCommentSniff extends SquizFunctionCommentSniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Debug;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class DebugCodeSniff implements Sniff
+class DebugCodeSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -52,6 +53,42 @@ class DebugCodeSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
+++ b/src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Debug;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class FirebugConsoleSniff implements Sniff
+class FirebugConsoleSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -61,6 +62,42 @@ class FirebugConsoleSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class AssignThisSniff implements Sniff
+class AssignThisSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -78,6 +79,42 @@ class AssignThisSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
@@ -11,11 +11,12 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class CreateWidgetTypeCallbackSniff implements Sniff
+class CreateWidgetTypeCallbackSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -215,6 +216,42 @@ class CreateWidgetTypeCallbackSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Objects;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class DisallowNewWidgetSniff implements Sniff
+class DisallowNewWidgetSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -56,6 +57,42 @@ class DisallowNewWidgetSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
@@ -14,10 +14,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class AjaxNullComparisonSniff implements Sniff
+class AjaxNullComparisonSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -100,6 +101,42 @@ class AjaxNullComparisonSniff implements Sniff
         }//end for
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php
@@ -11,11 +11,12 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class EvalObjectFactorySniff implements Sniff
+class EvalObjectFactorySniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -111,6 +112,42 @@ class EvalObjectFactorySniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class GetRequestDataSniff implements Sniff
+class GetRequestDataSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -103,6 +104,42 @@ class GetRequestDataSniff implements Sniff
         $phpcsFile->addError($error, $stackPtr, $type, $data);
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php
@@ -11,10 +11,11 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\PHP;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class ReturnFunctionValueSniff implements Sniff
+class ReturnFunctionValueSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -60,6 +61,42 @@ class ReturnFunctionValueSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
+++ b/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
@@ -11,11 +11,12 @@
 
 namespace PHP_CodeSniffer\Standards\MySource\Sniffs\Strings;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class JoinStringsSniff implements Sniff
+class JoinStringsSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -73,6 +74,42 @@ class JoinStringsSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'The MySource standard will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ClassDefinitionClosingBraceSpaceSniff implements Sniff
+class ClassDefinitionClosingBraceSpaceSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -131,6 +132,42 @@ class ClassDefinitionClosingBraceSpaceSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ClassDefinitionNameSpacingSniff implements Sniff
+class ClassDefinitionNameSpacingSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -108,6 +109,42 @@ class ClassDefinitionNameSpacingSniff implements Sniff
         }//end for
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ClassDefinitionOpeningBraceSpaceSniff implements Sniff
+class ClassDefinitionOpeningBraceSpaceSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -173,6 +174,42 @@ class ClassDefinitionOpeningBraceSpaceSniff implements Sniff
         }//end if
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ColonSpacingSniff implements Sniff
+class ColonSpacingSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -104,6 +105,42 @@ class ColonSpacingSniff implements Sniff
         }//end if
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class ColourDefinitionSniff implements Sniff
+class ColourDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -85,6 +86,42 @@ class ColourDefinitionSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class DisallowMultipleStyleDefinitionsSniff implements Sniff
+class DisallowMultipleStyleDefinitionsSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -68,6 +69,42 @@ class DisallowMultipleStyleDefinitionsSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class DuplicateClassDefinitionSniff implements Sniff
+class DuplicateClassDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -113,6 +114,42 @@ class DuplicateClassDefinitionSniff implements Sniff
         }//end while
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class DuplicateStyleDefinitionSniff implements Sniff
+class DuplicateStyleDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -85,6 +86,42 @@ class DuplicateStyleDefinitionSniff implements Sniff
         } while ($next !== false);
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class EmptyClassDefinitionSniff implements Sniff
+class EmptyClassDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -58,6 +59,42 @@ class EmptyClassDefinitionSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class EmptyStyleDefinitionSniff implements Sniff
+class EmptyStyleDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -61,6 +62,42 @@ class EmptyStyleDefinitionSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class ForbiddenStylesSniff implements Sniff
+class ForbiddenStylesSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -174,6 +175,42 @@ class ForbiddenStylesSniff implements Sniff
         }
 
     }//end addError()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class IndentationSniff implements Sniff
+class IndentationSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -147,6 +148,42 @@ class IndentationSniff implements Sniff
         }//end for
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class LowercaseStyleDefinitionSniff implements Sniff
+class LowercaseStyleDefinitionSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -94,6 +95,42 @@ class LowercaseStyleDefinitionSniff implements Sniff
         }//end for
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class MissingColonSniff implements Sniff
+class MissingColonSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -88,6 +89,42 @@ class MissingColonSniff implements Sniff
         }//end for
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class NamedColoursSniff implements Sniff
+class NamedColoursSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -90,6 +91,42 @@ class NamedColoursSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class OpacitySniff implements Sniff
+class OpacitySniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -98,6 +99,42 @@ class OpacitySniff implements Sniff
         }//end if
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class SemicolonSpacingSniff implements Sniff
+class SemicolonSpacingSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -100,6 +101,42 @@ class SemicolonSpacingSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class ShorthandSizeSniff implements Sniff
+class ShorthandSizeSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -178,6 +179,42 @@ class ShorthandSizeSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning CSS files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class DuplicatePropertySniff implements Sniff
+class DuplicatePropertySniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -79,6 +80,42 @@ class DuplicatePropertySniff implements Sniff
         }//end while
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -13,10 +13,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class JSLintSniff implements Sniff
+class JSLintSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -83,6 +84,42 @@ class JSLintSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -14,10 +14,11 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Debug;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 
-class JavaScriptLintSniff implements Sniff
+class JavaScriptLintSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -86,6 +87,42 @@ class JavaScriptLintSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class DisallowObjectStringIndexSniff implements Sniff
+class DisallowObjectStringIndexSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -82,6 +83,42 @@ class DisallowObjectStringIndexSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ObjectMemberCommaSniff implements Sniff
+class ObjectMemberCommaSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -61,6 +62,42 @@ class ObjectMemberCommaSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -12,10 +12,11 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util;
 
-class LanguageConstructSpacingSniff implements Sniff
+class LanguageConstructSpacingSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -86,6 +87,42 @@ class LanguageConstructSpacingSniff implements Sniff
         }//end if
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.3.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php
@@ -12,9 +12,10 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class PropertyLabelSpacingSniff implements Sniff
+class PropertyLabelSpacingSniff implements Sniff, DeprecatedSniff
 {
 
     /**
@@ -76,6 +77,42 @@ class PropertyLabelSpacingSniff implements Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return 'Support for scanning JavaScript files will be removed completely in v4.0.0.';
+
+    }//end getDeprecationMessage()
 
 
 }//end class

--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -12,13 +12,14 @@
 
 namespace PHP_CodeSniffer\Standards\Zend\Sniffs\Debug;
 
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Common;
 
-class CodeAnalyzerSniff implements Sniff
+class CodeAnalyzerSniff implements Sniff, DeprecatedSniff
 {
 
 
@@ -95,6 +96,42 @@ class CodeAnalyzerSniff implements Sniff
         return $phpcsFile->numTokens;
 
     }//end process()
+
+
+    /**
+     * Provide the version number in which the sniff was deprecated.
+     *
+     * @return string
+     */
+    public function getDeprecationVersion()
+    {
+        return 'v3.9.0';
+
+    }//end getDeprecationVersion()
+
+
+    /**
+     * Provide the version number in which the sniff will be removed.
+     *
+     * @return string
+     */
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+
+    }//end getRemovalVersion()
+
+
+    /**
+     * Provide a custom message to display with the deprecation.
+     *
+     * @return string
+     */
+    public function getDeprecationMessage()
+    {
+        return '';
+
+    }//end getDeprecationMessage()
 
 
 }//end class


### PR DESCRIPTION
# Description
The new messages themselves are not covered by automated tests, but the principle of this is tested via the tests for the `DeprecatedSniff` feature (PR #281).


## Suggested changelog entry
Added deprecation notices (hard deprecation) for:
- All sniffs which will be removed in PHPCS 4.0.

## Related issues/external references

Fixes #188
