### PR TITLE
Ruleset: remove test specific code 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 composer.lock
 phpstan.neon
 /node_modules/
+/tests/Standards/sniffStnd.xml

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -201,22 +201,6 @@ class Ruleset
                 Autoload::addSearchPath(dirname($standard), $namespace);
             }
 
-            if (defined('PHP_CODESNIFFER_IN_TESTS') === true && empty($restrictions) === false) {
-                // In unit tests, only register the sniffs that the test wants and not the entire standard.
-                foreach ($restrictions as $restriction) {
-                    $sniffs = array_merge($sniffs, $this->expandRulesetReference($restriction, dirname($standard)));
-                }
-
-                if (empty($sniffs) === true) {
-                    // Sniff reference could not be expanded, which probably means this
-                    // is an installed standard. Let the unit test system take care of
-                    // setting the correct sniff for testing.
-                    return;
-                }
-
-                break;
-            }
-
             if (PHP_CODESNIFFER_VERBOSITY === 1) {
                 echo "Registering sniffs in the $standardName standard... ";
                 if (count($config->standards) > 1 || PHP_CODESNIFFER_VERBOSITY > 2) {

--- a/tests/Core/Generators/GeneratorTest.php
+++ b/tests/Core/Generators/GeneratorTest.php
@@ -194,16 +194,6 @@ final class GeneratorTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", "--sniffs=$sniffs"]);
         $ruleset  = new Ruleset($config);
 
-        // In tests, the `--sniffs` setting doesn't work out of the box.
-        $sniffParts = explode('.', $sniffs);
-        $sniffFile  = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$sniffParts[0].DIRECTORY_SEPARATOR;
-        $sniffFile .= 'Sniffs'.DIRECTORY_SEPARATOR.$sniffParts[1].DIRECTORY_SEPARATOR.$sniffParts[2].'Sniff.php';
-
-        $sniffParts   = array_map('strtolower', $sniffParts);
-        $sniffName    = $sniffParts[0].'\sniffs\\'.$sniffParts[1].'\\'.$sniffParts[2].'sniff';
-        $restrictions = [$sniffName => true];
-        $ruleset->registerSniffs([$sniffFile], $restrictions, []);
-
         // Make the test OS independent.
         $this->expectOutputString('Documentation Title PCRE Fallback'.PHP_EOL);
 

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -94,16 +94,6 @@ final class HTMLTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", "--sniffs=$sniffs"]);
         $ruleset  = new Ruleset($config);
 
-        // In tests, the `--sniffs` setting doesn't work out of the box.
-        $sniffParts = explode('.', $sniffs);
-        $sniffFile  = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$sniffParts[0].DIRECTORY_SEPARATOR;
-        $sniffFile .= 'Sniffs'.DIRECTORY_SEPARATOR.$sniffParts[1].DIRECTORY_SEPARATOR.$sniffParts[2].'Sniff.php';
-
-        $sniffParts   = array_map('strtolower', $sniffParts);
-        $sniffName    = $sniffParts[0].'\sniffs\\'.$sniffParts[1].'\\'.$sniffParts[2].'sniff';
-        $restrictions = [$sniffName => true];
-        $ruleset->registerSniffs([$sniffFile], $restrictions, []);
-
         $expected = file_get_contents($pathToExpected);
         $this->assertNotFalse($expected, 'Output expectation file could not be found');
 

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -94,16 +94,6 @@ final class MarkdownTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", "--sniffs=$sniffs"]);
         $ruleset  = new Ruleset($config);
 
-        // In tests, the `--sniffs` setting doesn't work out of the box.
-        $sniffParts = explode('.', $sniffs);
-        $sniffFile  = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$sniffParts[0].DIRECTORY_SEPARATOR;
-        $sniffFile .= 'Sniffs'.DIRECTORY_SEPARATOR.$sniffParts[1].DIRECTORY_SEPARATOR.$sniffParts[2].'Sniff.php';
-
-        $sniffParts   = array_map('strtolower', $sniffParts);
-        $sniffName    = $sniffParts[0].'\sniffs\\'.$sniffParts[1].'\\'.$sniffParts[2].'sniff';
-        $restrictions = [$sniffName => true];
-        $ruleset->registerSniffs([$sniffFile], $restrictions, []);
-
         $expected = file_get_contents($pathToExpected);
         $this->assertNotFalse($expected, 'Output expectation file could not be found');
 

--- a/tests/Core/Generators/TextTest.php
+++ b/tests/Core/Generators/TextTest.php
@@ -94,16 +94,6 @@ final class TextTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard", "--sniffs=$sniffs"]);
         $ruleset  = new Ruleset($config);
 
-        // In tests, the `--sniffs` setting doesn't work out of the box.
-        $sniffParts = explode('.', $sniffs);
-        $sniffFile  = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$sniffParts[0].DIRECTORY_SEPARATOR;
-        $sniffFile .= 'Sniffs'.DIRECTORY_SEPARATOR.$sniffParts[1].DIRECTORY_SEPARATOR.$sniffParts[2].'Sniff.php';
-
-        $sniffParts   = array_map('strtolower', $sniffParts);
-        $sniffName    = $sniffParts[0].'\sniffs\\'.$sniffParts[1].'\\'.$sniffParts[2].'sniff';
-        $restrictions = [$sniffName => true];
-        $ruleset->registerSniffs([$sniffFile], $restrictions, []);
-
         $expected = file_get_contents($pathToExpected);
         $this->assertNotFalse($expected, 'Output expectation file could not be found');
 

--- a/tests/Core/Ruleset/RegisterSniffsTest.php
+++ b/tests/Core/Ruleset/RegisterSniffsTest.php
@@ -140,18 +140,17 @@ final class RegisterSniffsTest extends TestCase
     /**
      * Test that if only specific sniffs are requested, only those are registered.
      *
-     * {@internal Can't test this via the CLI arguments due to some code in the Ruleset class
-     * related to sniff tests.}
-     *
      * @return void
      */
     public function testRegisteredSniffsWithRestrictions()
     {
-        $restrictions = [
-            'psr1\\sniffs\\classes\\classdeclarationsniff'    => true,
-            'psr1\\sniffs\\files\\sideeffectssniff'           => true,
-            'psr1\\sniffs\\methods\\camelcapsmethodnamesniff' => true,
+        // Set up the ruleset.
+        $args    = [
+            '--standard=PSR1',
+            '--sniffs=PSR1.Classes.ClassDeclaration,PSR1.Files.SideEffects,PSR1.Methods.CamelCapsMethodName',
         ];
+        $config  = new ConfigDouble($args);
+        $ruleset = new Ruleset($config);
 
         $expected = [
             'PHP_CodeSniffer\\Standards\\PSR1\\Sniffs\\Classes\\ClassDeclarationSniff',
@@ -159,9 +158,10 @@ final class RegisterSniffsTest extends TestCase
             'PHP_CodeSniffer\\Standards\\PSR1\\Sniffs\\Methods\\CamelCapsMethodNameSniff',
         ];
 
-        self::$ruleset->registerSniffs(self::$psr1SniffAbsolutePaths, $restrictions, []);
+        $actual = array_keys($ruleset->sniffs);
+        sort($actual);
 
-        $this->assertSame($expected, array_keys(self::$ruleset->sniffs));
+        $this->assertSame($expected, $actual);
 
     }//end testRegisteredSniffsWithRestrictions()
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -169,35 +169,13 @@ final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
     public function testDeprecatedSniffsListDoesNotShowWhenSelectedSniffsAreNotDeprecated()
     {
         $standard = __DIR__.'/ShowSniffDeprecationsTest.xml';
-        $config   = new ConfigDouble(['.', "--standard=$standard"]);
-        $ruleset  = new Ruleset($config);
-
-        /*
-         * Apply sniff restrictions.
-         * For tests we need to manually trigger this if the standard is "installed", like with the fixtures these tests use.
-         */
-
-        $restrictions = [];
-        $sniffs       = [
-            'TestStandard.SetProperty.AllowedAsDeclared',
-            'TestStandard.SetProperty.AllowedViaStdClass',
+        $cliArgs  = [
+            '.',
+            "--standard=$standard",
+            '--sniffs=TestStandard.SetProperty.AllowedAsDeclared,TestStandard.SetProperty.AllowedViaStdClass',
         ];
-        foreach ($sniffs as $sniffCode) {
-            $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = $parts[0].'\\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
-            $restrictions[strtolower($sniffName)] = true;
-        }
-
-        $sniffFiles = [];
-        $allSniffs  = $ruleset->sniffCodes;
-        foreach ($allSniffs as $sniffName) {
-            $sniffFile    = str_replace('\\', DIRECTORY_SEPARATOR, $sniffName);
-            $sniffFile    = __DIR__.DIRECTORY_SEPARATOR.$sniffFile.'.php';
-            $sniffFiles[] = $sniffFile;
-        }
-
-        $ruleset->registerSniffs($sniffFiles, $restrictions, []);
-        $ruleset->populateTokenListeners();
+        $config   = new ConfigDouble($cliArgs);
+        $ruleset  = new Ruleset($config);
 
         $this->expectOutputString('');
 
@@ -215,38 +193,20 @@ final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
     public function testDeprecatedSniffsListDoesNotShowWhenAllDeprecatedSniffsAreExcluded()
     {
         $standard = __DIR__.'/ShowSniffDeprecationsTest.xml';
-        $config   = new ConfigDouble(['.', "--standard=$standard"]);
-        $ruleset  = new Ruleset($config);
-
-        /*
-         * Apply sniff restrictions.
-         * For tests we need to manually trigger this if the standard is "installed", like with the fixtures these tests use.
-         */
-
-        $exclusions = [];
-        $exclude    = [
+        $exclude  = [
             'TestStandard.Deprecated.WithLongReplacement',
             'TestStandard.Deprecated.WithoutReplacement',
             'TestStandard.Deprecated.WithReplacement',
             'TestStandard.Deprecated.WithReplacementContainingLinuxNewlines',
             'TestStandard.Deprecated.WithReplacementContainingNewlines',
         ];
-        foreach ($exclude as $sniffCode) {
-            $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = $parts[0].'\\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
-            $exclusions[strtolower($sniffName)] = true;
-        }
-
-        $sniffFiles = [];
-        $allSniffs  = $ruleset->sniffCodes;
-        foreach ($allSniffs as $sniffName) {
-            $sniffFile    = str_replace('\\', DIRECTORY_SEPARATOR, $sniffName);
-            $sniffFile    = __DIR__.DIRECTORY_SEPARATOR.$sniffFile.'.php';
-            $sniffFiles[] = $sniffFile;
-        }
-
-        $ruleset->registerSniffs($sniffFiles, [], $exclusions);
-        $ruleset->populateTokenListeners();
+        $cliArgs  = [
+            '.',
+            "--standard=$standard",
+            '--exclude='.implode(',', $exclude),
+        ];
+        $config   = new ConfigDouble($cliArgs);
+        $ruleset  = new Ruleset($config);
 
         $this->expectOutputString('');
 


### PR DESCRIPTION
# Description

### Ruleset: remove test specific code 

The PHPCS 2.7.1 release introduced a change to how sniff tests are run.
Originally, sniff tests would be run in the context of their ruleset. This could lead to parts of the sniff being untestable, like if the ruleset would exclude a error code or contained custom property settings.

As of PHPCS 2.7.1, sniff tests are run in isolation and no longer take the ruleset of the standard they belong to into account, which solves the above problem.

This change was introduced via commit 3df85dc.

Unfortunately, the way this change was made was via a change to the `Ruleset` class, not by changing the test framework.

It basically meant that the `Ruleset` class would now behave differently when the following two conditions were met:
1. It was being used in a test context (`PHP_CODESNIFFER_IN_TESTS` constant defined).
2. Sniff restrictions were applied via the Config, either by using the CLI `--sniffs` argument or by setting the `Config::$sniffs` property directly.

In other words, this now created a new problem when testing parts of the `Ruleset` class which would need the `Config::$sniffs` property to be set.
It also makes writing various other tests for the framework more difficult as there are plenty of times when tests would benefit from the `Config::$sniffs` property being respected. In other words, this led to work-arounds being needed in various other places in the tests, either by emulating the sniff selection or by bypassing the `Ruleset` conditions and doing the sniff selection in a test specific ruleset XML fixture file.

Aside from the above, it also makes the barrier to entry for contributors to write tests for PHPCS that much higher as the behaviour is non-intuitive.

All in all, time to get rid of the condition in the `Ruleset` class.

Now, of course, we do still want to test sniffs in isolation, so to do that the `AbstractSniffUnitTest` class has been updated to on-the-fly create ruleset XML files which only include a single sniff without any customizations.

I considered using `php://memory` or `php://temp` instead of writing the file to disk, however, neither of those work with `file_get_contents()`, which is used to read the XML ruleset files in the `Ruleset` class, so unfortunately, those temporary file writes cannot be avoided without making bigger changes, which is outside the scope of this PR.

Now, I wondered about the performance impact of writing a file to disk for every sniff being tested, and while there is a small, but noticeable, difference when running on Windows (20 vs 27 seconds for `--filter Standards`), IMO this difference is acceptable when offset against the hours and hours of dev time lost trying to debug why perfectly valid tests weren't working due to `--sniffs` not being respected in the tests.

And to be sure, I've also tested the new test isolation mechanism with an external standard which is using the PHPCS native test framework and it looks to be working fine.

Note: even though the `AbstractSniffUnitTest` will clean up the temporary file after each test, if the test run would crash, it could be possible for the file to remain on disk. With this in mind, the file name for the temporary file has been added to the `.gitignore` file.

Related to #966

### Tests: remove work-arounds for --sniffs not being respected 

Now that the `--sniffs` CLI argument will be respected in the tests, a number of work-arounds previously introduced can be removed.

Note: there may be a few more work-arounds which can be removed, like removing some fixture rulesets in favour of test inline sniff selection, but this should be a good first step.

## Suggested changelog entry
Changed:
The Ruleset class no longer has special behaviour when used in a test context.



