### PR TITLE
Config::setConfigData() is no longer static

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -193,7 +193,7 @@ class Config
      *
      * @var array<string, true|array<string, true>>
      */
-    private static $overriddenDefaults = [];
+    private $overriddenDefaults = [];
 
     /**
      * Config file data that has been loaded for the run.
@@ -406,7 +406,7 @@ class Config
         $this->restoreDefaults();
         $this->setCommandLineValues($cliArgs);
 
-        if (isset(self::$overriddenDefaults['standards']) === false) {
+        if (isset($this->overriddenDefaults['standards']) === false) {
             // They did not supply a standard to use.
             // Look for a default ruleset in the current directory or higher.
             $currentDir = getcwd();
@@ -461,8 +461,8 @@ class Config
             if (trim($fileContents) !== '') {
                 $this->stdin        = true;
                 $this->stdinContent = $fileContents;
-                self::$overriddenDefaults['stdin']        = true;
-                self::$overriddenDefaults['stdinContent'] = true;
+                $this->overriddenDefaults['stdin']        = true;
+                $this->overriddenDefaults['stdinContent'] = true;
             }
         }//end if
 
@@ -493,7 +493,7 @@ class Config
                 if ($arg === '-') {
                     // Asking to read from STDIN.
                     $this->stdin = true;
-                    self::$overriddenDefaults['stdin'] = true;
+                    $this->overriddenDefaults['stdin'] = true;
                     continue;
                 }
 
@@ -680,23 +680,23 @@ class Config
             }
 
             $this->verbosity++;
-            self::$overriddenDefaults['verbosity'] = true;
+            $this->overriddenDefaults['verbosity'] = true;
             break;
         case 'l' :
             $this->local = true;
-            self::$overriddenDefaults['local'] = true;
+            $this->overriddenDefaults['local'] = true;
             break;
         case 's' :
             $this->showSources = true;
-            self::$overriddenDefaults['showSources'] = true;
+            $this->overriddenDefaults['showSources'] = true;
             break;
         case 'a' :
             $this->interactive = true;
-            self::$overriddenDefaults['interactive'] = true;
+            $this->overriddenDefaults['interactive'] = true;
             break;
         case 'e':
             $this->explain = true;
-            self::$overriddenDefaults['explain'] = true;
+            $this->overriddenDefaults['explain'] = true;
             break;
         case 'p' :
             if ($this->quiet === true) {
@@ -705,7 +705,7 @@ class Config
             }
 
             $this->showProgress = true;
-            self::$overriddenDefaults['showProgress'] = true;
+            $this->overriddenDefaults['showProgress'] = true;
             break;
         case 'q' :
             // Quiet mode disables a few other settings as well.
@@ -713,11 +713,11 @@ class Config
             $this->showProgress = false;
             $this->verbosity    = 0;
 
-            self::$overriddenDefaults['quiet'] = true;
+            $this->overriddenDefaults['quiet'] = true;
             break;
         case 'm' :
             $this->recordErrors = false;
-            self::$overriddenDefaults['recordErrors'] = true;
+            $this->overriddenDefaults['recordErrors'] = true;
             break;
         case 'd' :
             $ini = explode('=', $this->cliArgs[($pos + 1)]);
@@ -729,15 +729,15 @@ class Config
             }
             break;
         case 'n' :
-            if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
+            if (isset($this->overriddenDefaults['warningSeverity']) === false) {
                 $this->warningSeverity = 0;
-                self::$overriddenDefaults['warningSeverity'] = true;
+                $this->overriddenDefaults['warningSeverity'] = true;
             }
             break;
         case 'w' :
-            if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
+            if (isset($this->overriddenDefaults['warningSeverity']) === false) {
                 $this->warningSeverity = $this->errorSeverity;
-                self::$overriddenDefaults['warningSeverity'] = true;
+                $this->overriddenDefaults['warningSeverity'] = true;
             }
             break;
         default:
@@ -776,46 +776,46 @@ class Config
             $output .= 'by Squiz and PHPCSStandards'.PHP_EOL;
             throw new DeepExitException($output, 0);
         case 'colors':
-            if (isset(self::$overriddenDefaults['colors']) === true) {
+            if (isset($this->overriddenDefaults['colors']) === true) {
                 break;
             }
 
             $this->colors = true;
-            self::$overriddenDefaults['colors'] = true;
+            $this->overriddenDefaults['colors'] = true;
             break;
         case 'no-colors':
-            if (isset(self::$overriddenDefaults['colors']) === true) {
+            if (isset($this->overriddenDefaults['colors']) === true) {
                 break;
             }
 
             $this->colors = false;
-            self::$overriddenDefaults['colors'] = true;
+            $this->overriddenDefaults['colors'] = true;
             break;
         case 'cache':
-            if (isset(self::$overriddenDefaults['cache']) === true) {
+            if (isset($this->overriddenDefaults['cache']) === true) {
                 break;
             }
 
             if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
                 $this->cache = true;
-                self::$overriddenDefaults['cache'] = true;
+                $this->overriddenDefaults['cache'] = true;
             }
             break;
         case 'no-cache':
-            if (isset(self::$overriddenDefaults['cache']) === true) {
+            if (isset($this->overriddenDefaults['cache']) === true) {
                 break;
             }
 
             $this->cache = false;
-            self::$overriddenDefaults['cache'] = true;
+            $this->overriddenDefaults['cache'] = true;
             break;
         case 'ignore-annotations':
-            if (isset(self::$overriddenDefaults['annotations']) === true) {
+            if (isset($this->overriddenDefaults['annotations']) === true) {
                 break;
             }
 
             $this->annotations = false;
-            self::$overriddenDefaults['annotations'] = true;
+            $this->overriddenDefaults['annotations'] = true;
             break;
         case 'config-set':
             if (isset($this->cliArgs[($pos + 1)]) === false
@@ -888,41 +888,41 @@ class Config
             $value = $this->cliArgs[($pos + 2)];
             $this->cliArgs[($pos + 1)] = '';
             $this->cliArgs[($pos + 2)] = '';
-            self::setConfigData($key, $value, true);
-            if (isset(self::$overriddenDefaults['runtime-set']) === false) {
-                self::$overriddenDefaults['runtime-set'] = [];
+            $this->setConfigData($key, $value, true);
+            if (isset($this->overriddenDefaults['runtime-set']) === false) {
+                $this->overriddenDefaults['runtime-set'] = [];
             }
 
-            self::$overriddenDefaults['runtime-set'][$key] = true;
+            $this->overriddenDefaults['runtime-set'][$key] = true;
             break;
         default:
             if (substr($arg, 0, 7) === 'sniffs=') {
-                if (isset(self::$overriddenDefaults['sniffs']) === true) {
+                if (isset($this->overriddenDefaults['sniffs']) === true) {
                     break;
                 }
 
                 $this->sniffs = $this->parseSniffCodes(substr($arg, 7), 'sniffs');
-                self::$overriddenDefaults['sniffs'] = true;
+                $this->overriddenDefaults['sniffs'] = true;
             } else if (substr($arg, 0, 8) === 'exclude=') {
-                if (isset(self::$overriddenDefaults['exclude']) === true) {
+                if (isset($this->overriddenDefaults['exclude']) === true) {
                     break;
                 }
 
                 $this->exclude = $this->parseSniffCodes(substr($arg, 8), 'exclude');
-                self::$overriddenDefaults['exclude'] = true;
+                $this->overriddenDefaults['exclude'] = true;
             } else if (defined('PHP_CODESNIFFER_IN_TESTS') === false
                 && substr($arg, 0, 6) === 'cache='
             ) {
-                if ((isset(self::$overriddenDefaults['cache']) === true
+                if ((isset($this->overriddenDefaults['cache']) === true
                     && $this->cache === false)
-                    || isset(self::$overriddenDefaults['cacheFile']) === true
+                    || isset($this->overriddenDefaults['cacheFile']) === true
                 ) {
                     break;
                 }
 
                 // Turn caching on.
                 $this->cache = true;
-                self::$overriddenDefaults['cache'] = true;
+                $this->overriddenDefaults['cache'] = true;
 
                 $this->cacheFile = Common::realpath(substr($arg, 6));
 
@@ -955,7 +955,7 @@ class Config
                     }
                 }//end if
 
-                self::$overriddenDefaults['cacheFile'] = true;
+                $this->overriddenDefaults['cacheFile'] = true;
 
                 if (is_dir($this->cacheFile) === true) {
                     $error  = 'ERROR: The specified cache file path "'.$this->cacheFile.'" is a directory'.PHP_EOL.PHP_EOL;
@@ -977,7 +977,7 @@ class Config
                 }
 
                 $this->bootstrap = array_merge($this->bootstrap, $bootstrap);
-                self::$overriddenDefaults['bootstrap'] = true;
+                $this->overriddenDefaults['bootstrap'] = true;
             } else if (substr($arg, 0, 10) === 'file-list=') {
                 $fileList = substr($arg, 10);
                 $path     = Common::realpath($fileList);
@@ -999,7 +999,7 @@ class Config
                     $this->processFilePath($inputFile);
                 }
             } else if (substr($arg, 0, 11) === 'stdin-path=') {
-                if (isset(self::$overriddenDefaults['stdinPath']) === true) {
+                if (isset($this->overriddenDefaults['stdinPath']) === true) {
                     break;
                 }
 
@@ -1010,9 +1010,9 @@ class Config
                     $this->stdinPath = trim(substr($arg, 11));
                 }
 
-                self::$overriddenDefaults['stdinPath'] = true;
+                $this->overriddenDefaults['stdinPath'] = true;
             } else if (PHP_CODESNIFFER_CBF === false && substr($arg, 0, 12) === 'report-file=') {
-                if (isset(self::$overriddenDefaults['reportFile']) === true) {
+                if (isset($this->overriddenDefaults['reportFile']) === true) {
                     break;
                 }
 
@@ -1032,7 +1032,7 @@ class Config
                     $this->reportFile = $dir.'/'.basename($this->reportFile);
                 }//end if
 
-                self::$overriddenDefaults['reportFile'] = true;
+                $this->overriddenDefaults['reportFile'] = true;
 
                 if (is_dir($this->reportFile) === true) {
                     $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" is a directory'.PHP_EOL.PHP_EOL;
@@ -1040,18 +1040,18 @@ class Config
                     throw new DeepExitException($error, 3);
                 }
             } else if (substr($arg, 0, 13) === 'report-width=') {
-                if (isset(self::$overriddenDefaults['reportWidth']) === true) {
+                if (isset($this->overriddenDefaults['reportWidth']) === true) {
                     break;
                 }
 
                 $this->reportWidth = substr($arg, 13);
-                self::$overriddenDefaults['reportWidth'] = true;
+                $this->overriddenDefaults['reportWidth'] = true;
             } else if (substr($arg, 0, 9) === 'basepath=') {
-                if (isset(self::$overriddenDefaults['basepath']) === true) {
+                if (isset($this->overriddenDefaults['basepath']) === true) {
                     break;
                 }
 
-                self::$overriddenDefaults['basepath'] = true;
+                $this->overriddenDefaults['basepath'] = true;
 
                 if (substr($arg, 9) === '') {
                     $this->basepath = null;
@@ -1105,7 +1105,7 @@ class Config
                     $reports[$report] = $output;
                 } else {
                     // This is a single report.
-                    if (isset(self::$overriddenDefaults['reports']) === true) {
+                    if (isset($this->overriddenDefaults['reports']) === true) {
                         break;
                     }
 
@@ -1116,29 +1116,29 @@ class Config
                 }//end if
 
                 // Remove the default value so the CLI value overrides it.
-                if (isset(self::$overriddenDefaults['reports']) === false) {
+                if (isset($this->overriddenDefaults['reports']) === false) {
                     $this->reports = $reports;
                 } else {
                     $this->reports = array_merge($this->reports, $reports);
                 }
 
-                self::$overriddenDefaults['reports'] = true;
+                $this->overriddenDefaults['reports'] = true;
             } else if (substr($arg, 0, 7) === 'filter=') {
-                if (isset(self::$overriddenDefaults['filter']) === true) {
+                if (isset($this->overriddenDefaults['filter']) === true) {
                     break;
                 }
 
                 $this->filter = substr($arg, 7);
-                self::$overriddenDefaults['filter'] = true;
+                $this->overriddenDefaults['filter'] = true;
             } else if (substr($arg, 0, 9) === 'standard=') {
                 $standards = trim(substr($arg, 9));
                 if ($standards !== '') {
                     $this->standards = explode(',', $standards);
                 }
 
-                self::$overriddenDefaults['standards'] = true;
+                $this->overriddenDefaults['standards'] = true;
             } else if (substr($arg, 0, 11) === 'extensions=') {
-                if (isset(self::$overriddenDefaults['extensions']) === true) {
+                if (isset($this->overriddenDefaults['extensions']) === true) {
                     break;
                 }
 
@@ -1164,47 +1164,47 @@ class Config
                 }
 
                 $this->extensions = $newExtensions;
-                self::$overriddenDefaults['extensions'] = true;
+                $this->overriddenDefaults['extensions'] = true;
             } else if (substr($arg, 0, 7) === 'suffix=') {
-                if (isset(self::$overriddenDefaults['suffix']) === true) {
+                if (isset($this->overriddenDefaults['suffix']) === true) {
                     break;
                 }
 
                 $this->suffix = substr($arg, 7);
-                self::$overriddenDefaults['suffix'] = true;
+                $this->overriddenDefaults['suffix'] = true;
             } else if (substr($arg, 0, 9) === 'parallel=') {
-                if (isset(self::$overriddenDefaults['parallel']) === true) {
+                if (isset($this->overriddenDefaults['parallel']) === true) {
                     break;
                 }
 
                 $this->parallel = max((int) substr($arg, 9), 1);
-                self::$overriddenDefaults['parallel'] = true;
+                $this->overriddenDefaults['parallel'] = true;
             } else if (substr($arg, 0, 9) === 'severity=') {
                 $this->errorSeverity   = (int) substr($arg, 9);
                 $this->warningSeverity = $this->errorSeverity;
-                if (isset(self::$overriddenDefaults['errorSeverity']) === false) {
-                    self::$overriddenDefaults['errorSeverity'] = true;
+                if (isset($this->overriddenDefaults['errorSeverity']) === false) {
+                    $this->overriddenDefaults['errorSeverity'] = true;
                 }
 
-                if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
-                    self::$overriddenDefaults['warningSeverity'] = true;
+                if (isset($this->overriddenDefaults['warningSeverity']) === false) {
+                    $this->overriddenDefaults['warningSeverity'] = true;
                 }
             } else if (substr($arg, 0, 15) === 'error-severity=') {
-                if (isset(self::$overriddenDefaults['errorSeverity']) === true) {
+                if (isset($this->overriddenDefaults['errorSeverity']) === true) {
                     break;
                 }
 
                 $this->errorSeverity = (int) substr($arg, 15);
-                self::$overriddenDefaults['errorSeverity'] = true;
+                $this->overriddenDefaults['errorSeverity'] = true;
             } else if (substr($arg, 0, 17) === 'warning-severity=') {
-                if (isset(self::$overriddenDefaults['warningSeverity']) === true) {
+                if (isset($this->overriddenDefaults['warningSeverity']) === true) {
                     break;
                 }
 
                 $this->warningSeverity = (int) substr($arg, 17);
-                self::$overriddenDefaults['warningSeverity'] = true;
+                $this->overriddenDefaults['warningSeverity'] = true;
             } else if (substr($arg, 0, 7) === 'ignore=') {
-                if (isset(self::$overriddenDefaults['ignored']) === true) {
+                if (isset($this->overriddenDefaults['ignored']) === true) {
                     break;
                 }
 
@@ -1226,11 +1226,11 @@ class Config
                 }
 
                 $this->ignored = $ignored;
-                self::$overriddenDefaults['ignored'] = true;
+                $this->overriddenDefaults['ignored'] = true;
             } else if (substr($arg, 0, 10) === 'generator='
                 && PHP_CODESNIFFER_CBF === false
             ) {
-                if (isset(self::$overriddenDefaults['generator']) === true) {
+                if (isset($this->overriddenDefaults['generator']) === true) {
                     break;
                 }
 
@@ -1250,21 +1250,21 @@ class Config
                 }
 
                 $this->generator = $this->validGenerators[$lowerCaseGeneratorName];
-                self::$overriddenDefaults['generator'] = true;
+                $this->overriddenDefaults['generator'] = true;
             } else if (substr($arg, 0, 9) === 'encoding=') {
-                if (isset(self::$overriddenDefaults['encoding']) === true) {
+                if (isset($this->overriddenDefaults['encoding']) === true) {
                     break;
                 }
 
                 $this->encoding = strtolower(substr($arg, 9));
-                self::$overriddenDefaults['encoding'] = true;
+                $this->overriddenDefaults['encoding'] = true;
             } else if (substr($arg, 0, 10) === 'tab-width=') {
-                if (isset(self::$overriddenDefaults['tabWidth']) === true) {
+                if (isset($this->overriddenDefaults['tabWidth']) === true) {
                     break;
                 }
 
                 $this->tabWidth = (int) substr($arg, 10);
-                self::$overriddenDefaults['tabWidth'] = true;
+                $this->overriddenDefaults['tabWidth'] = true;
             } else {
                 if ($this->dieOnUnknownArg === false) {
                     $eqPos = strpos($arg, '=');
@@ -1439,7 +1439,7 @@ class Config
             $files       = $this->files;
             $files[]     = $file;
             $this->files = $files;
-            self::$overriddenDefaults['files'] = true;
+            $this->overriddenDefaults['files'] = true;
         }
 
     }//end processFilePath()
@@ -1616,10 +1616,10 @@ class Config
      * @see    getConfigData()
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException If the config file can not be written.
      */
