### PR TITLE
Ruleset: configs in higher level ruleset(s) overrule configs set in included ruleset(s)

### DIFF
--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesATest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesATest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- This ruleset sets two config directives.
+         All included rulesets will try to override these and should fail.
+         Whether the config is set before, or after, the sub-rulesets are included, should be irrelevant.
+    -->
+    <config name="expectValueFromParentATestSetBeforeIncludes" value="parent A"/>
+
+    <!-- Include the overrides. -->
+    <rule ref="./ProcessRulesetConfigDirectivesIncludeATest.xml"/>
+    <rule ref="./ProcessRulesetConfigDirectivesIncludeBTest.xml"/>
+
+    <config name="expectValueFromParentATestSetAfterIncludes" value="parent A"/>
+
+    <!-- This directive should not be applied. Last included ruleset (parent B) should win. -->
+    <config name="expectValueFromParentBTest" value="parent A"/>
+
+    <!-- Prevent a "no sniffs were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesBTest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesBTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- For this config directive, this is the "highest" level, but the directive is also set in the "parent A"
+         ruleset, which is at the same "level".
+         In that case, the value which "wins" is determined by the order in which the rulesets are included.
+         In this case, that means that "parent B" should win as "parent A" is included _before_ parent B (via the CLI args),
+         so the value from "parent B" overwrites the value from the earlier read "parent A".
+    -->
+    <config name="expectValueFromParentBTest" value="parent B"/>
+
+    <!-- For this config directive, this is the "highest" level, but the directive is also set in the "grandchild B" ruleset.
+         Highest level should win, independently of whether the grandchild is a child of this ruleset, or of another ruleset.
+    -->
+    <config name="expectValueFromParentBTestAlsoInGrandChildB" value="parent B"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesIncludeATest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesIncludeATest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- This config directive should not be applied. Root should win. -->
+    <config name="expectValueFromParentATestSetBeforeIncludes" value="child A"/>
+
+    <!-- For this config directive, this is the "highest" level, so this one should be applied.
+         The included (grand)child ruleset will try to override this.
+    -->
+    <config name="expectValueFromChildATestSetBeforeIncludes" value="child A"/>
+
+    <!-- This directive should not be applied. Last included ruleset (child B) should win. -->
+    <config name="expectValueFromChildBTestInChildAAndChildB" value="child A"/>
+
+    <!-- Include the overrides. -->
+    <rule ref="./ProcessRulesetConfigDirectivesSubIncludeATest.xml"/>
+    <rule ref="./ProcessRulesetConfigDirectivesSubIncludeBTest.xml"/>
+
+    <!-- For this config directive, this is the "highest" level, so this one should be applied.
+         The included (grand)child ruleset will try to override this.
+    -->
+    <config name="expectValueFromChildATestSetAfterIncludes" value="child A"/>
+
+    <!-- This config directive should not be applied. Root should win. -->
+    <config name="expectValueFromParentATestSetAfterIncludes" value="child A"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesIncludeBTest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesIncludeBTest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- These config directives should not be applied. Root should win. -->
+    <config name="expectValueFromParentATestSetBeforeIncludes" value="child B"/>
+    <config name="expectValueFromParentATestSetAfterIncludes" value="child B"/>
+
+    <!-- For this config directive, this is the "highest" level, but the directive is also set in the "child A"
+         ruleset, which is at the same "level".
+         In that case, the value which "wins" is determined by the order in which the rulesets are included.
+         In this case, that means that "child B" should win as "child A" is included _before_ child B (from the root ruleset),
+         so the value from "child B" overwrites the value from the earlier read "child A".
+    -->
+    <config name="expectValueFromChildBTestInChildAAndChildB" value="child B"/>
+
+    <!-- For this config directive, this is the "highest" level, but the directive is also set in the "grandchild A" ruleset.
+         Highest level should win, independently of whether the grandchild is a child of this ruleset, or of another ruleset.
+    -->
+    <config name="expectValueFromChildBTestAlsoInGrandChildA" value="child B"/>
+
+    <!-- This directive is only set in this ruleset, so should be applied. -->
+    <config name="expectValueFromChildBTest" value="child B"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesSubIncludeATest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesSubIncludeATest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- These config directives should not be applied. Root should win. -->
+    <config name="expectValueFromParentATestSetBeforeIncludes" value="grandchild A"/>
+    <config name="expectValueFromParentATestSetAfterIncludes" value="grandchild A"/>
+
+    <!-- This directive should not be applied. Child A should win. -->
+    <config name="expectValueFromChildATestSetBeforeIncludes" value="grandchild A"/>
+
+    <!-- This directive should not be applied. Child B should win. -->
+    <config name="expectValueFromChildBTestAlsoInGrandChildA" value="grandchild A"/>
+
+    <!-- This directive is only set in this ruleset, so should be applied. -->
+    <config name="expectValueFromGrandChildATest" value="grandchild A"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesSubIncludeBTest.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetConfigDirectivesTest/ProcessRulesetConfigDirectivesSubIncludeBTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetConfigDirectivesTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- These config directives should not be applied. Root should win. -->
+    <config name="expectValueFromParentATestSetBeforeIncludes" value="grandchild B"/>
+    <config name="expectValueFromParentATestSetAfterIncludes" value="grandchild B"/>
+
+    <!-- This directive should not be applied. Child A should win. -->
+    <config name="expectValueFromChildATestSetAfterIncludes" value="grandchild B"/>
+
+    <!-- This directive should not be applied. Parent B should win. -->
+    <config name="expectValueFromParentBTestAlsoInGrandChildB" value="grandchild B"/>
+
+    <!-- This directive is only set in this ruleset, so should be applied. -->
+    <config name="expectValueFromGrandChildBTest" value="grandchild B"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/ProcessRulesetConfigDirectivesTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetConfigDirectivesTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::processRuleset
+ */
+final class ProcessRulesetConfigDirectivesTest extends TestCase
+{
+
+    /**
+     * Directory in which the XML fixtures for this test can be found (without trailing slash).
+     *
+     * @var string
+     */
+    private const FIXTURE_DIR = __DIR__.'/Fixtures/ProcessRulesetConfigDirectivesTest';
+
+    /**
+     * The Config object.
+     *
+     * @var \PHP_CodeSniffer\Config
+     */
+    private static $config;
+
+
+    /**
+     * Initialize the config and ruleset objects for this test only once (but do allow recording code coverage).
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        if (isset(self::$config) === false) {
+            // Set up the ruleset.
+            $standardA    = self::FIXTURE_DIR.'/ProcessRulesetConfigDirectivesATest.xml';
+            $standardB    = self::FIXTURE_DIR.'/ProcessRulesetConfigDirectivesBTest.xml';
+            self::$config = new ConfigDouble(["--standard=$standardA,$standardB"]);
+            new Ruleset(self::$config);
+        }
+
+    }//end setUp()
+
+
+    /**
+     * Make sure the Config object is destroyed.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+        // The explicit method call prevents potential stray test-local references to the $config object
+        // preventing the destructor from running the clean up (which without stray references would be
+        // automagically triggered when this object is destroyed, but we can't definitively rely on that).
+        if (isset(self::$config) === true) {
+            self::$config->__destruct();
+        }
+
+    }//end tearDownAfterClass()
+
+
+    /**
+     * Verify the config directives are set based on the nesting level of the ruleset.
+     *
+     * - Highest level ruleset (root) should win over lower level (included) ruleset.
+     * - When two rulesets at the same "level" both set the same config, last included ruleset should win.
+     * - But if no higher level ruleset sets the value, the values from lowel levels should be applied.
+     * - The order of includes versus config directives in a ruleset file is deliberately irrelevant.
+     *
+     * @param string $name     The name of the config setting we're checking.
+     * @param string $expected The expected value for that config setting.
+     *
+     * @dataProvider dataConfigDirectives
+     *
+     * @return void
+     */
+    public function testConfigDirectives($name, $expected)
+    {
+        $this->assertSame($expected, self::$config->getConfigData($name));
+
+    }//end testConfigDirectives()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataConfigDirectives()
+    {
+        return [
+            'Config set in parent A before includes; all includes try to overrule; parent A should win'           => [
+                'name'     => 'expectValueFromParentATestSetBeforeIncludes',
+                'expected' => 'parent A',
+            ],
+            'Config set in parent A after includes; all includes try to overrule; parent A should win'            => [
+                'name'     => 'expectValueFromParentATestSetAfterIncludes',
+                'expected' => 'parent A',
+            ],
+            'Config set in both parent A and parent B; B is included last via CLI; parent B should win'           => [
+                'name'     => 'expectValueFromParentBTest',
+                'expected' => 'parent B',
+            ],
+            'Config set in parent B; also set in non-direct grandchild B; parent B should win'                    => [
+                'name'     => 'expectValueFromParentBTestAlsoInGrandChildB',
+                'expected' => 'parent B',
+            ],
+            'Config set in child A before includes; also set in grandchild A; child A should win'                 => [
+                'name'     => 'expectValueFromChildATestSetBeforeIncludes',
+                'expected' => 'child A',
+            ],
+            'Config set in child A after includes; also set in grandchild B; child A should win'                  => [
+                'name'     => 'expectValueFromChildATestSetAfterIncludes',
+                'expected' => 'child A',
+            ],
+            'Config set in both child A and child B; B is included last via ruleset includes; child B should win' => [
+                'name'     => 'expectValueFromChildBTestInChildAAndChildB',
+                'expected' => 'child B',
+            ],
+            'Config set in child B; also set in non-direct grandchild A, child B should win'                      => [
+                'name'     => 'expectValueFromChildBTestAlsoInGrandChildA',
+                'expected' => 'child B',
+            ],
+            'Config set in child B - no overrules'                                                                => [
+                'name'     => 'expectValueFromChildBTest',
+                'expected' => 'child B',
+            ],
+            'Config set in grandchild A ruleset - no overrules'                                                   => [
+                'name'     => 'expectValueFromGrandChildATest',
+                'expected' => 'grandchild A',
+            ],
+            'Config set in grandchild B ruleset - no overrules'                                                   => [
+                'name'     => 'expectValueFromGrandChildBTest',
+                'expected' => 'grandchild B',
+            ],
+        ];
+
+    }//end dataConfigDirectives()
+
+
+}//end class


