### PR TITLE
Tokenizer/PHP: fix context sensitive keywords as goto labels

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -494,6 +494,7 @@ class PHP extends Tokenizer
         T_USE                      => true,
         T_NAMESPACE                => true,
         T_PAAMAYIM_NEKUDOTAYIM     => true,
+        T_GOTO                     => true,
     ];
 
     /**

--- a/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.inc
+++ b/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.inc
@@ -1,0 +1,78 @@
+<?php
+
+// Intentional parse errors!
+// Using a keyword as a "goto" label is a parse error, but should still be tokenized correctly as T_STRING to not confuse sniffs.
+
+function gotoLabels() {
+    goto /* testAbstract */ abstract;
+    goto /* testArray */ array;
+    goto /* testAs */ as;
+    goto /* testBreak */ break;
+    goto /* testCallable */ callable;
+    goto /* testCase */ case;
+    goto /* testCatch */ catch;
+    goto /* testClass */ class;
+    goto /* testClone */ clone;
+    goto /* testConst */ const;
+    goto /* testContinue */ continue;
+    goto /* testDeclare */ declare;
+    goto /* testDefault */ default;
+    goto /* testDo */ do;
+    goto /* testEcho */ echo;
+    goto /* testElse */ else;
+    goto /* testElseIf */ elseif;
+    goto /* testEmpty */ empty;
+    goto /* testEndDeclare */ enddeclare;
+    goto /* testEndFor */ endfor;
+    goto /* testEndForeach */ endforeach;
+    goto /* testEndIf */ endif;
+    goto /* testEndSwitch */ endswitch;
+    goto /* testEndWhile */ endwhile;
+    goto /* testEnum */ enum;
+    goto /* testEval */ eval;
+    goto /* testExit */ exit;
+    goto /* testExtends */ extends;
+    goto /* testFinal */ final;
+    goto /* testFinally */ finally;
+    goto /* testFn */ fn;
+    goto /* testFor */ for;
+    goto /* testForeach */ ForEach;
+    goto /* testFunction */ function;
+    goto /* testGlobal */ global;
+    goto /* testGoto */ goto;
+    goto /* testIf */ if;
+    goto /* testImplements */ implements;
+    goto /* testInclude */ include;
+    goto /* testIncludeOnce */ include_once;
+    goto /* testInstanceOf */ instanceof;
+    goto /* testInsteadOf */ insteadof;
+    goto /* testInterface */ interface;
+    goto /* testIsset */ isset;
+    goto /* testList */ list;
+    goto /* testMatch */ match;
+    goto /* testNamespace */ namespace;
+    goto /* testNew */ new;
+    goto /* testPrint */ print;
+    goto /* testPrivate */ private;
+    goto /* testProtected */ protected;
+    goto /* testPublic */ public;
+    goto /* testReadonly */ readonly;
+    goto /* testRequire */ require;
+    goto /* testRequireOnce */ require_once;
+    goto /* testReturn */ return;
+    goto /* testStatic */ static;
+    goto /* testSwitch */ switch;
+    goto /* testThrows */ throw;
+    goto /* testTrait */ trait;
+    goto /* testTry */ try;
+    goto /* testUnset */ unset;
+    goto /* testUse */ use;
+    goto /* testVar */ var;
+    goto /* testWhile */ while;
+    goto /* testYield */ yield;
+    goto /* testYieldFrom */ yield_from;
+
+    goto /* testAnd */ and;
+    goto /* testOr */ or;
+    goto /* testXor */ xor;
+}

