### PR TITLE
PSR12/FileHeader: add extra test

### DIFF
--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.19.inc
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.19.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Make sure the sniff doesn't trigger on closure use.
+ */
+
+declare(strict_types=1);
+
+namespace Test;
+
+$cl = function($a) use ($b) {};


### PR DESCRIPTION
# Description
Just safeguarding that the sniff doesn't trigger on closure `use`.


## Suggested changelog entry
_N/A_