### PR TITLE
AbstractPatternSniff::__construct(): remove the $ignoreComments property

### DIFF
--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -57,16 +57,9 @@ abstract class AbstractPatternSniff implements Sniff
 
     /**
      * Constructs a AbstractPatternSniff.
-     *
-     * @param boolean $ignoreComments If true, comments will be ignored.
      */
-    public function __construct($ignoreComments=null)
+    public function __construct()
     {
-        // This is here for backwards compatibility.
-        if ($ignoreComments !== null) {
-            $this->ignoreComments = $ignoreComments;
-        }
-
         $this->supplementaryTokens = $this->registerSupplementary();
 
     }//end __construct()


### PR DESCRIPTION
# Description
PHPCS deprecated the `$ignoreComments` parameter of the `AbstractPatternSniff::__construct()` sniff in version 1.4.0.

> - AbstractPatternSniff now sets the ignoreComments option using a public var rather than through the constructor
>     - This allows the setting to be overwritten in ruleset.xml files
>     - Old method remains for backwards compatibility

Time to remove this dead code.

Related to #6


## Suggested changelog entry
Removed: The `$ignoreComments` parameter for the `AbstractPatternSniff::__construct()` method.


