### PR TITLE
Ruleset: remove support for standards called "Internal"

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -892,11 +892,13 @@ class Ruleset
      */
     private function expandRulesetReference($ref, $rulesetDir, $depth=0)
     {
-        // Naming an (external) standard "Internal" is deprecated.
+        // Naming an (external) standard "Internal" is not supported.
         if (strtolower($ref) === 'internal') {
             $message  = 'The name "Internal" is reserved for internal use. A PHP_CodeSniffer standard should not be called "Internal".'.PHP_EOL;
             $message .= 'Contact the maintainer of the standard to fix this.';
-            $this->msgCache->add($message, MessageCollector::DEPRECATED);
+            $this->msgCache->add($message, MessageCollector::ERROR);
+
+            return [];
         }
 
         // Ignore internal sniffs codes as they are used to only

--- a/tests/Core/Ruleset/ExpandRulesetReferenceInternalStandardTest.xml
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceInternalStandardTest.xml
@@ -5,4 +5,6 @@
 
     <rule ref="Internal"/>
 
+    <!-- Prevent a "no sniffs were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
 </ruleset>

--- a/tests/Core/Ruleset/ExpandRulesetReferenceInternalTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceInternalTest.php
@@ -42,30 +42,30 @@ final class ExpandRulesetReferenceInternalTest extends AbstractRulesetTestCase
 
 
     /**
-     * While definitely not recommended, including a standard named "Internal", _does_ allow for sniffs to be registered.
+     * As of PHPCS 4.0, a standard can no longer be named "Internal".
      *
-     * Note: customizations (exclusions/property setting etc) for individual sniffs may not always be handled correctly,
-     * which is why naming a standard "Internal" is definitely not recommended.
+     * Standards with this name will be ignored.
      *
      * @return void
      */
-    public function testInternalStandardDoesGetExpanded()
+    public function testInternalStandardIsNotSupported()
     {
-        $message  = 'DEPRECATED: The name "Internal" is reserved for internal use. A PHP_CodeSniffer standard should not be called "Internal".'.PHP_EOL;
+        $message  = 'ERROR: The name "Internal" is reserved for internal use. A PHP_CodeSniffer standard should not be called "Internal".'.PHP_EOL;
         $message .= 'Contact the maintainer of the standard to fix this.'.PHP_EOL.PHP_EOL;
 
-        $this->expectOutputString($message);
+        $this->expectRuntimeExceptionMessage($message);
 
         // Set up the ruleset.
         $standard = __DIR__.'/ExpandRulesetReferenceInternalStandardTest.xml';
         $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
-        $expected = ['Internal.Valid.Valid' => 'Fixtures\\Internal\\Sniffs\\Valid\\ValidSniff'];
+        $expected = ['Generic.PHP.BacktickOperator' => 'PHP_CodeSniffer\\Standards\\Generic\\Sniffs\\PHP\\BacktickOperatorSniff'];
 
+        // This assertion will only take effect for PHPUnit 10+.
         $this->assertSame($expected, $ruleset->sniffCodes);
 
-    }//end testInternalStandardDoesGetExpanded()
+    }//end testInternalStandardIsNotSupported()
 
 
 }//end class


### PR DESCRIPTION
# Description

Standards called "Internal" were never really supported anyhow. This is now formalized.

Fixes #799

Related to #6


## Suggested changelog entry
Removed:
* Support for external standards called "Internal".
