### PR TITLE
CS/QA: various minor fixes

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -572,7 +572,7 @@ class Ruleset
             $autoloadPath = (string) $autoload;
 
             // Try relative autoload paths first.
-            $relativePath = Common::realPath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
+            $relativePath = Common::realpath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
 
             if ($relativePath !== false && is_file($relativePath) === true) {
                 $autoloadPath = $relativePath;

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -152,7 +152,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                     for ($i = $openingBrace; $i > $prev; $i--) {
                         if ($tokens[$i]['line'] === $tokens[$openingBrace]['line']) {
                             if ($tokens[$i]['column'] === 1) {
-                                $phpcsFile->fixer->addNewLineBefore($i);
+                                $phpcsFile->fixer->addNewlineBefore($i);
                             }
 
                             continue;

--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -87,7 +87,8 @@ class ControlStructureSpacingSniff implements Sniff
 
         if ($tokens[$parenOpener]['line'] === $tokens[$parenCloser]['line']) {
             // Conditions are all on the same line, so follow PSR2.
-            return $this->psr2ControlStructureSpacing->process($phpcsFile, $stackPtr);
+            $this->psr2ControlStructureSpacing->process($phpcsFile, $stackPtr);
+            return;
         }
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($parenOpener + 1), $parenCloser, true);

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -249,7 +249,7 @@ class DeclareStatementSniff implements Sniff
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
 
-                    $phpcsFile->fixer->addNewLineBefore($token);
+                    $phpcsFile->fixer->addNewlineBefore($token);
 
                     $phpcsFile->fixer->endChangeset();
                 }

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -152,7 +152,7 @@ class SwitchDeclarationSniff implements Sniff
                         $error = 'Terminating statement must be on a line by itself';
                         $fix   = $phpcsFile->addFixableError($error, $nextCloser, 'BreakNotNewLine');
                         if ($fix === true) {
-                            $phpcsFile->fixer->addNewLine($prev);
+                            $phpcsFile->fixer->addNewline($prev);
                             $phpcsFile->fixer->replaceToken($nextCloser, trim($tokens[$nextCloser]['content']));
                         }
                     } else {

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -36,7 +36,7 @@ class Standards
         $resolvedInstalledPaths = [];
         foreach ($installedPaths as $installedPath) {
             if (substr($installedPath, 0, 1) === '.') {
-                $installedPath = Common::realPath(__DIR__.$ds.'..'.$ds.'..'.$ds.$installedPath);
+                $installedPath = Common::realpath(__DIR__.$ds.'..'.$ds.'..'.$ds.$installedPath);
                 if ($installedPath === false) {
                     continue;
                 }
@@ -239,7 +239,7 @@ class Standards
         } else {
             // This could be a custom standard, installed outside our
             // standards directory.
-            $standard = Common::realPath($standard);
+            $standard = Common::realpath($standard);
             if ($standard === false) {
                 return false;
             }

--- a/tests/Core/File/GetConditionTest.php
+++ b/tests/Core/File/GetConditionTest.php
@@ -153,7 +153,7 @@ final class GetConditionTest extends AbstractMethodUnitTest
      */
     public function testNonExistentToken()
     {
-        $result = self::$phpcsFile->getCondition(100000, Tokens::$ooScopeTokens);
+        $result = self::$phpcsFile->getCondition(100000, T_CLASS);
         $this->assertFalse($result);
 
         $result = self::$phpcsFile->hasCondition(100000, T_IF);

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
@@ -28,7 +28,7 @@ final class RecurseScopeMapWithNamespaceOperatorTest extends AbstractTokenizerTe
      *
      * @return void
      */
-    public function testScopeSetting($testMarker, $tokenTypes, $open=T_OPEN_CURLY_BRACKET, $close=T_CLOSE_CURLY_BRACKET)
+    public function testScopeSetting($testMarker, $tokenTypes, $open=[T_OPEN_CURLY_BRACKET], $close=[T_CLOSE_CURLY_BRACKET])
     {
         $tokens = $this->phpcsFile->getTokens();
 


### PR DESCRIPTION
# Description
* Use the correct case for functions.
* Don't return result of a `void` function.
* A few type consistency fixes.


## Suggested changelog entry
_N/A_