### PR TITLE
GH Actions: test against libxml 2.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,12 @@ jobs:
           - php: '8.0'
             os: 'ubuntu-latest'
             libxml_minor: '2.11'
-          - php: '8.3'
+          - php: '8.2'
             os: 'ubuntu-latest'
             libxml_minor: '2.13'
+          - php: '8.3'
+            os: 'ubuntu-latest'
+            libxml_minor: '2.14'
 
           # Extra builds running only the unit tests with different PHP ini settings.
           - php: '5.5'


### PR DESCRIPTION
# Description

Libxml 2.14 has been released a few days ago. Considering the issues we've previously seen with different libxml versions, let's have at least one build which runs against libxml 2.14.

Ref: https://gitlab.gnome.org/GNOME/libxml2/-/blob/2.14/NEWS

## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #849