### PR TITLE
GH Actions: auto-remove label tweaks

### DIFF
--- a/.github/workflows/label-remove-outdated.yml
+++ b/.github/workflows/label-remove-outdated.yml
@@ -62,7 +62,8 @@ jobs:
 
   on-pr-close:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
+    # yamllint disable-line rule:line-length
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == false
 
     name: Clean up labels on PR close
 


### PR DESCRIPTION
# Description
PR #897 made a change to the "auto remove labels" workflow, but that change couldn't be tested until merged as it used the `pull_request_target` event, which always reads the workflows from the `master` branch and not from a PR branch.

I've now tested the change and while the _new_ addition looks to be correct, one of the pre-existing jobs _also_ ran, while it shouldn't have run.

This new commit attempts to fix that.

Again, we can't test this until merged, but will test once it has been merged.


## Suggested changelog entry
_N/A_