### PR TITLE
AbstractSniffTestCase: mark sniff tests without test case files as incomplete

### DIFF
--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -159,6 +159,9 @@ TEMPLATE;
 
         // Get a list of all test files to check.
         $testFiles = $this->getTestFiles($testFileBase);
+        if (empty($testFiles) === true) {
+            $this->markTestIncomplete('No test case files found for '.static::class);
+        }
 
         $sniffFile = preg_replace('`[/\\\\]Tests[/\\\\]`', DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR, $testFileBase);
         $sniffFile = str_replace('UnitTest.', 'Sniff.php', $sniffFile);


### PR DESCRIPTION
# Description
Previously, sniff tests without case files would silently pass.


## Suggested changelog entry
Changed:
- Tests which extend the `AbstractSniffTestCase` for which no test case files (`.inc` files) can be found, will now be marked as "incomplete".
    - Previously, those tests would silently pass.

