### PR TITLE
Tokenizer: remove support for the deprecated @codingStandard annotation syntax

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -361,38 +361,7 @@ class File
             ) {
                 $commentText      = ltrim($this->tokens[$stackPtr]['content'], " \t/*#");
                 $commentTextLower = strtolower($commentText);
-                if (strpos($commentText, '@codingStandards') !== false) {
-                    if (strpos($commentText, '@codingStandardsIgnoreFile') !== false) {
-                        // Ignoring the whole file, just a little late.
-                        $this->errors       = [];
-                        $this->warnings     = [];
-                        $this->errorCount   = 0;
-                        $this->warningCount = 0;
-                        $this->fixableCount = 0;
-                        return;
-                    } else if (strpos($commentText, '@codingStandardsChangeSetting') !== false) {
-                        $start   = strpos($commentText, '@codingStandardsChangeSetting');
-                        $comment = substr($commentText, ($start + 30));
-                        $parts   = explode(' ', $comment);
-                        if (count($parts) >= 2) {
-                            $sniffParts = explode('.', $parts[0]);
-                            if (count($sniffParts) >= 3) {
-                                // If the sniff code is not known to us, it has not been registered in this run.
-                                // But don't throw an error as it could be there for a different standard to use.
-                                if (isset($this->ruleset->sniffCodes[$parts[0]]) === true) {
-                                    $listenerCode  = array_shift($parts);
-                                    $propertyCode  = array_shift($parts);
-                                    $settings      = [
-                                        'value' => rtrim(implode(' ', $parts), " */\r\n"),
-                                        'scope' => 'sniff',
-                                    ];
-                                    $listenerClass = $this->ruleset->sniffCodes[$listenerCode];
-                                    $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
-                                }
-                            }
-                        }
-                    }//end if
-                } else if (substr($commentTextLower, 0, 16) === 'phpcs:ignorefile'
+                if (substr($commentTextLower, 0, 16) === 'phpcs:ignorefile'
                     || substr($commentTextLower, 0, 17) === '@phpcs:ignorefile'
                 ) {
                     // Ignoring the whole file, just a little late.

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -48,9 +48,7 @@ class LocalFile extends File
                 $firstContent .= fgets($handle);
                 fclose($handle);
 
-                if (strpos($firstContent, '@codingStandardsIgnoreFile') !== false
-                    || stripos($firstContent, 'phpcs:ignorefile') !== false
-                ) {
+                if (stripos($firstContent, 'phpcs:ignorefile') !== false) {
                     // We are ignoring the whole file.
                     $this->ignored = true;
                     return;

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.1.inc
@@ -83,10 +83,10 @@ function test() {
     $foo = function() { echo 'foo'; };
 }
 
-/* @codingStandardsIgnoreStart */
+/* phpcs:disable */
 class MyClass
 {
-    /* @codingStandardsIgnoreEnd */
+    /* phpcs:enable */
     public function __construct() {}
 }
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -158,10 +158,10 @@ function test() {
     $foo = function() { echo 'foo'; };
 }
 
-/* @codingStandardsIgnoreStart */
+/* phpcs:disable */
 class MyClass
 {
-    /* @codingStandardsIgnoreEnd */
+    /* phpcs:enable */
     public function __construct() {}
 }
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -18,10 +18,10 @@ function xmlParser() {}
 
 echo preg_replace_callback('~-([a-z])~', function ($match) { return strtoupper($match[1]); }, 'hello-world');
 
-/* @codingStandardsIgnoreStart */
+/* phpcs:disable */
 class MyClass
 {
-    /* @codingStandardsIgnoreEnd */
+    /* phpcs:enable */
     public function __construct() {}
 }
 ?>

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -259,56 +259,7 @@ abstract class Tokenizer
                 $commentText      = ltrim($this->tokens[$i]['content'], " \t/*#");
                 $commentText      = rtrim($commentText, " */\t\r\n");
                 $commentTextLower = strtolower($commentText);
-                if (strpos($commentText, '@codingStandards') !== false) {
-                    // If this comment is the only thing on the line, it tells us
-                    // to ignore the following line. If the line contains other content
-                    // then we are just ignoring this one single line.
-                    $ownLine = false;
-                    if ($i > 0) {
-                        for ($prev = ($i - 1); $prev >= 0; $prev--) {
-                            if ($this->tokens[$prev]['code'] === T_WHITESPACE) {
-                                continue;
-                            }
-
-                            break;
-                        }
-
-                        if ($this->tokens[$prev]['line'] !== $this->tokens[$i]['line']) {
-                            $ownLine = true;
-                        }
-                    }
-
-                    if ($ignoring === null
-                        && strpos($commentText, '@codingStandardsIgnoreStart') !== false
-                    ) {
-                        $ignoring = ['.all' => true];
-                        if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
-                        }
-                    } else if ($ignoring !== null
-                        && strpos($commentText, '@codingStandardsIgnoreEnd') !== false
-                    ) {
-                        if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = ['.all' => true];
-                        } else {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
-                        }
-
-                        $ignoring = null;
-                    } else if ($ignoring === null
-                        && strpos($commentText, '@codingStandardsIgnoreLine') !== false
-                    ) {
-                        $ignoring = ['.all' => true];
-                        if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']]       = $ignoring;
-                            $this->ignoredLines[($this->tokens[$i]['line'] + 1)] = $ignoring;
-                        } else {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
-                        }
-
-                        $ignoring = null;
-                    }//end if
-                } else if (substr($commentTextLower, 0, 6) === 'phpcs:'
+                if (substr($commentTextLower, 0, 6) === 'phpcs:'
                     || substr($commentTextLower, 0, 7) === '@phpcs:'
                 ) {
                     // If the @phpcs: syntax is being used, strip the @ to make

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -133,24 +133,6 @@ final class ErrorSuppressionTest extends TestCase
                 'before' => '/** phpcs:disable */'.PHP_EOL,
                 'after'  => '/** phpcs:enable */',
             ],
-
-            // Deprecated syntax.
-            'old style: slash comment'                                                 => [
-                'before' => '// @codingStandardsIgnoreStart'.PHP_EOL,
-                'after'  => '// @codingStandardsIgnoreEnd',
-            ],
-            'old style: star comment'                                                  => [
-                'before' => '/* @codingStandardsIgnoreStart */'.PHP_EOL,
-                'after'  => '/* @codingStandardsIgnoreEnd */',
-            ],
-            'old style: multi-line star comment'                                       => [
-                'before' => '/*'.PHP_EOL.' @codingStandardsIgnoreStart'.PHP_EOL.' */'.PHP_EOL,
-                'after'  => '/*'.PHP_EOL.' @codingStandardsIgnoreEnd'.PHP_EOL.' */',
-            ],
-            'old style: single line docblock comment'                                  => [
-                'before' => '/** @codingStandardsIgnoreStart */'.PHP_EOL,
-                'after'  => '/** @codingStandardsIgnoreEnd */',
-            ],
         ];
 
     }//end dataSuppressError()
@@ -233,16 +215,6 @@ EOD;
                 'before'  => '/** phpcs:disable */',
                 'between' => '/** phpcs:enable */',
             ],
