### PR TITLE
.gitattributes: tests are no longer included in zip packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,18 +5,21 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/
 # https://blog.madewithlove.be/post/gitattributes/
 #
-.github/                export-ignore
-scripts/                export-ignore
-.cspell.json            export-ignore
-.gitattributes          export-ignore
-.gitignore              export-ignore
-.markdownlint-cli2.yaml export-ignore
-.remarkignore           export-ignore
-.remarkrc               export-ignore
-.yamllint.yml           export-ignore
-phpcs.xml.dist          export-ignore
-phpstan.neon.dist       export-ignore
-phpunit.xml.dist        export-ignore
+.github/                            export-ignore
+scripts/                            export-ignore
+src/Standards/**/Tests/             export-ignore
+tests/Core/**/                      export-ignore
+.cspell.json                        export-ignore
+.gitattributes                      export-ignore
+.gitignore                          export-ignore
+.markdownlint-cli2.yaml             export-ignore
+.remarkignore                       export-ignore
+.remarkrc                           export-ignore
+.yamllint.yml                       export-ignore
+phpcs.xml.dist                      export-ignore
+phpstan.neon.dist                   export-ignore
+phpunit.xml.dist                    export-ignore
+tests/Core/ErrorSuppressionTest.php export-ignore
 
 #
 # Declare files that should always have CRLF line endings on checkout.


### PR DESCRIPTION
# Description

Tests are no longer included in zip packages, but the test _framework_ files will be.

This is set up in this way to prevent external standards having to use `--prefer-source` when their (sniff) tests are using the PHPCS test framework.



## Suggested changelog entry
Changed:
- Composer installs no longer include any test files.
    - The test framework files will still be included to allow for use by external standards.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#1908
Fixes squizlabs/PHP_CodeSniffer#3158
Closes #73
Fixes #636

