### PR TITLE
Tokenizer: isset/unset/empty/eval/exit/die now contain parenthesis information

### DIFF
--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -368,6 +368,11 @@ final class Tokens
         T_CATCH      => T_CATCH,
         T_DECLARE    => T_DECLARE,
         T_MATCH      => T_MATCH,
+        T_ISSET      => T_ISSET,
+        T_EMPTY      => T_EMPTY,
+        T_UNSET      => T_UNSET,
+        T_EVAL       => T_EVAL,
+        T_EXIT       => T_EXIT,
     ];
 
     /**

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapParenthesesTest.inc
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapParenthesesTest.inc
@@ -84,24 +84,29 @@ $a = ($b + $c/* testArbitraryParenthesesCloser */);
 /* testFunctionCallParenthesesOpener */
 do_something($b + $c, $d, false /* testFunctionCallParenthesesCloser */);
 
-/* testIssetParenthesesOpener */
+/* testIssetParenthesesOwner */
 $set = isset($b, $c/* testIssetParenthesesCloser */);
 
-/* testEmptyParenthesesOpener */
+/* testEmptyParenthesesOwner */
 $empty = empty($b /* testEmptyParenthesesCloser */);
 
-/* testUnsetParenthesesOpener */
+/* testUnsetParenthesesOwner */
 unset ($b, $c /* testUnsetParenthesesCloser */);
 
-/* testEvalParenthesesOpener */
+/* testEvalParenthesesOwner */
 $eval = eval("\$str = \"$str\";"/* testEvalParenthesesCloser */);
 
-/* testExitParenthesesOpener */
+/* testExitParenthesesOwner */
 exit ( 101 /* testExitParenthesesCloser */);
 
-/* testDieParenthesesOpener */
+/* testDieParenthesesOwner */
 die ('oopsie' /* testDieParenthesesCloser */);
 
+/* testExitNoParentheses */
+exit;
+
+/* testDieNoParentheses */
+die;
 
 /*
  * All together now, let's make things a little more interesting....

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapParenthesesTest.php
@@ -151,6 +151,30 @@ final class CreateTokenMapParenthesesTest extends AbstractTokenizerTestCase
                 'testMarker' => '/* testAnonClassParenthesesOwner */',
                 'tokenCode'  => T_ANON_CLASS,
             ],
+            'isset'                                          => [
+                'testMarker' => '/* testIssetParenthesesOwner */',
+                'tokenCode'  => T_ISSET,
+            ],
+            'empty'                                          => [
+                'testMarker' => '/* testEmptyParenthesesOwner */',
+                'tokenCode'  => T_EMPTY,
+            ],
+            'unset'                                          => [
+                'testMarker' => '/* testUnsetParenthesesOwner */',
+                'tokenCode'  => T_UNSET,
+            ],
+            'eval'                                           => [
+                'testMarker' => '/* testEvalParenthesesOwner */',
+                'tokenCode'  => T_EVAL,
+            ],
+            'exit'                                           => [
+                'testMarker' => '/* testExitParenthesesOwner */',
+                'tokenCode'  => T_EXIT,
+            ],
+            'die'                                            => [
+                'testMarker' => '/* testDieParenthesesOwner */',
+                'tokenCode'  => T_EXIT,
+            ],
 
             'if - nested outer'                              => [
                 'testMarker' => '/* testNestedOuterIfParenthesesOwner */',
@@ -233,24 +257,6 @@ final class CreateTokenMapParenthesesTest extends AbstractTokenizerTestCase
             'function call'                     => [
                 'testMarker' => '/* testFunctionCallParenthesesOpener */',
             ],
-            'isset'                             => [
-                'testMarker' => '/* testIssetParenthesesOpener */',
-            ],
-            'empty'                             => [
-                'testMarker' => '/* testEmptyParenthesesOpener */',
-            ],
-            'unset'                             => [
-                'testMarker' => '/* testUnsetParenthesesOpener */',
-            ],
-            'eval'                              => [
-                'testMarker' => '/* testEvalParenthesesOpener */',
-            ],
-            'exit'                              => [
-                'testMarker' => '/* testExitParenthesesOpener */',
-            ],
-            'die'                               => [
-                'testMarker' => '/* testDieParenthesesOpener */',
-            ],
             'function call - nested 1'          => [
                 'testMarker' => '/* testNestedFunctionCallAParenthesesOpener */',
             ],
@@ -304,6 +310,14 @@ final class CreateTokenMapParenthesesTest extends AbstractTokenizerTestCase
             'anonymous class without parentheses' => [
                 'testMarker' => '/* testAnonClassNoParentheses */',
                 'tokenCode'  => T_ANON_CLASS,
+            ],
+            'exit without parentheses'            => [
+                'testMarker' => '/* testExitNoParentheses */',
+                'tokenCode'  => T_EXIT,
+            ],
+            'die without parentheses'             => [
+                'testMarker' => '/* testDieNoParentheses */',
+                'tokenCode'  => T_EXIT,
             ],
         ];
 


### PR DESCRIPTION
# Description
~~**⚠️ This PR depends on PR #1010 + #1012, which need to be merged first. ⚠️**~~

---

## Suggested changelog entry
- T_ISSET, T_UNSET, T_EMPTY, T_EVAL and T_EXIT tokens now contain parenthesis information.
    - Previously, you had to find the opening and closing parenthesis by looking forward through the token stack.
    - Now, you can use the `parenthesis_owner`, `parenthesis_opener` and `parenthesis_closer` array indexes.


## Related issues/external references

Fixes #23