### PR TITLE
Remark/dead URL check: skip flaky PEAR links

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -14,8 +14,12 @@
             "skipUrlPatterns": [
                 "^https?://github\\.com/PHPCSStandards/PHP_CodeSniffer/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
                 "^https?://github\\.com/[A-Za-z0-9-]+",
+                "^https?://pear\\.php\\.net/bugs/bug\\.php\\?id=[0-9]+",
                 "^https?://x\\.com/PHP_CodeSniffer"
-            ]
+            ],
+            "deadOrAliveOptions": {
+                "maxRetries": 3
+            }
         }
     ],
     "remark-lint-no-duplicate-defined-urls",


### PR DESCRIPTION
# Description
... and retry other failing links to prevent having to rerun GHA jobs.

I suspect the PEAR website might see these checks as DDOS as when the GHA workflow runs, it will hit a few hundred URLs in quick succession, so let's not do this every time.

## Suggested changelog entry
_N/A_
