### PR TITLE
Ruleset: (CLI) `<arg>` settings in higher level ruleset(s) overrule args set in included ruleset(s)

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -105,6 +105,23 @@ class Config
     const DEFAULT_REPORT_WIDTH = 80;
 
     /**
+     * Translation table for config settings which can be changed via multiple CLI flags.
+     *
+     * If the flag name matches the setting name, there is no need to add it to this translation table.
+     * Similarly, if there is only one flag which can change a setting, there is no need to include
+     * it in this table, even if the flag name and the setting name don't match.
+     *
+     * @var array<string, string> Key is the CLI flag name, value the corresponding config setting name.
+     */
+    public const CLI_FLAGS_TO_SETTING_NAME = [
+        'n'                => 'warningSeverity',
+        'w'                => 'warningSeverity',
+        'warning-severity' => 'warningSeverity',
+        'no-colors'        => 'colors',
+        'no-cache'         => 'cache',
+    ];
+
+    /**
      * An array of settings that PHPCS and PHPCBF accept.
      *
      * This array is not meant to be accessed directly. Instead, use the settings

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/.phpcs.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/.phpcs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetCliArgsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- Issues squizlabs/PHP_CodeSniffer#2597 + squizlabs/PHP_CodeSniffer#2602: allow overruling CLI args when they have a single CLI flag names.
+         One value is set before the includes, one after to safeguard that the order in the file does not influence the results.
+    -->
+    <arg name="extensions" value="inc,install,module,php,profile,test,theme"/>
+
+    <!-- Issue squizlabs/PHP_CodeSniffer#2395: allow overruling CLI args when they have different CLI flag names. -->
+    <arg name="no-colors"/>
+
+    <!-- Miscellaneous other settings. -->
+    <arg name="report" value="full,summary,source"/>
+
+    <!-- Include the overrides. -->
+    <rule ref="./phpcs.xml.dist"/>
+    <rule ref="./config/phpcs/include-overrules.xml"/>
+
+    <!-- Issues squizlabs/PHP_CodeSniffer#2597 + squizlabs/PHP_CodeSniffer#2602: second test. -->
+    <arg name="tab-width" value="3"/>
+
+    <!-- Issue squizlabs/PHP_CodeSniffer#2395: second test. -->
+    <arg value="w"/>
+
+    <!-- Prevent a "no sniffs were registered" error. -->
+    <rule ref="Generic.PHP.BacktickOperator"/>
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/config/phpcs/include-overrules.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/config/phpcs/include-overrules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetCliArgsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- Issues squizlabs/PHP_CodeSniffer#2597 + squizlabs/PHP_CodeSniffer#2602: allow overruling CLI args when they have the CLI flag names.
+         The value from the parent ruleset should be applied, not the one from the child.
+    -->
+    <arg name="tab-width" value="5"/>
+
+    <!-- Paths must be resolved based on the ruleset location which included the directive. -->
+    <arg name="report-file" value="./report.txt"/>
+
+    <!-- Miscellaneous other settings. -->
+    <arg name="report-width" value="60"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/phpcs.xml.dist
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/phpcs.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetCliArgsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- Issue squizlabs/PHP_CodeSniffer#2395: allow overruling CLI args when they have different CLI flag names.
+         The values from the parent ruleset should be applied, not those from the child.
+    -->
+    <arg name="colors"/>
+    <arg value="qn"/>
+
+    <!-- Paths must be resolved based on the ruleset location which included the directive. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Miscellaneous other settings. -->
+    <arg name="parallel" value="10"/>
+
+    <!-- Include the overrides. -->
+    <rule ref="./vendor/OrgName/ExtStandard/ruleset.xml"/>
+
+    <!-- Issues squizlabs/PHP_CodeSniffer#2597 + squizlabs/PHP_CodeSniffer#2602: allow overruling CLI args when they have the CLI flag names.
+         The values from the parent ruleset should be applied, not those from the child.
+    -->
+    <arg name="extensions" value="inc,php"/>
+    <arg name="tab-width" value="4"/>
+
+    <!-- Miscellaneous other settings. -->
+    <arg name="report-width" value="120"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/vendor/OrgName/ExtStandard/bootstrap.php
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/vendor/OrgName/ExtStandard/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+// Do nothing. This is just a placeholder file for the "bootstrap" CLI flag test.

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/vendor/OrgName/ExtStandard/ruleset.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/vendor/OrgName/ExtStandard/ruleset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ProcessRulesetCliArgsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <!-- Issue squizlabs/PHP_CodeSniffer#2395. -->
+    <arg name="warning-severity" value="3"/>
+    <arg value="p"/>
+
+    <!-- Paths must be resolved based on the ruleset location which included the directive. -->
+    <arg name="bootstrap" value="./bootstrap.php"/>
+
+    <!-- Miscellaneous other settings. -->
+    <arg name="parallel" value="2"/>
+    <arg name="report" value="code,summary"/>
+
+</ruleset>

--- a/tests/Core/Ruleset/ProcessRulesetCliArgsTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetCliArgsTest.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::processRuleset
+ */
+final class ProcessRulesetCliArgsTest extends TestCase
+{
+
+    /**
+     * Directory in which the XML fixtures for this test can be found (without trailing slash).
+     *
+     * @var string
+     */
+    private const FIXTURE_DIR = __DIR__.'/Fixtures/ProcessRulesetCliArgsTest';
+
+    /**
+     * The Config object.
+     *
+     * @var \PHP_CodeSniffer\Config
+     */
+    private static $config;
+
+
+    /**
+     * Initialize the config and ruleset objects for this test only once (but do allow recording code coverage).
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        if (isset(self::$config) === false) {
+            // Set up the ruleset.
+            $standard     = self::FIXTURE_DIR.'/.phpcs.xml';
+            self::$config = new ConfigDouble(["--standard=$standard"]);
+            new Ruleset(self::$config);
+        }
+
+    }//end setUp()
+
+
+    /**
+     * Make sure the Config object is destroyed.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+        // The explicit method call prevents potential stray test-local references to the $config object
+        // preventing the destructor from running the clean up (which without stray references would be
+        // automagically triggered when this object is destroyed, but we can't definitively rely on that).
+        if (isset(self::$config) === true) {
+            self::$config->__destruct();
+        }
+
+    }//end tearDownAfterClass()
+
+
+    /**
+     * Verify the CLI arguments passed from within rulesets are set based on the nesting level of the ruleset.
+     *
+     * - Highest level ruleset (root) should win over lower level (included) ruleset.
+     * - When two rulesets at the same "level" both set the same ini, last included ruleset should win.
+     * - But if no higher level ruleset sets the value, the values from lowel levels should be applied.
+     * - The order of includes versus ini directives in a ruleset file is deliberately irrelevant.
+     *
+     * @param string $name     The name of the PHP ini setting we're checking.
+     * @param mixed  $expected The expected value for that ini setting.
+     *
+     * @dataProvider dataCliArgs
+     *
+     * @return void
+     */
+    public function testCliArgs($name, $expected)
+    {
+        $this->assertSame($expected, self::$config->{$name});
+
+    }//end testCliArgs()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataCliArgs()
+    {
+        return [
+            'Issue squiz#2395: "no-colors" set in parent before includes; "colors" set in child; parent should win'                  => [
+                'name'     => 'colors',
+                'expected' => false,
+            ],
+            'Issue squiz#2395: "w" set in parent after includes; "n" set in child; warningSeverity in grandchild; parent should win' => [
+                'name'     => 'warningSeverity',
+                'expected' => 5,
+            ],
+            'Issue squiz#2395: "q" in child A before includes; "p" set in grandchild A, child A should win'                          => [
+                'name'     => 'showProgress',
+                'expected' => false,
+            ],
+
+            'Issue squiz#2597: "extensions" set in parent before includes; also set in child; parent should win'                     => [
+                'name'     => 'extensions',
+                'expected' => [
+                    'inc'     => 'PHP',
+                    'install' => 'PHP',
+                    'module'  => 'PHP',
+                    'php'     => 'PHP',
+                    'profile' => 'PHP',
+                    'test'    => 'PHP',
+                    'theme'   => 'PHP',
+                ],
+            ],
+            'Issue squiz#2602: "tab-width" set in parent after includes; also set in both children; parent should win'               => [
+                'name'     => 'tabWidth',
+                'expected' => 3,
+            ],
+
+            // Verify overrule order for various other miscellaneous settings.
+            'Flag set in child A before includes; also set in grandchild A; child A should win'                                      => [
+                'name'     => 'parallel',
+                'expected' => 10,
+            ],
+            'Flag set in parent before includes; also set in grandchild A; parent should win'                                        => [
+                'name'     => 'reports',
+                'expected' => [
+                    'full'    => null,
+                    'summary' => null,
+                    'source'  => null,
+                ],
+            ],
+            'Flag set in child A after includes; also set in child B; child A should win'                                            => [
+                'name'     => 'reportWidth',
+                'expected' => 120,
+            ],
+        ];
+
+    }//end dataCliArgs()
+
+
+    /**
+     * Verify that path resolution for CLI flags passing paths is done based on the location of the ruleset setting the flag.
+     *
+     * @param string               $name     The name of the Config setting we're checking.
+     * @param string|array<string> $expected The expected value for that setting.
+     *
+     * @dataProvider dataCliArgsWithPaths
+     *
+     * @return void
+     */
+    public function testCliArgsWithPaths($name, $expected)
+    {
+        // Normalize slashes everywhere to allow the tests to pass on all OS-es.
+        $expected = $this->normalizeSlashes($expected);
+        $actual   = $this->normalizeSlashes(self::$config->{$name});
+
+        $this->assertSame($expected, $actual);
+
+    }//end testCliArgsWithPaths()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<string>>>
+     */
+    public static function dataCliArgsWithPaths()
+    {
+        return [
+            'Paths should be resolved based on the ruleset location: basepath'   => [
+                'name'     => 'basepath',
+                'expected' => self::FIXTURE_DIR,
+            ],
+            'Paths should be resolved based on the ruleset location: reportFile' => [
+                'name'     => 'reportFile',
+                'expected' => self::FIXTURE_DIR.'/config/phpcs/report.txt',
+            ],
+            'Paths should be resolved based on the ruleset location: bootstrap'  => [
+                'name'     => 'bootstrap',
+                'expected' => [
+                    self::FIXTURE_DIR.'/vendor/OrgName/ExtStandard/bootstrap.php',
+                ],
+            ],
+        ];
+
+    }//end dataCliArgsWithPaths()
+
+
+    /**
+     * Test helper to allow for path comparisons to succeed, independently of the OS on which the tests are run.
+     *
+     * @param string|array<string> $path Path(s) to normalize.
+     *
+     * @return string|array<string>
+     */
+    private function normalizeSlashes($path)
+    {
+        if (is_array($path) === true) {
+            foreach ($path as $k => $v) {
+                $path[$k] = $this->normalizeSlashes($v);
+            }
+
+            return $path;
+        }
+
+        return str_replace(DIRECTORY_SEPARATOR, '/', $path);
+
+    }//end normalizeSlashes()
+
+
+}//end class


