### PR TITLE
PSR12/CompoundNamespaceDepth: test tweak

### DIFF
--- a/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.inc
@@ -29,3 +29,6 @@ use Vendor\Package\SomeNamespace\{
     SubnamespaceOne\ClassB,
     ClassZ,
 };
+
+// Reset the property to its default value.
+// phpcs:set PSR12.Namespaces.CompoundNamespaceDepth maxDepth 2


### PR DESCRIPTION
# Description
Properties overruled in tests should always be reset as `// phpcs:set` is not limited to the current file.


## Suggested changelog entry
_N/A_