### PR TITLE
Tokenizer/PHP: change tokenization of long PHP open tags

### DIFF
--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -915,12 +915,12 @@ abstract class AbstractPatternSniff implements Sniff
 
         // Don't add a space after the closing php tag as it will add a new
         // whitespace token.
-        $tokenizer = new PHP('<?php '.$str.'?>', null);
+        $tokenizer = new PHP('<?php'."\n".$str.'?>', null);
         StatusWriter::resume();
 
         // Remove the <?php tag from the front and the end php tag from the back.
         $tokens = $tokenizer->getTokens();
-        $tokens = array_slice($tokens, 1, (count($tokens) - 2));
+        $tokens = array_slice($tokens, 2, (count($tokens) - 3));
 
         $patterns = [];
         foreach ($tokens as $patternInfo) {

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -113,19 +113,15 @@ class EmptyPHPStatementSniff implements Sniff
         if ($fix === true) {
             $phpcsFile->fixer->beginChangeset();
 
-            if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG
-                || $tokens[$prevNonEmpty]['code'] === T_OPEN_TAG_WITH_ECHO
-            ) {
-                // Check for superfluous whitespace after the semicolon which should be
-                // removed as the `<?php ` open tag token already contains whitespace,
-                // either a space or a new line.
-                if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-                    $replacement = str_replace(' ', '', $tokens[($stackPtr + 1)]['content']);
-                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), $replacement);
-                }
+            // Make sure there always remains one space between the open tag and the next content.
+            $replacement = ' ';
+            if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $replacement = '';
             }
 
