### PR TITLE
Tokenizer/Comment: add docblock open + close ptr to all docblock tokens

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -887,11 +887,8 @@ class PHP extends Tokenizer
                 || ($token[0] === T_COMMENT && strpos($token[1], '/**') === 0 && $token[1] !== '/**/'))
             ) {
                 $commentTokens = $commentTokenizer->tokenizeString($token[1], $this->eolChar, $newStackPtr);
-                foreach ($commentTokens as $commentToken) {
-                    $finalTokens[$newStackPtr] = $commentToken;
-                    $newStackPtr++;
-                }
-
+                $finalTokens  += $commentTokens;
+                $newStackPtr  += count($commentTokens);
                 continue;
             }
 


### PR DESCRIPTION
# Description
Previously, only tokens of type `T_DOC_COMMENT_OPEN_TAG ` would receive a `comment_closer` index and tokens of type `T_DOC_COMMENT_CLOSE_TAG ` would receive a `comment_opener` index (asymmetrically).

This commit changes this to set both the `comment_opener` as well as the `comment_closer` indexes on all docblock tokens. This should allow for more flexibility for sniffs examining docblocks.

Includes updated tests to safeguard this change.



## Suggested changelog entry
Changed:
All `T_DOC_COMMENT_*` tokens will now have the `comment_opener` and `comment_closer` indexes set.


## Related issues/external references

Fixes #484

