### PR TITLE
PHP 8.4 | PSR2/PropertyDeclaration: add support for final properties

### DIFF
--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
@@ -85,3 +85,14 @@ class ReadOnlyProp {
 
     readonly protected ?string $wrongOrder2;
 }
+
+class FinalProperties {
+    final public int $foo,
+        $bar,
+        $var = null;
+
+    final protected (D|N)|false  $foo;
+    final array $foo;
+    public FINAL ?int $wrongOrder1;
+    static protected final ?string $wrongOrder2;
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -82,3 +82,14 @@ class ReadOnlyProp {
 
     protected readonly ?string $wrongOrder2;
 }
+
+class FinalProperties {
+    final public int $foo,
+        $bar,
+        $var = null;
+
+    final protected (D|N)|false $foo;
+    final array $foo;
+    FINAL public ?int $wrongOrder1;
+    final protected static ?string $wrongOrder2;
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -56,6 +56,11 @@ final class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             82 => 1,
             84 => 1,
             86 => 1,
+            90 => 1,
+            94 => 1,
+            95 => 1,
+            96 => 1,
+            97 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description
Includes handling the modifier order when `final` is used. This introduces a new `FinalAfterVisibility` error code.

Includes tests.

Note: the modifier keyword order checks could probably do with some optimization, but that can be handled later.


## Suggested changelog entry
* Added support for PHP 8.4 final properties to the following sniffs:
    - PSR2.Classes.PropertyDeclaration
* The PSR2.Classes.PropertyDeclaration will now check that the `final` modifier keyword is placed before a visibility keyword. Errors will be reported via a new `FinalAfterVisibility` error code.

## Related issues/external references

Related to #734, follow up to #834 and #907