### PR TITLE
Squiz/ValidClassName: changed error code to correct describe what is being checked

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -74,7 +74,7 @@ class ValidClassNameSniff implements Sniff
                 $type,
                 $name,
             ];
-            $phpcsFile->addError($error, $nameStart, 'NotCamelCaps', $data);
+            $phpcsFile->addError($error, $nameStart, 'NotPascalCase', $data);
             $phpcsFile->recordMetric($stackPtr, 'PascalCase class name', 'no');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PascalCase class name', 'yes');


### PR DESCRIPTION

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->


## Suggested changelog entry
Changed:
- Changed the error code `Squiz.Classes.ValidClassName.NotCamelCaps` to `Squiz.Classes.ValidClassName.NotPascalCase`.
    - This reflects that the sniff is actually checking for `ClassName` and not `className`.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2046


