### PR TITLE
Ruleset: remove support for the deprecated ruleset.xml array property string-based syntax

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -1199,6 +1199,17 @@ class Ruleset
                     if (isset($prop['type']) === true
                         && (string) $prop['type'] === 'array'
                     ) {
+                        if (isset($prop['value']) === true) {
+                            $message  = 'Passing an array of values to a property using a comma-separated string'.PHP_EOL;
+                            $message .= 'is no longer supported since PHP_CodeSniffer 4.0.0.'.PHP_EOL;
+                            $message .= "The unsupported syntax was used for property \"$name\"".PHP_EOL;
+                            $message .= "for sniff \"$code\".".PHP_EOL;
+                            $message .= 'Pass array values via <element [key="..." ]value="..."> nodes instead.';
+                            $this->msgCache->add($message, MessageCollector::ERROR);
+
+                            continue;
+                        }
+
                         $values = [];
                         if (isset($prop['extend']) === true
                             && (string) $prop['extend'] === 'true'
@@ -1226,27 +1237,7 @@ class Ruleset
                             }
 
                             $printValue = rtrim($printValue, ',');
-                        } else if (isset($prop['value']) === true) {
-                            $message  = 'Passing an array of values to a property using a comma-separated string'.PHP_EOL;
-                            $message .= 'was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.'.PHP_EOL;
-                            $message .= "The deprecated syntax was used for property \"$name\"".PHP_EOL;
-                            $message .= "for sniff \"$code\".".PHP_EOL;
-                            $message .= 'Pass array values via <element [key="..." ]value="..."> nodes instead.';
-                            $this->msgCache->add($message, MessageCollector::DEPRECATED);
-
-                            $value      = (string) $prop['value'];
-                            $printValue = $value;
-                            if ($value !== '') {
-                                foreach (explode(',', $value) as $val) {
-                                    list($k, $v) = explode('=>', $val.'=>');
-                                    if ($v !== '') {
-                                        $values[trim($k)] = trim($v);
-                                    } else {
-                                        $values[] = trim($k);
-                                    }
-                                }
-                            }
-                        }//end if
+                        }
 
                         $this->ruleset[$code]['properties'][$name] = [
                             'value' => $values,

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -184,9 +184,9 @@ final class ExplainTest extends TestCase
         $ruleset  = new Ruleset($config);
 
         $expected  = PHP_EOL;
-        $expected .= 'The ShowSniffDeprecationsTest standard contains 11 sniffs'.PHP_EOL.PHP_EOL;
+        $expected .= 'The ShowSniffDeprecationsTest standard contains 12 sniffs'.PHP_EOL.PHP_EOL;
 
-        $expected .= 'TestStandard (11 sniffs)'.PHP_EOL;
+        $expected .= 'TestStandard (12 sniffs)'.PHP_EOL;
         $expected .= '------------------------'.PHP_EOL;
         $expected .= '  TestStandard.Deprecated.WithLongReplacement *'.PHP_EOL;
         $expected .= '  TestStandard.Deprecated.WithoutReplacement *'.PHP_EOL;
@@ -198,6 +198,7 @@ final class ExplainTest extends TestCase
         $expected .= '  TestStandard.SetProperty.AllowedViaStdClass'.PHP_EOL;
         $expected .= '  TestStandard.SetProperty.NotAllowedViaAttribute'.PHP_EOL;
         $expected .= '  TestStandard.SetProperty.PropertyTypeHandling'.PHP_EOL;
+        $expected .= '  TestStandard.SetProperty.PropertyTypeHandlingOldArrayFormat'.PHP_EOL;
         $expected .= '  TestStandard.ValidSniffs.RegisterEmptyArray'.PHP_EOL.PHP_EOL;
 
         $expected .= '* Sniffs marked with an asterix are deprecated.'.PHP_EOL;

--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -24,8 +24,4 @@
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsEmptyArray[]
 
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithOnlyValues[] string, 10, 1.5, null, true, false
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
-// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsOldSchoolEmptyArray[]
-
 echo 'hello!';

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingOldArrayFormatSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingOldArrayFormatSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\PropertyTypeHandlingOldArrayFormatTest
+ */
+
+namespace Fixtures\TestStandard\Sniffs\SetProperty;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+final class PropertyTypeHandlingOldArrayFormatSniff implements Sniff
+{
+
+    /**
+     * Used to verify that array properties passed as a string is no longer supported since PHPCS 4.0.0.
+     *
+     * @var array<mixed>
+     */
+    public $expectsOldSchoolArrayWithOnlyValues;
+
+    /**
+     * Used to verify that array properties passed as a string is no longer supported since PHPCS 4.0.0.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithKeysAndValues;
+
+    /**
+     * Used to verify that array properties passed as a string is no longer supported since PHPCS 4.0.0.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithExtendedValues;
+
+    /**
+     * Used to verify that array properties passed as a string is no longer supported since PHPCS 4.0.0.
+     *
+     * @var array<string, mixed>
+     */
+    public $expectsOldSchoolArrayWithExtendedKeysAndValues;
+
+    /**
+     * Used to verify that array properties passed as a string is no longer supported since PHPCS 4.0.0.
+     *
+     * @var array<mixed>
+     */
+    public $expectsOldSchoolEmptyArray;
+
+    public function register()
+    {
+        return [T_ECHO];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -143,41 +143,6 @@ final class PropertyTypeHandlingSniff implements Sniff
      */
     public $expectsEmptyArray;
 
-    /**
-     * Used to verify that array properties passed as a string get parsed to a proper array.
-     *
-     * @var array<mixed>
-     */
-    public $expectsOldSchoolArrayWithOnlyValues;
-
-    /**
-     * Used to verify that array properties passed as a string with keys get parsed to a proper array.
-     *
-     * @var array<string, mixed>
-     */
-    public $expectsOldSchoolArrayWithKeysAndValues;
-
-    /**
-     * Used to verify that array properties passed as a string can get extended.
-     *
-     * @var array<string, mixed>
-     */
-    public $expectsOldSchoolArrayWithExtendedValues;
-
-    /**
-     * Used to verify that array properties passed as a string can get extended.
-     *
-     * @var array<string, mixed>
-     */
-    public $expectsOldSchoolArrayWithExtendedKeysAndValues;
-
-    /**
-     * Used to verify that array properties passed as a string allow for setting a property to an empty array.
-     *
-     * @var array<mixed>
-     */
-    public $expectsOldSchoolEmptyArray;
-
     public function register()
     {
         return [T_ECHO];

--- a/tests/Core/Ruleset/ProcessRulesetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetTest.php
@@ -74,6 +74,7 @@ final class ProcessRulesetTest extends TestCase
             "$std.SetProperty.AllowedViaStdClass"                    => "$sniffDir\SetProperty\AllowedViaStdClassSniff",
             "$std.SetProperty.NotAllowedViaAttribute"                => "$sniffDir\SetProperty\NotAllowedViaAttributeSniff",
             "$std.SetProperty.PropertyTypeHandling"                  => "$sniffDir\SetProperty\PropertyTypeHandlingSniff",
+            "$std.SetProperty.PropertyTypeHandlingOldArrayFormat"    => "$sniffDir\SetProperty\PropertyTypeHandlingOldArrayFormatSniff",
             "$std.ValidSniffs.RegisterEmptyArray"                    => "$sniffDir\ValidSniffs\RegisterEmptyArraySniff",
         ];
 

--- a/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for the handling of properties being set via the ruleset.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\Ruleset\AbstractRulesetTestCase;
+
+/**
+ * Test the handling of an array property value using the PHPCS < 4.0 format set via the ruleset.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
+ */
+final class PropertyTypeHandlingOldArrayFormatTest extends AbstractRulesetTestCase
+{
+
+
+    /**
+     * Verify an error is thrown when an array property is set from the ruleset using a comma-separated string.
+     *
+     * Support for this format was (soft) deprecated in PHPCS 3.3.0 and removed in PHPCS 4.0.0.
+     *
+     * @return void
+     */
+    public function testUsingOldSchoolArrayFormatThrowsError()
+    {
+        $regex  = '`^(';
+        $regex .= 'ERROR: Passing an array of values to a property using a comma-separated string\R';
+        $regex .= 'is no longer supported since PHP_CodeSniffer 4\.0\.0\.\R';
+        $regex .= 'The unsupported syntax was used for property "expectsOldSchool(?:EmptyArray|ArrayWith(?:Extended|Only)?(?:KeysAnd)?Values)"\R';
+        $regex .= 'for sniff "';
+        $regex .= '(?:\./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingOldArrayFormatSniff\.php|TestStandard\.SetProperty\.PropertyTypeHandlingOldArrayFormat)';
+        $regex .= '"\.\R';
+        $regex .= 'Pass array values via <element \[key="\.\.\." \]value="\.\.\."> nodes instead\.\R';
+        $regex .= '){14}\R$`';
+
+        $this->expectRuntimeExceptionRegex($regex);
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/PropertyTypeHandlingOldArrayFormatTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        new Ruleset($config);
+
+    }//end testUsingOldSchoolArrayFormatThrowsError()
+
+
+}//end class

--- a/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PropertyTypeHandlingOldArrayFormatTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingOldArrayFormatSniff.php">
+        <properties>
+            <property name="expectsOldSchoolArrayWithOnlyValues" type="array" value="string, 10, 1.5, null, true, false" />
+
+            <property name="expectsOldSchoolArrayWithKeysAndValues" type="array" value="string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false" />
+
+            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" value="string" />
+            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" extend="true" value="15,another string" />
+
+            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" value="10=>10,string=>string" />
+            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" extend="true" value="15=>15,another string=>another string" />
+
+            <property name="expectsOldSchoolEmptyArray" type="array" value=""/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -39,35 +39,6 @@ final class PropertyTypeHandlingTest extends TestCase
 
 
     /**
-     * Verify a deprecation notice is shown when an array property is set from the ruleset using a comma-separated string.
-     *
-     * Support for this format was (soft) deprecated in PHPCS 3.3.0.
-     *
-     * @return void
-     */
-    public function testUsingOldSchoolArrayFormatShowsDeprecationNotice()
-    {
-        $regex  = '`^(';
-        $regex .= 'DEPRECATED: Passing an array of values to a property using a comma-separated string\R';
-        $regex .= 'was deprecated in PHP_CodeSniffer 3\.3\.0\. Support will be removed in PHPCS 4\.0\.0\.\R';
-        $regex .= 'The deprecated syntax was used for property "expectsOldSchool(?:EmptyArray|ArrayWith(?:Extended|Only)?(?:KeysAnd)?Values)"\R';
-        $regex .= 'for sniff "';
-        $regex .= '(?:\./tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff\.php|TestStandard\.SetProperty\.PropertyTypeHandling)';
-        $regex .= '"\.\R';
-        $regex .= 'Pass array values via <element \[key="\.\.\." \]value="\.\.\."> nodes instead\.\R';
-        $regex .= '){14}\R$`';
-
-        $this->expectOutputRegex($regex);
-
-        // Set up the ruleset.
-        $standard = __DIR__.'/PropertyTypeHandlingTest.xml';
-        $config   = new ConfigDouble(["--standard=$standard"]);
-        new Ruleset($config);
-
-    }//end testUsingOldSchoolArrayFormatShowsDeprecationNotice()
-
-
-    /**
      * Test the value type handling for properties set via a ruleset.
      *
      * @param string $propertyName Property name.
@@ -186,28 +157,16 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsBooleanFalseTrimmed',
                 'expected'     => false,
             ],
-            'Array with only values (new style)'             => [
+            'Array with only values'                         => [
                 'propertyName' => 'expectsArrayWithOnlyValues',
                 'expected'     => $expectedArrayOnlyValues,
             ],
-            'Array with keys and values (new style)'         => [
+            'Array with keys and values'                     => [
                 'propertyName' => 'expectsArrayWithKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValues,
             ],
-            'Empty array (new style)'                        => [
+            'Empty array'                                    => [
                 'propertyName' => 'expectsEmptyArray',
-                'expected'     => [],
-            ],
-            'Array with only values (old style)'             => [
-                'propertyName' => 'expectsOldSchoolArrayWithOnlyValues',
-                'expected'     => $expectedArrayOnlyValues,
-            ],
-            'Array with keys and values (old style)'         => [
-                'propertyName' => 'expectsOldSchoolArrayWithKeysAndValues',
-                'expected'     => $expectedArrayKeysAndValues,
-            ],
-            'Empty array (old style)'                        => [
-                'propertyName' => 'expectsOldSchoolEmptyArray',
                 'expected'     => [],
             ],
         ];
@@ -239,20 +198,12 @@ final class PropertyTypeHandlingTest extends TestCase
         ];
 
         return [
-            'Array with only values extended (new style)'     => [
+            'Array with only values extended'     => [
                 'propertyName' => 'expectsArrayWithExtendedValues',
                 'expected'     => $expectedArrayOnlyValuesExtended,
             ],
-            'Array with keys and values extended (new style)' => [
+            'Array with keys and values extended' => [
                 'propertyName' => 'expectsArrayWithExtendedKeysAndValues',
-                'expected'     => $expectedArrayKeysAndValuesExtended,
-            ],
-            'Array with only values extended (old style)'     => [
-                'propertyName' => 'expectsOldSchoolArrayWithExtendedValues',
-                'expected'     => $expectedArrayOnlyValuesExtended,
-            ],
-            'Array with keys and values extended (old style)' => [
-                'propertyName' => 'expectsOldSchoolArrayWithExtendedKeysAndValues',
                 'expected'     => $expectedArrayKeysAndValuesExtended,
             ],
         ];
@@ -262,9 +213,6 @@ final class PropertyTypeHandlingTest extends TestCase
 
     /**
      * Test Helper.
-     *
-     * Note: the deprecations for using comma-separated string to pass an array, are silenced in this helper
-     * as that's not what's being tested here.
      *
      * @see self::testTypeHandlingWhenSetViaRuleset()
      *
@@ -277,7 +225,7 @@ final class PropertyTypeHandlingTest extends TestCase
         if (isset($sniffObject) === false) {
             // Set up the ruleset.
             $standard = __DIR__.'/PropertyTypeHandlingTest.xml';
-            $config   = new ConfigDouble(["--standard=$standard", '-q']);
+            $config   = new ConfigDouble(["--standard=$standard"]);
             $ruleset  = new Ruleset($config);
 
             // Verify that our target sniff has been registered.

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -59,18 +59,6 @@
             </property>
 
             <property name="expectsEmptyArray" type="array"/>
-
-            <property name="expectsOldSchoolArrayWithOnlyValues" type="array" value="string, 10, 1.5, null, true, false" />
-
-            <property name="expectsOldSchoolArrayWithKeysAndValues" type="array" value="string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false" />
-
-            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" value="string" />
-            <property name="expectsOldSchoolArrayWithExtendedValues" type="array" extend="true" value="15,another string" />
-
-            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" value="10=>10,string=>string" />
-            <property name="expectsOldSchoolArrayWithExtendedKeysAndValues" type="array" extend="true" value="15=>15,another string=>another string" />
-
-            <property name="expectsOldSchoolEmptyArray" type="array" value=""/>
         </properties>
     </rule>
 


### PR DESCRIPTION
# Description
The old syntax was deprecated in PHPCS 3.3.0, which also introduced support for using `<element...>` nodes as a replacement.

Includes splitting off the tests for the old-style, comma-delimited string manner of setting an array property to a separate test class with its own fixtures.

Refs:
* squizlabs/PHP_CodeSniffer#1665


## Suggested changelog entry
- Support for the deprecated `ruleset.xml` array property string-based syntax has been removed.
    - Previously, an array value could be set using a comma-delimited string `print=>echo,create_function=>null`
    - Now, individual array elements are specified using an `element` tag with `key` and `value` attributes
        - For example, `<element key="print" value="echo">`


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#1983

Related to #6


