### PR TITLE
Generic/ScopeIndent: start debug info on new line

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -161,7 +161,7 @@ class ScopeIndentSniff implements Sniff
 
         if ($this->debug === true) {
             $line = $tokens[$stackPtr]['line'];
-            echo "Start with token $stackPtr on line $line with indent $currentIndent".PHP_EOL;
+            echo PHP_EOL."Start with token $stackPtr on line $line with indent $currentIndent".PHP_EOL;
         }
 
         if (empty($this->ignoreIndentation) === true) {


### PR DESCRIPTION
# Description
Depending on whether verbose output is requested or not, the debug output from the `ScopeIndent` sniff _may_ or _may not_ start on a new line. When it doesn't, it makes the output harder to read.

Fixed now.


## Suggested changelog entry
_N/A_