### PR DESCRIPTION
# Description

Again, this is a completely different solution to issues squizlabs/PHP_CodeSniffer#2395, squizlabs/PHP_CodeSniffer#2597, squizlabs/PHP_CodeSniffer#2602, compared to the original solution which was previously committed to the old 4.0 branch in response to issue squizlabs/PHP_CodeSniffer#2197.

The "old' solution was to process rulesets "top to bottom", i.e. every directive is processed when "read" while recursing through the rulesets. I've evaluated that solution carefully and found it counter-intuitive, which means that I expect that it would raise lots of support questions. I also expect that solution to break way more rulesets than is justified to solve these issues.

The original solution would require ruleset maintainers to have a high awareness of what CLI args are being set in included rulesets. Included rulesets are often PHPCS native standards or external standards, which are both subject to change in every new release. With ruleset processing being top-to-bottom, any "must have" `<arg>` settings would have to be set _before_ any include which could possibly also have that directive set. This also means that an external standard _adding_ a CLI arg (like `tab-width`) to one of their rulesets, would become a potentially breaking change, as a "consumer" ruleset may not realize they were relying on a default value for a "must have" CLI flag and that value being changed in an included ruleset could now break their CS scans.

So... having said that, this commit contains an alternative, far more specific, and far less invasive, solution for the originally posed problem.