-            for ($i = $stackPtr; $i > $prevNonEmpty; $i--) {
+            $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+
+            for ($i = ($stackPtr - 1); $i > $prevNonEmpty; $i--) {
                 if ($tokens[$i]['code'] !== T_SEMICOLON
                     && $tokens[$i]['code'] !== T_WHITESPACE
                 ) {

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.2.inc
@@ -1,5 +1,5 @@
 <!-- Tests with short open tag. -->
-
+<input name="<? ;something_else(); ?>" />
 <input name="<? ; something_else(); ?>" />
 <input name="<? something_else(); ; ?>" />
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.2.inc.fixed
@@ -1,6 +1,6 @@
 <!-- Tests with short open tag. -->
-
-<input name="<?something_else(); ?>" />
+<input name="<? something_else(); ?>" />
+<input name="<? something_else(); ?>" />
 <input name="<? something_else(); ?>" />
 
 /*

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -93,6 +93,7 @@ final class EmptyPHPStatementUnitTest extends AbstractSniffTestCase
             ];
         case 'EmptyPHPStatementUnitTest.2.inc':
             return [
+                2  => 1,
                 3  => 1,
                 4  => 1,
                 13 => 1,

--- a/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
@@ -56,8 +56,8 @@ class OpenTagSniff implements Sniff
             return $phpcsFile->numTokens;
         }
 
-        $next = $phpcsFile->findNext(T_INLINE_HTML, 0);
-        if ($next !== false) {
+        $hasInlineHTML = $phpcsFile->findNext(T_INLINE_HTML, 0);
+        if ($hasInlineHTML !== false) {
             // This rule only applies to PHP-only files.
             return $phpcsFile->numTokens;
         }
@@ -65,7 +65,15 @@ class OpenTagSniff implements Sniff
         $error = 'Opening PHP tag must be on a line by itself';
         $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotAlone');
         if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
+            // Remove whitespace between the open tag and the next non-empty token.
+            for ($i = ($stackPtr + 1); $i < $next; $i++) {
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
             $phpcsFile->fixer->addNewline($stackPtr);
+            $phpcsFile->fixer->endChangeset();
         }
 
         return $phpcsFile->numTokens;

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.2.inc.fixed
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.2.inc.fixed
@@ -1,2 +1,2 @@
-<?php 
+<?php
 echo 'hi';

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -194,11 +194,13 @@ class CommentedOutCodeSniff implements Sniff
         */
 
         // First token is always the opening tag.
-        if ($stringTokens[0]['code'] !== T_OPEN_TAG) {
+        if ($stringTokens[0]['code'] !== T_OPEN_TAG || $stringTokens[1]['code'] !== T_WHITESPACE) {
             return ($lastCommentBlockToken + 1);
         } else {
+            // Remove the PHP open tag + the whitespace token following it.
             array_shift($stringTokens);
-            --$numTokens;
+            array_shift($stringTokens);
+            $numTokens -= 2;
         }
 
         // Last token is always the closing tag, unless something went wrong.

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -347,16 +347,7 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         // Check that there is one, and only one space at the start of the statement.
-        $leadingSpace  = 0;
-        $isLongOpenTag = false;
-        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG
-            && stripos($tokens[$stackPtr]['content'], '<?php') === 0
-        ) {
-            // The long open tag token in a single line tag set always contains a single space after it.
-            $leadingSpace  = 1;
-            $isLongOpenTag = true;
-        }
-
+        $leadingSpace = 0;
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
             $leadingSpace += $tokens[($stackPtr + 1)]['length'];
         }
@@ -366,13 +357,11 @@ class EmbeddedPhpSniff implements Sniff
             $data  = [$leadingSpace];
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterOpen', $data);
             if ($fix === true) {
-                if ($isLongOpenTag === true) {
-                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
-                } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-                    // Short open tag with too much whitespace.
+                if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                    // Open tag with too much whitespace.
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
                 } else {
-                    // Short open tag without whitespace.
+                    // Open tag without whitespace.
                     $phpcsFile->fixer->addContent($stackPtr, ' ');
                 }
             }

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -520,7 +520,7 @@ final class FindStartOfStatementTest extends AbstractMethodTestCase
     public function testOpenTag()
     {
         $start  = $this->getTargetToken('/* testOpenTag */', T_OPEN_TAG);
-        $start += 2;
+        $start += 3;
         $found  = self::$phpcsFile->findStartOfStatement($start);
 
         $this->assertSame(($start - 1), $found);

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagEOF1Test.php
@@ -43,10 +43,18 @@ final class PHPOpenTagEOF1Test extends AbstractTokenizerTestCase
             $tokens[$stackPtr]['type'],
             'Token tokenized as '.$tokens[$stackPtr]['type'].', not T_OPEN_TAG (type)'
         );
-        $this->assertSame('<?php ', $tokens[$stackPtr]['content']);
+        $this->assertSame('<?php', $tokens[$stackPtr]['content']);
+
+        $this->assertArrayHasKey(($stackPtr + 1), $tokens, 'Missing whitespace token after open tag');
+        $this->assertSame(
+            T_WHITESPACE,
+            $tokens[($stackPtr + 1)]['code'],
+            'Missing whitespace token after open tag (code)'
+        );
+        $this->assertSame(' ', $tokens[($stackPtr + 1)]['content'], 'Missing whitespace token after open tag (content)');
 
         // Now make sure that this is the very last token in the file and there are no tokens after it.
-        $this->assertArrayNotHasKey(($stackPtr + 1), $tokens);
+        $this->assertArrayNotHasKey(($stackPtr + 2), $tokens);
 
     }//end testLongOpenTagAtEndOfFile()
 

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagTest.inc
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagTest.inc
@@ -1,0 +1,115 @@
+<?php /* testLongOpenTagWithNewLine */ ?>
+<?php
+echo 'with new line';
+?>
+
+<?php /* testLongOpenTagWithOneSpaceAndNewLine */ ?>
+<?php 
+echo 'with one space and new line';
+?>
+
+<?php /* testLongOpenTagWithTrailingWhiteSpaceAndNewLine */ ?>
+<?php    
+echo 'with trailing whitespace and new line';
+?>
+
+<?php /* testLongOpenTagOneSpace */ ?>
+<?php echo 'single line, one space'; ?>
+
+<?php /* testLongOpenTagMultiSpace */ ?>
+<?php      echo 'single line, multiple spaces'; ?>
+
+<?php /* testLongOpenTagWithDoubleNewLine */ ?>
+<?php
+
+echo 'with double new line';
+?>
+
+<?php /* testLongOpenTagWithTripleNewLine */ ?>
+<?php
+
+
+echo 'with triple new line';
+?>
+
+<?php /* testLongOpenTagWithNewLineAndIndentOnNextLine */ ?>
+    <?php
+    echo 'with new line and indent on next line';
+?>
+
+<!-- ====================================== -->
+
+<?php /* testCaseLongOpenTagWithNewLine */ ?>
+<?PHP
+echo 'with new line';
+?>
+
+<?php /* testCaseLongOpenTagWithOneSpaceAndNewLine */ ?>
+<?phP 
+echo 'with one space and new line';
+?>
+
+<?php /* testCaseLongOpenTagWithTrailingWhiteSpaceAndNewLine */ ?>
+<?Php    
+echo 'with trailing whitespace and new line';
+?>
+
+<?php /* testCaseLongOpenTagOneSpace */ ?>
+<?pHp echo 'single line, one space'; ?>
+
+<?php /* testCaseLongOpenTagMultiSpace */ ?>
+<?phP      echo 'single line, multiple spaces'; ?>
+
+<!-- ====================================== -->
+
+<?php /* testShortOpenEchoTagWithNewLine */ ?>
+<?=
+'with new line';
+?>
+
+<?php /* testShortOpenEchoTagWithOneSpaceAndNewLine */ ?>
+<?= 
+'with one space and new line';
+?>
+
+<?php /* testShortOpenEchoTagWithTrailingWhiteSpaceAndNewLine */ ?>
+<?=    
+'with trailing whitespace and new line';
+?>
+
+<?php /* testShortOpenEchoTagNoSpace */ ?>
+<?='single line, no space'; ?>
+
+<?php /* testShortOpenEchoTagOneSpace */ ?>
+<?= 'single line, one space'; ?>
+
+<?php /* testShortOpenEchoTagMultiSpace */ ?>
+<?=      'single line, multiple spaces'; ?>
+
+<!-- ====================================== -->
+
+<?php /* testShortOpenTagWithNewLine */ ?>
+<?
+echo 'with new line';
+?>
+
+<?php /* testShortOpenTagWithOneSpaceAndNewLine */ ?>
+<? 
+echo 'with one space and new line';
+?>
+
+<?php /* testShortOpenTagWithTrailingWhiteSpaceAndNewLine */ ?>
+<?    
+echo 'with trailing whitespace and new line';
+?>
+
+<?php /* testShortOpenTagNoSpace */ ?>
+<?echo 'single line, no space'; ?>
+
+<?php /* testShortOpenTagOneSpace */ ?>
+<? echo 'single line, one space'; ?>
+
+<?php /* testShortOpenTagMultiSpace */ ?>
+<?      echo 'single line, multiple spaces'; ?>
+
+<!-- ====================================== -->

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagTest.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagTest.php
@@ -1,0 +1,419 @@
+<?php
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the tokenization of PHP open tags.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class PHPOpenTagTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the tokenization of long PHP open tags does not include whitespace.
+     *
+     * @param string                           $testMarker     The comment prefacing the test.
+     * @param array<array<string, string|int>> $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataLongOpenTag
+     *
+     * @return void
+     */
+    public function testLongOpenTag($testMarker, array $expectedTokens)
+    {
+        $this->checkTokenSequence($testMarker, $expectedTokens);
+
+    }//end testLongOpenTag()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<array<string, string|int>>>>
+     */
+    public static function dataLongOpenTag()
+    {
+        $tokenType    = 'T_OPEN_TAG';
+        $tokenContent = '<?php';
+        $data         = self::getOpenTagTokenizationProvider('LongOpen', $tokenType, $tokenContent);
+
+        // Remove the "no space" case as that's a parse error with long open tags.
+        unset($data['open tag, no space']);
+
+        // Add extra tests to verify the "join or don't join" whitespace logic is correct.
+        $data['open tag + double new line'] = [
+            'testMarker'     => '/* testLongOpenTagWithDoubleNewLine */',
+            'expectedTokens' => [
+                [
+                    'type'       => $tokenType,
+                    'content'    => $tokenContent,
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 1,
+                ],
+                [
+                    'type'       => 'T_ECHO',
+                    'lineOffset' => 2,
+                ],
+            ],
+        ];
+        $data['open tag + triple new line'] = [
+            'testMarker'     => '/* testLongOpenTagWithTripleNewLine */',
+            'expectedTokens' => [
+                [
+                    'type'       => $tokenType,
+                    'content'    => $tokenContent,
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 1,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 2,
+                ],
+                [
+                    'type'       => 'T_ECHO',
+                    'lineOffset' => 3,
+                ],
+            ],
+        ];
+        $data['open tag + new line + indent on next line'] = [
+            'testMarker'     => '/* testLongOpenTagWithNewLineAndIndentOnNextLine */',
+            'expectedTokens' => [
+                [
+                    'type'       => $tokenType,
+                    'content'    => $tokenContent,
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => "\n",
+                    'lineOffset' => 0,
+                ],
+                [
+                    'type'       => 'T_WHITESPACE',
+                    'content'    => '    ',
+                    'lineOffset' => 1,
+                ],
+                [
+                    'type'       => 'T_ECHO',
+                    'lineOffset' => 1,
+                ],
+            ],
+        ];
+
+        return $data;
+
+    }//end dataLongOpenTag()
+
+
+    /**
+     * Test that the tokenization of non-lowercase long PHP open tags does not include whitespace
+     * and that the case of the tag is unchanged.
+     *
+     * @param string                           $testMarker     The comment prefacing the test.
+     * @param array<array<string, string|int>> $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataCaseLongOpenTag
+     *
+     * @return void
+     */
+    public function testCaseLongOpenTag($testMarker, array $expectedTokens)
+    {
+        $this->checkTokenSequence($testMarker, $expectedTokens);
+
+    }//end testCaseLongOpenTag()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<array<string, string|int>>>>
+     */
+    public static function dataCaseLongOpenTag()
+    {
+        $data = self::getOpenTagTokenizationProvider('CaseLongOpen', 'T_OPEN_TAG', '<?php');
+
+        // Remove the "no space" case as that's a parse error with long open tags.
+        unset($data['open tag, no space']);
+
+        // Update the expectations for the casing of the open tag.
+        $data['open tag + new line']['expectedTokens'][0]['content'] = '<?PHP';
+        $data['open tag + one space + new line']['expectedTokens'][0]['content']           = '<?phP';
+        $data['open tag + trailing whitespace + new line']['expectedTokens'][0]['content'] = '<?Php';
+        $data['open tag, one space']['expectedTokens'][0]['content']   = '<?pHp';
+        $data['open tag, multi space']['expectedTokens'][0]['content'] = '<?phP';
+
+        return $data;
+
+    }//end dataCaseLongOpenTag()
+
+
+    /**
+     * Test the tokenization of short PHP open echo tags (for consistency).
+     *
+     * @param string                           $testMarker     The comment prefacing the test.
+     * @param array<array<string, string|int>> $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataShortOpenEchoTag
+     *
+     * @return void
+     */
+    public function testShortOpenEchoTag($testMarker, array $expectedTokens)
+    {
+        $this->checkTokenSequence($testMarker, $expectedTokens);
+
+    }//end testShortOpenEchoTag()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<array<string, string|int>>>>
+     */
+    public static function dataShortOpenEchoTag()
+    {
+        return self::getOpenTagTokenizationProvider('ShortOpenEcho', 'T_OPEN_TAG_WITH_ECHO', '<?=');
+
+    }//end dataShortOpenEchoTag()
+
+
+    /**
+     * Test the tokenization of short PHP open tags (for consistency).
+     *
+     * @param string                           $testMarker     The comment prefacing the test.
+     * @param array<array<string, string|int>> $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataShortOpenTag
+     *
+     * @return void
+     */
+    public function testShortOpenTag($testMarker, array $expectedTokens)
+    {
+        if ((bool) ini_get('short_open_tag') === false) {
+            $this->markTestSkipped('short_open_tag=on is required for this test');
+        }
+
+        $this->checkTokenSequence($testMarker, $expectedTokens);
+
+    }//end testShortOpenTag()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<array<string, string|int>>>>
+     */
+    public static function dataShortOpenTag()
+    {
+        return self::getOpenTagTokenizationProvider('ShortOpen', 'T_OPEN_TAG', '<?');
+
+    }//end dataShortOpenTag()
+
+
+    /**
+     * Test helper. Check a token sequence complies with an expected token sequence.
+     *
+     * @param string                           $testMarker     The comment prefacing the test.
+     * @param array<array<string, string|int>> $expectedTokens The tokenization expected.
+     *
+     * @return void
+     */
+    private function checkTokenSequence($testMarker, array $expectedTokens)
+    {
+        $tokens   = $this->phpcsFile->getTokens();
+        $target   = $this->getTargetToken($testMarker, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO]);
+        $stackPtr = $target;
+
+        foreach ($expectedTokens as $tokenInfo) {
+            $this->assertSame(
+                constant($tokenInfo['type']),
+                $tokens[$stackPtr]['code'],
+                'Token tokenized as '.Tokens::tokenName($tokens[$stackPtr]['code']).', not '.$tokenInfo['type'].' (code)'
+            );
+            $this->assertSame(
+                $tokenInfo['type'],
+                $tokens[$stackPtr]['type'],
+                'Token tokenized as '.$tokens[$stackPtr]['type'].', not '.$tokenInfo['type'].' (type)'
+            );
+
+            if (isset($tokenInfo['content']) === true) {
+                $this->assertSame(
+                    $tokenInfo['content'],
+                    $tokens[$stackPtr]['content'],
+                    'Token content does not match expected content'
+                );
+            }
+
+            $this->assertSame(
+                ($tokens[$target]['line'] + $tokenInfo['lineOffset']),
+                $tokens[$stackPtr]['line'],
+                'Line number does not match expected line number'
+            );
+
+            ++$stackPtr;
+        }//end foreach
+
+    }//end checkTokenSequence()
+
+
+    /**
+     * Data provider generator.
+     *
+     * @param string $tagtype      The type of tag being examined.
+     * @param string $tokenType    The expected token type.
+     * @param string $tokenContent The expected token contents.
+     *
+     * @return array<string, array<string, string|array<array<string, string|int>>>>
+     */
+    private static function getOpenTagTokenizationProvider($tagtype, $tokenType, $tokenContent)
+    {
+        $lastTokenType = 'T_ECHO';
+        if ($tagtype === 'ShortOpenEcho') {
+            $lastTokenType = 'T_CONSTANT_ENCAPSED_STRING';
+        }
+
+        return [
+            'open tag + new line'                       => [
+                'testMarker'     => '/* test'.$tagtype.'TagWithNewLine */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => 'T_WHITESPACE',
+                        'content'    => "\n",
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 1,
+                    ],
+                ],
+            ],
+            'open tag + one space + new line'           => [
+                'testMarker'     => '/* test'.$tagtype.'TagWithOneSpaceAndNewLine */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => 'T_WHITESPACE',
+                        'content'    => ' '."\n",
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 1,
+                    ],
+                ],
+            ],
+            'open tag + trailing whitespace + new line' => [
+                'testMarker'     => '/* test'.$tagtype.'TagWithTrailingWhiteSpaceAndNewLine */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => 'T_WHITESPACE',
+                        'content'    => '    '."\n",
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 1,
+                    ],
+                ],
+            ],
+            'open tag, no space'                        => [
+                'testMarker'     => '/* test'.$tagtype.'TagNoSpace */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 0,
+                    ],
+                ],
+            ],
+            'open tag, one space'                       => [
+                'testMarker'     => '/* test'.$tagtype.'TagOneSpace */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => 'T_WHITESPACE',
+                        'content'    => ' ',
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 0,
+                    ],
+                ],
+            ],
+            'open tag, multi space'                     => [
+                'testMarker'     => '/* test'.$tagtype.'TagMultiSpace */',
+                'expectedTokens' => [
+                    [
+                        'type'       => $tokenType,
+                        'content'    => $tokenContent,
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => 'T_WHITESPACE',
+                        'content'    => '      ',
+                        'lineOffset' => 0,
+                    ],
+                    [
+                        'type'       => $lastTokenType,
+                        'lineOffset' => 0,
+                    ],
+                ],
+            ],
+        ];
+
+    }//end getOpenTagTokenizationProvider()
+
+
+}//end class

