### PR TITLE
Always display timing after run, except when in quiet mode

### DIFF
--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -15,7 +15,6 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Cbf implements Report
@@ -253,10 +252,6 @@ class Cbf implements Report
         }
 
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -12,7 +12,6 @@ namespace PHP_CodeSniffer\Reports;
 use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Common;
-use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Code implements Report
@@ -357,10 +356,6 @@ class Code implements Report
         }
 
         echo $cachedData;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 
 class Full implements Report
 {
@@ -249,10 +248,6 @@ class Full implements Report
         }
 
         echo $cachedData;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 
 class Info implements Report
 {
@@ -162,10 +161,6 @@ class Info implements Report
         }//end foreach
 
         echo str_repeat('-', 70).PHP_EOL;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 
 class Source implements Report
 {
@@ -265,10 +264,6 @@ class Source implements Report
         }
 
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 
 class Summary implements Report
 {
@@ -173,10 +172,6 @@ class Summary implements Report
         }
 
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -11,7 +11,6 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Timing;
 
 abstract class VersionControl implements Report
 {
@@ -346,10 +345,6 @@ abstract class VersionControl implements Report
         }
 
         echo PHP_EOL.str_repeat('-', $width).PHP_EOL.PHP_EOL;
-
-        if ($toScreen === true && $interactive === false) {
-            Timing::printRunTime();
-        }
 
     }//end generate()
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -120,17 +120,9 @@ class Runner
             $numErrors = $this->run();
 
             // Print all the reports for this run.
-            $toScreen = $this->reporter->printReports();
+            $this->reporter->printReports();
 
-            // Only print timer output if no reports were
-            // printed to the screen so we don't put additional output
-            // in something like an XML report. If we are printing to screen,
-            // the report types would have already worked out who should
-            // print the timer info.
-            if ($this->config->interactive === false
-                && ($toScreen === false
-                || (($this->reporter->totalErrors + $this->reporter->totalWarnings) === 0 && $this->config->showProgress === true))
-            ) {
+            if ($this->config->quiet === false) {
                 Timing::printRunTime();
             }
         } catch (DeepExitException $e) {
@@ -215,8 +207,10 @@ class Runner
             $this->run();
             $this->reporter->printReports();
 
-            echo PHP_EOL;
-            Timing::printRunTime();
+            if ($this->config->quiet === false) {
+                StatusWriter::write('');
+                Timing::printRunTime();
+            }
         } catch (DeepExitException $e) {
             echo $e->getMessage();
             return $e->getCode();


### PR DESCRIPTION
# Description

~~**⚠️ This PR depends on PR #1010, which needs to be merged first. ⚠️**~~

---

What with the Timing output now going to `STDERR`, we no longer need to be concerned about the Timing output ending up in `json`, `csv` or `xml` reports (to name a few).

In effect, this means, we can now always display Timing and memory usage info at the end of the run.

I'm making one exception though: timing will not be displayed when running in `quiet` mode.


## Suggested changelog entry

Add to changelog entry for STDERR change:
    - With this change in place, timing and memory consumption stats will now be displayed more often as it won't interfere with reports.

