### PR TITLE
Tests/Tokenizer: use markers for the `testSwitchDefault()` test

### DIFF
--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.inc
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.inc
@@ -28,8 +28,10 @@ function switchWithDefaultAndCurlies($i) {
         case 2:
             return 2;
         /* testSimpleSwitchDefaultWithCurlies */
-        default: {
+        default: /* testSimpleSwitchDefaultWithCurliesScopeOpener */ {
+            /* testSimpleSwitchDefaultWithCurliesConditionStop */
             return 'default';
+        /* testSimpleSwitchDefaultWithCurliesScopeCloser */
         }
     }
 }
@@ -60,6 +62,7 @@ function matchWithDefaultInSwitch() {
                 /* testMatchDefaultNestedInSwitchDefault */
                 default, => 'default',
             };
+            /* testSwitchDefaultCloserMarker */
             break;
     }
 }
@@ -97,6 +100,7 @@ function switchAndDefaultSharingScopeCloser($i) {
         /* testSwitchAndDefaultSharingScopeCloser */
         default:
             echo 'one';
+        /* testSwitchAndDefaultSharingScopeCloserScopeCloser */
     endswitch;
 }
 
@@ -111,6 +115,7 @@ function switchDefaultNestedIfWithAndWithoutBraces($i, $foo, $baz) {
             else {
                 echo 'else';
             }
+            /* testSwitchDefaultNestedIfWithAndWithoutBracesScopeCloser */
             break;
     }
 }

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -178,12 +178,12 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         $this->assertSame(
             $expectedScopeOpener,
             $tokenArray['scope_opener'],
-            sprintf('Scope opener of the T_DEFAULT token incorrect. Marker: %s.', $openerMarker)
+            sprintf('Scope opener of the T_DEFAULT token incorrect. Marker: %s.', $testMarker)
         );
         $this->assertSame(
             $expectedScopeCloser,
             $tokenArray['scope_closer'],
-            sprintf('Scope closer of the T_DEFAULT token incorrect. Marker: %s.', $closerMarker)
+            sprintf('Scope closer of the T_DEFAULT token incorrect. Marker: %s.', $testMarker)
         );
 
         $opener = $tokenArray['scope_opener'];

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -14,6 +14,20 @@ use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
 final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenizerTestCase
 {
 
+    /**
+     * Condition stop tokens when `default` is used with curlies.
+     *
+     * @var array<int>
+     */
+    protected $conditionStopTokens = [
+        T_BREAK,
+        T_CONTINUE,
+        T_EXIT,
+        T_GOTO,
+        T_RETURN,
+        T_THROW,
+    ];
+
 
     /**
      * Test that match "default" tokens does not get scope indexes.
@@ -257,15 +271,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStopMarker) === true) {
-                $tokenTypes = [
-                    T_BREAK,
-                    T_CONTINUE,
-                    T_EXIT,
-                    T_GOTO,
-                    T_RETURN,
-                    T_THROW,
-                ];
-                $end        = ($this->getTargetToken($conditionStopMarker, $tokenTypes) + 1);
+                $end = ( $this->getTargetToken($conditionStopMarker, $this->conditionStopTokens) + 1);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -283,9 +283,9 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
     {
         return [
             'simple_switch_default'                                     => [
-                'testMarker'       => '/* testSimpleSwitchDefault */',
-                'testOpenerMarker' => '/* testSimpleSwitchDefault */',
-                'testCloserMarker' => '/* testSimpleSwitchDefault */',
+                'testMarker'   => '/* testSimpleSwitchDefault */',
+                'openerMarker' => '/* testSimpleSwitchDefault */',
+                'closerMarker' => '/* testSimpleSwitchDefault */',
             ],
             'simple_switch_default_with_curlies'                        => [
                 // For a default structure with curly braces, the scope opener
@@ -293,37 +293,37 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                 // However, scope conditions will not be set for open to close,
                 // but only for the open token up to the "break/return/continue" etc.
                 'testMarker'          => '/* testSimpleSwitchDefaultWithCurlies */',
-                'testOpenerMarker'    => '/* testSimpleSwitchDefaultWithCurliesScopeOpener */',
-                'testCloserMarker'    => '/* testSimpleSwitchDefaultWithCurliesScopeCloser */',
+                'openerMarker'        => '/* testSimpleSwitchDefaultWithCurliesScopeOpener */',
+                'closerMarker'        => '/* testSimpleSwitchDefaultWithCurliesScopeCloser */',
                 'conditionStopMarker' => '/* testSimpleSwitchDefaultWithCurliesConditionStop */',
             ],
             'switch_default_toplevel'                                   => [
-                'testMarker'       => '/* testSwitchDefault */',
-                'testOpenerMarker' => '/* testSwitchDefault */',
-                'testCloserMarker' => '/* testSwitchDefaultCloserMarker */',
+                'testMarker'   => '/* testSwitchDefault */',
+                'openerMarker' => '/* testSwitchDefault */',
+                'closerMarker' => '/* testSwitchDefaultCloserMarker */',
             ],
             'switch_default_nested_in_match_case'                       => [
-                'testMarker'       => '/* testSwitchDefaultNestedInMatchCase */',
-                'testOpenerMarker' => '/* testSwitchDefaultNestedInMatchCase */',
-                'testCloserMarker' => '/* testSwitchDefaultNestedInMatchCase */',
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchCase */',
+                'openerMarker' => '/* testSwitchDefaultNestedInMatchCase */',
+                'closerMarker' => '/* testSwitchDefaultNestedInMatchCase */',
             ],
             'switch_default_nested_in_match_default'                    => [
-                'testMarker'       => '/* testSwitchDefaultNestedInMatchDefault */',
-                'testOpenerMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
-                'testCloserMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
+                'testMarker'   => '/* testSwitchDefaultNestedInMatchDefault */',
+                'openerMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
+                'closerMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
             ],
             'switch_and_default_sharing_scope_closer'                   => [
                 'testMarker'        => '/* testSwitchAndDefaultSharingScopeCloser */',
-                'testOpenerMarker'  => '/* testSwitchAndDefaultSharingScopeCloser */',
-                'testCloserMarker'  => '/* testSwitchAndDefaultSharingScopeCloserScopeCloser */',
+                'openerMarker'      => '/* testSwitchAndDefaultSharingScopeCloser */',
+                'closerMarker'      => '/* testSwitchAndDefaultSharingScopeCloserScopeCloser */',
                 'conditionStop'     => null,
                 'testContent'       => 'default',
                 'sharedScopeCloser' => true,
             ],
             'switch_and_default_with_nested_if_with_and_without_braces' => [
-                'testMarker'       => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
-                'testOpenerMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
-                'testCloserMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBracesScopeCloser */',
+                'testMarker'   => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
+                'openerMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
+                'closerMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBracesScopeCloser */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -123,30 +123,30 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      * Note: Cases and default structures within a switch control structure *do* get case/default scope
      * conditions.
      *
-     * @param string   $testMarker        The comment prefacing the target token.
-     * @param int      $openerOffset      The expected offset of the scope opener in relation to the testMarker.
-     * @param int      $closerOffset      The expected offset of the scope closer in relation to the testMarker.
-     * @param int|null $conditionStop     The expected offset in relation to the testMarker, at which tokens stop
-     *                                    having T_DEFAULT as a scope condition.
-     * @param string   $testContent       The token content to look for.
-     * @param bool     $sharedScopeCloser Whether to skip checking for the `scope_condition` of the
-     *                                    scope closer. Needed when the default and switch
-     *                                    structures share a scope closer. See
-     *                                    https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/810.
+     * @param string      $testMarker          The comment prefacing the target token.
+     * @param string      $openerMarker        The comment prefacing the scope opener token.
+     * @param string      $closerMarker        The comment prefacing the scope closer token.
+     * @param string|null $conditionStopMarker The expected offset in relation to the testMarker, after which tokens stop
+     *                                         having T_DEFAULT as a scope condition.
+     * @param string      $testContent         The token content to look for.
+     * @param bool        $sharedScopeCloser   Whether to skip checking for the `scope_condition` of the
+     *                                         scope closer. Needed when the default and switch
+     *                                         structures share a scope closer. See
+     *                                         https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/810.
      *
      * @dataProvider dataSwitchDefault
      * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
      *
      * @return void
      */
-    public function testSwitchDefault($testMarker, $openerOffset, $closerOffset, $conditionStop=null, $testContent='default', $sharedScopeCloser=false)
+    public function testSwitchDefault($testMarker, $openerMarker, $closerMarker, $conditionStopMarker=null, $testContent='default', $sharedScopeCloser=false)
     {
         $tokens = $this->phpcsFile->getTokens();
 
         $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT, T_STRING], $testContent);
         $tokenArray = $tokens[$token];
