### PR TITLE
Tests: allow for PHPUnit 10 and 11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@ tests/Core/**/                      export-ignore
 phpcs.xml.dist                      export-ignore
 phpstan.neon.dist                   export-ignore
 phpunit.xml.dist                    export-ignore
+phpunit-lte9.xml.dist               export-ignore
 tests/Core/ErrorSuppressionTest.php export-ignore
 
 #

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -259,10 +259,14 @@ To help you with this, a number of convenience scripts are available:
 * `composer check-all` will run the `cs` + `test` checks in one go.
 * `composer cs` will check for code style violations.
 * `composer cbf` will run the autofixers for code style violations.
-* `composer test` will run the unit tests.
-* `composer coverage` will run the unit tests with code coverage and show a text summary.
+* `composer test` will run the unit tests when using PHP 8.1+/PHPUnit 10+.
+* `composer test-lte9` will run the unit tests when using PHP < 8.1/PHPUnit <= 9.
+* `composer coverage` will run the unit tests with code coverage and show a text summary (PHP 8.1+/PHPUnit 10+).
+* `composer coverage-lte9` will run the unit tests with code coverage and show a text summary (PHP < 8.1/PHPUnit <= 9).
 * `composer coverage-local` will run the unit tests with code coverage and generate an HTML coverage report,
-    which will be placed in a `build/coverage-html` subdirectory.
+    which will be placed in a `build/coverage-html` subdirectory (PHP 8.1+/PHPUnit 10+).
+* `composer coverage-lte9-local` will run the unit tests with code coverage and generate an HTML coverage report,
+    which will be placed in a `build/coverage-html` subdirectory (PHP < 8.1/PHPUnit <= 9).
 * `composer build` will build the phpcs.phar and phpcbf.phar files.
 
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -55,19 +55,44 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        shell: bash
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(php "vendor/bin/phpunit" --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: "DEBUG: Show grabbed version"
+        run: echo ${{ steps.phpunit_version.outputs.VERSION }}
+
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        shell: bash
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          else
+            echo 'FILE=phpunit-lte9.xml.dist' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 'PHPCS: set the path to PHP'
         run: php "bin/phpcs" --config-set php_path php
 
       - name: 'PHPUnit: run the full test suite'
         if: ${{ matrix.os != 'windows-latest' }}
-        run: php "vendor/bin/phpunit" --no-coverage
+        run: php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
 
       - name: 'PHPUnit: run tests which may have different outcomes on Windows'
         if: ${{ matrix.os == 'windows-latest' }}
-        run: php "vendor/bin/phpunit" --group Windows --no-coverage
+        run: >
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
+          --group Windows
 
       - name: 'PHPUnit: run select tests in CBF mode'
-        run: php "vendor/bin/phpunit" --group CBF --exclude-group nothing --no-coverage
+        run: >
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
+          --group CBF --exclude-group nothing
         env:
           PHP_CODESNIFFER_CBF: '1'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,27 @@ jobs:
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           custom-cache-suffix: $(date -u "+%Y-%m")
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        shell: bash
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(php "vendor/bin/phpunit" --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+
+      - name: "DEBUG: Show grabbed version"
+        run: echo ${{ steps.phpunit_version.outputs.VERSION }}
+
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        shell: bash
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          else
+            echo 'FILE=phpunit-lte9.xml.dist' >> "$GITHUB_OUTPUT"
+          fi
+
       # Note: The code style check is run multiple times against every PHP version
       # as it also acts as an integration test.
       - name: 'PHPCS: set the path to PHP'
@@ -204,11 +225,13 @@ jobs:
 
       - name: 'PHPUnit: run the full test suite without code coverage'
         if: ${{ matrix.skip_tests != true }}
-        run: php "vendor/bin/phpunit" --no-coverage
+        run: php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
 
       - name: 'PHPUnit: run select tests in CBF mode'
         if: ${{ matrix.skip_tests != true }}
-        run: php "vendor/bin/phpunit" --group CBF --exclude-group nothing --no-coverage
+        run: >
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
+          --group CBF --exclude-group nothing
         env:
           PHP_CODESNIFFER_CBF: '1'
 
@@ -293,6 +316,18 @@ jobs:
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}
 
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        shell: bash
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          else
+            echo 'FILE=phpunit-lte9.xml.dist' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 'PHPCS: set the path to PHP'
         run: php "bin/phpcs" --config-set php_path php
 
@@ -302,18 +337,20 @@ jobs:
       # Using that option prevents issues with PHP-Parser backfilling PHP tokens during our test runs.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
         if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
-        run: php "vendor/bin/phpunit" --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+        run: >
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }}
+          --coverage-cache ./build/phpunit-cache --warm-coverage-cache
 
       - name: "Run the unit tests with code coverage"
         if: ${{ matrix.os != 'windows-latest' }}
         run: >
-          php "vendor/bin/phpunit"
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }}
           ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
 
       - name: "Run select tests in CBF mode with code coverage"
         if: ${{ matrix.os != 'windows-latest' }}
         run: >
-          php "vendor/bin/phpunit"
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }}
           ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
           --group CBF --exclude-group nothing --coverage-clover build/logs/clover-cbf.xml
         env:
@@ -322,8 +359,9 @@ jobs:
       - name: "Run the unit tests which may have different outcomes on Windows with code coverage"
         if: ${{ matrix.os == 'windows-latest' }}
         run: >
-          php "vendor/bin/phpunit" --group Windows
+          php "vendor/bin/phpunit" -c ${{ steps.phpunit_config.outputs.FILE }}
           ${{ steps.phpunit_version.outputs.VERSION >= '9.3' && '--coverage-cache ./build/phpunit-cache' || '' }}