---

This commit changes the processing of `arg` directives to be based on the inclusion depth, with the highest level ruleset setting a CLI arg value overruling the value for that arg as set in lower level (included) rulesets.

When two rulesets at the same "level" both set the same `arg` directive, the first one included "wins".

:point_right: Note: this is different from `<config>` directives where the **_last_** included ruleset wins. However, it means that for two rulesets at the same "level", the behaviour is unchanged, which makes the BC-break smaller.

To illustrate:
```
File: phpcs.xml.dist
Sets arg `tab-width` to `4`
Includes CompanyRulesetA

File CompanyRulesetA/ruleset.xml
Sets arg `tab-width` to `2`
```

In 3.x: `Config::$tabWidth` would be set to `2`
In 4.x: `Config::$tabWidth` will be set to `4` (higher level ruleset wins)

```
File: phpcs.xml.dist
Includes CompanyRulesetA and AnotherRuleset

File CompanyRulesetA/ruleset.xml
Sets arg `extensions` to `php,module,phpt`.

File AnotherRuleset/ruleset.xml
Sets arg `extensions` to `php,module,profile,test`
```

In 3.x: `Config::$extensions` would be set to `php,module,phpt`
In 4.x: `Config::$extensions` will be set to `php,module,phpt` (CompanyRulesetA and AnotherRuleset are at the same inclusion depth, first one wins)

The solution as implemented takes CLI flags which can be set using multiple different CLI arguments into account. What this means is as follows:
```
File: phpcs.xml.dist
Sets arg `no-colors`
Includes CompanyRulesetA

File CompanyRulesetA/ruleset.xml
Sets arg `colors`
```
In 3.x: `Config::$colors` would be set to `true`
In 4.x: `Config::$colors` will be set to `false` (higher level ruleset wins)

Includes ample tests.

Note: there are no tests covering the `cache` setting, while by rights, there should be, but this is (yet again) something where the global `PHP_CODESNIFFER_IN_TESTS` is checked from within the runtime code, which means that the `cache` directive cannot be set/changed from within the test suite. Yes, this should be changed, but that is outside of the scope of this PR. For now, this has been manually tested and found working. See #966.

Includes minor tweak to improve the debug information and only display that something was set when it actually has been set.



## Suggested changelog entry
- When processing rulesets, `<arg>` directives will be applied based on the nesting level of the ruleset.
    - Previously, it was not possible to overrule a `<arg>` directive set in an included ruleset from the "root" ruleset.
    - Now, `<arg>` directives set in the "root" ruleset will always "win" over directives in included rulesets.
    - When two included rulesets at the same nesting level both set the same directive, the value from the _first_ included ruleset "wins" (= same as before).
 


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2395
Fixes squizlabs/PHP_CodeSniffer#2597
Fixes squizlabs/PHP_CodeSniffer#2602
