### PR TITLE
Generic/ScopeIndent: bug fix for debug mode

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -644,7 +644,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 $conditionToken = array_pop($openScopes);
-                if ($this->debug === true) {
+                if ($this->debug === true && $conditionToken !== null) {
                     $line = $tokens[$conditionToken]['line'];
                     $type = $tokens[$conditionToken]['type'];
                     echo "\t=> removed open scope $conditionToken ($type) on line $line".PHP_EOL;


### PR DESCRIPTION
# Description
Prevent an "Undefined array index" PHP notice when running in debug mode when there are no scopes left.

Issue can be reproduced by running:
```bash
phpcs ./src/Runner.php --runtime-set scope_indent_debug 1
```

## Suggested changelog entry
Fixed: Generic.WhiteSpace.ScopeIndent: undefined array index notice when running in debug mode


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
