### PR TITLE
Tokenizer/PHP: goto label check - minor tweak

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2271,6 +2271,7 @@ class PHP extends Tokenizer
                     // Okay, so we have a colon, now we need to make sure that this is not
                     // class constant access, a ternary, enum or switch case.
                     $stopTokens = [
+                        T_DOUBLE_COLON       => true,
                         T_CASE               => true,
                         T_SEMICOLON          => true,
                         T_OPEN_TAG           => true,
@@ -2285,7 +2286,8 @@ class PHP extends Tokenizer
                         }
                     }
 
-                    if ($finalTokens[$x]['code'] !== T_CASE
+                    if ($finalTokens[$x]['code'] !== T_DOUBLE_COLON
+                        && $finalTokens[$x]['code'] !== T_CASE
                         && $finalTokens[$x]['code'] !== T_INLINE_THEN
                         && $finalTokens[$x]['code'] !== T_ENUM
                     ) {

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.inc
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.inc
@@ -63,8 +63,18 @@ switch ($x) {
         // Do something.
         break;
 
-    /* testNotGotoDeclarationClassConstant */
+    /* testNotGotoDeclarationClassConstantInCase */
     case MyClass::CONSTANT:
+        // Do something.
+        break;
+
+    /* testNotGotoDeclarationClassConstantWithSpace */
+    case MyClass   ::   MY_CONST:
+        // Do something.
+        break;
+
+    /* testNotGotoDeclarationClassConstantWithComment */
+    case  MyClass::/*comment*/OTHER_CONST:
         // Do something.
         break;
 

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.php
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.php
@@ -176,8 +176,16 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
                 'testContent' => 'CONSTANT',
             ],
             'not goto label - class constant followed by switch-case colon'      => [
-                'testMarker'  => '/* testNotGotoDeclarationClassConstant */',
+                'testMarker'  => '/* testNotGotoDeclarationClassConstantInCase */',
                 'testContent' => 'CONSTANT',
+            ],
+            'not goto label - spacey class constant in switch-case'              => [
+                'testMarker'  => '/* testNotGotoDeclarationClassConstantWithSpace */',
+                'testContent' => 'MY_CONST',
+            ],
+            'not goto label - class constant with comment in switch-case'        => [
+                'testMarker'  => '/* testNotGotoDeclarationClassConstantWithComment */',
+                'testContent' => 'OTHER_CONST',
             ],
             'not goto label - class property use followed by switch-case colon'  => [
                 'testMarker'  => '/* testNotGotoDeclarationClassProperty */',


### PR DESCRIPTION
# Description
While the check for a double colon works correctly when there is no whitespace/comments between the tokens, there could still be unnecessary token walking if there was (whitespace/comments).

Fixed now.

Includes some extra tests (which would previously already pass, but now more efficiently).

Follow up to squizlabs/PHP_CodeSniffer#155


## Suggested changelog entry
_N/A_