### PR TITLE
AttributesTest: simplify test code

### DIFF
--- a/tests/Core/Tokenizers/PHP/AttributesTest.php
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.php
@@ -19,7 +19,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
      * Test that attributes are parsed correctly.
      *
      * @param string            $testMarker The comment which prefaces the target token in the test file.
-     * @param int               $length     The number of tokens between opener and closer.
      * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
      *
      * @dataProvider dataAttribute
@@ -29,9 +28,12 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testAttribute($testMarker, $length, $tokenCodes)
+    public function testAttribute($testMarker, $tokenCodes)
     {
         $tokens = $this->phpcsFile->getTokens();
+
+        // Calculate the number of tokens between opener and closer (excluding the opener, including the closer).
+        $length = (count($tokenCodes) + 1);
 
         $attribute = $this->getTargetToken($testMarker, T_ATTRIBUTE);
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
@@ -71,14 +73,12 @@ final class AttributesTest extends AbstractTokenizerTestCase
         return [
             'class attribute'                                                                   => [
                 'testMarker' => '/* testAttribute */',
-                'length'     => 2,
                 'tokenCodes' => [
                     T_STRING
                 ],
             ],
             'class attribute with param'                                                        => [
                 'testMarker' => '/* testAttributeWithParams */',
-                'length'     => 7,
                 'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
@@ -90,7 +90,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'class attribute with named param'                                                  => [
                 'testMarker' => '/* testAttributeWithNamedParam */',
-                'length'     => 10,
                 'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
@@ -105,14 +104,12 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute'                                                                => [
                 'testMarker' => '/* testAttributeOnFunction */',
-                'length'     => 2,
                 'tokenCodes' => [
                     T_STRING
                 ],
             ],
             'function attribute with params'                                                    => [
                 'testMarker' => '/* testAttributeOnFunctionWithParams */',
-                'length'     => 17,
                 'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
@@ -134,7 +131,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute with arrow function as param'                                   => [
                 'testMarker' => '/* testAttributeWithShortClosureParameter */',
-                'length'     => 17,
                 'tokenCodes' => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
@@ -156,7 +152,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute; multiple comma separated classes'                              => [
                 'testMarker' => '/* testAttributeGrouping */',
-                'length'     => 26,
                 'tokenCodes' => [
                     T_STRING,
                     T_COMMA,
@@ -187,7 +182,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute; multiple comma separated classes, one per line'                => [
                 'testMarker' => '/* testAttributeMultiline */',
-                'length'     => 31,
                 'tokenCodes' => [
                     T_WHITESPACE,
                     T_WHITESPACE,
@@ -223,7 +217,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute; multiple comma separated classes, one per line, with comments' => [
                 'testMarker' => '/* testAttributeMultilineWithComment */',
-                'length'     => 34,
                 'tokenCodes' => [
                     T_WHITESPACE,
                     T_WHITESPACE,
@@ -262,7 +255,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute; using partially qualified and fully qualified class names'     => [
                 'testMarker' => '/* testFqcnAttribute */',
-                'length'     => 13,
                 'tokenCodes' => [
                     T_STRING,
                     T_NS_SEPARATOR,
@@ -335,7 +327,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @param string            $testMarker The comment which prefaces the target token in the test file.
      * @param int               $position   The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
-     * @param int               $length     The number of tokens between opener and closer.
      * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
      *
      * @dataProvider dataAttributeOnParameters
@@ -346,9 +337,12 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testAttributeOnParameters($testMarker, $position, $length, array $tokenCodes)
+    public function testAttributeOnParameters($testMarker, $position, array $tokenCodes)
     {
         $tokens = $this->phpcsFile->getTokens();
+
+        // Calculate the number of tokens between opener and closer (excluding the opener, including the closer).
+        $length = (count($tokenCodes) + 1);
 
         $function  = $this->getTargetToken($testMarker, T_FUNCTION);
         $attribute = ($function + $position);
@@ -394,7 +388,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             'parameter attribute; single, inline'                   => [
                 'testMarker' => '/* testSingleAttributeOnParameter */',
                 'position'   => 4,
-                'length'     => 2,
                 'tokenCodes' => [
                     T_STRING
                 ],
@@ -402,7 +395,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             'parameter attribute; multiple comma separated, inline' => [
                 'testMarker' => '/* testMultipleAttributesOnParameter */',
                 'position'   => 4,
-                'length'     => 10,
                 'tokenCodes' => [
                     T_STRING,
                     T_COMMA,
@@ -418,7 +410,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             'parameter attribute; single, multiline'                => [
                 'testMarker' => '/* testMultilineAttributesOnParameter */',
                 'position'   => 4,
-                'length'     => 13,
                 'tokenCodes' => [
                     T_WHITESPACE,
                     T_WHITESPACE,
@@ -443,7 +434,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
      * Test that an attribute containing text which looks like a PHP close tag is tokenized correctly.
      *
      * @param string               $testMarker              The comment which prefaces the target token in the test file.
-     * @param int                  $length                  The number of tokens between opener and closer.
      * @param array<array<string>> $expectedTokensAttribute The codes of tokens inside the attributes.
      * @param array<int|string>    $expectedTokensAfter     The codes of tokens after the attributes.
      *
@@ -453,9 +443,12 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testAttributeContainingTextLookingLikeCloseTag($testMarker, $length, array $expectedTokensAttribute, array $expectedTokensAfter)
+    public function testAttributeContainingTextLookingLikeCloseTag($testMarker, array $expectedTokensAttribute, array $expectedTokensAfter)
     {
         $tokens = $this->phpcsFile->getTokens();
+
+        // Calculate the number of tokens between opener and closer (excluding the opener, including the closer).
+        $length = count($expectedTokensAttribute);
 
         $attribute = $this->getTargetToken($testMarker, T_ATTRIBUTE);
 
@@ -501,7 +494,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
         return [
             'function attribute; string param with "?>"'            => [
                 'testMarker'              => '/* testAttributeContainingTextLookingLikeCloseTag */',
-                'length'                  => 5,
                 'expectedTokensAttribute' => [
                     [
                         'T_STRING',
@@ -538,7 +530,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
             ],
             'function attribute; string param with "?>"; multiline' => [
                 'testMarker'              => '/* testAttributeContainingMultilineTextLookingLikeCloseTag */',
-                'length'                  => 8,
                 'expectedTokensAttribute' => [
                     [
                         'T_STRING',
@@ -650,11 +641,14 @@ final class AttributesTest extends AbstractTokenizerTestCase
             T_CLOSE_PARENTHESIS,
         ];
 
+        // Calculate the number of tokens between opener and closer (excluding the opener, including the closer).
+        $outerAttributeLength = (count($tokenCodes) + 1);
+
         $attribute = $this->getTargetToken('/* testNestedAttributes */', T_ATTRIBUTE);
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
 
         $closer = $tokens[$attribute]['attribute_closer'];
-        $this->assertSame(($attribute + 24), $closer);
+        $this->assertSame(($attribute + $outerAttributeLength), $closer);
 
         $this->assertSame(T_ATTRIBUTE_END, $tokens[$closer]['code']);
 
@@ -663,37 +657,39 @@ final class AttributesTest extends AbstractTokenizerTestCase
 
         $this->assertArrayNotHasKey('nested_attributes', $tokens[$attribute]);
         $this->assertArrayHasKey('nested_attributes', $tokens[($attribute + 8)]);
-        $this->assertSame([$attribute => ($attribute + 24)], $tokens[($attribute + 8)]['nested_attributes']);
+        $this->assertSame([$attribute => ($attribute + $outerAttributeLength)], $tokens[($attribute + 8)]['nested_attributes']);
 
-        $test = function (array $tokens, $length, $nestedMap) use ($attribute) {
+        $test = function (array $tokens, $outerAttributeLength, $nestedMap) use ($attribute) {
             foreach ($tokens as $token) {
                 $this->assertArrayHasKey('attribute_closer', $token);
-                $this->assertSame(($attribute + $length), $token['attribute_closer']);
+                $this->assertSame(($attribute + $outerAttributeLength), $token['attribute_closer']);
                 $this->assertSame($nestedMap, $token['nested_attributes']);
             }
         };
 
-        $test(array_slice($tokens, ($attribute + 1), 7), 24, [$attribute => $attribute + 24]);
-        $test(array_slice($tokens, ($attribute + 8), 1), 8 + 5, [$attribute => $attribute + 24]);
-
         // Length here is 8 (nested attribute offset) + 5 (real length).
+        $innerAttributeLength = (8 + 5);
+
+        $test(array_slice($tokens, ($attribute + 1), 7), $outerAttributeLength, [$attribute => $attribute + $outerAttributeLength]);
+        $test(array_slice($tokens, ($attribute + 8), 1), $innerAttributeLength, [$attribute => $attribute + $outerAttributeLength]);
+
         $test(
             array_slice($tokens, ($attribute + 9), 4),
-            8 + 5,
+            $innerAttributeLength,
             [
-                $attribute     => $attribute + 24,
+                $attribute     => $attribute + $outerAttributeLength,
                 $attribute + 8 => $attribute + 13,
             ]
         );
 
-        $test(array_slice($tokens, ($attribute + 13), 1), 8 + 5, [$attribute => $attribute + 24]);
-        $test(array_slice($tokens, ($attribute + 14), 10), 24, [$attribute => $attribute + 24]);
+        $test(array_slice($tokens, ($attribute + 13), 1), $innerAttributeLength, [$attribute => $attribute + $outerAttributeLength]);
+        $test(array_slice($tokens, ($attribute + 14), 10), $outerAttributeLength, [$attribute => $attribute + $outerAttributeLength]);
 
         $map = array_map(
             static function ($token) {
                 return $token['code'];
             },
-            array_slice($tokens, ($attribute + 1), 23)
+            array_slice($tokens, ($attribute + 1), ($outerAttributeLength - 1))
         );
 
         $this->assertSame($tokenCodes, $map);


### PR DESCRIPTION
# Description
* Replace hard-coded "length" values provided via data providers with a simple `count()` calculation to prevent having to manually keep the `length` in sync with the contents of the `tokenCodes` arrays.
* Replace magic numbers in the `testNestedAttributes()` test with the same calculations assigned to variables to make the test more descriptive.


## Suggested changelog entry
_N/A_