--- a/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenMiscTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenMiscTest.php
@@ -41,10 +41,9 @@ EOD;
         $phpcsFile->parse();
 
         $tokens = $phpcsFile->getTokens();
-        $target = $phpcsFile->findNext(T_WHITESPACE, 0);
+        $target = 2;
 
         // Verify initial state.
-        $this->assertIsInt($target, 'Target token was not found');
         $this->assertSame('		', $tokens[$target]['content'], 'Content after initial parsing does not contain tabs');
         $this->assertSame(2, $tokens[$target]['length'], 'Length after initial parsing is not as expected');
         $this->assertArrayNotHasKey('orig_content', $tokens[$target], "Key 'orig_content' found in the initial token array.");


### PR DESCRIPTION
# Description

~~**⚠️ UPDATED: This PR depends on PR #1010, which needs to be merged first. ⚠️**~~ 

---

Change tokenization of long PHP open tags to no longer include whitespace (single space/new line).

This ensures the tokenization of all PHP open tags - long open tags `<?php`, short open tags `<?` and short open echo tags `<?=` - is consistent and should simplify handling of open tag tokens in sniffs and lower the cognitive load of sniff developers.

As per the detailed proposal in ticket #593.

Includes extensive unit tests, both ensuring the correct tokenization, as well as safeguarding consistency across the different open tags.

Includes the following additional updates to maintain the pre-existing behaviour:
* `AbstractPatternSniff` The `AbstractPatternSniff` tokenizes an arbitrary code pattern to determine the token pattern to sniff for. This tokenization now to takes the change in the PHP open tag tokenization into account.
* `Generic/EmptyPHPStatement` - replace now redundant special condition for PHP open tags + update "fixed" file for improved output + add extra test.
* `PSR12/OpenTag` - allow for the changed tokenization. The updated code also means that the fixer will no longer leave stray whitespace behind after a PHP open tag.
* `Squiz/CommentedOutCode` - allow for the changed tokenization.
* `Squiz/EmbeddedPhp` - code simplification.
* `FindStartOfStatementTest` - fixed token offset expectation as there is now an extra whitespace token.
* `ReplaceTabsInTokenMiscTest` - updated target finding



## Suggested changelog entry
Changed:
- `T_OPEN_TAG` tokens will no longer contain any whitespace. [#593]
    - Previously, "long" open tags could include either a single space or a new line character.
    - This whitespace will now be tokenized as a `T_WHITESPACE` token.


## Related issues/external references

Fixes #593
