### PR TITLE
File::getMethodParameters(): add extra test

### DIFF
--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -312,6 +312,9 @@ function() use() {};
 /* testClosureUse */
 function() use( $foo, $bar ) {};
 
+/* testClosureUseWithReference */
+$cl = function() use (&$foo, &$bar) {};
+
 /* testFunctionParamListWithTrailingComma */
 function trailingComma(
     ?string $foo  /*comment*/ ,

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -2936,6 +2936,51 @@ final class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify handling of a closure T_USE token with variables imported by reference.
+     *
+     * @return void
+     */
+    public function testClosureUseWithReference()
+    {
+        // Offsets are relative to the T_USE token.
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4,
+            'name'                => '$foo',
+            'content'             => '&$foo',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'reference_token'     => 3,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 5,
+        ];
+        $expected[1] = [
+            'token'               => 8,
+            'name'                => '$bar',
+            'content'             => '&$bar',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'reference_token'     => 7,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected, [T_USE]);
+
+    }//end testClosureUseWithReference()
+
+
+    /**
      * Verify function declarations with trailing commas are handled correctly.
      *
      * @return void


### PR DESCRIPTION
# Description
Just safeguarding handling of closure use with parameters imported by reference.


## Suggested changelog entry
_N/A_