-    public static function setConfigData($key, $value, $temp=false)
+    public function setConfigData($key, $value, $temp=false)
     {
-        if (isset(self::$overriddenDefaults['runtime-set']) === true
-            && isset(self::$overriddenDefaults['runtime-set'][$key]) === true
+        if (isset($this->overriddenDefaults['runtime-set']) === true
+            && isset($this->overriddenDefaults['runtime-set'][$key]) === true
         ) {
             return false;
         }

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -579,7 +579,7 @@ class Ruleset
                 continue;
             }
 
-            Config::setConfigData((string) $config['name'], (string) $config['value'], true);
+            $this->config->setConfigData((string) $config['name'], (string) $config['value'], true);
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 echo str_repeat("\t", $depth);
                 echo "\t=> set config value ".(string) $config['name'].': '.(string) $config['value'].PHP_EOL;

--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -80,7 +80,6 @@ final class ConfigDouble extends Config
      */
     public function __destruct()
     {
-        $this->setStaticConfigProperty('overriddenDefaults', []);
         $this->setStaticConfigProperty('executablePaths', []);
         $this->setStaticConfigProperty('configData', null);
         $this->setStaticConfigProperty('configDataFile', null);
@@ -107,13 +106,12 @@ final class ConfigDouble extends Config
 
 
     /**
-     * Reset a few properties on the Config class to their default values.
+     * Reset select properties on the Config class to their default values.
      *
      * @return void
      */
     private function resetSelectProperties()
     {
-        $this->setStaticConfigProperty('overriddenDefaults', []);
         $this->setStaticConfigProperty('executablePaths', []);
 
     }//end resetSelectProperties()
@@ -186,6 +184,11 @@ final class ConfigDouble extends Config
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
         $property->setAccessible(true);
+
+        if ($name === 'overriddenDefaults') {
+            return $property->getValue($this);
+        }
+
         return $property->getValue();
 
     }//end getStaticConfigProperty()
@@ -203,7 +206,13 @@ final class ConfigDouble extends Config
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
         $property->setAccessible(true);
-        $property->setValue(null, $value);
+
+        if ($name === 'overriddenDefaults') {
+            $property->setValue($this, $value);
+        } else {
+            $property->setValue(null, $value);
+        }
+
         $property->setAccessible(false);
 
     }//end setStaticConfigProperty()