-
-            // Deprecated syntax.
-            'old style: slash comment'                     => [
-                'before'  => '// @codingStandardsIgnoreStart',
-                'between' => '// @codingStandardsIgnoreEnd',
-            ],
-            'old style: single line docblock comment'      => [
-                'before'  => '/** @codingStandardsIgnoreStart */',
-                'between' => '/** @codingStandardsIgnoreEnd */',
-            ],
         ];
 
     }//end dataSuppressSomeErrors()
@@ -315,16 +287,6 @@ EOD;
             'disable/enable: single line docblock comment' => [
                 'before' => '/** phpcs:disable */',
                 'after'  => '/** phpcs:enable */',
-            ],
-
-            // Deprecated syntax.
-            'old style: slash comment'                     => [
-                'before' => '// @codingStandardsIgnoreStart',
-                'after'  => '// @codingStandardsIgnoreEnd',
-            ],
-            'old style: single line docblock comment'      => [
-                'before' => '/** @codingStandardsIgnoreStart */',
-                'after'  => '/** @codingStandardsIgnoreEnd */',
             ],
         ];
 
@@ -423,15 +385,6 @@ EOD;
             'ignore: end of line, hash comment, with @'  => [
                 'before' => '',
                 'after'  => ' # @phpcs:ignore',
-            ],
-
-            // Deprecated syntax.
-            'old style: line before, slash comment'      => [
-                'before' => '// @codingStandardsIgnoreLine',
-            ],
-            'old style: end of line, slash comment'      => [
-                'before' => '',
-                'after'  => ' // @codingStandardsIgnoreLine',
             ],
         ];
 