--- a/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.php
+++ b/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests the conversion of PHP native context sensitive keywords to T_STRING when used in a "goto" statement.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the conversion of PHP native context sensitive keywords to T_STRING when used in a "goto" statement.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class ContextSensitiveKeywordsGotoTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that context sensitive keyword is tokenized as string when used in a "goto" statement.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataStrings
+     *
+     * @return void
+     */
+    public function testStrings($testMarker)
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING]));
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
+
+    }//end testStrings()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testStrings()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataStrings()
+    {
+        return [
+            'abstract'     => ['/* testAbstract */'],
+            'array'        => ['/* testArray */'],
+            'as'           => ['/* testAs */'],
+            'break'        => ['/* testBreak */'],
+            'callable'     => ['/* testCallable */'],
+            'case'         => ['/* testCase */'],
+            'catch'        => ['/* testCatch */'],
+            'class'        => ['/* testClass */'],
+            'clone'        => ['/* testClone */'],
+            'const'        => ['/* testConst */'],
+            'continue'     => ['/* testContinue */'],
+            'declare'      => ['/* testDeclare */'],
+            'default'      => ['/* testDefault */'],
+            'do'           => ['/* testDo */'],
+            'echo'         => ['/* testEcho */'],
+            'else'         => ['/* testElse */'],
+            'elseif'       => ['/* testElseIf */'],
+            'empty'        => ['/* testEmpty */'],
+            'enddeclare'   => ['/* testEndDeclare */'],
+            'endfor'       => ['/* testEndFor */'],
+            'endforeach'   => ['/* testEndForeach */'],
+            'endif'        => ['/* testEndIf */'],
+            'endswitch'    => ['/* testEndSwitch */'],
+            'endwhile'     => ['/* testEndWhile */'],
+            'enum'         => ['/* testEnum */'],
+            'eval'         => ['/* testEval */'],
+            'exit'         => ['/* testExit */'],
+            'extends'      => ['/* testExtends */'],
+            'final'        => ['/* testFinal */'],
+            'finally'      => ['/* testFinally */'],
+            'fn'           => ['/* testFn */'],
+            'for'          => ['/* testFor */'],
+            'foreach'      => ['/* testForeach */'],
+            'function'     => ['/* testFunction */'],
+            'global'       => ['/* testGlobal */'],
+            'goto'         => ['/* testGoto */'],
+            'if'           => ['/* testIf */'],
+            'implements'   => ['/* testImplements */'],
+            'include'      => ['/* testInclude */'],
+            'include_once' => ['/* testIncludeOnce */'],
+            'instanceof'   => ['/* testInstanceOf */'],
+            'insteadof'    => ['/* testInsteadOf */'],
+            'interface'    => ['/* testInterface */'],
+            'isset'        => ['/* testIsset */'],
+            'list'         => ['/* testList */'],
+            'match'        => ['/* testMatch */'],
+            'namespace'    => ['/* testNamespace */'],
+            'new'          => ['/* testNew */'],
+            'print'        => ['/* testPrint */'],
+            'private'      => ['/* testPrivate */'],
+            'protected'    => ['/* testProtected */'],
+            'public'       => ['/* testPublic */'],
+            'readonly'     => ['/* testReadonly */'],
+            'require'      => ['/* testRequire */'],
+            'require_once' => ['/* testRequireOnce */'],
+            'return'       => ['/* testReturn */'],
+            'static'       => ['/* testStatic */'],
+            'switch'       => ['/* testSwitch */'],
+            'throws'       => ['/* testThrows */'],
+            'trait'        => ['/* testTrait */'],
+            'try'          => ['/* testTry */'],
+            'unset'        => ['/* testUnset */'],
+            'use'          => ['/* testUse */'],
+            'var'          => ['/* testVar */'],
+            'while'        => ['/* testWhile */'],
+            'yield'        => ['/* testYield */'],
+            'yield_from'   => ['/* testYieldFrom */'],
+            'and'          => ['/* testAnd */'],
+            'or'           => ['/* testOr */'],
+            'xor'          => ['/* testXor */'],
+        ];
+
+    }//end dataStrings()
+
+
+}//end class

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.inc
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.inc
@@ -52,6 +52,39 @@ function hasGoto() {
     do_something();
 }
 
