### PR TITLE
Ruleset: hard deprecate support for sniffs not implementing the `Sniff` interface

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -1409,7 +1409,12 @@ class Ruleset
                 continue;
             }
 
-            if ($reflection->implementsInterface('PHP_CodeSniffer\Sniffs\Sniff') === false) {
+            if ($reflection->implementsInterface('PHP_CodeSniffer\\Sniffs\\Sniff') === false) {
+                $message  = 'All sniffs must implement the PHP_CodeSniffer\\Sniffs\\Sniff interface.'.PHP_EOL;
+                $message .= "Interface not implemented for sniff $className.".PHP_EOL;
+                $message .= 'Contact the sniff author to fix the sniff.';
+                $this->msgCache->add($message, MessageCollector::DEPRECATED);
+
                 // Skip classes which don't implement the register() or process() methods.
                 if (method_exists($className, 'register') === false
                     || method_exists($className, 'process') === false

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/InvalidImplementsWithoutImplementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/InvalidImplementsWithoutImplementSniff.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsMissingInterfaceTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\MissingInterface;
+
+use PHP_CodeSniffer\Files\File;
+
+final class InvalidImplementsWithoutImplementSniff
+{
+
+    public function register()
+    {
+        return [T_OPEN_TAG];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsSniff.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsMissingInterfaceTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\MissingInterface;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+final class ValidImplementsSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_OPEN_TAG];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsViaAbstractSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsViaAbstractSniff.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\RegisterSniffsMissingInterfaceTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\MissingInterface;
+
+use PHP_CodeSniffer\Sniffs\AbstractArraySniff;
+
+final class ValidImplementsViaAbstractSniff extends AbstractArraySniff
+{
+
+    protected function processSingleLineArray($phpcsFile, $stackPtr, $arrayStart, $arrayEnd, $indices)
+	{
+		// Do something.
+    }
+
+    protected function processMultiLineArray($phpcsFile, $stackPtr, $arrayStart, $arrayEnd, $indices)
+	{
+		// Do something.
+    }
+}

--- a/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
+++ b/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
@@ -6,6 +6,7 @@
     <rule ref="TestStandard">
         <exclude name="TestStandard.InvalidSniffs"/>
         <exclude name="TestStandard.InvalidSniffError"/>
+        <exclude name="TestStandard.MissingInterface.InvalidImplementsWithoutImplement"/>
     </rule>
 
 </ruleset>

--- a/tests/Core/Ruleset/ProcessRulesetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetTest.php
@@ -67,6 +67,8 @@ final class ProcessRulesetTest extends TestCase
             "$std.DeprecatedInvalid.InvalidDeprecationMessage"       => "$sniffDir\DeprecatedInvalid\InvalidDeprecationMessageSniff",
             "$std.DeprecatedInvalid.InvalidDeprecationVersion"       => "$sniffDir\DeprecatedInvalid\InvalidDeprecationVersionSniff",
             "$std.DeprecatedInvalid.InvalidRemovalVersion"           => "$sniffDir\DeprecatedInvalid\InvalidRemovalVersionSniff",
+            "$std.MissingInterface.ValidImplements"                  => "$sniffDir\MissingInterface\ValidImplementsSniff",
+            "$std.MissingInterface.ValidImplementsViaAbstract"       => "$sniffDir\MissingInterface\ValidImplementsViaAbstractSniff",
             "$std.SetProperty.AllowedAsDeclared"                     => "$sniffDir\SetProperty\AllowedAsDeclaredSniff",
             "$std.SetProperty.AllowedViaMagicMethod"                 => "$sniffDir\SetProperty\AllowedViaMagicMethodSniff",
             "$std.SetProperty.AllowedViaStdClass"                    => "$sniffDir\SetProperty\AllowedViaStdClassSniff",

--- a/tests/Core/Ruleset/RegisterSniffsMissingInterfaceInvalidTest.xml
+++ b/tests/Core/Ruleset/RegisterSniffsMissingInterfaceInvalidTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RegisterSniffsMissingInterfaceTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
+
+    <rule ref="TestStandard.MissingInterface"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/RegisterSniffsMissingInterfaceTest.php
+++ b/tests/Core/Ruleset/RegisterSniffsMissingInterfaceTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests deprecation of support for sniffs not implementing the PHPCS `Sniff` interface.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests deprecation of support for sniffs not implementing the PHPCS `Sniff` interface.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::registerSniffs
+ */
+final class RegisterSniffsMissingInterfaceTest extends TestCase
+{
+
+
+    /**
+     * Test that no deprecation is shown when sniffs implement the `PHP_CodeSniffer\Sniffs\Sniff` interface.
+     *
+     * @return void
+     */
+    public function testNoNoticesForSniffsImplementingInterface()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/RegisterSniffsMissingInterfaceValidTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+
+        $this->expectOutputString('');
+
+        new Ruleset($config);
+
+    }//end testNoNoticesForSniffsImplementingInterface()
+
+
+    /**
+     * Test that a deprecation notice is shown if a sniff doesn't implement the Sniff interface.
+     *
+     * @return void
+     */
+    public function testDeprecationNoticeWhenSniffDoesntImplementInterface()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/RegisterSniffsMissingInterfaceInvalidTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+
+        $expected  = 'DEPRECATED: All sniffs must implement the PHP_CodeSniffer\\Sniffs\\Sniff interface.'.PHP_EOL;
+        $expected .= 'Interface not implemented for sniff Fixtures\\TestStandard\\Sniffs\\MissingInterface\\InvalidImplementsWithoutImplementSniff.'.PHP_EOL;
+        $expected .= 'Contact the sniff author to fix the sniff.'.PHP_EOL.PHP_EOL;
+
+        $this->expectOutputString($expected);
+
+        new Ruleset($config);
+
+    }//end testDeprecationNoticeWhenSniffDoesntImplementInterface()
+
+
+}//end class

--- a/tests/Core/Ruleset/RegisterSniffsMissingInterfaceValidTest.xml
+++ b/tests/Core/Ruleset/RegisterSniffsMissingInterfaceValidTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RegisterSniffsMissingInterfaceTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
+
+    <rule ref="TestStandard.MissingInterface.ValidImplements"/>
+    <rule ref="TestStandard.MissingInterface.ValidImplementsViaAbstract"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
@@ -7,6 +7,7 @@
         <exclude name="TestStandard.DeprecatedInvalid"/>
         <exclude name="TestStandard.InvalidSniffs"/>
         <exclude name="TestStandard.InvalidSniffError"/>
+        <exclude name="TestStandard.MissingInterface"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
# Description
While sniffs which don't implement the `Sniff` interface, but do implement the `register()` and `process()` methods, will _work_, it should be considered strongly discouraged.

This commit adds a new, non-blocking deprecation notice which will inform users if they are using a sniff which doesn't implement the `Sniff` interface.

The intention is to remove support for sniffs which don't implement the `Sniff` interface in PHPCS 4.0.

Includes tests.

This commit executes step 3 to address issue #694.


## Suggested changelog entry
Added deprecation notices (hard deprecation) for:
- Sniffs not implementing the `PHP_CodeSniffer\Sniffs\Sniff` interface, which will no longer be supported in PHPCS 4.0.