### PR DESCRIPTION
# Description

This is a completely different solution to issue squizlabs/PHP_CodeSniffer#2197, compared to the original solution which was previously committed to the old 4.0 branch.

The "old' solution was to process rulesets "top to bottom", i.e. every directive is processed when "read" while recursing through the rulesets. I've evaluated that solution carefully and found it counter-intuitive, which means that I expect that it would raise lots of support questions. I also expect that solution to break way more rulesets than is justified to solve issue squizlabs/PHP_CodeSniffer#2197.

The original solution would require ruleset maintainers to have a high awareness of what configs are being set in included rulesets. Included rulesets are often PHPCS native standards or external standards, which are both subject to change in every new release. With ruleset processing being top-to-bottom, any "must have" config directives would have to be set _before_ any include which could possibly also have that config directive set. This also means that an external standard _adding_ a config directive to one of their rulesets, would become a potentially breaking change, as a "consumer" ruleset may not realize they were relying on a default value for a "must have" config and that value being changed in an included ruleset could now break their CS scans.

So... having said that, this commit contains an alternative, far more specific, and far less invasive, solution for the originally posed problem.

---

This commit changes the processing of `config` directives to be based on the inclusion depth, with the highest level ruleset setting a config value overruling the value for that config as set in lower level (included) rulesets.

