### PR TITLE
PHP 8.4 | Various sniffs: add tests with final properties

### DIFF
--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.1.inc
@@ -54,3 +54,25 @@ class Regular_Class_Regular_Constants {
     protected const PROTECTED_CONST = 'foo';
     private const PRIVATE_CONST = true;
 }
+
+final class Final_Class_Final_Properties {
+    final readonly public ?MyType $final_public;
+    protected final $final_protected = 'foo';
+}
+
+final class Final_Class_Regular_Properties {
+    public $public = 23;
+    protected string $protected = 'foo';
+    private $private = true;
+}
+
+class Regular_Class_Final_Properties {
+    public static final $final_public = 23;
+    final readonly $final_protected = 'foo';
+}
+
+class Regular_Class_Regular_Properties {
+    public $public = 23;
+    protected $protected = 'foo';
+    private static bool $private = true;
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -58,6 +58,8 @@ final class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
                 33 => 1,
                 37 => 1,
                 38 => 1,
+                59 => 1,
+                60 => 1,
             ];
         default:
             return [];

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -14,3 +14,7 @@ ReadOnly class MyClass
 $a = new CLASS() {};
 
 $anon = new ReadOnly class() {};
+
+class FinalProperties {
+    FINAL int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -14,3 +14,7 @@ readonly class MyClass
 $a = new class() {};
 
 $anon = new readonly class() {};
+
+class FinalProperties {
+    final int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -41,6 +41,7 @@ final class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             11 => 1,
             14 => 1,
             16 => 1,
+            19 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -307,3 +307,10 @@ abstract class MyClass
 enum MyEnum {
 
 }
+
+class FinalProperties {
+    /**
+     * Comment should be ignored.
+     */
+    final int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -309,3 +309,10 @@ abstract class MyClass
 enum MyEnum {
 
 }
+
+class FinalProperties {
+    /**
+     * Comment should be ignored.
+     */
+    final int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -70,3 +70,7 @@ class MyClass {
 interface Base {
     protected $anonymous;
 }
+
+class PHP84FinalProperties {
+    final int $final;
+}

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -39,6 +39,7 @@ final class MemberVarScopeUnitTest extends AbstractSniffUnitTest
             41 => 1,
             66 => 2,
             67 => 1,
+            75 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
@@ -415,3 +415,16 @@ final class BlankLinesBetweenVsAttributesWithoutCommentIssueSquiz3594
 
     public $property2;
 }
+
+class PHP84FinalProperties {
+    final int $finalA;
+
+    /**
+     * Docblock
+     */
+    public final string $publicfinal;
+    #[AnAttribute]
+    final bool $finalB;
+
+    final private bool $finalPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
@@ -400,3 +400,18 @@ final class BlankLinesBetweenVsAttributesWithoutCommentIssueSquiz3594
     #[SingleAttribute]
     public $property2;
 }
+
+class PHP84FinalProperties {
+
+    final int $finalA;
+
+    /**
+     * Docblock
+     */
+    public final string $publicfinal;
+
+    #[AnAttribute]
+    final bool $finalB;
+
+    final private bool $finalPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -83,6 +83,8 @@ final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
                 412 => 1,
                 415 => 1,
                 416 => 1,
+                420 => 1,
+                427 => 1,
             ];
 
         default:

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -187,3 +187,8 @@ class ConstantVisibility {
     protected  const PROTECTED_SPACING_INCORRECT = true;
     private    const PRIVATE_SPACING_INCORRECT = true;
 }
+
+class FinalProperties {
+    final readonly public ?MyType $spacing_correct;
+    protected   final   $spacing_incorrect = 'foo';
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -180,3 +180,8 @@ class ConstantVisibility {
     protected const PROTECTED_SPACING_INCORRECT = true;
     private const PRIVATE_SPACING_INCORRECT = true;
 }
+
+class FinalProperties {
+    final readonly public ?MyType $spacing_correct;
+    protected final $spacing_incorrect = 'foo';
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -69,6 +69,7 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
                 186 => 1,
                 187 => 1,
                 188 => 1,
+                193 => 2,
             ];
 
         case 'ScopeKeywordSpacingUnitTest.3.inc':


### PR DESCRIPTION
# Description
### PHP 8.4 | Generic/UnnecessaryFinalModifier: add tests with final properties

### PHP 8.4 | Squiz/BlockComment: add test with final property

### PHP 8.4 | Squiz/LowercaseClassKeywords: add test with final property

### PHP 8.4 | Squiz/ScopeKeywordSpacing: add tests with final properties

### PHP 8.4 | Squiz/MemberVarSpacing: add tests with final properties

### PHP 8.4 | Squiz/MemberVarScope: add tests with final properties

## Suggested changelog entry
_N/A_

## Related issues/external references

Related to #734, follow up to #834 and #907