+// The "other" keywords are perfectly valid to be used as goto labels (just really confusing).
+function gotoLabels() {
+    /* testParentAsGotoTargetShouldBeString */
+    goto parent;
+    /* testParentAsGotoLabelShouldBeGotoLabel */
+    parent:
+        doSomething();
+
+    /* testSelfAsGotoTargetShouldBeString */
+    goto self;
+    /* testSelfAsGotoLabelShouldBeGotoLabel */
+    self:
+        doSomething();
+
+    /* testTrueAsGotoTargetShouldBeString */
+    goto true;
+    /* testTrueAsGotoLabelShouldBeGotoLabel */
+    true:
+        doSomething();
+
+    /* testFalseAsGotoTargetShouldBeString */
+    goto false;
+    /* testFalseAsGotoLabelShouldBeGotoLabel */
+    false:
+        doSomething();
+
+    /* testNullAsGotoTargetShouldBeString */
+    goto null;
+    /* testNullAsGotoLabelShouldBeGotoLabel */
+    null:
+        doSomething();
+}
+
 switch ($x) {
     /* testNotGotoDeclarationGlobalConstant */
     case CONSTANT:
@@ -70,6 +103,21 @@ switch ($x) {
 
     /* testNotGotoDeclarationClassProperty */
     case $obj->property:
+        // Do something.
+        break;
+
+    /* testNotGotoDeclarationTrueInCase */
+    case true:
+        // Do something.
+        break;
+
+    /* testNotGotoDeclarationFalseInCase */
+    case false:
+        // Do something.
+        break;
+
+    /* testNotGotoDeclarationNullInCase */
+    case null:
         // Do something.
         break;
 }

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.php
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.php
@@ -69,6 +69,27 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
                 'testMarker'  => '/* testGotoStatementInFunction */',
                 'testContent' => 'label',
             ],
+
+            'goto parent'                                           => [
+                'testMarker'  => '/* testParentAsGotoTargetShouldBeString */',
+                'testContent' => 'parent',
+            ],
+            'goto self'                                             => [
+                'testMarker'  => '/* testSelfAsGotoTargetShouldBeString */',
+                'testContent' => 'self',
+            ],
+            'goto true'                                             => [
+                'testMarker'  => '/* testTrueAsGotoTargetShouldBeString */',
+                'testContent' => 'true',
+            ],
+            'goto false'                                            => [
+                'testMarker'  => '/* testFalseAsGotoTargetShouldBeString */',
+                'testContent' => 'false',
+            ],
+            'goto null'                                             => [
+                'testMarker'  => '/* testNullAsGotoTargetShouldBeString */',
+                'testContent' => 'null',
+            ],
         ];
 
     }//end dataGotoStatement()
@@ -130,6 +151,27 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
                 'testMarker'  => '/* testGotoDeclarationInFunction */',
                 'testContent' => 'label',
             ],
+
+            'label in goto declaration - parent' => [
+                'testMarker'  => '/* testParentAsGotoLabelShouldBeGotoLabel */',
+                'testContent' => 'parent',
+            ],
+            'label in goto declaration - self'   => [
+                'testMarker'  => '/* testSelfAsGotoLabelShouldBeGotoLabel */',
+                'testContent' => 'self',
+            ],
+            'label in goto declaration - true'   => [
+                'testMarker'  => '/* testTrueAsGotoLabelShouldBeGotoLabel */',
+                'testContent' => 'true',
+            ],
+            'label in goto declaration - false'  => [
+                'testMarker'  => '/* testFalseAsGotoLabelShouldBeGotoLabel */',
+                'testContent' => 'false',
+            ],
+            'label in goto declaration - null'   => [
+                'testMarker'  => '/* testNullAsGotoLabelShouldBeGotoLabel */',
+                'testContent' => 'null',
+            ],
         ];
 
     }//end dataGotoDeclaration()
