### PR TITLE
Generic/HereNowdocIdentifierSpacing: minor tweak

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/HereNowdocIdentifierSpacingSniff.php
@@ -54,7 +54,7 @@ class HereNowdocIdentifierSpacingSniff implements Sniff
 
         $phpcsFile->recordMetric($stackPtr, 'Heredoc/nowdoc identifier', 'space between <<< and ID');
 
-        $error = 'There should be no space between the <<< and the heredoc/nowdoc identifier string';
+        $error = 'There should be no space between the <<< and the heredoc/nowdoc identifier string. Found: %s';
         $data  = [$tokens[$stackPtr]['content']];
 
         $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceFound', $data);


### PR DESCRIPTION
# Description
The sniff was set up to display the identifier including the incorrect spacing, but wasn't doing so.

Fixed now.


## Suggested changelog entry
Generic.WhiteSpace.HereNowdocIdentifierSpacing: improved error message text

## Related issues/external references

Related to #586

