### PR TITLE
PHP 7.4 | Tokenizer/PHP: handle PHP tag at end of file consistently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,12 @@ jobs:
           - php: '7.0'
             os: 'ubuntu-latest'
             custom_ini: true
+          - php: '8.0'
+            os: 'ubuntu-latest'
+            custom_ini: true
+          - php: '8.2'
+            os: 'ubuntu-latest'
+            custom_ini: true
 
     # yamllint disable-line rule:line-length
     name: "PHP: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }}${{ matrix.libxml_minor && format( ' with libxml {0}', matrix.libxml_minor ) || '' }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Win'  }})"
@@ -177,7 +183,7 @@ jobs:
           # Also turn on error_reporting to ensure all notices are shown.
           if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '5.5' ]]; then
             echo 'PHP_INI=error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On' >> "$GITHUB_OUTPUT"
-          elif [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '7.0' ]]; then
+          elif [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" != '5.5' ]]; then
             echo 'PHP_INI=error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -233,6 +239,7 @@ jobs:
           PHP_CODESNIFFER_CBF: '1'
 
       - name: 'PHPCS: check code style without cache, no parallel'
+        if: ${{ matrix.custom_ini == false }}
         id: phpcs
         run: >
           php "bin/phpcs" --no-cache --parallel=1

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.inc
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.inc
@@ -1,0 +1,4 @@
+<?php
+// This test case must be the last (only) test in the file without a new line after it!
+/* testLongOpenTagEndOfFileSpaceNoNewLine */ ?>
+<?php 

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * Prior to PHP 7.4, PHP didn't support stand-alone PHP open tags at the end of a file (without a new line),
+ * so we need to make sure that the tokenization in PHPCS is consistent and correct.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class PHPOpenTagEOF1Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the tokenization of a long PHP open tag at the very end of a file is correct and consistent.
+     *
+     * @return void
+     */
+    public function testLongOpenTagAtEndOfFile()
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $stackPtr = $this->getTargetToken('/* testLongOpenTagEndOfFileSpaceNoNewLine */', [T_OPEN_TAG, T_STRING, T_INLINE_HTML]);
+
+        $this->assertSame(
+            T_OPEN_TAG,
+            $tokens[$stackPtr]['code'],
+            'Token tokenized as '.Tokens::tokenName($tokens[$stackPtr]['code']).', not T_OPEN_TAG (code)'
+        );
+        $this->assertSame(
+            'T_OPEN_TAG',
+            $tokens[$stackPtr]['type'],
+            'Token tokenized as '.$tokens[$stackPtr]['type'].', not T_OPEN_TAG (type)'
+        );
+        $this->assertSame('<?php ', $tokens[$stackPtr]['content']);
+
+        // Now make sure that this is the very last token in the file and there are no tokens after it.
+        $this->assertArrayNotHasKey(($stackPtr + 1), $tokens);
+
+    }//end testLongOpenTagAtEndOfFile()
+
+
+}//end class

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF2Test.inc
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF2Test.inc
@@ -1,0 +1,4 @@
+<?php
+// This test case must be the last (only) test in the file without a new line after it!
+/* testLongOpenTagEndOfFileNoSpaceNoNewLine */ ?>
+<?php

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF2Test.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF2Test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * Prior to PHP 7.4, PHP didn't support stand-alone PHP open tags at the end of a file (without a new line),
+ * so we need to make sure that the tokenization in PHPCS is consistent and correct.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class PHPOpenTagEOF2Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the tokenization of a long PHP open tag at the very end of a file is correct and consistent.
+     *
+     * @return void
+     */
+    public function testLongOpenTagAtEndOfFile()
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $stackPtr = $this->getTargetToken('/* testLongOpenTagEndOfFileNoSpaceNoNewLine */', [T_OPEN_TAG, T_STRING, T_INLINE_HTML]);
+
+        $this->assertSame(
+            T_OPEN_TAG,
+            $tokens[$stackPtr]['code'],
+            'Token tokenized as '.Tokens::tokenName($tokens[$stackPtr]['code']).', not T_OPEN_TAG (code)'
+        );
+        $this->assertSame(
+            'T_OPEN_TAG',
+            $tokens[$stackPtr]['type'],
+            'Token tokenized as '.$tokens[$stackPtr]['type'].', not T_OPEN_TAG (type)'
+        );
+        $this->assertSame('<?php', $tokens[$stackPtr]['content']);
+
+        // Now make sure that this is the very last token in the file and there are no tokens after it.
+        $this->assertArrayNotHasKey(($stackPtr + 1), $tokens);
+
+    }//end testLongOpenTagAtEndOfFile()
+
+
+}//end class

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF3Test.inc
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF3Test.inc
@@ -1,0 +1,4 @@
+<?php
+// This test case must be the last (only) test in the file without a new line after it!
+/* testLongOpenTagEndOfFileNoSpaceNoNewLineUppercase */ ?>
+<?PHP

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF3Test.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF3Test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * Prior to PHP 7.4, PHP didn't support stand-alone PHP open tags at the end of a file (without a new line),
+ * so we need to make sure that the tokenization in PHPCS is consistent and correct.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class PHPOpenTagEOF3Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the tokenization of a long PHP open tag at the very end of a file is correct and consistent.
+     *
+     * @return void
+     */
+    public function testLongOpenTagAtEndOfFile()
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $stackPtr = $this->getTargetToken('/* testLongOpenTagEndOfFileNoSpaceNoNewLineUppercase */', [T_OPEN_TAG, T_STRING, T_INLINE_HTML]);
+
+        $this->assertSame(
+            T_OPEN_TAG,
+            $tokens[$stackPtr]['code'],
+            'Token tokenized as '.Tokens::tokenName($tokens[$stackPtr]['code']).', not T_OPEN_TAG (code)'
+        );
+        $this->assertSame(
+            'T_OPEN_TAG',
+            $tokens[$stackPtr]['type'],
+            'Token tokenized as '.$tokens[$stackPtr]['type'].', not T_OPEN_TAG (type)'
+        );
+        $this->assertSame('<?PHP', $tokens[$stackPtr]['content']);
+
+        // Now make sure that this is the very last token in the file and there are no tokens after it.
+        $this->assertArrayNotHasKey(($stackPtr + 1), $tokens);
+
+    }//end testLongOpenTagAtEndOfFile()
+
+
+}//end class


### PR DESCRIPTION
# Description
Prior to PHP 7.4, a PHP open tag at the end of a file was not tokenized correctly in PHP itself.

From the PHP 7.4 changelog:
> `<?php` at the end of the file (without trailing newline) will now be
> interpreted as an opening PHP tag. Previously it was interpreted either as
> `<? php` and resulted in a syntax error (with short_open_tag=1) or was
> interpreted as a literal `<?php` string (with short_open_tag=0).

This commit makes the tokenization of PHP open tags at the end of a file consistent in all PHP versions.

Includes tests.
Includes adding a few extra test builds which test with `short_open_tag=On` for various PHP versions.

Refs:
* https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.php-tag
* https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L37-L40


## Suggested changelog entry
Tokenizer/PHP: a PHP open tag at the very end of a file will now always be tokenized as `T_OPEN_TAG`, independently of the PHP version.
