### PR TITLE
Squiz/FunctionCommentThrowTag: bug fix - jump over attributes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -47,10 +47,24 @@ class FunctionCommentThrowTagSniff implements Sniff
             return;
         }
 
-        $find   = Tokens::$methodPrefixes;
-        $find[] = T_WHITESPACE;
+        $ignore = Tokens::$methodPrefixes;
+        $ignore[T_WHITESPACE] = T_WHITESPACE;
 
-        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
+            if (isset($ignore[$tokens[$commentEnd]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
+                && isset($tokens[$commentEnd]['attribute_opener']) === true
+            ) {
+                $commentEnd = $tokens[$commentEnd]['attribute_opener'];
+                continue;
+            }
+
+            break;
+        }
+
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
             // Function doesn't have a doc comment or is using the wrong type of comment.
             return;

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -509,3 +509,17 @@ namespace {
         }
     }
 }
+
+$anon = new class {
+    /**
+     * Tag and token number mismatch.
+     *
+     * @throws PHP_Exception1
+     * @throws PHP_Exception2
+     */
+    #[AnAttribute]
+    #[AnotherAttribute]
+    public function JumpOverAttributesToFindDocblock() {
+        throw new PHP_Exception1('Error');
+    }
+};

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -42,6 +42,7 @@ final class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
             219 => 1,
             287 => 1,
             397 => 1,
+            519 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Turns out this sniff was never updated to deal with attributes potentially being between a function declaration and the docblock preceding it, which could lead to false negatives.

Fixed now.

Includes test.

## Suggested changelog entry
Squiz.Commenting.FunctionCommentThrowTag : sniff would bow out when function has attributes attached leading to false negatives