### PR TITLE
Squiz/FunctionCommentThrowTag: improve comment tolerance

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -104,7 +104,7 @@ class FunctionCommentThrowTagSniff implements Sniff
                 don't know the exception class.
             */
 
-            $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($currPos + 1), null, true);
+            $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($currPos + 1), null, true);
             if ($tokens[$nextToken]['code'] === T_NEW
                 || $tokens[$nextToken]['code'] === T_NS_SEPARATOR
                 || $tokens[$nextToken]['code'] === T_STRING

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -523,3 +523,11 @@ $anon = new class {
         throw new PHP_Exception1('Error');
     }
 };
+
+
+/**
+ * @throws Wrong_Exception
+ */
+public function ImproveCommentTolerance() {
+    throw /*comment*/ new /*comment*/ Right_Exception('Error');
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -43,6 +43,7 @@ final class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
             287 => 1,
             397 => 1,
             519 => 1,
+            530 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Includes test.


## Suggested changelog entry
Squiz.Commenting.FunctionCommentThrowTag: prevent false positives/negatives for code interlaced with comments.



## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
