### PR TITLE
AbstractSniffTestCase: flag missing `.fixed` files

### DIFF
--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -227,8 +227,9 @@ TEMPLATE;
                             $failureMessages[] = "Fixed version of $filename does not match expected version in $fixedFilename; the diff is\n$diff";
                         }
                     }
-                } else if (is_callable([$this, 'addWarning']) === true) {
-                    $this->addWarning("Missing fixed version of $filename to verify the accuracy of fixes, while the sniff is making fixes against the test case file");
+                } else {
+                    $diff = trim($phpcsFile->fixer->generateDiff($testFile));
+                    $failureMessages[] = "Missing fixed version of $filename to verify the accuracy of fixes, while the sniff is making fixes against the test case file; the diff is\n$diff";
                 }
             }//end if
 


### PR DESCRIPTION
# Description
As per issue #300, the PHPCS native `AbstractSniffUnitTest` test case should flag sniff test case files which would lead to fixes, but for which no `.fixed` file is available to verify the fixes against.

It should also fail a test run when this occurs.

This commit makes it so.


## Suggested changelog entry
Changed:
All test case files (`inc`) which would be changed by the sniff under test if running the fixer, are now required to be accompanied by a `*.fixed` file.


## Related issues/external references

Fixes #300
