### PR TITLE
Tests: introduce new `AbstractRealConfigTestCase`

### DIFF
--- a/tests/Core/Config/AbstractRealConfigTestCase.php
+++ b/tests/Core/Config/AbstractRealConfigTestCase.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Test case with helper methods for tests which need to use the *real* Config class (instead of the ConfigDouble).
+ *
+ * This test case should be used sparingly and only when it cannot be avoided.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+abstract class AbstractRealConfigTestCase extends TestCase
+{
+
+
+    /**
+     * Set static properties in the Config class to prevent tests influencing each other.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function setConfigStatics()
+    {
+        // Set to the property's default value to clear out potentially set values from other tests.
+        self::setStaticConfigProperty('overriddenDefaults', []);
+        self::setStaticConfigProperty('executablePaths', []);
+
+        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
+        // from being read and influencing the tests.
+        self::setStaticConfigProperty('configData', []);
+        self::setStaticConfigProperty('configDataFile', '');
+
+    }//end setConfigStatics()
+
+
+    /**
+     * Clean up after each finished test.
+     *
+     * @after
+     *
+     * @return void
+     */
+    protected function clearArgv()
+    {
+        $_SERVER['argv'] = [];
+
+    }//end clearArgv()
+
+
+    /**
+     * Reset the static properties in the Config class to their true defaults to prevent this class
+     * from influencing other tests.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function resetConfigToDefaults()
+    {
+        self::setStaticConfigProperty('overriddenDefaults', []);
+        self::setStaticConfigProperty('executablePaths', []);
+        self::setStaticConfigProperty('configData', null);
+        self::setStaticConfigProperty('configDataFile', null);
+        $_SERVER['argv'] = [];
+
+    }//end resetConfigToDefaults()
+
+
+    /**
+     * Helper function to set a static property on the Config class.
+     *
+     * @param string $name  The name of the property to set.
+     * @param mixed  $value The value to set the property to.
+     *
+     * @return void
+     */
+    protected static function setStaticConfigProperty($name, $value)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+        $property->setAccessible(false);
+
+    }//end setStaticConfigProperty()
+
+
+}//end class

--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -10,72 +10,15 @@
 namespace PHP_CodeSniffer\Tests\Core\Config;
 
 use PHP_CodeSniffer\Config;
-use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
+use PHP_CodeSniffer\Tests\Core\Config\AbstractRealConfigTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Config reportWidth value.
  *
  * @covers \PHP_CodeSniffer\Config::__get
  */
-final class ReportWidthTest extends TestCase
+final class ReportWidthTest extends AbstractRealConfigTestCase
 {
-
-
-    /**
-     * Set static properties in the Config class to prevent tests influencing each other.
-     *
-     * @before
-     *
-     * @return void
-     */
-    protected function cleanConfig()
-    {
-        // Set to the property's default value to clear out potentially set values from other tests.
-        self::setStaticProperty('executablePaths', []);
-
-        // Set to a usable value to circumvent Config trying to find a phpcs.xml config file.
-        self::setStaticProperty('overriddenDefaults', ['standards' => ['PSR1']]);
-
-        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
-        // from being read and influencing the tests.
-        self::setStaticProperty('configData', []);
-        self::setStaticProperty('configDataFile', '');
-
-    }//end cleanConfig()
-
-
-    /**
-     * Clean up after each finished test.
-     *
-     * @after
-     *
-     * @return void
-     */
-    protected function resetConfig()
-    {
-        $_SERVER['argv'] = [];
-
-    }//end resetConfig()
-
-
-    /**
-     * Reset the static properties in the Config class to their true defaults to prevent this class
-     * from influencing other tests.
-     *
-     * @afterClass
-     *
-     * @return void
-     */
-    public static function resetConfigToDefaults()
-    {
-        self::setStaticProperty('overriddenDefaults', []);
-        self::setStaticProperty('executablePaths', []);
-        self::setStaticProperty('configData', null);
-        self::setStaticProperty('configDataFile', null);
-        $_SERVER['argv'] = [];
-
-    }//end resetConfigToDefaults()
 
 
     /**
@@ -88,7 +31,7 @@ final class ReportWidthTest extends TestCase
      */
     public function testReportWidthDefault()
     {
-        $config = new Config();
+        $config = new Config(['--standard=PSR1']);
 
         // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
         $this->assertTrue(is_int($config->reportWidth), 'Report width is not an integer');
@@ -112,9 +55,9 @@ final class ReportWidthTest extends TestCase
             'show_warnings'    => '0',
         ];
 
-        $this->setStaticProperty('configData', $phpCodeSnifferConfig);
+        $this->setStaticConfigProperty('configData', $phpCodeSnifferConfig);
 
-        $config = new Config();
+        $config = new Config(['--standard=PSR1']);
 
         // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
         $this->assertTrue(is_int($config->reportWidth), 'Report width is not an integer');
@@ -139,9 +82,9 @@ final class ReportWidthTest extends TestCase
             'report_width'     => '120',
         ];
 
-        $this->setStaticProperty('configData', $phpCodeSnifferConfig);
+        $this->setStaticConfigProperty('configData', $phpCodeSnifferConfig);
 
