### PR TITLE
Squiz/FunctionSpacing: fix regression - only look at first docblock

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -127,15 +127,18 @@ class FunctionSpacingSniff implements Sniff
         }
 
         // Skip past function docblocks and attributes.
-        $prev = $startOfDeclarationLine;
+        // Only the first docblock is a function docblock. Other docblocks should be disregarded.
+        $prev         = $startOfDeclarationLine;
+        $seenDocblock = false;
         if ($startOfDeclarationLine > 0) {
             for ($prev = ($startOfDeclarationLine - 1); $prev > 0; $prev--) {
                 if ($tokens[$prev]['code'] === T_WHITESPACE) {
                     continue;
                 }
 
-                if ($tokens[$prev]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
-                    $prev = $tokens[$prev]['comment_opener'];
+                if ($seenDocblock === false && $tokens[$prev]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+                    $prev         = $tokens[$prev]['comment_opener'];
+                    $seenDocblock = true;
                     continue;
                 }
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc
@@ -726,3 +726,27 @@ class SilenceBeforeErrorIfPreviousThingWasAFunctionBug
 
     }//end blankLineDetectionB()
 }//end class
+
+// Issue #945.
+class OnlyAcceptFirstDocblockAsBelongingWithFunction {
+    /**
+     * Superfluous docblock
+     */
+
+
+    /**
+     * Function docblock
+     */
+    function correctSpacing($x) {}
+
+
+    /**
+     * Superfluous docblock
+     */
+    /**
+     * Function docblock
+     */
+    function incorrectSpacing($x) {}
+
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.1.inc.fixed
@@ -822,3 +822,29 @@ class SilenceBeforeErrorIfPreviousThingWasAFunctionBug
 
 
 }//end class
+
+// Issue #945.
+class OnlyAcceptFirstDocblockAsBelongingWithFunction {
+    /**
+     * Superfluous docblock
+     */
+
+
+    /**
+     * Function docblock
+     */
+    function correctSpacing($x) {}
+
+
+    /**
+     * Superfluous docblock
+     */
+
+
+    /**
+     * Function docblock
+     */
+    function incorrectSpacing($x) {}
+
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -110,6 +110,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffUnitTest
                 714 => 1,
                 717 => 1,
                 727 => 1,
+                749 => 1,
             ];
 
         case 'FunctionSpacingUnitTest.2.inc':


### PR DESCRIPTION
# Description
To determine whether there are the correct number of lines before the function declaration, the sniff skips over attributes and docblocks to find the first bit of code which doesn't belong with the function declaration.

While the change in PR #826 improved this for attributes _before_ the docblock, it didn't take multiple docblocks into account and would skip over more than just the first docblock.

Fixed now.

Includes tests.


## Suggested changelog entry
Fixed: Squiz.WhiteSpace.FunctionSpacing would get confused when there are two docblocks above a function declaration.

## Related issues/external references

Fixes #826

Fixes #945
Closes #938


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