When two rulesets at the same "level" both set the same `config` directive, the last one included "wins".

To illustrate:
```
File: phpcs.xml.dist
Sets config `testVersion` to `7.2-`
Includes CompanyRulesetA

File CompanyRulesetA/ruleset.xml
Sets config `testVersion` to `8.1-`
```

In 3.x: `testVersion` would be set to `8.1-`
In 4.x: `testVersion` will be set to `7.2-` (higher level ruleset wins)

```
File: phpcs.xml.dist
Includes CompanyRulesetA and AnotherRuleset

File CompanyRulesetA/ruleset.xml
Sets config `testVersion` to `8.2-`

File AnotherRuleset/ruleset.xml
Sets config `testVersion` to `5.6-`
```

In 3.x: `testVersion` would be set to `5.6-`
In 4.x: `testVersion` will be set to `5.6-` (CompanyRulesetA and AnotherRuleset are at the same inclusion depth, last one wins)

Includes ample tests.
Includes minor tweak to improve the debug information and only display that something was set when it actually has been set.


## Suggested changelog entry
Changed:
- When processing rulesets, `<config>` directives will be applied based on the nesting level of the ruleset.
    - Previously, it was not possible to overrule a `<config>` directive set in an included ruleset from the "root" ruleset.
    - Now, `<config>` directives set in the "root" ruleset will always "win" over directives in included rulesets.
    - When two included rulesets at the same nesting level both set the same directive, the value from the _last_ included ruleset "wins" (= same as before).


## Related issues/external references

Related to squizlabs/PHP_CodeSniffer#1821 - point 2
Fixes squizlabs/PHP_CodeSniffer#2197
