### PR TITLE
Squiz/Heredoc: make sniff more modular

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
@@ -42,8 +42,19 @@ class HeredocSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $error = 'Use of heredoc and nowdoc syntax ("<<<") is not allowed; use standard strings or inline HTML instead';
-        $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+        $tokens = $phpcsFile->getTokens();
+
+        $codePrefix = 'Heredoc';
+        $data       = ['heredoc'];
+        if ($tokens[$stackPtr]['code'] === T_START_NOWDOC) {
+            $codePrefix = 'Nowdoc';
+            $data       = ['nowdoc'];
+        }
+
+        $data[] = trim($tokens[$stackPtr]['content']);
+
+        $error = 'Use of %s syntax (%s) is not allowed; use standard strings or inline HTML instead';
+        $phpcsFile->addError($error, $stackPtr, $codePrefix.'NotAllowed', $data);
 
     }//end process()
 


### PR DESCRIPTION
# Description
Until now, the sniff would blindly forbid both heredoc and nowdoc syntax.

With the change as proposed in this PR, the sniff still does so, but now uses different error codes for encountered heredocs vs nowdocs, which allows for selectively ignoring one or the other, either from the ruleset or inline.

Includes updating the error message to be more specific for each error code as well.



## Suggested changelog entry
- The error code `Squiz.PHP.Heredoc.NotAllowed` has been replaced by `Squiz.PHP.Heredoc.HeredocNotAllowed` and `Squiz.PHP.Heredoc.NowdocNotAllowed`.
    - This allows for forbidding either heredocs or nowdocs without forbidding both.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2318

