### PR TITLE
PHP 8.2 | Generic/[Lower|Upper]CaseConstant: bug fix - ignore DNF property types

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -43,21 +43,23 @@ class LowerCaseConstantSniff implements Sniff
      * @var array<int|string, int|string>
      */
     private $propertyTypeTokens = [
-        T_CALLABLE             => T_CALLABLE,
-        T_SELF                 => T_SELF,
-        T_PARENT               => T_PARENT,
-        T_FALSE                => T_FALSE,
-        T_TRUE                 => T_TRUE,
-        T_NULL                 => T_NULL,
-        T_STRING               => T_STRING,
-        T_NAME_QUALIFIED       => T_NAME_QUALIFIED,
-        T_NAME_FULLY_QUALIFIED => T_NAME_FULLY_QUALIFIED,
-        T_NAME_RELATIVE        => T_NAME_RELATIVE,
-        T_NS_SEPARATOR         => T_NS_SEPARATOR,
-        T_NAMESPACE            => T_NAMESPACE,
-        T_TYPE_UNION           => T_TYPE_UNION,
-        T_TYPE_INTERSECTION    => T_TYPE_INTERSECTION,
-        T_NULLABLE             => T_NULLABLE,
+        T_CALLABLE               => T_CALLABLE,
+        T_SELF                   => T_SELF,
+        T_PARENT                 => T_PARENT,
+        T_FALSE                  => T_FALSE,
+        T_TRUE                   => T_TRUE,
+        T_NULL                   => T_NULL,
+        T_STRING                 => T_STRING,
+        T_NAME_QUALIFIED         => T_NAME_QUALIFIED,
+        T_NAME_FULLY_QUALIFIED   => T_NAME_FULLY_QUALIFIED,
+        T_NAME_RELATIVE          => T_NAME_RELATIVE,
+        T_NS_SEPARATOR           => T_NS_SEPARATOR,
+        T_NAMESPACE              => T_NAMESPACE,
+        T_TYPE_UNION             => T_TYPE_UNION,
+        T_TYPE_INTERSECTION      => T_TYPE_INTERSECTION,
+        T_TYPE_OPEN_PARENTHESIS  => T_TYPE_OPEN_PARENTHESIS,
+        T_TYPE_CLOSE_PARENTHESIS => T_TYPE_CLOSE_PARENTHESIS,
+        T_NULLABLE               => T_NULLABLE,
     ];
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
@@ -151,3 +151,7 @@ class TypedConstants {
 
 // Global constants can not be typed.
 const MYCONST = TRUE;
+
+class SkipOverPHP82DNFTypes {
+    protected (\FullyQualified&Partially\Qualified)|TRUE $propertyC;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
@@ -151,3 +151,7 @@ class TypedConstants {
 
 // Global constants can not be typed.
 const MYCONST = true;
+
+class SkipOverPHP82DNFTypes {
+    protected (\FullyQualified&Partially\Qualified)|TRUE $propertyC;
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
@@ -96,3 +96,7 @@ class TypedThings {
 }
 
 $cl = function (int|false $param = null, Type|null $obj = new MyObj(false)) : string|false|null {};
+
+class SkipOverPHP82DNFTypes {
+    protected (\FullyQualified&Partially\Qualified)|false $propertyC;
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
@@ -96,3 +96,7 @@ class TypedThings {
 }
 
 $cl = function (int|false $param = NULL, Type|null $obj = new MyObj(FALSE)) : string|false|null {};
+
+class SkipOverPHP82DNFTypes {
+    protected (\FullyQualified&Partially\Qualified)|false $propertyC;
+}


### PR DESCRIPTION
# Description
The `Generic.PHP.LowerCaseConstant` sniff is supposed to flag uppercase use of the `true`/`false`/`null` constants and its sister-sniff `UpperCaseConstant` flags the lowercase variants. Both sniffs, however, are supposed to **_ignore_** the use of these keywords in type declarations - which may have their own rules.

Some previous PRs already fixed most of the issues with that (#119, #330), but it looks like DNF-types in property declarations were not yet handled correctly.

Fixed now.

Includes tests.


## Suggested changelog entry
Generic.PHP.LowerCaseConstant and Generic.PHP.UpperCaseConstant will now correctly ignore DNF types for properties.

