### PR TITLE
Generic/DeprecatedFunctions: add test which will work for PHP 8.0+

### DIFF
--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.inc
@@ -2,3 +2,4 @@
 
 create_function(); // Deprecated PHP 7.2.
 mbsplit(); // Deprecated PHP 7.3.
+libxml_disable_entity_loader(); // Deprecated PHP 8.0.

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -40,6 +40,10 @@ final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
             $errors[4] = 1;
         }
 
+        if (PHP_VERSION_ID >= 80000) {
+            $errors[5] = 1;
+        }
+
         return $errors;
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Both functions used in the tests were removed in PHP 8.0, so when running the tests on PHP 8.0, nothing would be tested anymore.

## Suggested changelog entry
_N/A_