### PR TITLE
Generic/FunctionCallArgumentSpacing: improve XML documentation

### DIFF
--- a/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
@@ -1,18 +1,18 @@
-<documentation title="Function Argument Spacing">
+<documentation title="Function Call Argument Spacing">
     <standard>
     <![CDATA[
-    Function arguments should have one space after a comma.
+    There should be no space before and exactly one space, or a new line, after a comma when passing arguments to a function or method.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Single spaces after a comma.">
+        <code title="Valid: No space before and exactly one space after a comma.">
         <![CDATA[
 foo($bar,<em> </em>$baz);
         ]]>
         </code>
-        <code title="Invalid: No spaces after a comma.">
+        <code title="Invalid: A space before and no space after a comma.">
         <![CDATA[
-foo($bar,<em></em>$baz);
+foo($bar<em> </em>,<em></em>$baz);
         ]]>
         </code>
     </code_comparison>

--- a/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
@@ -7,16 +7,12 @@
     <code_comparison>
         <code title="Valid: Single spaces after a comma.">
         <![CDATA[
-function foo($bar,<em> </em>$baz)
-{
-}
+foo($bar,<em> </em>$baz);
         ]]>
         </code>
         <code title="Invalid: No spaces after a comma.">
         <![CDATA[
-function foo($bar,<em></em>$baz)
-{
-}
+foo($bar,<em></em>$baz);
         ]]>
         </code>
     </code_comparison>

--- a/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Function Argument Spacing">
     <standard>
     <![CDATA[
-    Function arguments should have one space after a comma, and single spaces surrounding the equals sign for default values.
+    Function arguments should have one space after a comma.
     ]]>
     </standard>
     <code_comparison>
@@ -15,22 +15,6 @@ function foo($bar,<em> </em>$baz)
         <code title="Invalid: No spaces after a comma.">
         <![CDATA[
 function foo($bar,<em></em>$baz)
-{
-}
-        ]]>
-        </code>
-    </code_comparison>
-    <code_comparison>
-        <code title="Valid: Single spaces around an equals sign in function declaration.">
-        <![CDATA[
-function foo($bar, $baz<em> </em>=<em> </em>true)
-{
-}
-        ]]>
-        </code>
-        <code title="Invalid: No spaces around an equals sign in function declaration.">
-        <![CDATA[
-function foo($bar, $baz<em></em>=<em></em>true)
 {
 }
         ]]>


### PR DESCRIPTION
# Description

### Generic/FunctionCallArgumentSpacing: update XML doc to remove info about spacing around equal sign

The FunctionCallArgumentSpacing sniff used to check for spacing around the equal sign in the arguments of a function declaration. But this was removed in https://github.com/squizlabs/PHP_CodeSniffer/pull/2399
(commit https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/feeda473f045825c1caa213c3b7ab6dc6a99b746).

This commit updates the sniff XML doc to reflect this change.

### Generic/FunctionCallArgumentSpacing: fix code examples in the XML doc

The code examples in the XML documentation of this sniff were incorrect, as the sniff does not check spacing in function argument definitions. It only checks spacing in function and method calls.

As far as I could check, this has always been the case, or at least it has been the case for a long time. Since tests were added for this sniff when it was part of the PEAR standard and called MethodCallArgumentSpacing, it ignored function definitions and checked only function calls:

https://github.com/squizlabs/PHP_CodeSniffer/commit/7b84951474ff24d394eb71e42ad79db99cf776bb#diff-56e2f69852c3071fbf86d20fbb49f38dae17cff8731154d8b1b7495c4ad8eeb0R24-R27

Here is the sniff code where it ignores function definitions:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/57a9ed734e2ab06c062fe0e463745eab483cf722/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php#L55-L66


### Generic/FunctionCallArgumentSpacing: improve XML documentation

- `<documentation>` title now matches the sniff name
- Mention in the description that the sniff is about function and method calls.
- `<standard>` and `<code>` descriptions now mention that the sniff also checks for spaces before the comma.


## Suggested changelog entry

Generic.Functions.FunctionCallArgumentSpacing: minor fixes and improvements to the XML documentation


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
