### PR TITLE
Ruleset: improve type handling of user-set properties

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -226,9 +226,7 @@ class ForbiddenFunctionsSniff implements Sniff
             $pattern = strtolower($function);
         }
 
-        if ($this->forbiddenFunctions[$pattern] !== null
-            && $this->forbiddenFunctions[$pattern] !== 'null'
-        ) {
+        if ($this->forbiddenFunctions[$pattern] !== null) {
             $type  .= 'WithAlternative';
             $data[] = $this->forbiddenFunctions[$pattern];
             $error .= '; use %s() instead';

--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -12,6 +12,7 @@
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsNull null
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsNullCase NULL
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsNullTrimmed   null
 
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrue true
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsBooleanTrueCase True

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -53,18 +53,25 @@ final class PropertyTypeHandlingSniff implements Sniff
     public $expectsFloatButAcceptsString;
 
     /**
-     * Used to verify that null gets set as a string.
+     * Used to verify that null gets set as a proper null value.
      *
      * @var null
      */
     public $expectsNull;
 
     /**
-     * Used to verify that null gets set as a string.
+     * Used to verify that null gets set as a proper null value.
      *
      * @var null
      */
     public $expectsNullCase;
+
+    /**
+     * Used to verify that null gets set as a proper null value.
+     *
+     * @var null
+     */
+    public $expectsNullTrimmed;
 
     /**
      * Used to verify that booleans get set as proper boolean values.

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHP_CodeSniffer\Ruleset::processRule
  * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
+ * @covers \PHP_CodeSniffer\Ruleset::getRealPropertyValue
  */
 final class PropertyTypeHandlingTest extends TestCase
 {
@@ -91,17 +92,17 @@ final class PropertyTypeHandlingTest extends TestCase
             'string',
             '10',
             '1.5',
-            'null',
-            'true',
-            'false',
+            null,
+            true,
+            false,
         ];
         $expectedArrayKeysAndValues = [
             'string' => 'string',
             10       => '10',
             'float'  => '1.5',
-            'null'   => 'null',
-            'true'   => 'true',
-            'false'  => 'false',
+            'null'   => null,
+            'true'   => true,
+            'false'  => false,
         ];
 
         return [
@@ -125,13 +126,17 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsFloatButAcceptsString',
                 'expected'     => '12.345',
             ],
-            'Null value gets set as string'                  => [
+            'Null value gets set as null'                    => [
                 'propertyName' => 'expectsNull',
-                'expected'     => 'null',
+                'expected'     => null,
             ],
-            'Null (uppercase) value gets set as string'      => [
+            'Null (uppercase) value gets set as null'        => [
                 'propertyName' => 'expectsNullCase',
-                'expected'     => 'NULL',
+                'expected'     => null,
+            ],
+            'Null (with spaces) value gets set as null'      => [
+                'propertyName' => 'expectsNullTrimmed',
+                'expected'     => null,
             ],
             'True value gets set as boolean'                 => [
                 'propertyName' => 'expectsBooleanTrue',
@@ -139,7 +144,7 @@ final class PropertyTypeHandlingTest extends TestCase
             ],
             'True (mixed case) value gets set as string'     => [
                 'propertyName' => 'expectsBooleanTrueCase',
-                'expected'     => 'True',
+                'expected'     => true,
             ],
             'True (with spaces) value gets set as boolean'   => [
                 'propertyName' => 'expectsBooleanTrueTrimmed',
@@ -151,7 +156,7 @@ final class PropertyTypeHandlingTest extends TestCase
             ],
             'False (mixed case) value gets set as string'    => [
                 'propertyName' => 'expectsBooleanFalseCase',
-                'expected'     => 'fALSe',
+                'expected'     => false,
             ],
             'False (with spaces) value gets set as boolean'  => [
                 'propertyName' => 'expectsBooleanFalseTrimmed',

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -12,6 +12,7 @@
 
             <property name="expectsNull" value="null"/>
             <property name="expectsNullCase" value="NULL"/>
+            <property name="expectsNullTrimmed" value="   null"/>
 
             <!-- Also tests that property names get cleaned of surrounding whitespace. -->
             <property name="  expectsBooleanTrue " value="true"/>


### PR DESCRIPTION
# Description

Consistently cast all variation of `'true'`, `'false'` and `'null'` to respectively `true`, `false` and `null`. Including when these values are used as values in an array property value.

Includes minor simplification now possible for the `Generic.PHP.ForbiddenFunctions` sniff.


## Suggested changelog entry
Changed:
- Type casting for sniff property values set from within a ruleset has been made more consistent. [#708]
    - `true` and `false` will now always be set to a boolean value, independently of the case in which the value was provided.
    - `null` will now be set to an actual `null` value. Previously, the sniff property would have been set to string `'null'`.
    - Array element values will now also get the type casting treatment. Previously, array values would always be strings.

## Related issues/external references

Fixes #708