--- a/tests/Core/Config/AbstractRealConfigTestCase.php
+++ b/tests/Core/Config/AbstractRealConfigTestCase.php
@@ -25,7 +25,6 @@ abstract class AbstractRealConfigTestCase extends TestCase
     protected function setUp(): void
     {
         // Set to the property's default value to clear out potentially set values from other tests.
-        self::setStaticConfigProperty('overriddenDefaults', []);
         self::setStaticConfigProperty('executablePaths', []);
 
         // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
@@ -56,7 +55,6 @@ abstract class AbstractRealConfigTestCase extends TestCase
      */
     public static function tearDownAfterClass(): void
     {
-        self::setStaticConfigProperty('overriddenDefaults', []);
         self::setStaticConfigProperty('executablePaths', []);
         self::setStaticConfigProperty('configData', null);
         self::setStaticConfigProperty('configDataFile', null);

--- a/tests/Core/Config/IssueSquiz2675Test.php
+++ b/tests/Core/Config/IssueSquiz2675Test.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Config.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Tests\Core\Config\AbstractRealConfigTestCase;
+
+/**
+ * Tests that multiple consecutively created instances of the Config class with the same configuration will have the same settings.
+ *
+ * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2675
+ *
+ * @coversNothing
+ */
+final class IssueSquiz2675Test extends AbstractRealConfigTestCase
+{
+
+
+    /**
+     * Tests that multiple consecutively created instances of the Config class with the same configuration will have the same settings.
+     *
+     * @return void
+     */
+    public function testIssueSquiz2675()
+    {
+        $configA = new Config(['--tab-width=4']);
+
+        $this->assertSame(4, $configA->tabWidth, 'Tab width not correctly set when Config is first created');
+
+        $configB = new Config(['--tab-width=4']);
+
+        $this->assertSame(4, $configB->tabWidth, 'Tab width not correctly set when Config is created a second time');
+
+    }//end testIssueSquiz2675()
+
+
+}//end class


### PR DESCRIPTION

# Description



## Suggested changelog entry
- The `Config::setConfigData()` method is no longer static.
    - The associated (`private`) `Config::$overriddenDefaults` property is also no longer static.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2675