-        $config = new Config();
+        $config = new Config(['--standard=PSR1']);
         $this->assertSame(120, $config->reportWidth);
 
     }//end testReportWidthCanBeSetFromConfFile()
@@ -159,6 +102,7 @@ final class ReportWidthTest extends TestCase
     {
         $_SERVER['argv'] = [
             'phpcs',
+            '--standard=PSR1',
             '--report-width=100',
         ];
 
@@ -180,6 +124,7 @@ final class ReportWidthTest extends TestCase
     {
         $_SERVER['argv'] = [
             'phpcs',
+            '--standard=PSR1',
             '--report-width=100',
             '--report-width=200',
         ];
@@ -209,10 +154,11 @@ final class ReportWidthTest extends TestCase
             'report_width'     => '120',
         ];
 
-        $this->setStaticProperty('configData', $phpCodeSnifferConfig);
+        $this->setStaticConfigProperty('configData', $phpCodeSnifferConfig);
 
         $cliArgs = [
             'phpcs',
+            '--standard=PSR1',
             '--report-width=180',
         ];
 
@@ -231,7 +177,7 @@ final class ReportWidthTest extends TestCase
      */
     public function testReportWidthInputHandlingForAuto()
     {
-        $config = new Config();
+        $config = new Config(['--standard=PSR1']);
         $config->reportWidth = 'auto';
 
         // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
@@ -254,7 +200,7 @@ final class ReportWidthTest extends TestCase
      */
     public function testReportWidthInputHandling($value, $expected)
     {
-        $config = new Config();
+        $config = new Config(['--standard=PSR1']);
         $config->reportWidth = $value;
 
         $this->assertSame($expected, $config->reportWidth);
@@ -309,24 +255,6 @@ final class ReportWidthTest extends TestCase
         ];
 
     }//end dataReportWidthInputHandling()
-
-
-    /**
-     * Helper function to set a static property on the Config class.
-     *
-     * @param string $name  The name of the property to set.
-     * @param mixed  $value The value to set the property to.
-     *
-     * @return void
-     */
-    public static function setStaticProperty($name, $value)
-    {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
-        $property->setValue(null, $value);
-        $property->setAccessible(false);
-
-    }//end setStaticProperty()
 
 
 }//end class

--- a/tests/Core/Runner/AbstractRunnerTestCase.php
+++ b/tests/Core/Runner/AbstractRunnerTestCase.php
@@ -11,83 +11,9 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Runner;
 
-use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
+use PHP_CodeSniffer\Tests\Core\Config\AbstractRealConfigTestCase;
 
-abstract class AbstractRunnerTestCase extends TestCase
+abstract class AbstractRunnerTestCase extends AbstractRealConfigTestCase
 {
-
-
-    /**
-     * Set static properties in the Config class to prevent tests influencing each other.
-     *
-     * @before
-     *
-     * @return void
-     */
-    public function setConfigStatics()
-    {
-        // Set to the property's default value to clear out potentially set values from other tests.
-        self::setStaticConfigProperty('overriddenDefaults', []);
-        self::setStaticConfigProperty('executablePaths', []);
-
-        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
-        // from being read and influencing the tests.
-        self::setStaticConfigProperty('configData', []);
-        self::setStaticConfigProperty('configDataFile', '');
-
-    }//end setConfigStatics()
-
-
-    /**
-     * Clean up after each finished test.
-     *
-     * @after
-     *
-     * @return void
-     */
-    public function clearArgv()
-    {
-        $_SERVER['argv'] = [];
-
-    }//end clearArgv()
-
-
-    /**
-     * Reset the static properties in the Config class to their true defaults to prevent this class
-     * from influencing other tests.
-     *
-     * @afterClass
-     *
-     * @return void
-     */
-    public static function reset()
-    {
-        self::setStaticConfigProperty('overriddenDefaults', []);
-        self::setStaticConfigProperty('executablePaths', []);
-        self::setStaticConfigProperty('configData', null);
-        self::setStaticConfigProperty('configDataFile', null);
-        $_SERVER['argv'] = [];
-
-    }//end reset()
-
-
-    /**
-     * Helper function to set a static property on the Config class.
-     *
-     * @param string $name  The name of the property to set.
-     * @param mixed  $value The value to set the property to.
-     *
-     * @return void
-     */
-    public static function setStaticConfigProperty($name, $value)
-    {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
-        $property->setValue(null, $value);
-        $property->setAccessible(false);
-
-    }//end setStaticConfigProperty()
-
 
 }//end class


### PR DESCRIPTION
# Description
As the `Config` class contains a number of `static` properties, it is important to avoid tests influencing each other if the tests would cause changes to the value of the static properties.

This was already handled correctly in the two places were the _real_ `Config` class is being used in the tests, but that meant those test classes now contain duplicate code.

This new `AbstractRealConfigTestCase` class removes that code duplication.

This test case should be used in the rare circumstances that the _real_ `Config` class needs to be used in the tests.

In most cases, using the `ConfigDouble` class is much preferred, but for select tests for the `Config` class itself + for tests involving the `Runner` class, using the real `Config` class cannot be avoided.


## Suggested changelog entry
_N/A_