### PR TITLE
Squiz/OperatorBracket: stability tweak 

### DIFF
--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -148,7 +148,6 @@ class OperatorBracketSniff implements Sniff
             T_DOUBLE_COLON,
             T_OPEN_SQUARE_BRACKET,
             T_CLOSE_SQUARE_BRACKET,
-            T_MODULUS,
             T_NONE,
             T_BITWISE_NOT,
         ];
@@ -290,7 +289,6 @@ class OperatorBracketSniff implements Sniff
             T_OBJECT_OPERATOR          => true,
             T_NULLSAFE_OBJECT_OPERATOR => true,
             T_DOUBLE_COLON             => true,
-            T_MODULUS                  => true,
             T_ISSET                    => true,
             T_ARRAY                    => true,
             T_NONE                     => true,

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -133,23 +133,23 @@ class OperatorBracketSniff implements Sniff
 
         // Tokens that are allowed inside a bracketed operation.
         $allowed = [
-            T_VARIABLE,
-            T_LNUMBER,
-            T_DNUMBER,
-            T_STRING,
-            T_WHITESPACE,
-            T_NS_SEPARATOR,
-            T_THIS,
-            T_SELF,
-            T_STATIC,
-            T_PARENT,
-            T_OBJECT_OPERATOR,
-            T_NULLSAFE_OBJECT_OPERATOR,
-            T_DOUBLE_COLON,
-            T_OPEN_SQUARE_BRACKET,
-            T_CLOSE_SQUARE_BRACKET,
-            T_NONE,
-            T_BITWISE_NOT,
+            T_VARIABLE                 => T_VARIABLE,
+            T_LNUMBER                  => T_LNUMBER,
+            T_DNUMBER                  => T_DNUMBER,
+            T_STRING                   => T_STRING,
+            T_WHITESPACE               => T_WHITESPACE,
+            T_NS_SEPARATOR             => T_NS_SEPARATOR,
+            T_THIS                     => T_THIS,
+            T_SELF                     => T_SELF,
+            T_STATIC                   => T_STATIC,
+            T_PARENT                   => T_PARENT,
+            T_OBJECT_OPERATOR          => T_OBJECT_OPERATOR,
+            T_NULLSAFE_OBJECT_OPERATOR => T_NULLSAFE_OBJECT_OPERATOR,
+            T_DOUBLE_COLON             => T_DOUBLE_COLON,
+            T_OPEN_SQUARE_BRACKET      => T_OPEN_SQUARE_BRACKET,
+            T_CLOSE_SQUARE_BRACKET     => T_CLOSE_SQUARE_BRACKET,
+            T_NONE                     => T_NONE,
+            T_BITWISE_NOT              => T_BITWISE_NOT,
         ];
 
         $allowed += Tokens::$operators;
@@ -171,7 +171,7 @@ class OperatorBracketSniff implements Sniff
                     // We allow simple operations to not be bracketed.
                     // For example, ceil($one / $two).
                     for ($prev = ($stackPtr - 1); $prev > $bracket; $prev--) {
-                        if (in_array($tokens[$prev]['code'], $allowed, true) === true) {
+                        if (isset($allowed[$tokens[$prev]['code']]) === true) {
                             continue;
                         }
 
@@ -187,7 +187,7 @@ class OperatorBracketSniff implements Sniff
                     }
 
                     for ($next = ($stackPtr + 1); $next < $endBracket; $next++) {
-                        if (in_array($tokens[$next]['code'], $allowed, true) === true) {
+                        if (isset($allowed[$tokens[$next]['code']]) === true) {
                             continue;
                         }
 


### PR DESCRIPTION
# Description

### Squiz/OperatorBracket: remove some redundancy 

The `%` modulus token is included in the `Tokens::$operators` array. No need to add it separately.

### Squiz/OperatorBracket: stability tweak 

The `$allowed` tokens array is joined after declaration with the `Tokens::$operators` array. This is only reliable if the keys in both arrays are unique (or intended to be overwritten).
However, with the `$allowed` array being numerically indexed and PHP native tokens also being integers, this was not the case and could lead to one of the tokens in the original array (unintentionally) being disregarded/overwritten by one of the tokens in the `Tokens::$operators` array.

Fixed now, by making setting the tokens constants both as the key as well as the value, making the entries in the array suitable for an array join operation.

## Suggested changelog entry
_N/A_