@@ -138,21 +180,35 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
     /**
      * Verify that the constant used in a switch - case statement is not confused with a goto label.
      *
-     * @param string $testMarker  The comment prefacing the target token.
-     * @param string $testContent The token content to expect.
+     * @param string $testMarker   The comment prefacing the target token.
+     * @param string $testContent  The token content to expect.
+     * @param string $expectedType Optional. The token type which is expected (not T_GOTO_LABEL).
+     *                             Defaults to `T_STRING`.
      *
      * @dataProvider dataNotAGotoDeclaration
      *
      * @return void
      */
-    public function testNotAGotoDeclaration($testMarker, $testContent)
+    public function testNotAGotoDeclaration($testMarker, $testContent, $expectedType='T_STRING')
     {
+        $targetTypes  = [
+            T_STRING     => T_STRING,
+            T_GOTO_LABEL => T_GOTO_LABEL,
+        ];
+        $expectedCode = T_STRING;
+
+        if ($expectedType !== 'T_STRING') {
+            $expectedCode = constant($expectedType);
+            $targetTypes[$expectedCode] = $expectedCode;
+        }
+
+        $target = $this->getTargetToken($testMarker, $targetTypes, $testContent);
+
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, [T_GOTO_LABEL, T_STRING], $testContent);
         $tokenArray = $tokens[$target];
 
-        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
-        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
+        $this->assertSame($expectedCode, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not '.$expectedType.' (code)');
+        $this->assertSame($expectedType, $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not '.$expectedType.' (type)');
 
     }//end testNotAGotoDeclaration()
 
@@ -182,6 +238,21 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
             'not goto label - class property use followed by switch-case colon'  => [
                 'testMarker'  => '/* testNotGotoDeclarationClassProperty */',
                 'testContent' => 'property',
+            ],
+            'not goto label - true followed by switch-case colon'                => [
+                'testMarker'   => '/* testNotGotoDeclarationTrueInCase */',
+                'testContent'  => 'true',
+                'expectedType' => 'T_TRUE',
+            ],
+            'not goto label - false followed by switch-case colon'               => [
+                'testMarker'   => '/* testNotGotoDeclarationFalseInCase */',
+                'testContent'  => 'false',
+                'expectedType' => 'T_FALSE',
+            ],
+            'not goto label - null followed by switch-case colon'                => [
+                'testMarker'   => '/* testNotGotoDeclarationNullInCase */',
+                'testContent'  => 'null',
+                'expectedType' => 'T_NULL',
             ],
             'not goto label - global constant followed by ternary else'          => [
                 'testMarker'  => '/* testNotGotoDeclarationGlobalConstantInTernary */',


### PR DESCRIPTION
# Description
Previously quite some work has already been done to ensure that keywords which can be used in a non-keyword context would be tokenized as `T_STRING` in those situations.

The `goto` context was, however, not taken into account.

It should be noted that none of the official PHP keywords are allowed to be used as `goto` labels, so all cases covered by the `ContextSensitiveKeywordsGotoTest` are in actual fact parse errors.

Having said that, those keywords being tokenized as the keyword, instead of as `T_STRING`, could seriously confuse sniffs, which is why, IMO, they should be (re-)tokenized to `T_STRING`.

For the record: the "other" context sensitive keywords - `parent`, `self`, `true`, `false` and `null` are actually allowed as labels for `goto` statements, even though this makes for some pretty confusing code. Example: https://3v4l.org/dcbmm

Either way, fixed now (for the most part).

Note: This fix does not include fixing the (re-)tokenization of keywords to `T_GOTO_LABEL` for the "goto target statement". I'm not sure this can be done reliably without breaking other things, so that's considered outside the scope of this PR.

Includes plenty of tests to safeguard the change.

Related to #185


## Suggested changelog entry
Changed:
Context sensitive keywords used as a label in a `goto` statement will now be tokenized as `T_STRING` to prevent confusing sniffs.


