### PR TITLE
PropertyTypeHandlingTest: split data provider

### DIFF
--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -22,14 +22,10 @@
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedValues[] string, 15, another string
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsEmptyArray[]
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithOnlyValues[] string, 10, 1.5, null, true, false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedValues[] string, 15, another string
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithExtendedKeysAndValues[] 10=>10,string=>string,15=>15,another string=>another string
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolEmptyArray[]
 
 echo 'hello!';

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -45,6 +45,7 @@ final class PropertyTypeHandlingTest extends TestCase
      * @param mixed  $expected     Expected property value.
      *
      * @dataProvider dataTypeHandling
+     * @dataProvider dataArrayPropertyExtending
      *
      * @return void
      */
@@ -80,6 +81,7 @@ final class PropertyTypeHandlingTest extends TestCase
      * Data provider.
      *
      * @see self::testTypeHandlingWhenSetViaRuleset()
+     * @see self::testTypeHandlingWhenSetInline()
      *
      * @return array<string, array<string, mixed>>
      */
@@ -102,6 +104,99 @@ final class PropertyTypeHandlingTest extends TestCase
             'false'  => 'false',
         ];
 
+        return [
+            'String value (default)'                         => [
+                'propertyName' => 'expectsString',
+                'expected'     => 'arbitraryvalue',
+            ],
+            'String value with whitespace gets trimmed'      => [
+                'propertyName' => 'expectsTrimmedString',
+                'expected'     => 'some value',
+            ],
+            'String with whitespace only value becomes null' => [
+                'propertyName' => 'emptyStringBecomesNull',
+                'expected'     => null,
+            ],
+            'Integer value gets set as string'               => [
+                'propertyName' => 'expectsIntButAcceptsString',
+                'expected'     => '12345',
+            ],
+            'Float value gets set as string'                 => [
+                'propertyName' => 'expectsFloatButAcceptsString',
+                'expected'     => '12.345',
+            ],
+            'Null value gets set as string'                  => [
+                'propertyName' => 'expectsNull',
+                'expected'     => 'null',
+            ],
+            'Null (uppercase) value gets set as string'      => [
+                'propertyName' => 'expectsNullCase',
+                'expected'     => 'NULL',
+            ],
+            'True value gets set as boolean'                 => [
+                'propertyName' => 'expectsBooleanTrue',
+                'expected'     => true,
+            ],
+            'True (mixed case) value gets set as string'     => [
+                'propertyName' => 'expectsBooleanTrueCase',
+                'expected'     => 'True',
+            ],
+            'True (with spaces) value gets set as boolean'   => [
+                'propertyName' => 'expectsBooleanTrueTrimmed',
+                'expected'     => true,
+            ],
+            'False value gets set as boolean'                => [
+                'propertyName' => 'expectsBooleanFalse',
+                'expected'     => false,
+            ],
+            'False (mixed case) value gets set as string'    => [
+                'propertyName' => 'expectsBooleanFalseCase',
+                'expected'     => 'fALSe',
+            ],
+            'False (with spaces) value gets set as boolean'  => [
+                'propertyName' => 'expectsBooleanFalseTrimmed',
+                'expected'     => false,
+            ],
+            'Array with only values (new style)'             => [
+                'propertyName' => 'expectsArrayWithOnlyValues',
+                'expected'     => $expectedArrayOnlyValues,
+            ],
+            'Array with keys and values (new style)'         => [
+                'propertyName' => 'expectsArrayWithKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValues,
+            ],
+            'Empty array (new style)'                        => [
+                'propertyName' => 'expectsEmptyArray',
+                'expected'     => [],
+            ],
+            'Array with only values (old style)'             => [
+                'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
+                'expected'     => $expectedArrayOnlyValues,
+            ],
+            'Array with keys and values (old style)'         => [
+                'propertyName' => 'expectsOldSchoolArrayWithKeysAndValues',
+                'expected'     => $expectedArrayKeysAndValues,
+            ],
+            'Empty array (old style)'                        => [
+                'propertyName' => 'expectsOldSchoolEmptyArray',
+                'expected'     => [],
+            ],
+        ];
+
+    }//end dataTypeHandling()
+
+
+    /**
+     * Data provider.
+     *
+     * Array property extending is a feature which is only supported from a ruleset, not for inline property setting.
+     *
+     * @see self::testTypeHandlingWhenSetViaRuleset()
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataArrayPropertyExtending()
+    {
         $expectedArrayOnlyValuesExtended    = [
             'string',
             '15',
@@ -115,66 +210,6 @@ final class PropertyTypeHandlingTest extends TestCase
         ];
 
         return [
-            'String value (default)'                          => [
-                'propertyName' => 'expectsString',
-                'expected'     => 'arbitraryvalue',
-            ],
-            'String value with whitespace gets trimmed'       => [
-                'propertyName' => 'expectsTrimmedString',
-                'expected'     => 'some value',
-            ],
-            'String with whitespace only value becomes null'  => [
-                'propertyName' => 'emptyStringBecomesNull',
-                'expected'     => null,
-            ],
-            'Integer value gets set as string'                => [
-                'propertyName' => 'expectsIntButAcceptsString',
-                'expected'     => '12345',
-            ],
-            'Float value gets set as string'                  => [
-                'propertyName' => 'expectsFloatButAcceptsString',
-                'expected'     => '12.345',
-            ],
-            'Null value gets set as string'                   => [
-                'propertyName' => 'expectsNull',
-                'expected'     => 'null',
-            ],
-            'Null (uppercase) value gets set as string'       => [
-                'propertyName' => 'expectsNullCase',
-                'expected'     => 'NULL',
-            ],
-            'True value gets set as boolean'                  => [
-                'propertyName' => 'expectsBooleanTrue',
-                'expected'     => true,
-            ],
-            'True (mixed case) value gets set as string'      => [
-                'propertyName' => 'expectsBooleanTrueCase',
-                'expected'     => 'True',
-            ],
-            'True (with spaces) value gets set as boolean'    => [
-                'propertyName' => 'expectsBooleanTrueTrimmed',
-                'expected'     => true,
-            ],
-            'False value gets set as boolean'                 => [
-                'propertyName' => 'expectsBooleanFalse',
-                'expected'     => false,
-            ],
-            'False (mixed case) value gets set as string'     => [
-                'propertyName' => 'expectsBooleanFalseCase',
-                'expected'     => 'fALSe',
-            ],
-            'False (with spaces) value gets set as boolean'   => [
-                'propertyName' => 'expectsBooleanFalseTrimmed',
-                'expected'     => false,
-            ],
-            'Array with only values (new style)'              => [
-                'propertyName' => 'expectsArrayWithOnlyValues',
-                'expected'     => $expectedArrayOnlyValues,
-            ],
-            'Array with keys and values (new style)'          => [
-                'propertyName' => 'expectsArrayWithKeysAndValues',
-                'expected'     => $expectedArrayKeysAndValues,
-            ],
             'Array with only values extended (new style)'     => [
                 'propertyName' => 'expectsArrayWithExtendedValues',
                 'expected'     => $expectedArrayOnlyValuesExtended,
@@ -182,18 +217,6 @@ final class PropertyTypeHandlingTest extends TestCase
             'Array with keys and values extended (new style)' => [
                 'propertyName' => 'expectsArrayWithExtendedKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValuesExtended,
-            ],
-            'Empty array (new style)'                         => [
-                'propertyName' => 'expectsEmptyArray',
-                'expected'     => [],
-            ],
-            'Array with only values (old style)'              => [
-                'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
-                'expected'     => $expectedArrayOnlyValues,
-            ],
-            'Array with keys and values (old style)'          => [
-                'propertyName' => 'expectsOldSchoolArrayWithKeysAndValues',
-                'expected'     => $expectedArrayKeysAndValues,
             ],
             'Array with only values extended (old style)'     => [
                 'propertyName' => 'expectsOldSchoolArrayWithExtendedValues',
@@ -203,13 +226,9 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsOldSchoolArrayWithExtendedKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValuesExtended,
             ],
-            'Empty array (old style)'                         => [
-                'propertyName' => 'expectsOldSchoolEmptyArray',
-                'expected'     => [],
-            ],
         ];
 
-    }//end dataTypeHandling()
+    }//end dataArrayPropertyExtending()
 
 
     /**
@@ -225,7 +244,7 @@ final class PropertyTypeHandlingTest extends TestCase
 
         if (isset($sniffObject) === false) {
             // Set up the ruleset.
-            $standard = __DIR__."/PropertyTypeHandlingTest.xml";
+            $standard = __DIR__.'/PropertyTypeHandlingTest.xml';
             $config   = new ConfigDouble(["--standard=$standard"]);
             $ruleset  = new Ruleset($config);
 
@@ -255,7 +274,7 @@ final class PropertyTypeHandlingTest extends TestCase
 
         if (isset($sniffObject) === false) {
             // Set up the ruleset.
-            $standard = __DIR__."/PropertyTypeHandlingInlineTest.xml";
+            $standard = __DIR__.'/PropertyTypeHandlingInlineTest.xml';
             $config   = new ConfigDouble(["--standard=$standard"]);
             $ruleset  = new Ruleset($config);
 


### PR DESCRIPTION
# Description
The `PropertyTypeHandlingTest` class tests the setting of property values from the ruleset as well as via inline `// phpcs:set ...`  annotations.

As both ways of setting the property value should be supported in the same manner, the tests used one data provider for both tests and the fixtures (`PropertyTypeHandlingTest.xml` ruleset and the `Fixtures/PropertyTypeHandlingInline.inc` file containing the inline annotations) mirrored the exact same test cases.

There is one feature, however, which is only supported when setting properties via the ruleset, not when setting them via inline annotations: array property extending.

Until now, the tests for that were also mirrored in the inline annotation tests, even though the feature isn't supported for inline annotations.

This commit now splits the data provider in two:
* One data provider for the tests which apply for both (= most tests).
* One specifically for extending array properties.

That second data provider will now only be used by the `testTypeHandlingWhenSetViaRuleset()` test method.

This should make it more straight-forward to add additional tests for property extending in the future.

---

In case anyone is wondering: As `phpcs:set` is only supposed to be used in tests, I don't think adding support for the `extend` option to inline properties is necessary.

## Suggested changelog entry
_N/A_
