### PR TITLE
Ruleset: hard deprecate $supportedTokenizers set to CSS/JS only

### DIFF
--- a/tests/Core/Filters/Filter/AcceptTest.xml
+++ b/tests/Core/Filters/Filter/AcceptTest.xml
@@ -8,6 +8,8 @@
     <exclude-pattern>*/Other/Main\.php$</exclude-pattern>
 
     <rule ref="Generic">
+        <exclude name="Generic.Debug"/>
+
         <!-- Standard specific directory pattern. -->
         <exclude-pattern>/anything/*</exclude-pattern>
         <!-- Standard specific file pattern. -->

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ImplementsDeprecatedInterfaceSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ImplementsDeprecatedInterfaceSniff.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ImplementsDeprecatedInterfaceSniff implements Sniff, DeprecatedSniff
+{
+
+    public $supportedTokenizers = [
+        'CSS',
+        'JS',
+    ];
+
+    public function getDeprecationVersion()
+    {
+        return 'v3.4.0';
+    }
+
+    public function getRemovalVersion()
+    {
+        return 'v4.0.0';
+    }
+
+    public function getDeprecationMessage()
+    {
+        return '';
+    }
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSAndJSSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSAndJSSniff.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForCSSAndJSSniff implements Sniff
+{
+
+    public $supportedTokenizers = [
+        'CSS',
+        'JS',
+    ];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSAndUnrecognizedSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSAndUnrecognizedSniff.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForCSSAndUnrecognizedSniff implements Sniff
+{
+
+    public $supportedTokenizers = [
+        'CSS',
+        'Unrecognized',
+    ];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForCSSSniff.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForCSSSniff implements Sniff
+{
+
+    public $supportedTokenizers = ['CSS'];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForEmptySniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForEmptySniff.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForEmptySniff implements Sniff
+{
+
+    public $supportedTokenizers = [];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForJSSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForJSSniff.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForJSSniff implements Sniff
+{
+
+    public $supportedTokenizers = ['JS'];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForPHPAndCSSAndJSSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForPHPAndCSSAndJSSniff.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForPHPAndCSSAndJSSniff implements Sniff
+{
+
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+        'CSS',
+    ];
+
+    public function register()
+    {
+        return [
+            T_OPEN_TAG,
+            T_OPEN_TAG_WITH_ECHO
+        ];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForUnrecognizedTokenizersSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForUnrecognizedTokenizersSniff.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PopulateTokenListenersSupportedTokenizersTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SupportedTokenizers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ListensForUnrecognizedTokenizersSniff implements Sniff
+{
+
+    public $supportedTokenizers = [
+        'SCSS',
+        'TypeScript',
+    ];
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/PopulateTokenListenersSupportedTokenizersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersSupportedTokenizersTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Test the Ruleset::populateTokenListeners() method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+
+/**
+ * Test the Ruleset::populateTokenListeners() method shows a deprecation notice for sniffs supporting JS and/or CSS tokenizers.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::populateTokenListeners
+ */
+final class PopulateTokenListenersSupportedTokenizersTest extends AbstractRulesetTestCase
+{
+
+    /**
+     * The Config object.
+     *
+     * @var \PHP_CodeSniffer\Config
+     */
+    private static $config;
+
+
+    /**
+     * Initialize the config and ruleset objects for this test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function initializeConfig()
+    {
+        // Set up the ruleset.
+        $standard     = __DIR__.'/PopulateTokenListenersSupportedTokenizersTest.xml';
+        self::$config = new ConfigDouble(["--standard=$standard"]);
+
+    }//end initializeConfig()
+
+
+    /**
+     * Verify that a deprecation notice is shown if a non-deprecated sniff supports the JS/CSS tokenizer(s).
+     *
+     * Additionally, this test verifies that:
+     * - No deprecation notice is thrown if the complete sniff is deprecated.
+     * - No deprecation notice is thrown when the sniff _also_ supports PHP.
+     * - No deprecation notice is thrown when no tokenizers are supported (not sure why anyone would do that, but :shrug:).
+     *
+     * {@internal The test uses a data provider to verify the messages as the _order_ of the messages depends
+     * on the OS on which the tests are run (order in which files are retrieved), which makes the order within the
+     * complete message too unpredictable to test in one go.}
+     *
+     * @param string $expected The expected message output in regex format.
+     *
+     * @dataProvider dataDeprecatedTokenizersTriggerDeprecationNotice
+     *
+     * @return void
+     */
+    public function testDeprecatedTokenizersTriggerDeprecationNotice($expected)
+    {
+        $this->expectOutputRegex($expected);
+
+        new Ruleset(self::$config);
+
+    }//end testDeprecatedTokenizersTriggerDeprecationNotice()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedTokenizersTriggerDeprecationNotice()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataDeprecatedTokenizersTriggerDeprecationNotice()
+    {
+        $cssJsDeprecated  = '`DEPRECATED: Scanning CSS/JS files is deprecated and support will be removed in PHP_CodeSniffer 4\.0\.\R';
+        $cssJsDeprecated .= 'The %1$s sniff is listening for %2$s\.\R`';
+
+        $customTokenizer  = '`DEPRECATED: Support for custom tokenizers will be removed in PHP_CodeSniffer 4\.0\.\R';
+        $customTokenizer .= 'The %1$s sniff is listening for %2$s\.\R`';
+
+        return [
+            'Listens for CSS'                            => [
+                'expected' => sprintf($cssJsDeprecated, 'TestStandard.SupportedTokenizers.ListensForCSS', 'CSS'),
+            ],
+            'Listens for JS'                             => [
+                'expected' => sprintf($cssJsDeprecated, 'TestStandard.SupportedTokenizers.ListensForJS', 'JS'),
+            ],
+            'Listens for both CSS and JS'                => [
+                'expected' => sprintf($cssJsDeprecated, 'TestStandard.SupportedTokenizers.ListensForCSSAndJS', 'CSS, JS'),
+            ],
+            'Listens for CSS and something unrecognized' => [
+                'expected' => sprintf($cssJsDeprecated, 'TestStandard.SupportedTokenizers.ListensForCSSAndUnrecognized', 'CSS, Unrecognized'),
+            ],
+            'Listens for only unrecognized tokenizers'   => [
+                'expected' => sprintf($customTokenizer, 'TestStandard.SupportedTokenizers.ListensForUnrecognizedTokenizers', 'SCSS, TypeScript'),
+            ],
+        ];
+
+    }//end dataDeprecatedTokenizersTriggerDeprecationNotice()
+
+
+}//end class