@@ -554,10 +507,6 @@ EOD;
                 'before' => '# phpcs:disable',
                 'after'  => '# phpcs:enable',
             ],
-            'old style: slash comment, no single line suppression'                            => [
-                'before' => '// @codingStandardsIgnoreStart',
-                'after'  => '// @codingStandardsIgnoreEnd',
-            ],
 
             // Process with line suppression nested within disable/enable suppression.
             'disable/enable: slash comment, next line nested single line suppression'         => [
@@ -571,10 +520,6 @@ EOD;
             'disable/enable: hash comment, next line nested single line suppression'          => [
                 'before' => '# @phpcs:disable'.PHP_EOL.'# @phpcs:ignore',
                 'after'  => '# @phpcs:enable',
-            ],
-            'old style: slash comment, next line nested single line suppression'              => [
-                'before' => '// @codingStandardsIgnoreStart'.PHP_EOL.'// @codingStandardsIgnoreLine',
-                'after'  => '// @codingStandardsIgnoreEnd',
             ],
         ];
 
@@ -660,16 +605,6 @@ EOD;
             'disable/enable: single line docblock comment, with @' => [
                 'before' => '/** @phpcs:disable */',
                 'after'  => '/** @phpcs:enable */',
-            ],
-
-            // Deprecated syntax.
-            'old style: start/end, slash comment'                  => [
-                'before' => '//@codingStandardsIgnoreStart',
-                'after'  => '//@codingStandardsIgnoreEnd',
-            ],
-            'old style: start/end, single line docblock comment'   => [
-                'before' => '/** @codingStandardsIgnoreStart */',
-                'after'  => '/** @codingStandardsIgnoreEnd */',
             ],
         ];
 
@@ -764,26 +699,6 @@ EOD;
             'ignoreFile: late comment, slash comment'                 => [
                 'before' => '',
                 'after'  => '// phpcs:ignoreFile',
-            ],
-
-            // Deprecated syntax.
-            'old style: start of file, slash comment'                 => [
-                'before' => '// @codingStandardsIgnoreFile',
-            ],
-            'old style: start of file, single-line star comment'      => [
-                'before' => '/* @codingStandardsIgnoreFile */',
-            ],
-            'old style: start of file, multi-line star comment'       => [
-                'before' => '/*'.PHP_EOL.' @codingStandardsIgnoreFile'.PHP_EOL.' */',
-            ],
-            'old style: start of file, single-line docblock comment'  => [
-                'before' => '/** @codingStandardsIgnoreFile */',
-            ],
-
-            // Deprecated syntax, late comment.
-            'old style: late comment, slash comment'                  => [
-                'before' => '',
-                'after'  => '// @codingStandardsIgnoreFile',
             ],
         ];
 


### PR DESCRIPTION
# Description
This annotation syntax was deprecated in PHPCS 3.2.0, which also introduced the new `// phpcs:...` syntax as a replacement.


## Suggested changelog entry
Removed:
- Support for the deprecated `@codingStandard` annotation syntax has been removed. 
    - Use the `phpcs:` or `@phpcs:` syntax instead
        - Replace `@codingStandardsIgnoreFile` with `phpcs:ignoreFile`
        - Replace `@codingStandardsIgnoreStart` with `phpcs:disable`
        - Replace `@codingStandardsIgnoreEnd` with `phpcs:enable`
        - Replace `@codingStandardsIgnoreLine` with `phpcs:ignore`
        - Replace `@codingStandardsChangeSetting` with `phpcs:set`


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#1954

Related to #6
