### PR TITLE
Fixer: improve debug information

### DIFF
--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -12,6 +12,7 @@
 
 namespace PHP_CodeSniffer;
 
+use InvalidArgumentException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Common;
@@ -402,7 +403,7 @@ class Fixer
             if ($bt[1]['class'] === __CLASS__) {
                 $sniff = 'Fixer';
             } else {
-                $sniff = Common::getSniffCode($bt[1]['class']);
+                $sniff = $this->getSniffCodeForDebug($bt[1]['class']);
             }
 
             $line = $bt[0]['line'];
@@ -487,7 +488,7 @@ class Fixer
                     $line  = $bt[0]['line'];
                 }
 
-                $sniff = Common::getSniffCode($sniff);
+                $sniff = $this->getSniffCodeForDebug($sniff);
 
                 $numChanges = count($this->changeset);
 
@@ -544,7 +545,7 @@ class Fixer
                 $line  = $bt[0]['line'];
             }
 
-            $sniff = Common::getSniffCode($sniff);
+            $sniff = $this->getSniffCodeForDebug($sniff);
 
             $tokens     = $this->currentFile->getTokens();
             $type       = $tokens[$stackPtr]['type'];
@@ -659,7 +660,7 @@ class Fixer
                 $line  = $bt[0]['line'];
             }
 
-            $sniff = Common::getSniffCode($sniff);
+            $sniff = $this->getSniffCodeForDebug($sniff);
 
             $tokens     = $this->currentFile->getTokens();
             $type       = $tokens[$stackPtr]['type'];
@@ -841,6 +842,26 @@ class Fixer
         }
 
     }//end changeCodeBlockIndent()
+
+
+    /**
+     * Get the sniff code for the current sniff or the class name if the passed class is not a sniff.
+     *
+     * @param string $className Class name.
+     *
+     * @return string
+     */
+    private function getSniffCodeForDebug($className)
+    {
+        try {
+            $sniffCode = Common::getSniffCode($className);
+            return $sniffCode;
+        } catch (InvalidArgumentException $e) {
+            // Sniff code could not be determined. This may be an abstract sniff class or a helper class.
+            return $className;
+        }
+
+    }//end getSniffCodeForDebug()
 
 
 }//end class


### PR DESCRIPTION
# Description
If an error/fixer conflict occurs while running the PHPCBF, additional information about the issue will be displayed in verbose mode, however, the code creating the debug info did not take into account that part of the fixer code may be in helper classes, instead of directly in the sniff class.

This should fix that and make the debug information more, well... informational ;-)


## Suggested changelog entry
Fixed potential `InvalidArgumentException` when displaying verbose information about issues encountered while running the fixer.

## Related issues/external references

Related to slevomat/coding-standard#1739



## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
