### PR TITLE
PHP 8.4 | Generic/[Lower|Upper]CaseConstant: add support for final properties

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -77,6 +77,7 @@ class LowerCaseConstantSniff implements Sniff
         $targets[] = T_VAR;
         $targets[] = T_STATIC;
         $targets[] = T_READONLY;
+        $targets[] = T_FINAL;
 
         // Register function keywords to filter out param/return type declarations.
         $targets[] = T_FUNCTION;
@@ -137,6 +138,7 @@ class LowerCaseConstantSniff implements Sniff
             || $tokens[$stackPtr]['code'] === T_VAR
             || $tokens[$stackPtr]['code'] === T_STATIC
             || $tokens[$stackPtr]['code'] === T_READONLY
+            || $tokens[$stackPtr]['code'] === T_FINAL
         ) {
             $skipOver = (Tokens::$emptyTokens + $this->propertyTypeTokens);
             $skipTo   = $phpcsFile->findNext($skipOver, ($stackPtr + 1), null, true);

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
@@ -155,3 +155,8 @@ const MYCONST = TRUE;
 class SkipOverPHP82DNFTypes {
     protected (\FullyQualified&Partially\Qualified)|TRUE $propertyC;
 }
+
+class SkipOverPHP84FinalProperties {
+    final MyType|FALSE $propA;
+    private static final NULL|MyClass $propB;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
@@ -155,3 +155,8 @@ const MYCONST = true;
 class SkipOverPHP82DNFTypes {
     protected (\FullyQualified&Partially\Qualified)|TRUE $propertyC;
 }
+
+class SkipOverPHP84FinalProperties {
+    final MyType|FALSE $propA;
+    private static final NULL|MyClass $propB;
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
@@ -100,3 +100,8 @@ $cl = function (int|false $param = null, Type|null $obj = new MyObj(false)) : st
 class SkipOverPHP82DNFTypes {
     protected (\FullyQualified&Partially\Qualified)|false $propertyC;
 }
+
+class SkipOverPHP84FinalProperties {
+    final MyType|false $propA;
+    private static final null|MyClass $propB;
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
@@ -100,3 +100,8 @@ $cl = function (int|false $param = NULL, Type|null $obj = new MyObj(FALSE)) : st
 class SkipOverPHP82DNFTypes {
     protected (\FullyQualified&Partially\Qualified)|false $propertyC;
 }
+
+class SkipOverPHP84FinalProperties {
+    final MyType|false $propA;
+    private static final null|MyClass $propB;
+}


### PR DESCRIPTION
# Description
The `Generic.PHP.LowerCaseConstant` sniff is supposed to flag uppercase use of the `true`/`false`/null` constants and its sister-sniff `UpperCaseConstant` flags the lowercase variants. Both sniffs, however, are supposed to **_ignore_** the use of these keywords in type declarations - which may have their own rules.

This commit adds support for skipping over the types in PHP 8.4 `final` property declarations.

Includes tests.


## Suggested changelog entry
Added support for PHP 8.4 final properties to the following sniffs:
- Generic.PHP.LowerCaseConstant
- Generic.PHP.UpperCaseConstant


## Related issues/external references

Related to #734, follow up to #834 and #907

