### PR TITLE
Runner: removed use of deprecated auto_detect_line_endings ini setting

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -255,10 +255,6 @@ class Runner
             define('PHP_CODESNIFFER_CBF', false);
         }
 
-        // Ensure this option is enabled or else line endings will not always
-        // be detected properly for files created on a Mac with the /r line ending.
-        @ini_set('auto_detect_line_endings', true);
-
         // Disable the PCRE JIT as this caused issues with parallel running.
         ini_set('pcre.jit', false);
 


### PR DESCRIPTION
# Description

This ini setting has been deprecated by PHP itself.

Ref:
* squizlabs/PHP_CodeSniffer#3394

## Suggested changelog entry
Removed:
- Removed use of the deprecated `auto_detect_line_endings` ini setting.
    - This removes support for files with `\r` line endings.


