### PR TITLE
Removed all parse error warnings from sniffs

### DIFF
--- a/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -49,8 +49,7 @@ class OpeningBraceSameLineSniff implements Sniff
         $errorData       = [strtolower($tokens[$stackPtr]['content']).' '.$tokens[$scopeIdentifier]['content']];
 
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
-            $error = 'Possible parse error: %s missing opening or closing brace';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
@@ -47,7 +47,7 @@ class Test_Class_Bad_H extends Test_Class_Bad_G			{
 class Test_Class_Bad_I implements Test_Interface_Bad_C{
 }
 
-// This one should be flagged as a potential parse error.
+// This one should be ignored as a potential parse error.
 class Test_Class_Bad_H
 
 // This is OK.

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
@@ -47,7 +47,7 @@ class Test_Class_Bad_H extends Test_Class_Bad_G {
 class Test_Class_Bad_I implements Test_Interface_Bad_C {
 }
 
-// This one should be flagged as a potential parse error.
+// This one should be ignored as a potential parse error.
 class Test_Class_Bad_H
 
 // This is OK.

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -60,7 +60,7 @@ final class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [51 => 1];
+        return [];
 
     }//end getWarningList()
 

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -48,8 +48,7 @@ class ClassDeclarationSniff implements Sniff
         $errorData = [strtolower($tokens[$stackPtr]['content'])];
 
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
-            $error = 'Possible parse error: %s missing opening or closing brace';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -88,10 +88,6 @@ final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList($testFile='')
     {
-        if ($testFile === 'ClassDeclarationUnitTest.2.inc') {
-            return [11 => 1];
-        }
-
         return[];
 
     }//end getWarningList()

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -49,9 +49,7 @@ class ValidClassNameSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
-            $error = 'Possible parse error: %s missing opening or closing brace';
-            $data  = [$tokens[$stackPtr]['content']];
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $data);
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -62,8 +62,7 @@ class ClosingDeclarationCommentSniff implements Sniff
             }
 
             if (isset($tokens[$stackPtr]['scope_closer']) === false) {
-                $error = 'Possible parse error: non-abstract method defined as abstract';
-                $phpcsFile->addWarning($error, $stackPtr, 'Abstract');
+                // Parse error or live coding.
                 return;
             }
 
@@ -80,9 +79,7 @@ class ClosingDeclarationCommentSniff implements Sniff
         }//end if
 
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
-            $error = 'Possible parse error: %s missing opening or closing brace';
-            $data  = [$tokens[$stackPtr]['content']];
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $data);
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -59,14 +59,12 @@ class ForEachLoopDeclarationSniff implements Sniff
 
         $openingBracket = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr);
         if ($openingBracket === false) {
-            $error = 'Possible parse error: FOREACH has no opening parenthesis';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingOpenParenthesis');
+            // Parse error or live coding.
             return;
         }
 
         if (isset($tokens[$openingBracket]['parenthesis_closer']) === false) {
-            $error = 'Possible parse error: FOREACH has no closing parenthesis';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingCloseParenthesis');
+            // Parse error or live coding.
             return;
         }
 
@@ -134,8 +132,7 @@ class ForEachLoopDeclarationSniff implements Sniff
 
         $asToken = $phpcsFile->findNext(T_AS, $openingBracket);
         if ($asToken === false) {
-            $error = 'Possible parse error: FOREACH has no AS statement';
-            $phpcsFile->addWarning($error, $stackPtr, 'MissingAs');
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -67,8 +67,7 @@ class ForLoopDeclarationSniff implements Sniff
 
         $openingBracket = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr);
         if ($openingBracket === false || isset($tokens[$openingBracket]['parenthesis_closer']) === false) {
-            $error = 'Possible parse error: no opening/closing parenthesis for FOR keyword';
-            $phpcsFile->addWarning($error, $stackPtr, 'NoOpenBracket');
+            // Parse error or live coding.
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -123,8 +123,7 @@ class SwitchDeclarationSniff implements Sniff
             }
 
             if (isset($tokens[$nextCase]['scope_opener']) === false) {
-                $error = 'Possible parse error: CASE missing opening colon';
-                $phpcsFile->addWarning($error, $nextCase, 'MissingColon');
+                // Parse error or live coding.
                 continue;
             }
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -78,17 +78,7 @@ final class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList($testFile='')
     {
-        switch ($testFile) {
-        case 'ClosingDeclarationCommentUnitTest.1.inc':
-            return [71 => 1];
-
-        case 'ClosingDeclarationCommentUnitTest.2.inc':
-        case 'ClosingDeclarationCommentUnitTest.3.inc':
-            return [7 => 1];
-
-        default:
-            return [];
-        }
+        return [];
 
     }//end getWarningList()
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.2.inc
@@ -2,5 +2,5 @@
 
 // Parse error/live coding test (no parentheses).
 // This test has to be the only test in the file!
-// Testing the "NoOpenBracket" warning.
+// This should be ignored.
 for

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.3.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.3.inc
@@ -2,5 +2,5 @@
 
 // Parse error/live coding test (no close parenthesis).
 // This test has to be the only test in the file!
-// Testing the "NoOpenBracket" warning.
+// This should be ignored.
 for ($i = 10;

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -86,14 +86,7 @@ final class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList($testFile='')
     {
-        switch ($testFile) {
-        case 'ForLoopDeclarationUnitTest.2.inc':
-        case 'ForLoopDeclarationUnitTest.3.inc':
-            return [6 => 1];
-
-        default:
-            return [];
-        }//end switch
+        return [];
 
     }//end getWarningList()
 


### PR DESCRIPTION
# Description

Ref:
* squizlabs/PHP_CodeSniffer#2455


## Suggested changelog entry
- None of the included sniffs will warn about possible parse errors any more.
    - This improves the experience when the file is being checked inside an editor during live coding.
    - If you want to detect parse errors, use the `Generic.PHP.Syntax` sniff or a dedicated linter instead.

