### PR TITLE
Generic/OpeningFunctionBraceKernighanRitchie: improve XML documentation

### DIFF
--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -8,7 +8,6 @@
         <code title="Valid: Brace on same line.">
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')<em> {</em>
-    ...
 }
         ]]>
         </code>
@@ -16,7 +15,6 @@ function fooFunction($arg1, $arg2 = '')<em> {</em>
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')
 <em>{</em>
-    ...
 }
         ]]>
         </code>

--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -1,7 +1,7 @@
 <documentation title="Opening Function Brace Kerninghan Ritchie">
     <standard>
     <![CDATA[
-    The function opening brace must be on the same line as the function declaration, with exactly
+    The function opening brace must be on the same line as the end of the function declaration, with exactly
     one space between them, and must be the last content on the line.
     ]]>
     </standard>

--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -1,17 +1,18 @@
-<documentation title="Opening Brace in Function Declarations">
+<documentation title="Opening Function Brace Kerninghan Ritchie">
     <standard>
     <![CDATA[
-    Function declarations follow the "Kernighan/Ritchie style". The function brace is on the same line as the function declaration. One space is required between the closing parenthesis and the brace.
+    The function opening brace must be on the same line as the function declaration closing
+    parenthesis, with exactly one space between them, and must be the last content on the line.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Brace on same line.">
+        <code title="Valid: Opening brace on the same line.">
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')<em> {</em>
 }
         ]]>
         </code>
-        <code title="Invalid: Brace on next line.">
+        <code title="Invalid: Opening brace on the next line.">
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')
 <em>{</em>

--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -1,8 +1,8 @@
 <documentation title="Opening Function Brace Kerninghan Ritchie">
     <standard>
     <![CDATA[
-    The function opening brace must be on the same line as the function declaration closing
-    parenthesis, with exactly one space between them, and must be the last content on the line.
+    The function opening brace must be on the same line as the function declaration, with exactly
+    one space between them, and must be the last content on the line.
     ]]>
     </standard>
     <code_comparison>

--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -9,6 +9,7 @@
         <code title="Valid: Opening brace on the same line.">
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')<em> {</em>
+    // Do something.
 }
         ]]>
         </code>
@@ -16,6 +17,7 @@ function fooFunction($arg1, $arg2 = '')<em> {</em>
         <![CDATA[
 function fooFunction($arg1, $arg2 = '')
 <em>{</em>
+    // Do something.
 }
         ]]>
         </code>

--- a/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -1,8 +1,9 @@
 <documentation title="Opening Function Brace Kerninghan Ritchie">
     <standard>
     <![CDATA[
-    The function opening brace must be on the same line as the end of the function declaration, with exactly
-    one space between them, and must be the last content on the line.
+    The function opening brace must be on the same line as the end of the function declaration, with
+    exactly one space between the end of the declaration and the brace. The brace must be the last
+    content on the line.
     ]]>
     </standard>
     <code_comparison>


### PR DESCRIPTION
# Description

### Generic/OpeningFunctionBraceKernighanRitchie: fix syntax errors in the XML doc code examples

### Generic/OpeningFunctionBraceKernighanRitchie: improve XML doc

- `<documentation>` title matches the sniff name.
- Don't mention the Kernighan/Ritchie style in the `<standard>` description as, according to Wikipedia, this style uses the opening brace for functions on a separate line and not on the same line (https://en.wikipedia.org/wiki/Indentation_style#K&R).
- I believe it is more precise to say that the sniff checks if the opening brace is on the same line as the closing parenthesis and not the function declaration, as the function declaration can be multi-line.
- Mention in the `<standard>` description that there must be no content on the line after the opening brace.
- Improve the title of the `<code>` blocks.

## Suggested changelog entry
Generic.Functions.OpeningFunctionBraceKernighanRitchie: minor fixes and improvements to the XML documentation


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