--- a/tests/Core/Ruleset/PopulateTokenListenersSupportedTokenizersTest.xml
+++ b/tests/Core/Ruleset/PopulateTokenListenersSupportedTokenizersTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PopulateTokenListenersDeprecatedTokenizerTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
+
+    <rule ref="TestStandard.SupportedTokenizers"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.php
@@ -131,31 +131,31 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
     public static function dataSniffListensToTokenss()
     {
         return [
-            'Generic.Files.EndFileNewline'                     => [
-                'sniffClass'    => 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\Files\\EndFileNewlineSniff',
+            'TestStandard.SupportedTokenizers.ListensForPHPAndCSSAndJS' => [
+                'sniffClass'    => 'Fixtures\\TestStandard\\Sniffs\\SupportedTokenizers\\ListensForPHPAndCSSAndJSSniff',
                 'expectedCount' => 2,
             ],
-            'Generic.NamingConventions.UpperCaseConstantName'  => [
+            'Generic.NamingConventions.UpperCaseConstantName'           => [
                 'sniffClass'    => 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\NamingConventions\\UpperCaseConstantNameSniff',
                 'expectedCount' => 2,
             ],
-            'PSR1.Files.SideEffects'                           => [
+            'PSR1.Files.SideEffects'                                    => [
                 'sniffClass'    => 'PHP_CodeSniffer\\Standards\\PSR1\\Sniffs\\Files\\SideEffectsSniff',
                 'expectedCount' => 1,
             ],
-            'PSR12.ControlStructures.BooleanOperatorPlacement' => [
+            'PSR12.ControlStructures.BooleanOperatorPlacement'          => [
                 'sniffClass'    => 'PHP_CodeSniffer\\Standards\\PSR12\\Sniffs\\ControlStructures\\BooleanOperatorPlacementSniff',
                 'expectedCount' => 5,
             ],
-            'Squiz.ControlStructures.ForEachLoopDeclaration'   => [
+            'Squiz.ControlStructures.ForEachLoopDeclaration'            => [
                 'sniffClass'    => 'PHP_CodeSniffer\\Standards\\Squiz\\Sniffs\\ControlStructures\\ForEachLoopDeclarationSniff',
                 'expectedCount' => 1,
             ],
-            'TestStandard.Deprecated.WithReplacement'          => [
+            'TestStandard.Deprecated.WithReplacement'                   => [
                 'sniffClass'    => 'Fixtures\\TestStandard\\Sniffs\\Deprecated\\WithReplacementSniff',
                 'expectedCount' => 1,
             ],
-            'TestStandard.ValidSniffs.RegisterEmptyArray'      => [
+            'TestStandard.ValidSniffs.RegisterEmptyArray'               => [
                 'sniffClass'    => 'Fixtures\\TestStandard\\Sniffs\\ValidSniffs\\RegisterEmptyArraySniff',
                 'expectedCount' => 0,
             ],
@@ -313,7 +313,7 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
      */
     public function testSetsSupportedTokenizersToPHPByDefault()
     {
-        $exclude  = 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\Files\\EndFileNewlineSniff';
+        $exclude  = 'Fixtures\\TestStandard\\Sniffs\\SupportedTokenizers\\ListensForPHPAndCSSAndJSSniff';
         $expected = ['PHP' => 'PHP'];
 
         foreach (self::$ruleset->tokenListeners as $token => $listeners) {
@@ -354,7 +354,7 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
      */
     public function testSetsSupportedTokenizersWhenProvidedBySniff($token)
     {
-        $sniffClass = 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\Files\\EndFileNewlineSniff';
+        $sniffClass = 'Fixtures\\TestStandard\\Sniffs\\SupportedTokenizers\\ListensForPHPAndCSSAndJSSniff';
         $expected   = [
             'PHP' => 'PHP',
             'JS'  => 'JS',

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.xml
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.xml
@@ -21,7 +21,7 @@
     </rule>
 
     <!-- Test setting supported Tokenizers when provided. -->
-    <rule ref="Generic.Files.EndFileNewline"/>
+    <rule ref="TestStandard.SupportedTokenizers.ListensForPHPAndCSSAndJS"/>
 
     <!-- Test that a sniff which doesn't register any tokens is accepted without errors. -->
     <rule ref="TestStandard.ValidSniffs.RegisterEmptyArray"/>

--- a/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
+++ b/tests/Core/Ruleset/ProcessRulesetAutoExpandSniffsDirectoryTest.xml
@@ -4,6 +4,7 @@
     <config name="installed_paths" value="./tests/Core/Ruleset/Fixtures/TestStandard/"/>
 
     <rule ref="TestStandard">
+        <exclude name="TestStandard.SupportedTokenizers"/>
         <exclude name="TestStandard.InvalidSniffs"/>
         <exclude name="TestStandard.InvalidSniffError"/>
     </rule>

--- a/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
+++ b/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
@@ -2,6 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SetSniffPropertyTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <rule ref="Generic">
+        <exclude name="Generic.Debug"/>
         <properties>
             <property name="doesnotexist" value="2"/>
         </properties>

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.xml
@@ -5,6 +5,7 @@
 
     <rule ref="TestStandard">
         <exclude name="TestStandard.DeprecatedInvalid"/>
+        <exclude name="TestStandard.SupportedTokenizers"/>
         <exclude name="TestStandard.InvalidSniffs"/>
         <exclude name="TestStandard.InvalidSniffError"/>
     </rule>


### PR DESCRIPTION
# Description

⚠️ **_This PR needs for PR #888 to be merged first._** ⚠️ 

---

Support for the JS and CSS Tokenizers will be removed in PHPCS 4.0.

This was announced in squizlabs/PHP_CodeSniffer#2448 and has been formalized via a soft deprecation (documentation and changelog only) in the PHPCS 3.9.0 release (see #276).

This commit implements a deprecation notice to alert sniff maintainers and ruleset maintainers to sniffs which are exclusively aimed at CSS and/or JS files.

This deprecation notice will not be shown if the sniff is formally deprecated via an implementation of the `DeprecatedSniff` interface (to prevent duplicate notifications).

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.3.0


Includes an update to two tests in the `PopulateTokenListenersTest` to make these use one of the newly introduced fixtures to make these tests less dependent on the actual sniffs in PHPCS.

## Suggested changelog entry
Added deprecation notices (hard deprecation) for:
- Sniffs which don't listen for PHP, like JS/CSS specific sniffs,, which will no longer be supported in PHPCS 4.0.


## Related issues/external references

Fixes #740