### PR TITLE
Ruleset: hard deprecate support for standards called "Internal"

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -892,6 +892,13 @@ class Ruleset
      */
     private function expandRulesetReference($ref, $rulesetDir, $depth=0)
     {
+        // Naming an (external) standard "Internal" is deprecated.
+        if (strtolower($ref) === 'internal') {
+            $message  = 'The name "Internal" is reserved for internal use. A PHP_CodeSniffer standard should not be called "Internal".'.PHP_EOL;
+            $message .= 'Contact the maintainer of the standard to fix this.';
+            $this->msgCache->add($message, MessageCollector::DEPRECATED);
+        }
+
         // Ignore internal sniffs codes as they are used to only
         // hide and change internal messages.
         if (substr($ref, 0, 9) === 'Internal.') {

--- a/tests/Core/Ruleset/ExpandRulesetReferenceInternalTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceInternalTest.php
@@ -51,6 +51,11 @@ final class ExpandRulesetReferenceInternalTest extends AbstractRulesetTestCase
      */
     public function testInternalStandardDoesGetExpanded()
     {
+        $message  = 'DEPRECATED: The name "Internal" is reserved for internal use. A PHP_CodeSniffer standard should not be called "Internal".'.PHP_EOL;
+        $message .= 'Contact the maintainer of the standard to fix this.'.PHP_EOL.PHP_EOL;
+
+        $this->expectOutputString($message);
+
         // Set up the ruleset.
         $standard = __DIR__.'/ExpandRulesetReferenceInternalStandardTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);


### PR DESCRIPTION
# Description
Support for standards called `Internal` was soft deprecated in PHPCS 3.12.0

This PR adds a new Ruleset deprecation notice for when such a standard would be requested from a ruleset.

Support for sniffs not following the naming conventions will be removed in PHPCS 4.0.

Includes test.



## Suggested changelog entry
Added deprecation notices (hard deprecation) for:
- Standards called `Internal`, which will no longer be supported in PHPCS 4.0.


## Related issues/external references

Related to #799
