### PR TITLE
Change default standard from PEAR to PSR12

### DIFF
--- a/CodeSniffer.conf.dist
+++ b/CodeSniffer.conf.dist
@@ -1,6 +1,6 @@
 <?php
  $phpCodeSnifferConfig = array (
-  'default_standard' => 'PSR2',
+  'default_standard' => 'PSR12',
   'report_format' => 'summary',
   'show_warnings' => '0',
   'show_progress' => '1',

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ php bin/phpcbf -h
 
 ## Getting Started
 
-The default coding standard used by PHP_CodeSniffer is the PEAR coding standard. To check a file against the PEAR coding standard, simply specify the file's location:
+The default coding standard used by PHP_CodeSniffer is the PSR12 coding standard. To check a file against the PSR12 coding standard, simply specify the file's location:
 ```bash
 phpcs /path/to/code/myfile.php
 ```
@@ -106,9 +106,9 @@ Or if you wish to check an entire directory you can specify the directory locati
 ```bash
 phpcs /path/to/code-directory
 ```
-If you wish to check your code against the PSR-12 coding standard, use the `--standard` command line argument:
+If you wish to check your code against the PEAR coding standard, use the `--standard` command line argument:
 ```bash
-phpcs --standard=PSR12 /path/to/code-directory
+phpcs --standard=PEAR /path/to/code-directory
 ```
 
 If PHP_CodeSniffer finds any coding standard errors, a report will be shown after running the command.

--- a/src/Config.php
+++ b/src/Config.php
@@ -530,7 +530,7 @@ class Config
     public function restoreDefaults()
     {
         $this->files           = [];
-        $this->standards       = ['PEAR'];
+        $this->standards       = ['PSR12'];
         $this->verbosity       = 0;
         $this->interactive     = false;
         $this->cache           = false;


### PR DESCRIPTION
# Description


## Suggested changelog entry
Changed:
The default coding standard has changed from `PEAR` to `PSR12`.
