### PR TITLE
PHP 8.4 | Squiz/VariableComment: add support for final properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -36,6 +36,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_VAR                    => T_VAR,
             T_STATIC                 => T_STATIC,
             T_READONLY               => T_READONLY,
+            T_FINAL                  => T_FINAL,
             T_WHITESPACE             => T_WHITESPACE,
             T_STRING                 => T_STRING,
             T_NS_SEPARATOR           => T_NS_SEPARATOR,

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -462,3 +462,10 @@ class DNFTypes
      */
     private (\Iterator&namespace\Countable)|false|null $variableName;
 }
+
+class PHP84FinalProperties {
+    /**
+     * @var integer
+     */
+    final int $hasDocblock;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -462,3 +462,10 @@ class DNFTypes
      */
     private (\Iterator&namespace\Countable)|false|null $variableName;
 }
+
+class PHP84FinalProperties {
+    /**
+     * @var integer
+     */
+    final int $hasDocblock;
+}


### PR DESCRIPTION
# Description
If a property uses the `final` modifier keyword, the property docblock (providing there is one) would never be found, leading to false positives.

Fixed now.

Includes tests.

## Suggested changelog entry
Added support for PHP 8.4 final properties to the following sniffs:
- Squiz.Commenting.VariableComment

## Related issues/external references

Related to #734, follow up to #834 and #907
