### PR TITLE
Generic/LanguageConstructSpacing: add extra test

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.1.inc
@@ -98,3 +98,7 @@ yield
 yield
     // phpcs:ignore Stnd.Category.SniffName
     from $test();
+
+// Closure use should be ignored. These are subject to their own rules.
+$cl = function() use ($b) {};
+$cl = function() use($b) {};

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.1.inc.fixed
@@ -92,3 +92,7 @@ yield
 yield
     // phpcs:ignore Stnd.Category.SniffName
     from $test();
+
+// Closure use should be ignored. These are subject to their own rules.
+$cl = function() use ($b) {};
+$cl = function() use($b) {};


### PR DESCRIPTION

# Description
Just safeguarding that the sniff doesn't trigger on closure `use`.


## Suggested changelog entry
_N/A_
