### PR TITLE
Squiz/DocCommentAlignment: add support for final classes and final properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -72,6 +72,7 @@ class DocCommentAlignmentSniff implements Sniff
             T_PROTECTED => true,
             T_STATIC    => true,
             T_ABSTRACT  => true,
+            T_FINAL     => true,
             T_PROPERTY  => true,
             T_OBJECT    => true,
             T_PROTOTYPE => true,

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -101,3 +101,16 @@ enum Suits: string
  * Example with no errors.
  **************************************************************************/
 function example() {}
+
+/**
+  *  Some info about the class here.
+    */
+final class FinalClassWithFinalProp
+{
+    /**
+   *Some info about the property here.
+    *
+     *  @var int
+      */
+    final $property = 10;
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -101,3 +101,16 @@ enum Suits: string
  * Example with no errors.
  **************************************************************************/
 function example() {}
+
+/**
+ *  Some info about the class here.
+ */
+final class FinalClassWithFinalProp
+{
+    /**
+     * Some info about the property here.
+     *
+     * @var int
+     */
+    final $property = 10;
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -56,6 +56,13 @@ final class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
             $errors[91] = 1;
             $errors[95] = 1;
             $errors[96] = 1;
+
+            $errors[106] = 1;
+            $errors[107] = 1;
+            $errors[111] = 2;
+            $errors[112] = 1;
+            $errors[113] = 1;
+            $errors[114] = 1;
         }
 
         return $errors;


### PR DESCRIPTION
# Description
If a class or property used the `final` keyword, the docblock would not be recognized as one which needed examining.

Fixed now.

Includes tests.


## Suggested changelog entry
* Added support for PHP 8.4 final properties to the following sniffs:
    - Squiz.Commenting.DocCommentAlignment
* Squiz.Commenting.DocCommentAlignment will now examine docblocks for `final` classes.

## Related issues/external references

Related to #734, follow up to #834 and #907
