### PR TITLE
Config::setSettings(): void method should not return

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -374,7 +374,7 @@ class Config
      */
     public function setSettings($settings)
     {
-        return $this->settings = $settings;
+        $this->settings = $settings;
 
     }//end setSettings()
 


### PR DESCRIPTION
# Description



## Suggested changelog entry
Changed:
The `Config::setSettings()` method is now a `void` method.
