### PR TITLE
Remove public error properties of sniffs that don't need them

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -20,13 +20,6 @@ class MultipleStatementAlignmentSniff implements Sniff
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var boolean
-     */
-    public $error = false;
-
-    /**
      * The maximum amount of padding before the alignment is ignored.
      *
      * If the amount of padding required to align this assignment with the
@@ -377,11 +370,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                 $foundText,
             ];
 
-            if ($this->error === true) {
-                $fix = $phpcsFile->addFixableError($error, $assignment, $type, $errorData);
-            } else {
-                $fix = $phpcsFile->addFixableWarning($error, $assignment, $type.'Warning', $errorData);
-            }
+            $fix = $phpcsFile->addFixableWarning($error, $assignment, $type, $errorData);
 
             $errorGenerated = true;
 

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -17,13 +17,6 @@ class UnnecessaryStringConcatSniff implements Sniff
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var boolean
-     */
-    public $error = true;
-
-    /**
      * If true, strings concatenated over multiple lines are allowed.
      *
      * Useful if you break strings over multiple lines to work
@@ -94,11 +87,7 @@ class UnnecessaryStringConcatSniff implements Sniff
         }
 
         $error = 'String concat is not required here; use a single string instead';
-        if ($this->error === true) {
-            $phpcsFile->addError($error, $stackPtr, 'Found');
-        } else {
-            $phpcsFile->addWarning($error, $stackPtr, 'Found');
-        }
+        $phpcsFile->addError($error, $stackPtr, 'Found');
 
     }//end process()
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.1.inc
@@ -28,7 +28,3 @@ $shouldNotTrigger = 'My' /* comment */ . 'string';
 $string = 'Multiline strings are allowed '
         . 'when setting is enabled.';
 // phpcs:set Generic.Strings.UnnecessaryStringConcat allowMultiline false
-
-// phpcs:set Generic.Strings.UnnecessaryStringConcat error false
-$throwWarning = 'My' . 'string';
-// phpcs:set Generic.Strings.UnnecessaryStringConcat error true

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -56,21 +56,11 @@ final class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList()
     {
-        switch ($testFile) {
-        case 'UnnecessaryStringConcatUnitTest.1.inc':
-            return [
-                33 => 1,
-            ];
-
-        default:
-            return [];
-        }
+        return [];
 
     }//end getWarningList()
 

--- a/src/Standards/Squiz/ruleset.xml
+++ b/src/Standards/Squiz/ruleset.xml
@@ -46,9 +46,9 @@
 
     <!-- Have 20 chars padding maximum and always show as errors -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <type>error</type>
         <properties>
             <property name="maxPadding" value="20"/>
-            <property name="error" value="true"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
# Description

Fixes squizlabs/PHP_CodeSniffer#2823

Related to #186


## Suggested changelog entry
Removed:
- Removed `error` property of sniff `Generic.Strings.UnnecessaryStringConcat`
    - This sniff now always produces errors
    - To make this sniff produce warnings, include the following in a `ruleset.xml` or `[.]phpcs.xml[.dist]` file:
        ```xml
        <rule ref="Generic.Strings.UnnecessaryStringConcat">
            <type>warning</type>
        </rule>
        ```
- Removed `error` property of sniff `Generic.Formatting.MultipleStatementAlignment`.
    - This sniff now always produces warnings
    - The `Generic.Formatting.MultipleStatementAlignment.IncorrectWarning` error code has been removed.
        - Refer to the `Generic.Formatting.MultipleStatementAlignment.Incorrect` error code instead.
    - The `Generic.Formatting.MultipleStatementAlignment.NotSameWarning` error code has been removed.
        - Refer to the `Generic.Formatting.MultipleStatementAlignment.NotSame` error code instead.
    - To make this sniff produce errors, include the following in a `ruleset.xml` or `[.]phpcs.xml[.dist]` file:
        ```xml
        <rule ref="Generic.Formatting.MultipleStatementAlignment">
            <type>error</type>
        </rule>
        ```
