### PR TITLE
ProcessRulesetBrokenRulesetTest: more tweaks for different libxml output

### DIFF
--- a/tests/Core/Ruleset/ProcessRulesetBrokenRulesetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetBrokenRulesetTest.php
@@ -23,6 +23,8 @@ use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState         disabled
  *
+ * @group Windows
+ *
  * @covers \PHP_CodeSniffer\Ruleset::processRuleset
  */
 final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
@@ -60,7 +62,7 @@ final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
         $config   = new ConfigDouble(["--standard=$standard"]);
 
         $regex  = '`^ERROR: Ruleset \S+ProcessRulesetBrokenRulesetSingleErrorTest\.xml is not valid\R';
-        $regex .= '- On line 3, column 1: Premature end of data in tag ruleset line 2\R$`';
+        $regex .= '- On line 3, column 1: (Premature end of data in tag ruleset line 2|EndTag: \'</\' not found)\R$`';
 
         $this->expectRuntimeExceptionRegex($regex);
 
@@ -81,8 +83,8 @@ final class ProcessRulesetBrokenRulesetTest extends AbstractRulesetTestCase
 
         $regex  = '`^ERROR: Ruleset \S+ProcessRulesetBrokenRulesetMultiErrorTest\.xml is not valid\R';
         $regex .= '- On line 8, column 12: Opening and ending tag mismatch: property line 7 and rule\R';
-        $regex .= '- On line 10, column 11: Opening and ending tag mismatch: properties line 5 and ruleset\R';
-        $regex .= '(- On line 11, column 1: Premature end of data in tag rule line 4\R)?$`';
+        $regex .= '- On line 10, column 11: Opening and ending tag mismatch: properties line [57] and ruleset\R';
+        $regex .= '(- On line 11, column 1: (Premature end of data in tag rule(set)? line [24]|EndTag: \'</\' not found)\R)*$`';
 
         $this->expectRuntimeExceptionRegex($regex);
 


### PR DESCRIPTION
# Description
Looks like there are some more libxml quirks to take into account with different message content on different OSes.

This updates the tests to allow for them to pass on PHP < 8.0 with libxml 2.9.x on Windows.

Also adds the `@group Windows` annotation to ensure these tests are also run on Windows in CI.


## Suggested changelog entry
_N/A_