### PR TITLE
Filters/ExactMatch: remove the deprecated `getBlacklist()` and `getWhitelist()` methods

### DIFF
--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -48,20 +48,10 @@ abstract class ExactMatch extends Filter
 
         if ($this->disallowedFiles === null) {
             $this->disallowedFiles = $this->getDisallowedFiles();
-
-            // BC-layer.
-            if ($this->disallowedFiles === null) {
-                $this->disallowedFiles = $this->getBlacklist();
-            }
         }
 
         if ($this->allowedFiles === null) {
             $this->allowedFiles = $this->getAllowedFiles();
-
-            // BC-layer.
-            if ($this->allowedFiles === null) {
-                $this->allowedFiles = $this->getWhitelist();
-            }
         }
 
         $filePath = Common::realpath($this->current());
@@ -102,55 +92,21 @@ abstract class ExactMatch extends Filter
     /**
      * Get a list of file paths to exclude.
      *
-     * @deprecated 3.9.0 Implement the `getDisallowedFiles()` method instead.
-     *                   The `getDisallowedFiles()` method will be made abstract and therefore required
-     *                   in v4.0 and this method will be removed.
-     *                   If both methods are implemented, the new `getDisallowedFiles()` method will take precedence.
+     * @since 3.9.0 Replaces the `getBlacklist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
-    abstract protected function getBlacklist();
+    abstract protected function getDisallowedFiles();
 
 
     /**
      * Get a list of file paths to include.
      *
-     * @deprecated 3.9.0 Implement the `getAllowedFiles()` method instead.
-     *                   The `getAllowedFiles()` method will be made abstract and therefore required
-     *                   in v4.0 and this method will be removed.
-     *                   If both methods are implemented, the new `getAllowedFiles()` method will take precedence.
+     * @since 3.9.0 Replaces the `getWhitelist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
-    abstract protected function getWhitelist();
-
-
-    /**
-     * Get a list of file paths to exclude.
-     *
-     * @since 3.9.0 Replaces the deprecated `getBlacklist()` method.
-     *
-     * @return array|null
-     */
-    protected function getDisallowedFiles()
-    {
-        return null;
-
-    }//end getDisallowedFiles()
-
-
-    /**
-     * Get a list of file paths to include.
-     *
-     * @since 3.9.0 Replaces the deprecated `getWhitelist()` method.
-     *
-     * @return array|null
-     */
-    protected function getAllowedFiles()
-    {
-        return null;
-
-    }//end getAllowedFiles()
+    abstract protected function getAllowedFiles();
 
 
 }//end class

--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -18,7 +18,7 @@ class GitModified extends ExactMatch
     /**
      * Get a list of file paths to exclude.
      *
-     * @since 3.9.0
+     * @since 3.9.0 Replaces the `getBlacklist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
@@ -30,25 +30,9 @@ class GitModified extends ExactMatch
 
 
     /**
-     * Get a list of file paths to exclude.
-     *
-     * @deprecated 3.9.0 Overload the `getDisallowedFiles()` method instead.
-     *
-     * @codeCoverageIgnore
-     *
-     * @return array
-     */
-    protected function getBlacklist()
-    {
-        return $this->getDisallowedFiles();
-
-    }//end getBlacklist()
-
-
-    /**
      * Get a list of file paths to include.
      *
-     * @since 3.9.0
+     * @since 3.9.0 Replaces the `getWhitelist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
@@ -80,22 +64,6 @@ class GitModified extends ExactMatch
         return $modified;
 
     }//end getAllowedFiles()
-
-
-    /**
-     * Get a list of file paths to include.
-     *
-     * @deprecated 3.9.0 Overload the `getAllowedFiles()` method instead.
-     *
-     * @codeCoverageIgnore
-     *
-     * @return array
-     */
-    protected function getWhitelist()
-    {
-        return $this->getAllowedFiles();
-
-    }//end getWhitelist()
 
 
     /**

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -20,7 +20,7 @@ class GitStaged extends ExactMatch
     /**
      * Get a list of file paths to exclude.
      *
-     * @since 3.9.0
+     * @since 3.9.0 Replaces the `getBlacklist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
@@ -32,25 +32,9 @@ class GitStaged extends ExactMatch
 
 
     /**
-     * Get a list of file paths to exclude.
-     *
-     * @deprecated 3.9.0 Overload the `getDisallowedFiles()` method instead.
-     *
-     * @codeCoverageIgnore
-     *
-     * @return array
-     */
-    protected function getBlacklist()
-    {
-        return $this->getDisallowedFiles();
-
-    }//end getBlacklist()
-
-
-    /**
      * Get a list of file paths to include.
      *
-     * @since 3.9.0
+     * @since 3.9.0 Replaces the `getWhitelist()` method, which was removed in PHPCS 4.0.0.
      *
      * @return array
      */
@@ -82,22 +66,6 @@ class GitStaged extends ExactMatch
         return $modified;
 
     }//end getAllowedFiles()
-
-
-    /**
-     * Get a list of file paths to include.
-     *
-     * @deprecated 3.9.0 Overload the `getAllowedFiles()` method instead.
-     *
-     * @codeCoverageIgnore
-     *
-     * @return array
-     */
-    protected function getWhitelist()
-    {
-        return $this->getAllowedFiles();
-
-    }//end getWhitelist()
 
 
     /**


### PR DESCRIPTION
# Description
* Removes the deprecated `getBlacklist()` and `getWhitelist()` methods.
* Makes the `getDisallowedFiles()` and `getAllowedFiles()` replacement methods `abstract`.


## Suggested changelog entry
Removed:
* The abstract `PHP_CodeSniffer\Filters\ExactMatch::getBlacklist()` and `PHP_CodeSniffer\Filters\ExactMatch::getWhitelist()` methods.
    - These have been replaced by the `ExactMatch::getDisallowedFiles()` and `ExactMatch::getAllowedFiles()` methods.


## Related issues/external references

Related to #198
Fixes #199