+          --group Windows
 
       - name: "Upload coverage results to Coveralls (normal run)"
         if: ${{ success() }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -56,7 +56,12 @@ jobs:
           pattern: "phpcs.xml.dist"
           xsd-file: "phpcs.xsd"
 
-      - name: "Validate PHPUnit config for well-formedness"
+      - name: "Validate PHPUnit <= 9 config for well-formedness"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit-lte9.xml.dist"
+
+      - name: "Validate PHPUnit 10+ config for well-formedness"
         uses: phpcsstandards/xmllint-validate@v1
         with:
           pattern: "phpunit.xml.dist"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /CodeSniffer.conf
 /phpcs.xml
 /phpunit.xml
+/phpunitlte9.xml
+/phpunit-lte9.xml
 .phpunit.result.cache
 /build/
 .idea/*

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-xmlwriter": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.3.4"
+        "phpunit/phpunit": "^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3"
     },
     "bin": [
         "bin/phpcbf",
@@ -61,13 +61,25 @@
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
         ],
+        "test-lte9": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-lte9.xml.dist --no-coverage"
+        ],
         "coverage": [
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit -d max_execution_time=0"
         ],
+        "coverage-lte9": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-lte9.xml.dist -d max_execution_time=0"
+        ],
         "coverage-local": [
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html -d max_execution_time=0"
+        ],
+        "coverage-lte9-local": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-lte9.xml.dist --coverage-html ./build/coverage-html -d max_execution_time=0"
         ],
         "build": [
             "Composer\\Config::disableProcessTimeout",
@@ -81,9 +93,12 @@
     "scripts-descriptions": {
         "cs": "Check for code style violations.",
         "cbf": "Fix code style violations.",
-        "test": "Run the unit tests without code coverage.",
-        "coverage": "Run the unit tests with code coverage.",
-        "coverage-local": "Run the unit tests with code coverage and generate an HTML report in a 'build' directory.",
+        "test": "PHPUnit 10+: Run the unit tests without code coverage.",
+        "test-lte9": "PHPUnit <= 9: Run the unit tests without code coverage.",
+        "coverage": "PHPUnit 10+: Run the unit tests with code coverage.",
+        "coverage-lte9": "PHPUnit <= 9: Run the unit tests with code coverage.",
+        "coverage-local": "PHPUnit 10+: Run the unit tests with code coverage and generate an HTML report in a 'build' directory.",
+        "coverage-lte9-local": "PHPUnit <= 9: Run the unit tests with code coverage and generate an HTML report in a 'build' directory.",
         "build": "Create PHAR files for PHPCS and PHPCBF.",
         "check-all": "Run all checks (phpcs, tests)."
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,14 @@ parameters:
     paths:
         - requirements.php
         - src
+    excludePaths:
+        - src/Standards/Generic/Tests/*
+        - src/Standards/PEAR/Tests/*
+        - src/Standards/PSR1/Tests/*
+        - src/Standards/PSR2/Tests/*
+        - src/Standards/PSR12/Tests/*
+        - src/Standards/Squiz/Tests/*
+        - src/Standards/Zend/Tests/*
     bootstrapFiles:
         - tests/bootstrap.php
 

--- a/phpunit-lte9.xml.dist
+++ b/phpunit-lte9.xml.dist
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
     backupGlobals="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
     bootstrap="tests/bootstrap.php"
-    cacheDirectory="build/phpunit-cache"
-    displayDetailsOnTestsThatTriggerErrors="true"
-    displayDetailsOnTestsThatTriggerWarnings="true"
-    displayDetailsOnTestsThatTriggerNotices="true"
-    displayDetailsOnTestsThatTriggerDeprecations="true"
-    displayDetailsOnPhpunitDeprecations="false"
-    failOnWarning="true"
-    failOnNotice="true"
-    failOnDeprecation="true"
-    failOnPhpunitDeprecation="false"
-    requireCoverageMetadata="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertDeprecationsToExceptions="true"
+    forceCoversAnnotation="true"
     >
     <testsuites>
         <testsuite name="PHPCS_Core">
@@ -39,22 +33,20 @@
         </exclude>
     </groups>
 
-    <source>
-        <include>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">./src</directory>
             <file>./autoload.php</file>
-        </include>
-        <exclude>
-            <directory suffix="UnitTest.php">./src/Standards</directory>
-        </exclude>
-    </source>
+            <exclude>
+                <directory suffix="UnitTest.php">./src/Standards</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 
-    <coverage includeUncoveredFiles="true">
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <text outputFile="php://stdout" showOnlySummary="true"/>
-        </report>
-    </coverage>
+    <logging>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 
     <php>
         <env name="PHP_CODESNIFFER_CBF" value="0"/>

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ArrayIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff
  */
-final class ArrayIndentUnitTest extends AbstractSniffUnitTest
+final class ArrayIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowLongArraySyntax sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowLongArraySyntaxSniff
  */
-final class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowLongArraySyntaxUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowShortArraySyntax sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowShortArraySyntaxSniff
  */
-final class DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+final class DisallowShortArraySyntaxUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DuplicateClassName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\DuplicateClassNameSniff
  */
-final class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
+final class DuplicateClassNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OpeningBraceSameLine sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\OpeningBraceSameLineSniff
  */
-final class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
+final class OpeningBraceSameLineUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the AssignmentInCondition sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff
  */
-final class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
+final class AssignmentInConditionUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EmptyPHPStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyPHPStatementSniff
  */
-final class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
+final class EmptyPHPStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EmptyStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff
  */
-final class EmptyStatementUnitTest extends AbstractSniffUnitTest
+final class EmptyStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForLoopShouldBeWhileLoop sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopShouldBeWhileLoopSniff
  */
-final class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffUnitTest
+final class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForLoopWithTestFunctionCall sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\ForLoopWithTestFunctionCallSniff
  */
-final class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffUnitTest
+final class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the JumbledIncrementer sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\JumbledIncrementerSniff
  */
-final class JumbledIncrementerUnitTest extends AbstractSniffUnitTest
+final class JumbledIncrementerUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceUnitTest.php
@@ -10,14 +10,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the RequireExplicitBooleanOperatorPrecedence sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\RequireExplicitBooleanOperatorPrecedenceSniff
  */
-final class RequireExplicitBooleanOperatorPrecedenceUnitTest extends AbstractSniffUnitTest
+final class RequireExplicitBooleanOperatorPrecedenceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnconditionalIfStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnconditionalIfStatementSniff
  */
-final class UnconditionalIfStatementUnitTest extends AbstractSniffUnitTest
+final class UnconditionalIfStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnnecessaryFinalModifier sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnnecessaryFinalModifierSniff
  */
-final class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
+final class UnnecessaryFinalModifierUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnusedFunctionParameter sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff
  */
-final class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
+final class UnusedFunctionParameterUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UselessOverridingMethod sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UselessOverridingMethodSniff
  */
-final class UselessOverridingMethodUnitTest extends AbstractSniffUnitTest
+final class UselessOverridingMethodUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DocCommentSniff sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff
  */
-final class DocCommentUnitTest extends AbstractSniffUnitTest
+final class DocCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -10,14 +10,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Fixme sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\FixmeSniff
  */
-final class FixmeUnitTest extends AbstractSniffUnitTest
+final class FixmeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Todo sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff
  */
-final class TodoUnitTest extends AbstractSniffUnitTest
+final class TodoUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowYodaConditions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\DisallowYodaConditionsSniff
  */
-final class DisallowYodaConditionsUnitTest extends AbstractSniffUnitTest
+final class DisallowYodaConditionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InlineControlStructure sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff
  */
-final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
+final class InlineControlStructureUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ByteOrderMark sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff
  */
-final class ByteOrderMarkUnitTest extends AbstractSniffUnitTest
+final class ByteOrderMarkUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EndFileNewline sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff
  */
-final class EndFileNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNewlineUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EndFileNoNewline sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNoNewlineSniff
  */
-final class EndFileNoNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNoNewlineUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ExecutableFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ExecutableFileSniff
  */
-final class ExecutableFileUnitTest extends AbstractSniffUnitTest
+final class ExecutableFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InlineHTML sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\InlineHTMLSniff
  */
-final class InlineHTMLUnitTest extends AbstractSniffUnitTest
+final class InlineHTMLUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LineEndings sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff
  */
-final class LineEndingsUnitTest extends AbstractSniffUnitTest
+final class LineEndingsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LineLength sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff
  */
-final class LineLengthUnitTest extends AbstractSniffUnitTest
+final class LineLengthUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
@@ -12,14 +12,14 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercasedFilename sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LowercasedFilenameSniff
  */
-final class LowercasedFilenameUnitTest extends AbstractSniffUnitTest
+final class LowercasedFilenameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneClassPerFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneClassPerFileSniff
  */
-final class OneClassPerFileUnitTest extends AbstractSniffUnitTest
+final class OneClassPerFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneInterfacePerFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneInterfacePerFileSniff
  */
-final class OneInterfacePerFileUnitTest extends AbstractSniffUnitTest
+final class OneInterfacePerFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneInterfacePerFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneObjectStructurePerFileSniff
  */
-final class OneObjectStructurePerFileUnitTest extends AbstractSniffUnitTest
+final class OneObjectStructurePerFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OneTraitPerFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneTraitPerFileSniff
  */
-final class OneTraitPerFileUnitTest extends AbstractSniffUnitTest
+final class OneTraitPerFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowMultipleStatements sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\DisallowMultipleStatementsSniff
  */
-final class DisallowMultipleStatementsUnitTest extends AbstractSniffUnitTest
+final class DisallowMultipleStatementsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MultipleStatementAlignment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff
  */
-final class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
+final class MultipleStatementAlignmentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SpaceAfterCast sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff
  */
-final class SpaceAfterCastUnitTest extends AbstractSniffUnitTest
+final class SpaceAfterCastUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SpaceAfterNot sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff
  */
-final class SpaceAfterNotUnitTest extends AbstractSniffUnitTest
+final class SpaceAfterNotUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SpaceBeforeCast sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceBeforeCastSniff
  */
-final class SpaceBeforeCastUnitTest extends AbstractSniffUnitTest
+final class SpaceBeforeCastUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionCallArgumentSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\FunctionCallArgumentSpacingSniff
  */
-final class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionCallArgumentSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OpeningFunctionBraceBsdAllman sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceBsdAllmanSniff
  */
-final class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
+final class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OpeningFunctionBraceKernighanRitchie sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceKernighanRitchieSniff
  */
-final class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffUnitTest
+final class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Metrics;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CyclomaticComplexity sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff
  */
-final class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
+final class CyclomaticComplexityUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Metrics;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NestingLevel sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff
  */
-final class NestingLevelUnitTest extends AbstractSniffUnitTest
+final class NestingLevelUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
@@ -8,14 +8,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the AbstractClassNamePrefix sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\AbstractClassNamePrefixSniff
  */
-final class AbstractClassNamePrefixUnitTest extends AbstractSniffUnitTest
+final class AbstractClassNamePrefixUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CamelCapsFunctionName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff
  */
-final class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
+final class CamelCapsFunctionNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ConstructorName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\ConstructorNameSniff
  */
-final class ConstructorNameUnitTest extends AbstractSniffUnitTest
+final class ConstructorNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
@@ -8,14 +8,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InterfaceNameSuffix sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\InterfaceNameSuffixSniff
  */
-final class InterfaceNameSuffixUnitTest extends AbstractSniffUnitTest
+final class InterfaceNameSuffixUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
@@ -8,14 +8,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the TraitNameSuffix sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\TraitNameSuffixSniff
  */
-final class TraitNameSuffixUnitTest extends AbstractSniffUnitTest
+final class TraitNameSuffixUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidConstantName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff
  */
-final class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
+final class UpperCaseConstantNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the BacktickOperator sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\BacktickOperatorSniff
  */
-final class BacktickOperatorUnitTest extends AbstractSniffUnitTest
+final class BacktickOperatorUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CharacterBeforePHPOpeningTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\CharacterBeforePHPOpeningTagSniff
  */
-final class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffUnitTest
+final class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClosingPHPTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ClosingPHPTagSniff
  */
-final class ClosingPHPTagUnitTest extends AbstractSniffUnitTest
+final class ClosingPHPTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DeprecatedFunctions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff
  */
-final class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
+final class DeprecatedFunctionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowAlternativePHPTags sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowAlternativePHPTagsSniff
  */
-final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
+final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
@@ -8,14 +8,14 @@
  */
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowRequestSuperglobal sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowRequestSuperglobalSniff
  */
-final class DisallowRequestSuperglobalUnitTest extends AbstractSniffUnitTest
+final class DisallowRequestSuperglobalUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowShortOpenTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowShortOpenTagSniff
  */
-final class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
+final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DiscourageGoto sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DiscourageGotoSniff
  */
-final class DiscourageGotoUnitTest extends AbstractSniffUnitTest
+final class DiscourageGotoUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForbiddenFunctions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff
  */
-final class ForbiddenFunctionsUnitTest extends AbstractSniffUnitTest
+final class ForbiddenFunctionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowerCaseConstant sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff
  */
-final class LowerCaseConstantUnitTest extends AbstractSniffUnitTest
+final class LowerCaseConstantUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowerCaseKeyword sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseKeywordSniff
  */
-final class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
+final class LowerCaseKeywordUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowerCaseType sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseTypeSniff
  */
-final class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
+final class LowerCaseTypeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NoSilencedErrors sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff
  */
-final class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest
+final class NoSilencedErrorsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the RequireStrictType sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\RequireStrictTypesSniff
  */
-final class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
+final class RequireStrictTypesUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SAPIUsage sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SAPIUsageSniff
  */
-final class SAPIUsageUnitTest extends AbstractSniffUnitTest
+final class SAPIUsageUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -10,14 +10,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Syntax sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\SyntaxSniff
  */
-final class SyntaxUnitTest extends AbstractSniffUnitTest
+final class SyntaxUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UpperCaseConstant sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\UpperCaseConstantSniff
  */
-final class UpperCaseConstantUnitTest extends AbstractSniffUnitTest
+final class UpperCaseConstantUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Strings;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnnecessaryHeredoc sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryHeredocSniff
  */
-final class UnnecessaryHeredocUnitTest extends AbstractSniffUnitTest
+final class UnnecessaryHeredocUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\Strings;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UnnecessaryStringConcat sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff
  */
-final class UnnecessaryStringConcatUnitTest extends AbstractSniffUnitTest
+final class UnnecessaryStringConcatUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\VersionControl;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the GitMergeConflict sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\GitMergeConflictSniff
  */
-final class GitMergeConflictUnitTest extends AbstractSniffUnitTest
+final class GitMergeConflictUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\VersionControl;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SubversionProperties sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\SubversionPropertiesSniff
  */
-final class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
+final class SubversionPropertiesUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ArbitraryParenthesesSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ArbitraryParenthesesSpacingSniff
  */
-final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest
+final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowSpaceIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowSpaceIndentSniff
  */
-final class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
+final class DisallowSpaceIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowTabIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff
  */
-final class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
+final class DisallowTabIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/HereNowdocIdentifierSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the HereNowdocIdentifierSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\HereNowdocIdentifierSpacingSniff
  */
-final class HereNowdocIdentifierSpacingUnitTest extends AbstractSniffUnitTest
+final class HereNowdocIdentifierSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the IncrementDecrementSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\IncrementDecrementSpacingSniff
  */
-final class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
+final class IncrementDecrementSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LanguageConstructSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\LanguageConstructSpacingSniff
  */
-final class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
+final class LanguageConstructSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ScopeIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff
  */
-final class ScopeIndentUnitTest extends AbstractSniffUnitTest
+final class ScopeIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SpreadOperatorSpacingAfter sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\SpreadOperatorSpacingAfterSniff
  */
-final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
+final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Classes\ClassDeclarationSniff
  */
-final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff
  */
-final class ClassCommentUnitTest extends AbstractSniffUnitTest
+final class ClassCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FileComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff
  */
-final class FileCommentUnitTest extends AbstractSniffUnitTest
+final class FileCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff
  */
-final class FunctionCommentUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InlineComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\InlineCommentSniff
  */
-final class InlineCommentUnitTest extends AbstractSniffUnitTest
+final class InlineCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ControlSignature sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\ControlSignatureSniff
  */
-final class ControlSignatureUnitTest extends AbstractSniffUnitTest
+final class ControlSignatureUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MultiLineCondition sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\ControlStructures\MultiLineConditionSniff
  */
-final class MultiLineConditionUnitTest extends AbstractSniffUnitTest
+final class MultiLineConditionUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
+++ b/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the IncludingFile sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Files\IncludingFileSniff
  */
-final class IncludingFileUnitTest extends AbstractSniffUnitTest
+final class IncludingFileUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MultiLineAssignment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Formatting\MultiLineAssignmentSniff
  */
-final class MultiLineAssignmentUnitTest extends AbstractSniffUnitTest
+final class MultiLineAssignmentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionCallSignature sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionCallSignatureSniff
  */
-final class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
+final class FunctionCallSignatureUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionDeclarationSniff
  */
-final class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidDefaultValue sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff
  */
-final class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
+final class ValidDefaultValueUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidClassName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidClassNameSniff
  */
-final class ValidClassNameUnitTest extends AbstractSniffUnitTest
+final class ValidClassNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidFunctionName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
+final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidVariableName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ObjectOperatorIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ObjectOperatorIndentSniff
  */
-final class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
+final class ObjectOperatorIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ScopeClosingBrace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeClosingBraceSniff
  */
-final class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ScopeClosingBraceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PEAR\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ScopeIndent sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeIndentSniff
  */
-final class ScopeIndentUnitTest extends AbstractSniffUnitTest
+final class ScopeIndentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR1\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff
  */
-final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR1\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SideEffects sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff
  */
-final class SideEffectsUnitTest extends AbstractSniffUnitTest
+final class SideEffectsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR1\Tests\Methods;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CamelCapsMethodName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff
  */
-final class CamelCapsMethodNameUnitTest extends AbstractSniffUnitTest
+final class CamelCapsMethodNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the AnonClassDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\AnonClassDeclarationSniff
  */
-final class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class AnonClassDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassInstantiation sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClassInstantiationSniff
  */
-final class ClassInstantiationUnitTest extends AbstractSniffUnitTest
+final class ClassInstantiationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClosingBrace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\ClosingBraceSniff
  */
-final class ClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ClosingBraceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OpeningBraceSpace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Classes\OpeningBraceSpaceSniff
  */
-final class OpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class OpeningBraceSpaceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the BooleanOperatorPlacement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlacementSniff
  */
-final class BooleanOperatorPlacementUnitTest extends AbstractSniffUnitTest
+final class BooleanOperatorPlacementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ControlStructureSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\ControlStructureSpacingSniff
  */
-final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DeclareStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\DeclareStatementSniff
  */
-final class DeclareStatementUnitTest extends AbstractSniffUnitTest
+final class DeclareStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FileHeader sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff
  */
-final class FileHeaderUnitTest extends AbstractSniffUnitTest
+final class FileHeaderUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ImportStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\ImportStatementSniff
  */
-final class ImportStatementUnitTest extends AbstractSniffUnitTest
+final class ImportStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OpenTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\OpenTagSniff
  */
-final class OpenTagUnitTest extends AbstractSniffUnitTest
+final class OpenTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NullableWhitespace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff
  */
-final class NullableTypeDeclarationUnitTest extends AbstractSniffUnitTest
+final class NullableTypeDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ReturnTypeDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\ReturnTypeDeclarationSniff
  */
-final class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+final class ReturnTypeDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Keywords;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ShortFormTypeKeywords sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Keywords\ShortFormTypeKeywordsSniff
  */
-final class ShortFormTypeKeywordsUnitTest extends AbstractSniffUnitTest
+final class ShortFormTypeKeywordsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
+++ b/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CompoundNamespaceDepth sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Namespaces\CompoundNamespaceDepthSniff
  */
-final class CompoundNamespaceDepthUnitTest extends AbstractSniffUnitTest
+final class CompoundNamespaceDepthUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OperatorSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff
  */
-final class OperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class OperatorSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Properties;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ConstantVisibility sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Properties\ConstantVisibilitySniff
  */
-final class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
+final class ConstantVisibilityUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR12\Tests\Traits;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UseDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Traits\UseDeclarationSniff
  */
-final class UseDeclarationUnitTest extends AbstractSniffUnitTest
+final class UseDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff
  */
-final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the PropertyDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff
  */
-final class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
+final class PropertyDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff
  */
-final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ElseIfDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ElseIfDeclarationSniff
  */
-final class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class ElseIfDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SwitchDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSniff
  */
-final class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
+final class SwitchDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClosingTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\ClosingTagSniff
  */
-final class ClosingTagUnitTest extends AbstractSniffUnitTest
+final class ClosingTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EndFileNewline sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\EndFileNewlineSniff
  */
-final class EndFileNewlineUnitTest extends AbstractSniffUnitTest
+final class EndFileNewlineUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionCallSignature sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff
  */
-final class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
+final class FunctionCallSignatureUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionClosingBrace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionClosingBraceSniff
  */
-final class FunctionClosingBraceUnitTest extends AbstractSniffUnitTest
+final class FunctionClosingBraceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Methods;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MethodDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
  */
-final class MethodDeclarationUnitTest extends AbstractSniffUnitTest
+final class MethodDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NamespaceDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\NamespaceDeclarationSniff
  */
-final class NamespaceDeclarationUnitTest extends AbstractSniffUnitTest
+final class NamespaceDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\PSR2\Tests\Namespaces;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the UseDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\UseDeclarationSniff
  */
-final class UseDeclarationUnitTest extends AbstractSniffUnitTest
+final class UseDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ArrayBracketSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
  */
-final class ArrayBracketSpacingUnitTest extends AbstractSniffUnitTest
+final class ArrayBracketSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Arrays;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ArrayDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayDeclarationSniff
  */
-final class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
+final class ArrayDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassDeclarationSniff
  */
-final class ClassDeclarationUnitTest extends AbstractSniffUnitTest
+final class ClassDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -10,14 +10,14 @@
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
 use DirectoryIterator;
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassFileName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ClassFileNameSniff
  */
-final class ClassFileNameUnitTest extends AbstractSniffUnitTest
+final class ClassFileNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercaseClassKeywords sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\LowercaseClassKeywordsSniff
  */
-final class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
+final class LowercaseClassKeywordsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SelfMemberReference sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\SelfMemberReferenceSniff
  */
-final class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
+final class SelfMemberReferenceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Classes;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidClassName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ValidClassNameSniff
  */
-final class ValidClassNameUnitTest extends AbstractSniffUnitTest
+final class ValidClassNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the BlockComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\BlockCommentSniff
  */
-final class BlockCommentUnitTest extends AbstractSniffUnitTest
+final class BlockCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClassComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClassCommentSniff
  */
-final class ClassCommentUnitTest extends AbstractSniffUnitTest
+final class ClassCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClosingDeclarationComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClosingDeclarationCommentSniff
  */
-final class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
+final class ClosingDeclarationCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DocCommentAlignment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff
  */
-final class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
+final class DocCommentAlignmentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EmptyCatchComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\EmptyCatchCommentSniff
  */
-final class EmptyCatchCommentUnitTest extends AbstractSniffUnitTest
+final class EmptyCatchCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FileComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FileCommentSniff
  */
-final class FileCommentUnitTest extends AbstractSniffUnitTest
+final class FileCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionCommentThrowTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentThrowTagSniff
  */
-final class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentThrowTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff
  */
-final class FunctionCommentUnitTest extends AbstractSniffUnitTest
+final class FunctionCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InlineComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\InlineCommentSniff
  */
-final class InlineCommentUnitTest extends AbstractSniffUnitTest
+final class InlineCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LongConditionClosingComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\LongConditionClosingCommentSniff
  */
-final class LongConditionClosingCommentUnitTest extends AbstractSniffUnitTest
+final class LongConditionClosingCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the PostStatementComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\PostStatementCommentSniff
  */
-final class PostStatementCommentUnitTest extends AbstractSniffUnitTest
+final class PostStatementCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Commenting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the VariableComment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\VariableCommentSniff
  */
-final class VariableCommentUnitTest extends AbstractSniffUnitTest
+final class VariableCommentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ControlSignature sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff
  */
-final class ControlSignatureUnitTest extends AbstractSniffUnitTest
+final class ControlSignatureUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ElseIfDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ElseIfDeclarationSniff
  */
-final class ElseIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class ElseIfDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForEachLoopDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForEachLoopDeclarationSniff
  */
-final class ForEachLoopDeclarationUnitTest extends AbstractSniffUnitTest
+final class ForEachLoopDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ForLoopDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForLoopDeclarationSniff
  */
-final class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
+final class ForLoopDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InlineIfDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\InlineIfDeclarationSniff
  */
-final class InlineIfDeclarationUnitTest extends AbstractSniffUnitTest
+final class InlineIfDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercaseDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\LowercaseDeclarationSniff
  */
-final class LowercaseDeclarationUnitTest extends AbstractSniffUnitTest
+final class LowercaseDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\ControlStructures;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SwitchDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\SwitchDeclarationSniff
  */
-final class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
+final class SwitchDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FileExtension sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Files\FileExtensionSniff
  */
-final class FileExtensionUnitTest extends AbstractSniffUnitTest
+final class FileExtensionUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Formatting;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OperatorBracket sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Formatting\OperatorBracketSniff
  */
-final class OperatorBracketUnitTest extends AbstractSniffUnitTest
+final class OperatorBracketUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionDeclarationArgumentSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff
  */
-final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationSniff
  */
-final class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionDuplicateArgument sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDuplicateArgumentSniff
  */
-final class FunctionDuplicateArgumentUnitTest extends AbstractSniffUnitTest
+final class FunctionDuplicateArgumentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the GlobalFunction sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\GlobalFunctionSniff
  */
-final class GlobalFunctionUnitTest extends AbstractSniffUnitTest
+final class GlobalFunctionUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercaseFunctionKeywords sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\LowercaseFunctionKeywordsSniff
  */
-final class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
+final class LowercaseFunctionKeywordsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Functions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MultiLineFunctionDeclaration sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\MultiLineFunctionDeclarationSniff
  */
-final class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
+final class MultiLineFunctionDeclarationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidFunctionName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-final class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
+final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidVariableName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Objects;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ObjectInstantiation sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Objects\ObjectInstantiationSniff
  */
-final class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
+final class ObjectInstantiationUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ComparisonOperatorUsage sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ComparisonOperatorUsageSniff
  */
-final class ComparisonOperatorUsageUnitTest extends AbstractSniffUnitTest
+final class ComparisonOperatorUsageUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the IncrementDecrementUsage sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\IncrementDecrementUsageSniff
  */
-final class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
+final class IncrementDecrementUsageUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Operators;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidLogicalOperators sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
  */
-final class ValidLogicalOperatorsUnitTest extends AbstractSniffUnitTest
+final class ValidLogicalOperatorsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CommentedOutCode sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff
  */
-final class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
+final class CommentedOutCodeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowBooleanStatement sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowBooleanStatementSniff
  */
-final class DisallowBooleanStatementUnitTest extends AbstractSniffUnitTest
+final class DisallowBooleanStatementUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowComparisonAssignment sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowComparisonAssignmentSniff
  */
-final class DisallowComparisonAssignmentUnitTest extends AbstractSniffUnitTest
+final class DisallowComparisonAssignmentUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowObEndFlush sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowInlineIfSniff
  */
-final class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
+final class DisallowInlineIfUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowMultipleAssignments sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff
  */
-final class DisallowMultipleAssignmentsUnitTest extends AbstractSniffUnitTest
+final class DisallowMultipleAssignmentsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DisallowSizeFunctionsInLoops sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowSizeFunctionsInLoopsSniff
  */
-final class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffUnitTest
+final class DisallowSizeFunctionsInLoopsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DiscouragedFunctions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DiscouragedFunctionsSniff
  */
-final class DiscouragedFunctionsUnitTest extends AbstractSniffUnitTest
+final class DiscouragedFunctionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EmbeddedPhp sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EmbeddedPhpSniff
  */
-final class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
+final class EmbeddedPhpUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Eval sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EvalSniff
  */
-final class EvalUnitTest extends AbstractSniffUnitTest
+final class EvalUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the GlobalKeyword sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\GlobalKeywordSniff
  */
-final class GlobalKeywordUnitTest extends AbstractSniffUnitTest
+final class GlobalKeywordUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the Heredoc sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\HeredocSniff
  */
-final class HeredocUnitTest extends AbstractSniffUnitTest
+final class HeredocUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the InnerFunctions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\InnerFunctionsSniff
  */
-final class InnerFunctionsUnitTest extends AbstractSniffUnitTest
+final class InnerFunctionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LowercasePHPFunctions sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\LowercasePHPFunctionsSniff
  */
-final class LowercasePHPFunctionsUnitTest extends AbstractSniffUnitTest
+final class LowercasePHPFunctionsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\PHP;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the NonExecutableCode sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\NonExecutableCodeSniff
  */
-final class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
+final class NonExecutableCodeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MemberVarScope sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff
  */
-final class MemberVarScopeUnitTest extends AbstractSniffUnitTest
+final class MemberVarScopeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MethodScope sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff
  */
-final class MethodScopeUnitTest extends AbstractSniffUnitTest
+final class MethodScopeUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Scope;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the StaticThisUsage sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\StaticThisUsageSniff
  */
-final class StaticThisUsageUnitTest extends AbstractSniffUnitTest
+final class StaticThisUsageUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ConcatenationSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff
  */
-final class ConcatenationSpacingUnitTest extends AbstractSniffUnitTest
+final class ConcatenationSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the DoubleQuoteUsage sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\DoubleQuoteUsageSniff
  */
-final class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
+final class DoubleQuoteUsageUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\Strings;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the EchoedStrings sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\EchoedStringsSniff
  */
-final class EchoedStringsUnitTest extends AbstractSniffUnitTest
+final class EchoedStringsUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the CastSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\CastSpacingSniff
  */
-final class CastSpacingUnitTest extends AbstractSniffUnitTest
+final class CastSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ControlStructureSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff
  */
-final class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
+final class ControlStructureSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionClosingBraceSpace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionClosingBraceSpaceSniff
  */
-final class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class FunctionClosingBraceSpaceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionOpeningBraceSpace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionOpeningBraceSpaceSniff
  */
-final class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
+final class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the FunctionSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionSpacingSniff
  */
-final class FunctionSpacingUnitTest extends AbstractSniffUnitTest
+final class FunctionSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the LogicalOperatorSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LogicalOperatorSpacingSniff
  */
-final class LogicalOperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class LogicalOperatorSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the MemberVarSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\MemberVarSpacingSniff
  */
-final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
+final class MemberVarSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ObjectOperatorSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
  */
-final class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class ObjectOperatorSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the OperatorSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff
  */
-final class OperatorSpacingUnitTest extends AbstractSniffUnitTest
+final class OperatorSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ScopeClosingBrace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff
  */
-final class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
+final class ScopeClosingBraceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ScopeKeywordSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeKeywordSpacingSniff
  */
-final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
+final class ScopeKeywordSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SemicolonSpacing sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff
  */
-final class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
+final class SemicolonSpacingUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Squiz\Tests\WhiteSpace;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the SuperfluousWhitespace sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff
  */
-final class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
+final class SuperfluousWhitespaceUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Zend\Tests\Files;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ClosingTag sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\Files\ClosingTagSniff
  */
-final class ClosingTagUnitTest extends AbstractSniffUnitTest
+final class ClosingTagUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Standards\Zend\Tests\NamingConventions;
 
-use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
 
 /**
  * Unit test class for the ValidVariableName sniff.
  *
  * @covers \PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff
  */
-final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
+final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 {
 
 

--- a/tests/Core/AbstractMethodTestCase.php
+++ b/tests/Core/AbstractMethodTestCase.php
@@ -16,7 +16,7 @@ use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractMethodUnitTest extends TestCase
+abstract class AbstractMethodTestCase extends TestCase
 {
 
     /**

--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @covers \PHP_CodeSniffer\Files\File::findEndOfStatement
  */
-final class FindEndOfStatementTest extends AbstractMethodUnitTest
+final class FindEndOfStatementTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::findExtendedClassName method.
  *
  * @covers \PHP_CodeSniffer\Files\File::findExtendedClassName
  */
-final class FindExtendedClassNameTest extends AbstractMethodUnitTest
+final class FindExtendedClassNameTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames method.
  *
  * @covers \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames
  */
-final class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
+final class FindImplementedInterfaceNamesTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -11,7 +11,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @covers \PHP_CodeSniffer\Files\File::findStartOfStatement
  */
-final class FindStartOfStatementTest extends AbstractMethodUnitTest
+final class FindStartOfStatementTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getClassProperties method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getClassProperties
  */
-final class GetClassPropertiesTest extends AbstractMethodUnitTest
+final class GetClassPropertiesTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetConditionTest.php
+++ b/tests/Core/File/GetConditionTest.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
@@ -18,7 +18,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @covers \PHP_CodeSniffer\Files\File::getCondition
  * @covers \PHP_CodeSniffer\Files\File::hasCondition
  */
-final class GetConditionTest extends AbstractMethodUnitTest
+final class GetConditionTest extends AbstractMethodTestCase
 {
 
     /**

--- a/tests/Core/File/GetDeclarationNameParseError1Test.php
+++ b/tests/Core/File/GetDeclarationNameParseError1Test.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getDeclarationName method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
  */
-final class GetDeclarationNameParseError1Test extends AbstractMethodUnitTest
+final class GetDeclarationNameParseError1Test extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetDeclarationNameParseError2Test.php
+++ b/tests/Core/File/GetDeclarationNameParseError2Test.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getDeclarationName method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
  */
-final class GetDeclarationNameParseError2Test extends AbstractMethodUnitTest
+final class GetDeclarationNameParseError2Test extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetDeclarationNameTest.php
+++ b/tests/Core/File/GetDeclarationNameTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getDeclarationName method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getDeclarationName
  */
-final class GetDeclarationNameTest extends AbstractMethodUnitTest
+final class GetDeclarationNameTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getMemberProperties
  */
-final class GetMemberPropertiesTest extends AbstractMethodUnitTest
+final class GetMemberPropertiesTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetMethodParametersParseError1Test.php
+++ b/tests/Core/File/GetMethodParametersParseError1Test.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-final class GetMethodParametersParseError1Test extends AbstractMethodUnitTest
+final class GetMethodParametersParseError1Test extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetMethodParametersParseError2Test.php
+++ b/tests/Core/File/GetMethodParametersParseError2Test.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-final class GetMethodParametersParseError2Test extends AbstractMethodUnitTest
+final class GetMethodParametersParseError2Test extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -11,14 +11,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodParameters
  */
-final class GetMethodParametersTest extends AbstractMethodUnitTest
+final class GetMethodParametersTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodProperties method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getMethodProperties
  */
-final class GetMethodPropertiesTest extends AbstractMethodUnitTest
+final class GetMethodPropertiesTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/GetTokensAsStringTest.php
+++ b/tests/Core/File/GetTokensAsStringTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getTokensAsString method.
  *
  * @covers \PHP_CodeSniffer\Files\File::getTokensAsString
  */
-final class GetTokensAsStringTest extends AbstractMethodUnitTest
+final class GetTokensAsStringTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::isReference method.
  *
  * @covers \PHP_CodeSniffer\Files\File::isReference
  */
-final class IsReferenceTest extends AbstractMethodUnitTest
+final class IsReferenceTest extends AbstractMethodTestCase
 {
 
 

--- a/tests/Core/Sniffs/AbstractArraySniffTest.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTest.php
@@ -9,14 +9,14 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Sniffs;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 
 /**
  * Tests for the \PHP_CodeSniffer\Sniffs\AbstractArraySniff.
  *
  * @covers \PHP_CodeSniffer\Sniffs\AbstractArraySniff
  */
-final class AbstractArraySniffTest extends AbstractMethodUnitTest
+final class AbstractArraySniffTest extends AbstractMethodTestCase
 {
 
     /**

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -2,7 +2,7 @@
 /**
  * Base class to use when testing parts of the tokenizer.
  *
- * This is a near duplicate of the AbstractMethodUnitTest class, with the
+ * This is a near duplicate of the AbstractMethodTestCase class, with the
  * difference being that it allows for recording code coverage for tokenizer tests.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
@@ -15,7 +15,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizers;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -90,7 +90,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
      */
     public function testTestMarkersAreUnique()
     {
-        AbstractMethodUnitTest::assertTestMarkersAreUnique($this->phpcsFile);
+        AbstractMethodTestCase::assertTestMarkersAreUnique($this->phpcsFile);
 
     }//end testTestMarkersAreUnique()
 
@@ -109,7 +109,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
      */
     protected function getTargetToken($commentString, $tokenType, $tokenContent=null)
     {
-        return AbstractMethodUnitTest::getTargetTokenFromFile($this->phpcsFile, $commentString, $tokenType, $tokenContent);
+        return AbstractMethodTestCase::getTargetTokenFromFile($this->phpcsFile, $commentString, $tokenType, $tokenContent);
 
     }//end getTargetToken()
 

--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -22,7 +22,7 @@ use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-abstract class AbstractSniffUnitTest extends TestCase
+abstract class AbstractSniffTestCase extends TestCase
 {
 
     /**


### PR DESCRIPTION
# Description

### Tests/Core: rename AbstractMethodUnitTest to AbstractMethodTestCase 

... to comply with PHPUnit naming conventions, which are more strictly enforced as of PHPUnit 10.

Ref: sebastianbergmann/phpunit#5132

### Tests/Sniffs: rename AbstractSniffUnitTest to AbstractSniffTestCase 

... to comply with PHPUnit naming conventions, which are more strictly enforced as of PHPUnit 10.

Ref: sebastianbergmann/phpunit#5132

### Tests: allow for PHPUnit 10 and 11

This commit makes the necessary changes in the CI wiring to allow for running the tests on PHPUnit 8, 9, 10 and 11 and still failing them on PHP deprecations and notices like before.

The PHPUnit configuration file specification has undergone changes in PHPUnit 9.3, 10.0, 10.1 and 10.5.32/11.3.3.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed, though the "old" way is still supported on PHPUnit 9, but not on PHPUnit 10.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed and failing test runs on PHP deprecations or notices was no longer possible.
* In PHPUnit 10.1 a further iteration was released on the way to specify code coverage, which now expects a `<source>` element.
    Additionally, it is now possible again to fail a test run on PHP deprecations/notices.
* In PHPUnit 10.5.32/11.3.3 new `displayDetailsOnPhpunitDeprecations` and `failOnPhpunitDeprecation` options were introduced.
    As of PHPUnit 10.0, the option to fail tests on (PHP) deprecation notices would **_also_** fail the tests on PHPUnit deprecation notices, while those are only relevant when upgrading to the _next_ PHPUnit version. This made things a bit awkward. This was, at long last, fixed via the new options in PHPUnit 10.5.32/11.3.3.

While the `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3, some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

With that in mind, I deem it more appropriate to have a dedicated PHPUnit configuration file for PHPUnit 10/11 to ensure the test runs will behave as intended.
To be forward compatible, the default PHPUnit config file `phpunit.xml.dist` will now use the PHPUnit 10+ format, while a separate `phpunit-lte9.xml.dist` file will be used for PHPUnit 8 and 9.

> :point_up: This means that contributors who run on recent PHP versions, should just be able to run `vendor/bin/phpunit`. Only contributors who run on PHP < 8.1 and therefore run on PHPUnit < 10, will need to be aware of the difference in the config files.

All in all, this commit makes the following changes:
* Rename the "old" PHPUnit configuration file to `phpunit-lte9.xml.dist`
    - This file has also been added to `.gitattributes` to ignore for distribution packages.
    - An entry for `phpunit-lte9.xml` has been added to the `.gitignore` file.
        While a contributor can choose the name for a config overload file for the `phpunit-lte9.xml.dist` file freely, it is a good convention to use the same name as the file being overloaded, minus the `.dist`, so ignoring that filename by default seems appropriate.
    - Composer scripts have been added to run the tests with the `phpunit-lte9.xml.dist` file and these new scripts are also mentioned in the `CONTRIBUTING` file.
* The `phpunit.xml.dist` now contains the PHPUnit configuration for running the tests on PHPUnit 10.5+.
    This includes the appropriate settings to fail the test runs on any PHP deprecations, notices or warnings.
    Take note that the `cacheDirectory` option has been set to a custom directory which is already git ignored.
* The GH Actions scripts have been updated to include a PHPUnit version based toggle and run the tests with the correct configuration file depending on the PHPUnit version being used.
* Composer: allow for PHPUnit 10 on version 10.5.32 or higher and PHPUnit 11 on v 11.3.3 or higher.
    The 10.5.32/11.3.3 version are deliberately set as the minimum as:
    - the `failOnNotice` and `failOnDeprecation` attributes can now be set in the XML config file (PHPUnit 10.1+).
    - the `source` element for the XML config file was introduced in 10.1.
    - the `displayDetailsOnPhpunitDeprecations` and `failOnPhpunitDeprecation` attributes can be set (PHPUnit 10.5.32/11.3.3+).

Refs:
* https://phpunit.de/announcements/phpunit-10.html
* sebastianbergmann/phpunit#5196
* sebastianbergmann/phpunit@fb6673f
* sebastianbergmann/phpunit#5937
* sebastianbergmann/phpunit@1a5d2b8


### PHPStan: exclude *all* test files

The `/tests` directory was already excluded, but the _sniff_ test directories were not and what with a different PHPUnit version being used and PHPStan - apparently - struggling to understand the inheritance, let's just exclude the rest of the test files as well until such time as the PHPStan setup is made compatible with the tests.

## Suggested changelog entry
Changed:
- The test framework is now compatible with PHPUnit 8.x - 11.x (ignoring PHPUnit deprecations related to PHPUnit 12).
- The two abstract base tests cases have been renamed.
    - Replace `PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest` with `PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase`.
    - Replace `PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest` with `PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase`.

