### PR TITLE
PSR12/ImportStatement: test tweak

### DIFF
--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc
@@ -7,7 +7,7 @@ use function Vendor\Package\{functionA, functionB, functionC};
 use FUNCTION \Another\Vendor\functionD;
 
 use CONST Vendor\Package\{CONSTANT_A, CONSTANT_B, CONSTANT_C};
-use const Another\Vendor\CONSTANT_D;
+use const \Another\Vendor\CONSTANT_D;
 
 class ClassName3
 {

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
@@ -31,9 +31,10 @@ final class ImportStatementUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2 => 1,
-            4 => 1,
-            7 => 1,
+            2  => 1,
+            4  => 1,
+            7  => 1,
+            10 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Looking at the tests, each type of import `use` should have at least one test with a leading namespace separator and one without to properly cover what the sniff is looking for.

Looks like adding the leading `\` was missed for the `use const` tests.


## Suggested changelog entry
_N/A