-        $expectedScopeOpener = ($token + $openerOffset);
-        $expectedScopeCloser = ($token + $closerOffset);
+        $expectedScopeOpener = $this->getTargetToken($openerMarker, [T_COLON, T_OPEN_CURLY_BRACKET, T_SEMICOLON]);
+        $expectedScopeCloser = $this->getTargetToken($closerMarker, [T_BREAK, T_CLOSE_CURLY_BRACKET, T_RETURN, T_ENDSWITCH]);
 
         // Make sure we're looking at the right token.
         $this->assertSame(
@@ -178,44 +178,44 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         $this->assertSame(
             $expectedScopeOpener,
             $tokenArray['scope_opener'],
-            sprintf('Scope opener of the T_DEFAULT token incorrect. Marker: %s.', $testMarker)
+            sprintf('Scope opener of the T_DEFAULT token incorrect. Marker: %s.', $openerMarker)
         );
         $this->assertSame(
             $expectedScopeCloser,
             $tokenArray['scope_closer'],
-            sprintf('Scope closer of the T_DEFAULT token incorrect. Marker: %s.', $testMarker)
+            sprintf('Scope closer of the T_DEFAULT token incorrect. Marker: %s.', $closerMarker)
         );
 
         $opener = $tokenArray['scope_opener'];
         $this->assertArrayHasKey(
             'scope_condition',
             $tokens[$opener],
-            sprintf('Opener scope condition is not set. Marker: %s.', $testMarker)
+            sprintf('Opener scope condition is not set. Marker: %s.', $openerMarker)
         );
         $this->assertArrayHasKey(
             'scope_opener',
             $tokens[$opener],
-            sprintf('Opener scope opener is not set. Marker: %s.', $testMarker)
+            sprintf('Opener scope opener is not set. Marker: %s.', $openerMarker)
         );
         $this->assertArrayHasKey(
             'scope_closer',
             $tokens[$opener],
-            sprintf('Opener scope closer is not set. Marker: %s.', $testMarker)
+            sprintf('Opener scope closer is not set. Marker: %s.', $openerMarker)
         );
         $this->assertSame(
             $token,
             $tokens[$opener]['scope_condition'],
-            sprintf('Opener scope condition is not the T_DEFAULT token. Marker: %s.', $testMarker)
+            sprintf('Opener scope condition is not the T_DEFAULT token. Marker: %s.', $openerMarker)
         );
         $this->assertSame(
             $expectedScopeOpener,
             $tokens[$opener]['scope_opener'],
-            sprintf('T_DEFAULT opener scope opener token incorrect. Marker: %s.', $testMarker)
+            sprintf('T_DEFAULT opener scope opener token incorrect. Marker: %s.', $openerMarker)
         );
         $this->assertSame(
             $expectedScopeCloser,
             $tokens[$opener]['scope_closer'],
-            sprintf('T_DEFAULT opener scope closer token incorrect. Marker: %s.', $testMarker)
+            sprintf('T_DEFAULT opener scope closer token incorrect. Marker: %s.', $openerMarker)
         );
 
         $closer = $expectedScopeCloser;
@@ -225,39 +225,39 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
             $this->assertArrayHasKey(
                 'scope_condition',
                 $tokens[$closer],
-                sprintf('Closer scope condition is not set. Marker: %s.', $testMarker)
+                sprintf('Closer scope condition is not set. Marker: %s.', $closerMarker)
             );
             $this->assertArrayHasKey(
                 'scope_opener',
                 $tokens[$closer],
-                sprintf('Closer scope opener is not set. Marker: %s.', $testMarker)
+                sprintf('Closer scope opener is not set. Marker: %s.', $closerMarker)
             );
             $this->assertArrayHasKey(
                 'scope_closer',
                 $tokens[$closer],
-                sprintf('Closer scope closer is not set. Marker: %s.', $testMarker)
+                sprintf('Closer scope closer is not set. Marker: %s.', $closerMarker)
             );
             $this->assertSame(
                 $token,
                 $tokens[$closer]['scope_condition'],
-                sprintf('Closer scope condition is not the T_DEFAULT token. Marker: %s.', $testMarker)
+                sprintf('Closer scope condition is not the T_DEFAULT token. Marker: %s.', $closerMarker)
             );
             $this->assertSame(
                 $expectedScopeOpener,
                 $tokens[$closer]['scope_opener'],
-                sprintf('T_DEFAULT closer scope opener token incorrect. Marker: %s.', $testMarker)
+                sprintf('T_DEFAULT closer scope opener token incorrect. Marker: %s.', $closerMarker)
             );
             $this->assertSame(
                 $expectedScopeCloser,
                 $tokens[$closer]['scope_closer'],
-                sprintf('T_DEFAULT closer scope closer token incorrect. Marker: %s.', $testMarker)
+                sprintf('T_DEFAULT closer scope closer token incorrect. Marker: %s.', $closerMarker)
             );
         }//end if
 
         if (($opener + 1) !== $closer) {
             $end = $closer;
-            if (isset($conditionStop) === true) {
-                $end = ($token + $conditionStop + 1);
+            if (isset($conditionStopMarker) === true) {
+                $end = ($this->getTargetToken($conditionStopMarker, [T_RETURN]) + 1);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {
@@ -283,47 +283,47 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
     {
         return [
             'simple_switch_default'                                     => [
-                'testMarker'   => '/* testSimpleSwitchDefault */',
-                'openerOffset' => 1,
-                'closerOffset' => 4,
+                'testMarker'       => '/* testSimpleSwitchDefault */',
+                'testOpenerMarker' => '/* testSimpleSwitchDefault */',
+                'testCloserMarker' => '/* testSimpleSwitchDefault */',
             ],
             'simple_switch_default_with_curlies'                        => [
                 // For a default structure with curly braces, the scope opener
                 // will be the open curly and the closer the close curly.
                 // However, scope conditions will not be set for open to close,
                 // but only for the open token up to the "break/return/continue" etc.
-                'testMarker'    => '/* testSimpleSwitchDefaultWithCurlies */',
-                'openerOffset'  => 3,
-                'closerOffset'  => 12,
-                'conditionStop' => 6,
+                'testMarker'          => '/* testSimpleSwitchDefaultWithCurlies */',
+                'testOpenerMarker'    => '/* testSimpleSwitchDefaultWithCurliesScopeOpener */',
+                'testCloserMarker'    => '/* testSimpleSwitchDefaultWithCurliesScopeCloser */',
+                'conditionStopMarker' => '/* testSimpleSwitchDefaultWithCurliesConditionStop */',
             ],
             'switch_default_toplevel'                                   => [
-                'testMarker'   => '/* testSwitchDefault */',
-                'openerOffset' => 1,
-                'closerOffset' => 43,
+                'testMarker'       => '/* testSwitchDefault */',
+                'testOpenerMarker' => '/* testSwitchDefault */',
+                'testCloserMarker' => '/* testSwitchDefaultCloserMarker */',
             ],
             'switch_default_nested_in_match_case'                       => [
-                'testMarker'   => '/* testSwitchDefaultNestedInMatchCase */',
-                'openerOffset' => 1,
-                'closerOffset' => 20,
+                'testMarker'       => '/* testSwitchDefaultNestedInMatchCase */',
+                'testOpenerMarker' => '/* testSwitchDefaultNestedInMatchCase */',
+                'testCloserMarker' => '/* testSwitchDefaultNestedInMatchCase */',
             ],
             'switch_default_nested_in_match_default'                    => [
-                'testMarker'   => '/* testSwitchDefaultNestedInMatchDefault */',
-                'openerOffset' => 1,
-                'closerOffset' => 18,
+                'testMarker'       => '/* testSwitchDefaultNestedInMatchDefault */',
+                'testOpenerMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
+                'testCloserMarker' => '/* testSwitchDefaultNestedInMatchDefault */',
             ],
             'switch_and_default_sharing_scope_closer'                   => [
                 'testMarker'        => '/* testSwitchAndDefaultSharingScopeCloser */',
-                'openerOffset'      => 1,
-                'closerOffset'      => 10,
+                'testOpenerMarker'  => '/* testSwitchAndDefaultSharingScopeCloser */',
+                'testCloserMarker'  => '/* testSwitchAndDefaultSharingScopeCloserScopeCloser */',
                 'conditionStop'     => null,
                 'testContent'       => 'default',
                 'sharedScopeCloser' => true,
             ],
             'switch_and_default_with_nested_if_with_and_without_braces' => [
-                'testMarker'   => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
-                'openerOffset' => 1,
-                'closerOffset' => 48,
+                'testMarker'       => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
+                'testOpenerMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBraces */',
+                'testCloserMarker' => '/* testSwitchDefaultNestedIfWithAndWithoutBracesScopeCloser */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -257,7 +257,15 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStopMarker) === true) {
-                $end = ($this->getTargetToken($conditionStopMarker, [T_RETURN]) + 1);
+                $tokenTypes = [
+                    T_BREAK,
+                    T_CONTINUE,
+                    T_EXIT,
+                    T_GOTO,
+                    T_RETURN,
+                    T_THROW,
+                ];
+                $end        = ($this->getTargetToken($conditionStopMarker, $tokenTypes) + 1);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {
@@ -267,7 +275,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                     sprintf('T_DEFAULT condition not added for token belonging to the T_DEFAULT structure. Marker: %s.', $testMarker)
                 );
             }
-        }
+        }//end if
 
     }//end testSwitchDefault()
 


### PR DESCRIPTION
# Description

This PR improves the `RecurseScopeMapDefaultKeywordConditionsTest::testSwitchDefault()` test method by replacing offsets with markers. This helps stabilize the tests.

This PR is the last one in a series of PRs to improve the `RecurseScopeMapDefaultKeywordConditionsTest` tests. The other PRs in this series are #813, #850, #870, and #902.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
