### PR TITLE
Issue template: minor tweak

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,13 +51,13 @@ A clear and concise description of what you expected to happen.
 
 ## Versions (please complete the following information)
 
-|                                       |                                                                                                           |
-|--------------------------|----------------------------------------------------------------------  |
-| Operating System           | [e.g., Windows 10, MacOS 10.15]                                                       |
-| PHP version                    | [e.g., 7.2, 8.1]                                                                                     |
-| PHP_CodeSniffer version | [e.g., 3.7.2, master]                                                                            |
-| Standard                         | [e.g., PSR2, PSR12, Squiz, custom]                                                      |
-| Install type                      | [e.g. Composer (global/local), PHAR, git clone, other (please expand)] |
+|                                          |                                                                                                                |
+|-----------------------------|---------------------------------------------------------------------------- |
+| Operating System            | (e.g., Windows 10, MacOS 10.15)                                                           |
+| PHP version                      | (e.g., 7.2, 8.1)                                                                                          |
+| PHP_CodeSniffer version | (e.g., 3.7.2, master)                                                                                  |
+| Standard                          | (e.g., PSR2, PSR12, Squiz, custom)                                                          |
+| Install type                       | (e.g. Composer (global/local), PHAR, git clone, other (please expand)) |
 
 ## Additional context
 


### PR DESCRIPTION
# Description
Change square brackets to parentheses to avoid "undefined reference" markdown error.

Includes re-aligning the table.



## Suggested changelog entry
_N/A_

## Related issues/external references

Related to: https://github.com/remarkjs/remark-lint/releases/tag/remark-lint-no-undefined-references%405.0.2
