### PR TITLE
Tokens: introduce class constants to replace the static properties and start using them

### DIFF
--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -63,7 +63,7 @@ function stripWhitespaceAndComments($fullpath, $config)
             continue;
         }
 
-        if (isset(Tokens::$emptyTokens[$token['code']]) === false) {
+        if (isset(Tokens::EMPTY_TOKENS[$token['code']]) === false) {
             $stripped .= $token['content'];
             continue;
         }

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1560,7 +1560,7 @@ class File
                 $paramCount++;
                 break;
             case T_EQUAL:
-                $defaultStart = $this->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                $defaultStart = $this->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
                 $equalToken   = $i;
                 break;
             }//end switch
@@ -1676,7 +1676,7 @@ class File
                 $scopeOpener = $this->tokens[$stackPtr]['scope_opener'];
             }
 
-            $valid  = Tokens::$nameTokens;
+            $valid  = Tokens::NAME_TOKENS;
             $valid += [
                 T_CALLABLE               => T_CALLABLE,
                 T_SELF                   => T_SELF,
@@ -1794,7 +1794,7 @@ class File
         $conditions = array_keys($conditions);
         $ptr        = array_pop($conditions);
         if (isset($this->tokens[$ptr]) === false
-            || isset(Tokens::$ooScopeTokens[$this->tokens[$ptr]['code']]) === false
+            || isset(Tokens::OO_SCOPE_TOKENS[$this->tokens[$ptr]['code']]) === false
             || $this->tokens[$ptr]['code'] === T_ENUM
         ) {
             throw new RuntimeException('$stackPtr is not a class member var');
@@ -1822,7 +1822,7 @@ class File
             T_FINAL     => T_FINAL,
         ];
 
-        $valid += Tokens::$emptyTokens;
+        $valid += Tokens::EMPTY_TOKENS;
 
         $scope          = 'public';
         $scopeSpecified = false;
@@ -1877,7 +1877,7 @@ class File
 
         if ($i < $stackPtr) {
             // We've found a type.
-            $valid  = Tokens::$nameTokens;
+            $valid  = Tokens::NAME_TOKENS;
             $valid += [
                 T_CALLABLE               => T_CALLABLE,
                 T_SELF                   => T_SELF,
@@ -2014,7 +2014,7 @@ class File
         }
 
         $tokenBefore = $this->findPrevious(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($stackPtr - 1),
             null,
             true
@@ -2038,14 +2038,14 @@ class File
             return true;
         }
 
-        if (isset(Tokens::$assignmentTokens[$this->tokens[$tokenBefore]['code']]) === true) {
+        if (isset(Tokens::ASSIGNMENT_TOKENS[$this->tokens[$tokenBefore]['code']]) === true) {
             // This is directly after an assignment. It's a reference. Even if
             // it is part of an operation, the other tests will handle it.
             return true;
         }
 
         $tokenAfter = $this->findNext(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($stackPtr + 1),
             null,
             true
@@ -2084,8 +2084,8 @@ class File
             if ($this->tokens[$tokenAfter]['code'] === T_VARIABLE) {
                 return true;
             } else {
-                $skip   = Tokens::$emptyTokens;
-                $skip  += Tokens::$nameTokens;
+                $skip   = Tokens::EMPTY_TOKENS;
+                $skip  += Tokens::NAME_TOKENS;
                 $skip[] = T_SELF;
                 $skip[] = T_PARENT;
                 $skip[] = T_STATIC;
@@ -2309,7 +2309,7 @@ class File
      */
     public function findStartOfStatement($start, $ignore=null)
     {
-        $startTokens = Tokens::$blockOpeners;
+        $startTokens = Tokens::BLOCK_OPENERS;
         $startTokens[T_OPEN_SHORT_ARRAY]   = true;
         $startTokens[T_OPEN_TAG]           = true;
         $startTokens[T_OPEN_TAG_WITH_ECHO] = true;
@@ -2395,7 +2395,7 @@ class File
                     // If it is the scope opener, go the first non-empty token after. $start will have been part of the first condition.
                     if ($prevMatch <= $this->tokens[$matchExpression]['scope_opener']) {
                         // We're before the arrow in the first case.
-                        $next = $this->findNext(Tokens::$emptyTokens, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
+                        $next = $this->findNext(Tokens::EMPTY_TOKENS, ($this->tokens[$matchExpression]['scope_opener'] + 1), null, true);
                         if ($next === false) {
                             // Shouldn't be possible.
                             return $start;
@@ -2412,7 +2412,7 @@ class File
                     }
 
                     // In both cases, go to the first non-empty token after.
-                    $next = $this->findNext(Tokens::$emptyTokens, ($prevMatch + 1), null, true);
+                    $next = $this->findNext(Tokens::EMPTY_TOKENS, ($prevMatch + 1), null, true);
                     if ($next === false) {
                         // Shouldn't be possible.
                         return $start;
@@ -2480,7 +2480,7 @@ class File
                 }
             }//end if
 
-            if (isset(Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+            if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
         }//end for
@@ -2575,7 +2575,7 @@ class File
                     continue;
                 }
 
-                if ($i === $start && isset(Tokens::$scopeOpeners[$this->tokens[$i]['code']]) === true) {
+                if ($i === $start && isset(Tokens::SCOPE_OPENERS[$this->tokens[$i]['code']]) === true) {
                     return $this->tokens[$i]['scope_closer'];
                 }
 
@@ -2595,7 +2595,7 @@ class File
                 }
             }//end if
 
-            if (isset(Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+            if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
         }//end for
@@ -2778,7 +2778,7 @@ class File
             return false;
         }
 
-        $find   = Tokens::$nameTokens;
+        $find   = Tokens::NAME_TOKENS;
         $find[] = T_WHITESPACE;
 
         $end  = $this->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
@@ -2827,7 +2827,7 @@ class File
             return false;
         }
 
-        $find   = Tokens::$nameTokens;
+        $find   = Tokens::NAME_TOKENS;
         $find[] = T_WHITESPACE;
         $find[] = T_COMMA;
 

--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -60,7 +60,7 @@ abstract class AbstractArraySniff implements Sniff
             $arrayEnd   = $tokens[$stackPtr]['bracket_closer'];
         }
 
-        $lastContent = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($arrayEnd - 1), null, true);
+        $lastContent = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($arrayEnd - 1), null, true);
         if ($tokens[$lastContent]['code'] === T_COMMA) {
             // Last array item ends with a comma.
             $phpcsFile->recordMetric($stackPtr, 'Array end comma', 'yes');
@@ -71,12 +71,12 @@ abstract class AbstractArraySniff implements Sniff
         $indices = [];
 
         $current = $arrayStart;
-        while (($next = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), $arrayEnd, true)) !== false) {
+        while (($next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($current + 1), $arrayEnd, true)) !== false) {
             $end = $this->getNext($phpcsFile, $next, $arrayEnd);
 
             if ($tokens[$end]['code'] === T_DOUBLE_ARROW) {
                 $indexEnd   = $phpcsFile->findPrevious(T_WHITESPACE, ($end - 1), null, true);
-                $valueStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+                $valueStart = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
 
                 $indices[] = [
                     'index_start' => $next,

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -256,7 +256,7 @@ abstract class AbstractPatternSniff implements Sniff
 
         $ignoreTokens = [T_WHITESPACE => T_WHITESPACE];
         if ($this->ignoreComments === true) {
-            $ignoreTokens += Tokens::$commentTokens;
+            $ignoreTokens += Tokens::COMMENT_TOKENS;
         }
 
         $origStackPtr = $stackPtr;
@@ -350,10 +350,10 @@ abstract class AbstractPatternSniff implements Sniff
                     $found = 'abc';
                 } else if ($pattern[$i]['type'] === 'newline') {
                     if ($this->ignoreComments === true
-                        && isset(Tokens::$commentTokens[$tokens[$stackPtr]['code']]) === true
+                        && isset(Tokens::COMMENT_TOKENS[$tokens[$stackPtr]['code']]) === true
                     ) {
                         $startComment = $phpcsFile->findPrevious(
-                            Tokens::$commentTokens,
+                            Tokens::COMMENT_TOKENS,
                             ($stackPtr - 1),
                             null,
                             true
@@ -381,7 +381,7 @@ abstract class AbstractPatternSniff implements Sniff
                             // can ignore the error here.
                             if (($tokens[($stackPtr - 1)]['content'] !== $phpcsFile->eolChar)
                                 && ($this->ignoreComments === true
-                                && isset(Tokens::$commentTokens[$tokens[($stackPtr - 1)]['code']]) === false)
+                                && isset(Tokens::COMMENT_TOKENS[$tokens[($stackPtr - 1)]['code']]) === false)
                             ) {
                                 $hasError = true;
                             } else {
@@ -425,7 +425,7 @@ abstract class AbstractPatternSniff implements Sniff
                     if ($this->ignoreComments === true) {
                         // If we are ignoring comments, check to see if this current
                         // token is a comment. If so skip it.
-                        if (isset(Tokens::$commentTokens[$tokens[$stackPtr]['code']]) === true) {
+                        if (isset(Tokens::COMMENT_TOKENS[$tokens[$stackPtr]['code']]) === true) {
                             continue;
                         }
 
@@ -433,7 +433,7 @@ abstract class AbstractPatternSniff implements Sniff
                         // current token as we should allow a space before a
                         // comment for readability.
                         if (isset($tokens[($stackPtr + 1)]) === true
-                            && isset(Tokens::$commentTokens[$tokens[($stackPtr + 1)]['code']]) === true
+                            && isset(Tokens::COMMENT_TOKENS[$tokens[($stackPtr + 1)]['code']]) === true
                         ) {
                             continue;
                         }
@@ -448,7 +448,7 @@ abstract class AbstractPatternSniff implements Sniff
                         } else {
                             // Get all the whitespace to the next token.
                             $next = $phpcsFile->findNext(
-                                Tokens::$emptyTokens,
+                                Tokens::EMPTY_TOKENS,
                                 $stackPtr,
                                 null,
                                 true
@@ -535,7 +535,7 @@ abstract class AbstractPatternSniff implements Sniff
                         $hasComment = false;
                         for ($j = $stackPtr; $j < $next; $j++) {
                             $found .= $tokens[$j]['content'];
-                            if (isset(Tokens::$commentTokens[$tokens[$j]['code']]) === true) {
+                            if (isset(Tokens::COMMENT_TOKENS[$tokens[$j]['code']]) === true) {
                                 $hasComment = true;
                             }
                         }
@@ -590,7 +590,7 @@ abstract class AbstractPatternSniff implements Sniff
                 } else {
                     // Find the previous opener.
                     $next = $phpcsFile->findPrevious(
-                        Tokens::$blockOpeners,
+                        Tokens::BLOCK_OPENERS,
                         $stackPtr
                     );
 
@@ -640,7 +640,7 @@ abstract class AbstractPatternSniff implements Sniff
                 } else {
                     if ($this->ignoreComments === false) {
                         // The newline character cannot be part of a comment.
-                        if (isset(Tokens::$commentTokens[$tokens[$newline]['code']]) === true) {
+                        if (isset(Tokens::COMMENT_TOKENS[$tokens[$newline]['code']]) === true) {
                             $hasError = true;
                         }
                     }

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -49,7 +49,7 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        $scopes = Tokens::$ooScopeTokens;
+        $scopes = Tokens::OO_SCOPE_TOKENS;
 
         $listen = [
             T_VARIABLE,
@@ -97,7 +97,7 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
         $conditions = array_reverse($tokens[$stackPtr]['conditions'], true);
         $inFunction = false;
         foreach ($conditions as $scope => $code) {
-            if (isset(Tokens::$ooScopeTokens[$code]) === true) {
+            if (isset(Tokens::OO_SCOPE_TOKENS[$code]) === true) {
                 break;
             }
 

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -60,7 +60,7 @@ class ArrayIndentSniff extends AbstractArraySniff
         $tokens = $phpcsFile->getTokens();
 
         // Determine how far indented the entire array declaration should be.
-        $ignore     = Tokens::$emptyTokens;
+        $ignore     = Tokens::EMPTY_TOKENS;
         $ignore[]   = T_DOUBLE_ARROW;
         $prev       = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
         $start      = $phpcsFile->findStartOfStatement($prev);
@@ -108,7 +108,7 @@ class ArrayIndentSniff extends AbstractArraySniff
                 $start = $index['value_start'];
             }
 
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($start - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($start - 1), null, true);
             if ($tokens[$prev]['line'] === $tokens[$start]['line']) {
                 // This index isn't the only content on the line
                 // so we can't check indent rules.

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -62,7 +62,7 @@ class DuplicateClassNameSniff implements Sniff
         while ($stackPtr !== false) {
             // Keep track of what namespace we are in.
             if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
                 if ($nextNonEmpty !== false) {
                     if ($tokens[$nextNonEmpty]['code'] === T_STRING
                         || $tokens[$nextNonEmpty]['code'] === T_NAME_QUALIFIED

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -44,10 +44,10 @@ class AssignmentInConditionSniff implements Sniff
      */
     public function register()
     {
-        $this->assignmentTokens = Tokens::$assignmentTokens;
+        $this->assignmentTokens = Tokens::ASSIGNMENT_TOKENS;
         unset($this->assignmentTokens[T_DOUBLE_ARROW]);
 
-        $starters = Tokens::$booleanOperators;
+        $starters = Tokens::BOOLEAN_OPERATORS;
         $starters[T_SEMICOLON]        = T_SEMICOLON;
         $starters[T_OPEN_PARENTHESIS] = T_OPEN_PARENTHESIS;
 
@@ -133,7 +133,7 @@ class AssignmentInConditionSniff implements Sniff
             }
 
             for ($i = $hasAssignment; $i > $conditionStart; $i--) {
-                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                     continue;
                 }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -70,7 +70,7 @@ class EmptyPHPStatementSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prevNonEmpty]['code'] !== T_SEMICOLON
             && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG
             && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG_WITH_ECHO

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -76,7 +76,7 @@ class EmptyStatementSniff implements Sniff
         }
 
         $next = $phpcsFile->findNext(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($token['scope_opener'] + 1),
             ($token['scope_closer'] - 1),
             true

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
@@ -75,7 +75,7 @@ class ForLoopShouldBeWhileLoopSniff implements Sniff
             $code = $tokens[$next]['code'];
             if ($code === T_SEMICOLON) {
                 ++$index;
-            } else if (isset(Tokens::$emptyTokens[$code]) === false) {
+            } else if (isset(Tokens::EMPTY_TOKENS[$code]) === false) {
                 ++$parts[$index];
             }
         }

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
@@ -80,13 +80,13 @@ class ForLoopWithTestFunctionCallSniff implements Sniff
                 continue;
             } else if ($position > 1) {
                 break;
-            } else if ($code !== T_VARIABLE && isset(Tokens::$nameTokens[$code]) === false) {
+            } else if ($code !== T_VARIABLE && isset(Tokens::NAME_TOKENS[$code]) === false) {
                 continue;
             }
 
             // Find next non empty token, if it is a open parenthesis we have a
             // function call.
-            $index = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+            $index = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
 
             if ($tokens[$index]['code'] === T_OPEN_PARENTHESIS) {
                 $error = 'Avoid function calls in a FOR loop test part';

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
@@ -53,11 +53,11 @@ class RequireExplicitBooleanOperatorPrecedenceSniff implements Sniff
      */
     public function register()
     {
-        $this->searchTargets = Tokens::$booleanOperators;
+        $this->searchTargets = Tokens::BOOLEAN_OPERATORS;
         $this->searchTargets[T_INLINE_THEN] = T_INLINE_THEN;
         $this->searchTargets[T_INLINE_ELSE] = T_INLINE_ELSE;
 
-        return Tokens::$booleanOperators;
+        return Tokens::BOOLEAN_OPERATORS;
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
@@ -75,7 +75,7 @@ class UnconditionalIfStatementSniff implements Sniff
         for (; $next <= $end; ++$next) {
             $code = $tokens[$next]['code'];
 
-            if (isset(Tokens::$emptyTokens[$code]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$code]) === true) {
                 continue;
             } else if ($code !== T_TRUE && $code !== T_FALSE) {
                 $goodCondition = true;

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -152,14 +152,14 @@ class UnusedFunctionParameterSniff implements Sniff
             T_END_NOWDOC           => T_END_NOWDOC,
             T_DOUBLE_QUOTED_STRING => T_DOUBLE_QUOTED_STRING,
         ];
-        $validTokens += Tokens::$emptyTokens;
+        $validTokens += Tokens::EMPTY_TOKENS;
 
         for (; $next <= $end; ++$next) {
             $token = $tokens[$next];
             $code  = $token['code'];
 
             // Ignorable tokens.
-            if (isset(Tokens::$emptyTokens[$code]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$code]) === true) {
                 continue;
             }
 
@@ -171,13 +171,13 @@ class UnusedFunctionParameterSniff implements Sniff
 
                 // A return statement as the first content indicates an interface method.
                 if ($code === T_RETURN) {
-                    $firstNonEmptyTokenAfterReturn = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                    $firstNonEmptyTokenAfterReturn = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
                     if ($tokens[$firstNonEmptyTokenAfterReturn]['code'] === T_SEMICOLON && $implements !== false) {
                         return;
                     }
 
                     $secondNonEmptyTokenAfterReturn = $phpcsFile->findNext(
-                        Tokens::$emptyTokens,
+                        Tokens::EMPTY_TOKENS,
                         ($firstNonEmptyTokenAfterReturn + 1),
                         null,
                         true

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -94,7 +94,7 @@ class UselessOverridingMethodSniff implements Sniff
         for (; $next <= $end; ++$next) {
             $code = $tokens[$next]['code'];
 
-            if (isset(Tokens::$emptyTokens[$code]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$code]) === true) {
                 continue;
             } else if ($code === T_RETURN) {
                 continue;
@@ -109,7 +109,7 @@ class UselessOverridingMethodSniff implements Sniff
         }
 
         // Find next non empty token index, should be double colon.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
 
         // Skip for invalid code.
         if ($tokens[$next]['code'] !== T_DOUBLE_COLON) {
@@ -117,7 +117,7 @@ class UselessOverridingMethodSniff implements Sniff
         }
 
         // Find next non empty token index, should be the name of the method being called.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
 
         // Skip for invalid code or other method.
         if (strcasecmp($tokens[$next]['content'], $methodName) !== 0) {
@@ -125,7 +125,7 @@ class UselessOverridingMethodSniff implements Sniff
         }
 
         // Find next non empty token index, should be the open parenthesis.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
 
         // Skip for invalid code.
         if ($tokens[$next]['code'] !== T_OPEN_PARENTHESIS || isset($tokens[$next]['parenthesis_closer']) === false) {
@@ -143,7 +143,7 @@ class UselessOverridingMethodSniff implements Sniff
                 --$parenthesisCount;
             } else if ($parenthesisCount === 1 && $code === T_COMMA) {
                 $parameters[] = '';
-            } else if (isset(Tokens::$emptyTokens[$code]) === false) {
+            } else if (isset(Tokens::EMPTY_TOKENS[$code]) === false) {
                 $parameters[(count($parameters) - 1)] .= $tokens[$next]['content'];
             }
 
@@ -152,13 +152,13 @@ class UselessOverridingMethodSniff implements Sniff
             }
         }//end for
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
         if ($tokens[$next]['code'] !== T_SEMICOLON && $tokens[$next]['code'] !== T_CLOSE_TAG) {
             return;
         }
 
         // This list deliberately does not include the `T_OPEN_TAG_WITH_ECHO` as that token implicitly is an echo statement, i.e. content.
-        $nonContent = Tokens::$emptyTokens;
+        $nonContent = Tokens::EMPTY_TOKENS;
         $nonContent[T_OPEN_TAG]  = T_OPEN_TAG;
         $nonContent[T_CLOSE_TAG] = T_CLOSE_TAG;
 

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -272,7 +272,7 @@ class DocCommentSniff implements Sniff
 
             // Check that there was single blank line after the tag block
             // but account for multi-line tag comments.
-            $find = Tokens::$phpcsCommentTokens;
+            $find = Tokens::PHPCS_ANNOTATION_TOKENS;
             $find[T_DOC_COMMENT_TAG] = T_DOC_COMMENT_TAG;
 
             $lastTag = $group[$pos];

--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -25,7 +25,7 @@ class FixmeSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return array_diff(Tokens::COMMENT_TOKENS, Tokens::PHPCS_ANNOTATION_TOKENS);
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -24,7 +24,7 @@ class TodoSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return array_diff(Tokens::COMMENT_TOKENS, Tokens::PHPCS_ANNOTATION_TOKENS);
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -25,7 +25,7 @@ class DisallowYodaConditionsSniff implements Sniff
      */
     public function register()
     {
-        $tokens = Tokens::$comparisonTokens;
+        $tokens = Tokens::COMPARISON_TOKENS;
         unset($tokens[T_COALESCE]);
 
         return $tokens;
@@ -45,7 +45,7 @@ class DisallowYodaConditionsSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens         = $phpcsFile->getTokens();
-        $previousIndex  = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $previousIndex  = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         $relevantTokens = [
             T_CLOSE_SHORT_ARRAY,
             T_CLOSE_PARENTHESIS,
@@ -68,9 +68,9 @@ class DisallowYodaConditionsSniff implements Sniff
             }
         }
 
-        $prevIndex = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousIndex - 1), null, true);
+        $prevIndex = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($previousIndex - 1), null, true);
 
-        if (in_array($tokens[$prevIndex]['code'], Tokens::$arithmeticTokens, true) === true) {
+        if (in_array($tokens[$prevIndex]['code'], Tokens::ARITHMETIC_TOKENS, true) === true) {
             return;
         }
 
@@ -81,14 +81,14 @@ class DisallowYodaConditionsSniff implements Sniff
         // Is it a parenthesis.
         if ($tokens[$previousIndex]['code'] === T_CLOSE_PARENTHESIS) {
             $beforeOpeningParenthesisIndex = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($tokens[$previousIndex]['parenthesis_opener'] - 1),
                 null,
                 true
             );
 
             if ($beforeOpeningParenthesisIndex === false || $tokens[$beforeOpeningParenthesisIndex]['code'] !== T_ARRAY) {
-                if (isset(Tokens::$nameTokens[$tokens[$beforeOpeningParenthesisIndex]['code']]) === true) {
+                if (isset(Tokens::NAME_TOKENS[$tokens[$beforeOpeningParenthesisIndex]['code']]) === true) {
                     return;
                 }
 
@@ -106,7 +106,7 @@ class DisallowYodaConditionsSniff implements Sniff
 
                 // If there is nothing inside the parenthesis, it is not a Yoda condition.
                 $opener = $tokens[$previousIndex]['parenthesis_opener'];
-                $prev   = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($previousIndex - 1), ($opener + 1), true);
+                $prev   = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($previousIndex - 1), ($opener + 1), true);
                 if ($prev === false) {
                     return;
                 }
@@ -149,16 +149,16 @@ class DisallowYodaConditionsSniff implements Sniff
             return true; // @codeCoverageIgnore
         }
 
-        $staticTokens  = Tokens::$emptyTokens;
-        $staticTokens += Tokens::$textStringTokens;
-        $staticTokens += Tokens::$assignmentTokens;
-        $staticTokens += Tokens::$equalityTokens;
-        $staticTokens += Tokens::$comparisonTokens;
-        $staticTokens += Tokens::$arithmeticTokens;
-        $staticTokens += Tokens::$operators;
-        $staticTokens += Tokens::$booleanOperators;
-        $staticTokens += Tokens::$castTokens;
-        $staticTokens += Tokens::$bracketTokens;
+        $staticTokens  = Tokens::EMPTY_TOKENS;
+        $staticTokens += Tokens::TEXT_STRING_TOKENS;
+        $staticTokens += Tokens::ASSIGNMENT_TOKENS;
+        $staticTokens += Tokens::EQUALITY_TOKENS;
+        $staticTokens += Tokens::COMPARISON_TOKENS;
+        $staticTokens += Tokens::ARITHMETIC_TOKENS;
+        $staticTokens += Tokens::OPERATORS;
+        $staticTokens += Tokens::BOOLEAN_OPERATORS;
+        $staticTokens += Tokens::CAST_TOKENS;
+        $staticTokens += Tokens::BRACKET_TOKENS;
         $staticTokens += [
             T_DOUBLE_ARROW => T_DOUBLE_ARROW,
             T_COMMA        => T_COMMA,

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -64,7 +64,7 @@ class InlineControlStructureSniff implements Sniff
 
         // Ignore the ELSE in ELSE IF. We'll process the IF part later.
         if ($tokens[$stackPtr]['code'] === T_ELSE) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($tokens[$next]['code'] === T_IF) {
                 return;
             }
@@ -73,7 +73,7 @@ class InlineControlStructureSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_WHILE || $tokens[$stackPtr]['code'] === T_FOR) {
             // This could be from a DO WHILE, which doesn't have an opening brace or a while/for without body.
             if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
-                $afterParensCloser = $phpcsFile->findNext(Tokens::$emptyTokens, ($tokens[$stackPtr]['parenthesis_closer'] + 1), null, true);
+                $afterParensCloser = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($tokens[$stackPtr]['parenthesis_closer'] + 1), null, true);
                 if ($afterParensCloser === false) {
                     // Live coding.
                     return;
@@ -110,7 +110,7 @@ class InlineControlStructureSniff implements Sniff
             $start = $tokens[$stackPtr]['parenthesis_closer'];
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($start + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($start + 1), null, true);
         if ($nextNonEmpty === false) {
             // Live coding or parse error.
             return;
@@ -188,7 +188,7 @@ class InlineControlStructureSniff implements Sniff
                     || $type === T_IF || $type === T_ELSEIF
                     || $type === T_TRY || $type === T_CATCH || $type === T_FINALLY
                 ) {
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
                     if ($next === false) {
                         break;
                     }
@@ -220,7 +220,7 @@ class InlineControlStructureSniff implements Sniff
                     }
                 } else if ($type === T_CLOSURE) {
                     // There should be a semicolon after the closing brace.
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
                     if ($next !== false && $tokens[$next]['code'] === T_SEMICOLON) {
                         $end = $next;
                     }
@@ -248,7 +248,7 @@ class InlineControlStructureSniff implements Sniff
             $end = $lastNonEmpty;
         }
 
-        $nextContent = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+        $nextContent = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
         if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
             // Looks for completely empty statements.
             $next = $phpcsFile->findNext(T_WHITESPACE, ($closer + 1), ($end + 1), true);
@@ -268,9 +268,9 @@ class InlineControlStructureSniff implements Sniff
                     }
                 }
 
-                if (isset(Tokens::$commentTokens[$tokens[$endLine]['code']]) === false
+                if (isset(Tokens::COMMENT_TOKENS[$tokens[$endLine]['code']]) === false
                     && ($tokens[$endLine]['code'] !== T_WHITESPACE
-                    || isset(Tokens::$commentTokens[$tokens[($endLine - 1)]['code']]) === false)
+                    || isset(Tokens::COMMENT_TOKENS[$tokens[($endLine - 1)]['code']]) === false)
                 ) {
                     $endLine = $end;
                 }

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -113,15 +113,15 @@ class LineLengthSniff implements Sniff
         }
 
         $onlyComment = false;
-        if (isset(Tokens::$commentTokens[$tokens[$stackPtr]['code']]) === true) {
-            $prevNonWhiteSpace = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if (isset(Tokens::COMMENT_TOKENS[$tokens[$stackPtr]['code']]) === true) {
+            $prevNonWhiteSpace = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$stackPtr]['line'] !== $tokens[$prevNonWhiteSpace]['line']) {
                 $onlyComment = true;
             }
         }
 
         if ($onlyComment === true
-            && isset(Tokens::$phpcsCommentTokens[$tokens[$stackPtr]['code']]) === true
+            && isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$stackPtr]['code']]) === true
         ) {
             // Ignore PHPCS annotation comments that are on a line by themselves.
             return;
@@ -130,7 +130,7 @@ class LineLengthSniff implements Sniff
         $lineLength = ($tokens[$stackPtr]['column'] + $tokens[$stackPtr]['length'] - 1);
 
         if ($this->ignoreComments === true
-            && isset(Tokens::$commentTokens[$tokens[$stackPtr]['code']]) === true
+            && isset(Tokens::COMMENT_TOKENS[$tokens[$stackPtr]['code']]) === true
         ) {
             // Trailing comments are being ignored in line length calculations.
             if ($onlyComment === true) {

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -45,7 +45,7 @@ class MultipleStatementAlignmentSniff implements Sniff
      */
     public function register()
     {
-        $tokens = Tokens::$assignmentTokens;
+        $tokens = Tokens::ASSIGNMENT_TOKENS;
         unset($tokens[T_DOUBLE_ARROW]);
         return $tokens;
 
@@ -114,10 +114,10 @@ class MultipleStatementAlignmentSniff implements Sniff
             $end = $phpcsFile->numTokens;
         }
 
-        $find = Tokens::$assignmentTokens;
+        $find = Tokens::ASSIGNMENT_TOKENS;
         unset($find[T_DOUBLE_ARROW]);
 
-        $scopes = Tokens::$scopeOpeners;
+        $scopes = Tokens::SCOPE_OPENERS;
         unset($scopes[T_CLOSURE]);
         unset($scopes[T_ANON_CLASS]);
 
@@ -154,7 +154,7 @@ class MultipleStatementAlignmentSniff implements Sniff
 
             if (isset($find[$tokens[$assign]['code']]) === false) {
                 // A blank line indicates that the assignment block has ended.
-                if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$assign]['code']]) === false
                     && ($tokens[$assign]['line'] - $tokens[$lastCode]['line']) > 1
                     && $tokens[$assign]['level'] === $tokens[$stackPtr]['level']
                     && $arrayEnd === null
@@ -180,7 +180,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                     $arrayEnd = $tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer'];
                 }
 
-                if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$assign]['code']]) === false) {
                     $lastCode = $assign;
 
                     if ($tokens[$assign]['code'] === T_SEMICOLON) {
@@ -243,7 +243,7 @@ class MultipleStatementAlignmentSniff implements Sniff
             }//end if
 
             $var = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($assign - 1),
                 null,
                 true

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
@@ -38,7 +38,7 @@ class SpaceAfterCastSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$castTokens;
+        return Tokens::CAST_TOKENS;
 
     }//end register()
 
@@ -68,7 +68,7 @@ class SpaceAfterCastSniff implements Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -61,7 +61,7 @@ class SpaceAfterNotSniff implements Sniff
             $pluralizeSpace = '';
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
@@ -24,7 +24,7 @@ class SpaceBeforeCastSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$castTokens;
+        return Tokens::CAST_TOKENS;
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -24,7 +24,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
      */
     public function register()
     {
-        $targets   = Tokens::$nameTokens;
+        $targets   = Tokens::NAME_TOKENS;
         $targets[] = T_ISSET;
         $targets[] = T_UNSET;
         $targets[] = T_SELF;
@@ -58,7 +58,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
         $functionName    = $stackPtr;
-        $ignoreTokens    = Tokens::$emptyTokens;
+        $ignoreTokens    = Tokens::EMPTY_TOKENS;
         $ignoreTokens[]  = T_BITWISE_AND;
         $functionKeyword = $phpcsFile->findPrevious($ignoreTokens, ($stackPtr - 1), null, true);
         if ($tokens[$functionKeyword]['code'] === T_FUNCTION || $tokens[$functionKeyword]['code'] === T_CLASS) {
@@ -74,7 +74,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
 
         // If the next non-whitespace token after the function or method call
         // is not an opening parenthesis then it can't really be a *call*.
-        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($functionName + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($functionName + 1), null, true);
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -144,8 +144,8 @@ class FunctionCallArgumentSpacingSniff implements Sniff
 
             if ($tokens[$nextSeparator]['code'] === T_COMMA) {
                 if ($tokens[($nextSeparator - 1)]['code'] === T_WHITESPACE) {
-                    $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextSeparator - 2), null, true);
-                    if (isset(Tokens::$heredocTokens[$tokens[$prev]['code']]) === false) {
+                    $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($nextSeparator - 2), null, true);
+                    if (isset(Tokens::HEREDOC_TOKENS[$tokens[$prev]['code']]) === false) {
                         $error = 'Space found before comma in argument list';
                         $fix   = $phpcsFile->addFixableError($error, $nextSeparator, 'SpaceBeforeComma');
                         if ($fix === true) {
@@ -175,7 +175,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                 } else {
                     // If there is a newline in the space, then they must be formatting
                     // each argument on a newline, which is valid, so ignore it.
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextSeparator + 1), null, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextSeparator + 1), null, true);
                     if ($tokens[$next]['line'] === $tokens[$nextSeparator]['line']) {
                         $space = $tokens[($nextSeparator + 1)]['length'];
                         if ($space > 1) {

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -81,7 +81,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
         }
 
         // Find the end of the function declaration.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openingBrace - 1), $closeBracket, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($openingBrace - 1), $closeBracket, true);
 
         $functionLine = $tokens[$prev]['line'];
         $braceLine    = $tokens[$openingBrace]['line'];
@@ -103,7 +103,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                         break;
                     }
 
-                    if (isset(Tokens::$phpcsCommentTokens[$tokens[$nextLine]['code']]) === true) {
+                    if (isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$nextLine]['code']]) === true) {
                         $hasTrailingAnnotation = true;
                     }
                 }
@@ -165,7 +165,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
             }//end if
         }//end if
 
-        $ignore   = Tokens::$phpcsCommentTokens;
+        $ignore   = Tokens::PHPCS_ANNOTATION_TOKENS;
         $ignore[] = T_WHITESPACE;
         $next     = $phpcsFile->findNext($ignore, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -74,7 +74,7 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
         $openingBrace = $tokens[$stackPtr]['scope_opener'];
 
         // Find the end of the function declaration.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openingBrace - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($openingBrace - 1), null, true);
 
         $functionLine = $tokens[$prev]['line'];
         $braceLine    = $tokens[$openingBrace]['line'];
@@ -117,7 +117,7 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, "$metricType opening brace placement", 'same line');
         }//end if
 
-        $ignore   = Tokens::$phpcsCommentTokens;
+        $ignore   = Tokens::PHPCS_ANNOTATION_TOKENS;
         $ignore[] = T_WHITESPACE;
         $next     = $phpcsFile->findNext($ignore, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -84,7 +84,7 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION], true);
+        parent::__construct(Tokens::OO_SCOPE_TOKENS, [T_FUNCTION], true);
 
     }//end __construct()
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -109,7 +109,7 @@ class ConstructorNameSniff extends AbstractScopeSniff
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
         $startIndex       = $tokens[$stackPtr]['scope_opener'];
         while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, ($startIndex + 1), $endFunctionIndex)) !== false) {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($doubleColonIndex + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($doubleColonIndex + 1), null, true);
             if ($tokens[$nextNonEmpty]['code'] !== T_STRING
                 || strtolower($tokens[$nextNonEmpty]['content']) !== $parentClassNameLc
             ) {
@@ -117,7 +117,7 @@ class ConstructorNameSniff extends AbstractScopeSniff
                 continue;
             }
 
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($doubleColonIndex - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($doubleColonIndex - 1), null, true);
             if ($tokens[$prevNonEmpty]['code'] === T_PARENT
                 || $tokens[$prevNonEmpty]['code'] === T_SELF
                 || $tokens[$prevNonEmpty]['code'] === T_STATIC

--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -56,7 +56,7 @@ class UpperCaseConstantNameSniff implements Sniff
                 return;
             }
 
-            $constant = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($assignmentOperator - 1), ($stackPtr + 1), true);
+            $constant = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($assignmentOperator - 1), ($stackPtr + 1), true);
             if ($constant === false) {
                 return;
             }
@@ -89,7 +89,7 @@ class UpperCaseConstantNameSniff implements Sniff
         }
 
         // Make sure this is not a method call or class instantiation.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prev]['code'] === T_OBJECT_OPERATOR
             || $tokens[$prev]['code'] === T_DOUBLE_COLON
             || $tokens[$prev]['code'] === T_NULLSAFE_OBJECT_OPERATOR
@@ -105,7 +105,7 @@ class UpperCaseConstantNameSniff implements Sniff
 
         // If the next non-whitespace token after this token
         // is not an opening parenthesis then it is not a function call.
-        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($openBracket === false || $tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -114,7 +114,7 @@ class UpperCaseConstantNameSniff implements Sniff
         // constant name). This could happen when live coding, if the constant is a variable or an
         // expression, or if handling a first-class callable or a function definition outside the
         // global scope.
-        $constPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        $constPtr = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
         if ($constPtr === false || $tokens[$constPtr]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -73,7 +73,7 @@ class DisallowShortOpenTagSniff implements Sniff
         }
 
         if ($token['code'] === T_OPEN_TAG_WITH_ECHO) {
-            $nextVar = $tokens[$phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true)];
+            $nextVar = $tokens[$phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true)];
             if ($nextVar['code'] !== T_CLOSE_TAG) {
                 $error = 'Short PHP opening tag used with echo; expected "<?php echo %s ..." but found "%s %s ..."';
                 $data  = [

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -141,14 +141,14 @@ class ForbiddenFunctionsSniff implements Sniff
             T_IMPLEMENTS               => true,
         ];
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if (isset($ignore[$tokens[$nextToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -63,7 +63,7 @@ class LowerCaseConstantSniff implements Sniff
         $targets = $this->targets;
 
         // Register scope modifiers to filter out property type declarations.
-        $targets  += Tokens::$scopeModifiers;
+        $targets  += Tokens::SCOPE_MODIFIERS;
         $targets[] = T_VAR;
         $targets[] = T_STATIC;
         $targets[] = T_READONLY;
@@ -124,13 +124,13 @@ class LowerCaseConstantSniff implements Sniff
          * declarations, in which case, it is correct to skip over them.
          */
 
-        if (isset(Tokens::$scopeModifiers[$tokens[$stackPtr]['code']]) === true
+        if (isset(Tokens::SCOPE_MODIFIERS[$tokens[$stackPtr]['code']]) === true
             || $tokens[$stackPtr]['code'] === T_VAR
             || $tokens[$stackPtr]['code'] === T_STATIC
             || $tokens[$stackPtr]['code'] === T_READONLY
             || $tokens[$stackPtr]['code'] === T_FINAL
         ) {
-            $skipOver = (Tokens::$emptyTokens + $this->propertyTypeTokens);
+            $skipOver = (Tokens::EMPTY_TOKENS + $this->propertyTypeTokens);
             $skipTo   = $phpcsFile->findNext($skipOver, ($stackPtr + 1), null, true);
             if ($skipTo !== false) {
                 return $skipTo;

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -25,7 +25,7 @@ class LowerCaseKeywordSniff implements Sniff
      */
     public function register()
     {
-        $targets  = Tokens::$contextSensitiveKeywords;
+        $targets  = Tokens::CONTEXT_SENSITIVE_KEYWORDS;
         $targets += [
             T_ANON_CLASS    => T_ANON_CLASS,
             T_CLOSURE       => T_CLOSURE,

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -50,8 +50,8 @@ class LowerCaseTypeSniff implements Sniff
      */
     public function register()
     {
-        $tokens   = Tokens::$castTokens;
-        $tokens  += Tokens::$ooScopeTokens;
+        $tokens   = Tokens::CAST_TOKENS;
+        $tokens  += Tokens::OO_SCOPE_TOKENS;
         $tokens[] = T_FUNCTION;
         $tokens[] = T_CLOSURE;
         $tokens[] = T_FN;
@@ -73,7 +73,7 @@ class LowerCaseTypeSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset(Tokens::$castTokens[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(Tokens::CAST_TOKENS[$tokens[$stackPtr]['code']]) === true) {
             // A cast token.
             $this->processType(
                 $phpcsFile,
@@ -90,7 +90,7 @@ class LowerCaseTypeSniff implements Sniff
          * Check OO constant and property types.
          */
 
-        if (isset(Tokens::$ooScopeTokens[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(Tokens::OO_SCOPE_TOKENS[$tokens[$stackPtr]['code']]) === true) {
             if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
                 return;
             }
@@ -113,7 +113,7 @@ class LowerCaseTypeSniff implements Sniff
                 }
 
                 if ($tokens[$i]['code'] === T_CONST) {
-                    $ignore = Tokens::$emptyTokens;
+                    $ignore = Tokens::EMPTY_TOKENS;
                     $ignore[T_NULLABLE] = T_NULLABLE;
 
                     $startOfType = $phpcsFile->findNext($ignore, ($i + 1), null, true);
@@ -128,9 +128,9 @@ class LowerCaseTypeSniff implements Sniff
                         return;
                     }
 
-                    $constName = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($assignmentOperator - 1), null, true);
+                    $constName = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($assignmentOperator - 1), null, true);
                     if ($startOfType !== $constName) {
-                        $endOfType = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($constName - 1), null, true);
+                        $endOfType = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($constName - 1), null, true);
 
                         $error     = 'PHP constant type declarations must be lowercase; expected "%s" but found "%s"';
                         $errorCode = 'ConstantTypeFound';
@@ -274,7 +274,7 @@ class LowerCaseTypeSniff implements Sniff
         $type           = '';
 
         for ($i = $typeDeclStart; $i <= $typeDeclEnd; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -55,7 +55,7 @@ class RequireStrictTypesSniff implements Sniff
 
             do {
                 $next = $phpcsFile->findNext(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($next + 1),
                     $tokens[$declare]['parenthesis_closer'],
                     true
@@ -82,7 +82,7 @@ class RequireStrictTypesSniff implements Sniff
         }
 
         // Strict types declaration found, make sure strict types is enabled.
-        $skip     = Tokens::$emptyTokens;
+        $skip     = Tokens::EMPTY_TOKENS;
         $skip[]   = T_EQUAL;
         $valuePtr = $phpcsFile->findNext($skip, ($next + 1), null, true);
 

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -58,8 +58,8 @@ class UnnecessaryStringConcatSniff implements Sniff
             return;
         }
 
-        if (isset(Tokens::$stringTokens[$tokens[$prev]['code']]) === false
-            || isset(Tokens::$stringTokens[$tokens[$next]['code']]) === false
+        if (isset(Tokens::STRING_TOKENS[$tokens[$prev]['code']]) === false
+            || isset(Tokens::STRING_TOKENS[$tokens[$next]['code']]) === false
         ) {
             // Bow out as at least one of the two tokens being concatenated is not a string.
             return;

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -49,7 +49,7 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
      */
     public function register()
     {
-        $this->ignoreTokens = Tokens::$functionNameTokens;
+        $this->ignoreTokens = Tokens::FUNCTION_NAME_TOKENS;
 
         $this->ignoreTokens[T_VARIABLE]            = T_VARIABLE;
         $this->ignoreTokens[T_CLOSE_PARENTHESIS]   = T_CLOSE_PARENTHESIS;
@@ -99,7 +99,7 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
             $opener = $tokens[$stackPtr]['parenthesis_opener'];
         }
 
-        $preOpener = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+        $preOpener = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($opener - 1), null, true);
         if ($preOpener !== false
             && isset($this->ignoreTokens[$tokens[$preOpener]['code']]) === true
             && ($tokens[$preOpener]['code'] !== T_CLOSE_CURLY_BRACKET

--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -51,10 +51,10 @@ class IncrementDecrementSpacingSniff implements Sniff
         }
 
         // Is this a pre-increment/decrement ?
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty !== false
             && ($tokens[$nextNonEmpty]['code'] === T_VARIABLE
-            || isset(Tokens::$nameTokens[$tokens[$nextNonEmpty]['code']]) === true)
+            || isset(Tokens::NAME_TOKENS[$tokens[$nextNonEmpty]['code']]) === true)
         ) {
             if ($nextNonEmpty === ($stackPtr + 1)) {
                 $phpcsFile->recordMetric($stackPtr, 'Spacing between in/decrementor and variable', 0);
@@ -104,10 +104,10 @@ class IncrementDecrementSpacingSniff implements Sniff
         }//end if
 
         // Is this a post-increment/decrement ?
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($prevNonEmpty !== false
             && ($tokens[$prevNonEmpty]['code'] === T_VARIABLE
-            || isset(Tokens::$nameTokens[$tokens[$prevNonEmpty]['code']]) === true
+            || isset(Tokens::NAME_TOKENS[$tokens[$prevNonEmpty]['code']]) === true
             || $tokens[$prevNonEmpty]['code'] === T_CLOSE_SQUARE_BRACKET)
         ) {
             if ($prevNonEmpty === ($stackPtr - 1)) {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -72,7 +72,7 @@ class LanguageConstructSpacingSniff implements Sniff
 
         $content = $tokens[$stackPtr]['content'];
         if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_NAME_FULLY_QUALIFIED) {
                 // Namespace keyword used as operator, not as the language construct.
                 // Note: in PHP >= 8 namespaced names no longer allow for whitespace/comments between the parts (parse error).
@@ -90,13 +90,13 @@ class LanguageConstructSpacingSniff implements Sniff
             // Handle potentially multi-line/multi-token "yield from" expressions.
             if (preg_match('`yield\s+from`i', $content) !== 1) {
                 for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-                    if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false
+                    if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === false
                         && $tokens[$i]['code'] !== T_YIELD_FROM
                     ) {
                         break;
                     }
 
-                    if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                    if (isset(Tokens::COMMENT_TOKENS[$tokens[$i]['code']]) === true) {
                         $hasComment = true;
                     }
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -684,7 +684,7 @@ class ScopeIndentSniff implements Sniff
             }//end if
 
             if ($checkToken !== null
-                && isset(Tokens::$scopeOpeners[$tokens[$checkToken]['code']]) === true
+                && isset(Tokens::SCOPE_OPENERS[$tokens[$checkToken]['code']]) === true
                 && in_array($tokens[$checkToken]['code'], $this->nonIndentingScopes, true) === false
                 && isset($tokens[$checkToken]['scope_opener']) === true
             ) {
@@ -747,10 +747,10 @@ class ScopeIndentSniff implements Sniff
             // Method prefix indentation has to be exact or else it will break
             // the rest of the function declaration, and potentially future ones.
             if ($checkToken !== null
-                && isset(Tokens::$methodPrefixes[$tokens[$checkToken]['code']]) === true
+                && isset(Tokens::METHOD_MODIFIERS[$tokens[$checkToken]['code']]) === true
                 && $tokens[($checkToken + 1)]['code'] !== T_DOUBLE_COLON
             ) {
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($checkToken + 1), null, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($checkToken + 1), null, true);
                 if ($next === false
                     || ($tokens[$next]['code'] !== T_CLOSURE
                     && $tokens[$next]['code'] !== T_VARIABLE
@@ -950,7 +950,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 $i    = $phpcsFile->findNext([T_END_HEREDOC, T_END_NOWDOC], ($i + 1));
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
                 if ($tokens[$next]['code'] === T_COMMA) {
                     $i = $next;
                 }
@@ -1148,7 +1148,7 @@ class ScopeIndentSniff implements Sniff
                     continue;
                 }
 
-                if (isset(Tokens::$scopeOpeners[$condition]) === true
+                if (isset(Tokens::SCOPE_OPENERS[$condition]) === true
                     && in_array($condition, $this->nonIndentingScopes, true) === false
                 ) {
                     if ($this->debug === true) {
@@ -1228,7 +1228,7 @@ class ScopeIndentSniff implements Sniff
                         StatusWriter::write('* using parenthesis *', 1);
                     }
 
-                    $prev      = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parens - 1), null, true);
+                    $prev      = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($parens - 1), null, true);
                     $condition = 0;
                 } else if ($condition > 0) {
                     if ($this->debug === true) {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -61,7 +61,7 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
             $pluralizeSpace = '';
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -69,7 +69,7 @@ class FunctionCommentSniff implements Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        $ignore = Tokens::$methodPrefixes;
+        $ignore = Tokens::METHOD_MODIFIERS;
         $ignore[T_WHITESPACE] = T_WHITESPACE;
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
@@ -133,7 +133,7 @@ class FunctionCommentSniff implements Sniff
                     || $tokens[$i]['code'] !== T_WHITESPACE
                     || $tokens[$i]['line'] === $tokens[($i + 1)]['line']
                     // Do not report blank lines after a PHPCS annotation as removing the blank lines could change the meaning.
-                    || isset(Tokens::$phpcsCommentTokens[$tokens[($i - 1)]['code']]) === true
+                    || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[($i - 1)]['code']]) === true
                 ) {
                     continue;
                 }

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -108,11 +108,11 @@ class MultiLineConditionSniff implements Sniff
                         // Account for a comment at the end of the line.
                         $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
                         if ($tokens[$next]['code'] !== T_COMMENT
-                            && isset(Tokens::$phpcsCommentTokens[$tokens[$next]['code']]) === false
+                            && isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$next]['code']]) === false
                         ) {
                             $phpcsFile->fixer->addNewlineBefore($closeBracket);
                         } else {
-                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
                             $phpcsFile->fixer->beginChangeset();
                             $phpcsFile->fixer->replaceToken($closeBracket, '');
                             $phpcsFile->fixer->addContentBefore($next, ')');
@@ -137,7 +137,7 @@ class MultiLineConditionSniff implements Sniff
                 }//end if
 
                 if ($tokens[$i]['code'] === T_COMMENT
-                    || isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]) === true
+                    || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$i]['code']]) === true
                 ) {
                     $prevLine = $tokens[$i]['line'];
                     continue;
@@ -168,12 +168,12 @@ class MultiLineConditionSniff implements Sniff
                     }
                 }
 
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, $i, null, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $i, null, true);
                 if ($next !== $closeBracket && $tokens[$next]['line'] === $tokens[$i]['line']) {
-                    if (isset(Tokens::$booleanOperators[$tokens[$next]['code']]) === false) {
-                        $prev    = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $openBracket, true);
+                    if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$next]['code']]) === false) {
+                        $prev    = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), $openBracket, true);
                         $fixable = true;
-                        if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === false
+                        if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$prev]['code']]) === false
                             && $phpcsFile->findNext(T_WHITESPACE, ($prev + 1), $next, true) !== false
                         ) {
                             // Condition spread over multi-lines interspersed with comments.
@@ -186,7 +186,7 @@ class MultiLineConditionSniff implements Sniff
                         } else {
                             $fix = $phpcsFile->addFixableError($error, $next, 'StartWithBoolean');
                             if ($fix === true) {
-                                if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true) {
+                                if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$prev]['code']]) === true) {
                                     $phpcsFile->fixer->beginChangeset();
                                     $phpcsFile->fixer->replaceToken($prev, '');
                                     $phpcsFile->fixer->addContentBefore($next, $tokens[$prev]['content'].' ');
@@ -204,7 +204,7 @@ class MultiLineConditionSniff implements Sniff
                 $prevLine = $tokens[$i]['line'];
             }//end if
 
-            if (isset(Tokens::$nameTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true) {
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), null, true);
                 if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
                     // This is a function call, so skip to the end as they

--- a/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
+++ b/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
@@ -49,7 +49,7 @@ class IncludingFileSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS) {
             $error = '"%s" is a statement not a function; no parentheses are required';
             $data  = [$tokens[$stackPtr]['content']];
@@ -87,8 +87,8 @@ class IncludingFileSniff implements Sniff
         // Check to see if they are assigning the return value of this
         // including call. If they are then they are probably checking it, so
         // it's conditional.
-        $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if (isset(Tokens::$assignmentTokens[$tokens[$previous]['code']]) === true) {
+        $previous = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
+        if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$previous]['code']]) === true) {
             // The have assigned the return value to it, so its conditional.
             $inCondition = true;
         }

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -52,7 +52,7 @@ class FunctionCallSignatureSniff implements Sniff
      */
     public function register()
     {
-        $tokens = Tokens::$functionNameTokens;
+        $tokens = Tokens::FUNCTION_NAME_TOKENS;
 
         $tokens[] = T_VARIABLE;
         $tokens[] = T_CLOSE_CURLY_BRACKET;
@@ -87,7 +87,7 @@ class FunctionCallSignatureSniff implements Sniff
         }
 
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -100,7 +100,7 @@ class FunctionCallSignatureSniff implements Sniff
         }
 
         // Find the previous non-empty token.
-        $search   = Tokens::$emptyTokens;
+        $search   = Tokens::EMPTY_TOKENS;
         $search[] = T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === T_FUNCTION) {
@@ -129,7 +129,7 @@ class FunctionCallSignatureSniff implements Sniff
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
         if ($tokens[$next]['code'] === T_SEMICOLON) {
-            if (isset(Tokens::$emptyTokens[$tokens[($closeBracket + 1)]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[($closeBracket + 1)]['code']]) === true) {
                 $error = 'Space after closing parenthesis of function call prohibited';
                 $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'SpaceAfterCloseBracket');
                 if ($fix === true) {
@@ -284,7 +284,7 @@ class FunctionCallSignatureSniff implements Sniff
                     // We want to jump over any whitespace or inline comment and
                     // move the closing parenthesis after any other token.
                     $prev = ($closer - 1);
-                    while (isset(Tokens::$emptyTokens[$tokens[$prev]['code']]) === true) {
+                    while (isset(Tokens::EMPTY_TOKENS[$tokens[$prev]['code']]) === true) {
                         if (($tokens[$prev]['code'] === T_COMMENT)
                             && (strpos($tokens[$prev]['content'], '*/') !== false)
                         ) {
@@ -337,7 +337,7 @@ class FunctionCallSignatureSniff implements Sniff
             // We are in a multi-line string, so find the start and use
             // the indent from there.
             $prev  = $phpcsFile->findPrevious(T_CONSTANT_ENCAPSED_STRING, ($first - 2), null, true);
-            $first = $phpcsFile->findFirstOnLine(Tokens::$emptyTokens, $prev, true);
+            $first = $phpcsFile->findFirstOnLine(Tokens::EMPTY_TOKENS, $prev, true);
             if ($first === false) {
                 $first = ($prev + 1);
             }
@@ -392,7 +392,7 @@ class FunctionCallSignatureSniff implements Sniff
             }
         }//end if
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
             $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ContentAfterOpenBracket');
@@ -446,7 +446,7 @@ class FunctionCallSignatureSniff implements Sniff
             }
         }//end if
 
-        $i = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        $i = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
 
         if ($tokens[($i - 1)]['code'] === T_WHITESPACE
             && $tokens[($i - 1)]['line'] === $tokens[$i]['line']
@@ -466,12 +466,12 @@ class FunctionCallSignatureSniff implements Sniff
                 $lastLine = $tokens[$i]['line'];
 
                 // Ignore heredoc indentation.
-                if (isset(Tokens::$heredocTokens[$tokens[$i]['code']]) === true) {
+                if (isset(Tokens::HEREDOC_TOKENS[$tokens[$i]['code']]) === true) {
                     continue;
                 }
 
                 // Ignore multi-line string indentation.
-                if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === true
+                if (isset(Tokens::STRING_TOKENS[$tokens[$i]['code']]) === true
                     && $tokens[$i]['code'] === $tokens[($i - 1)]['code']
                 ) {
                     continue;
@@ -584,7 +584,7 @@ class FunctionCallSignatureSniff implements Sniff
             // If we are within an argument we should be ignoring commas
             // as these are not signalling the end of an argument.
             if ($inArg === false && $tokens[$i]['code'] === T_COMMA) {
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closeBracket, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), $closeBracket, true);
                 if ($next === false) {
                     continue;
                 }

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -296,7 +296,7 @@ class FunctionDeclarationSniff implements Sniff
             $error = 'The closing parenthesis and the opening brace of a multi-line function declaration must be on the same line';
             $code  = 'NewlineBeforeOpenBrace';
 
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), $closeBracket, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($opener - 1), $closeBracket, true);
             if ($tokens[$prev]['line'] === $tokens[$opener]['line']) {
                 // End of the return type is not on the same line as the close parenthesis.
                 $phpcsFile->addError($error, $opener, $code);
@@ -500,7 +500,7 @@ class FunctionDeclarationSniff implements Sniff
             if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS
                 && isset($tokens[$i]['parenthesis_closer']) === true
             ) {
-                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
+                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), null, true);
                 if ($tokens[$prevNonEmpty]['code'] !== T_USE) {
                     // Since PHP 8.1, a default value can contain a class instantiation.
                     // Skip over these "function calls" as they have their own indentation rules.

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -55,7 +55,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION], true);
+        parent::__construct(Tokens::OO_SCOPE_TOKENS, [T_FUNCTION], true);
 
     }//end __construct()
 

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -24,7 +24,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
      */
     public function __construct()
     {
-        AbstractScopeSniff::__construct(Tokens::$ooScopeTokens, [T_VARIABLE], false);
+        AbstractScopeSniff::__construct(Tokens::OO_SCOPE_TOKENS, [T_VARIABLE], false);
 
     }//end __construct()
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -31,7 +31,7 @@ class ScopeClosingBraceSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$scopeOpeners;
+        return Tokens::SCOPE_OPENERS;
 
     }//end register()
 

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -125,7 +125,7 @@ class SideEffectsSniff implements Sniff
             }
 
             // Ignore whitespace and comments.
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 
@@ -142,7 +142,7 @@ class SideEffectsSniff implements Sniff
             }
 
             // Ignore logical operators.
-            if (isset(Tokens::$booleanOperators[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 
@@ -155,7 +155,7 @@ class SideEffectsSniff implements Sniff
                 if (isset($tokens[$i]['scope_opener']) === true) {
                     $i = $tokens[$i]['scope_closer'];
                     if ($tokens[$i]['code'] === T_ENDDECLARE) {
-                        $semicolon = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                        $semicolon = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
                         if ($semicolon !== false && $tokens[$semicolon]['code'] === T_SEMICOLON) {
                             $i = $semicolon;
                         }
@@ -171,7 +171,7 @@ class SideEffectsSniff implements Sniff
             }
 
             // Ignore function/class prefixes.
-            if (isset(Tokens::$methodPrefixes[$tokens[$i]['code']]) === true
+            if (isset(Tokens::METHOD_MODIFIERS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === T_READONLY
             ) {
                 continue;
@@ -205,7 +205,7 @@ class SideEffectsSniff implements Sniff
                 || $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED)
                 && strtolower(ltrim($tokens[$i]['content'], '\\')) === 'define'
             ) {
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_OBJECT_OPERATOR
                     && $tokens[$prev]['code'] !== T_NULLSAFE_OBJECT_OPERATOR
                     && $tokens[$prev]['code'] !== T_DOUBLE_COLON
@@ -231,12 +231,12 @@ class SideEffectsSniff implements Sniff
                 || $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED)
                 && strtolower(ltrim($tokens[$i]['content'], '\\')) === 'defined'
             ) {
-                $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
                 if ($openBracket !== false
                     && $tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS
                     && isset($tokens[$openBracket]['parenthesis_closer']) === true
                 ) {
-                    $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
+                    $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), null, true);
                     if ($tokens[$prev]['code'] !== T_OBJECT_OPERATOR
                         && $tokens[$prev]['code'] !== T_NULLSAFE_OBJECT_OPERATOR
                         && $tokens[$prev]['code'] !== T_DOUBLE_COLON

--- a/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
@@ -195,7 +195,7 @@ class AnonClassDeclarationSniff extends ClassDeclarationSniff
                     // We want to jump over any whitespace or inline comment and
                     // move the closing parenthesis after any other token.
                     $prev = ($closeBracket - 1);
-                    while (isset(Tokens::$emptyTokens[$tokens[$prev]['code']]) === true) {
+                    while (isset(Tokens::EMPTY_TOKENS[$tokens[$prev]['code']]) === true) {
                         if (($tokens[$prev]['code'] === T_COMMENT)
                             && (strpos($tokens[$prev]['content'], '*/') !== false)
                         ) {

--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -43,7 +43,7 @@ class ClassInstantiationSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Find the class name.
-        $allowed  = Tokens::$nameTokens;
+        $allowed  = Tokens::NAME_TOKENS;
         $allowed += [
             T_SELF                     => T_SELF,
             T_STATIC                   => T_STATIC,
@@ -55,7 +55,7 @@ class ClassInstantiationSniff implements Sniff
             T_DOUBLE_COLON             => T_DOUBLE_COLON,
         ];
 
-        $allowed += Tokens::$emptyTokens;
+        $allowed += Tokens::EMPTY_TOKENS;
 
         $classNameEnd = null;
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
@@ -101,7 +101,7 @@ class ClassInstantiationSniff implements Sniff
         $error = 'Parentheses must be used when instantiating a new class';
         $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MissingParentheses');
         if ($fix === true) {
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($classNameEnd - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($classNameEnd - 1), null, true);
             $phpcsFile->fixer->addContent($prev, '()');
         }
 

--- a/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
@@ -24,7 +24,7 @@ class OpeningBraceSpaceSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
 
     }//end register()
 

--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -124,7 +124,7 @@ class ControlStructureSpacingSniff implements Sniff
         for ($i = $parenOpener; $i < $parenCloser; $i++) {
             if ($tokens[$i]['column'] !== 1
                 || $tokens[($i + 1)]['line'] > $tokens[$i]['line']
-                || isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true
+                || isset(Tokens::COMMENT_TOKENS[$tokens[$i]['code']]) === true
             ) {
                 continue;
             }
@@ -134,8 +134,8 @@ class ControlStructureSpacingSniff implements Sniff
             }
 
             // Leave indentation inside multi-line strings.
-            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']]) === true
-                || isset(Tokens::$heredocTokens[$tokens[$i]['code']]) === true
+            if (isset(Tokens::TEXT_STRING_TOKENS[$tokens[$i]['code']]) === true
+                || isset(Tokens::HEREDOC_TOKENS[$tokens[$i]['code']]) === true
             ) {
                 continue;
             }

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -236,7 +236,7 @@ class DeclareStatementSniff implements Sniff
             }
 
             // The open curly bracket must be the last code on the line.
-            $token = $phpcsFile->findNext(Tokens::$emptyTokens, ($curlyBracket + 1), null, true);
+            $token = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($curlyBracket + 1), null, true);
             if ($tokens[$curlyBracket]['line'] === $tokens[$token]['line']) {
                 $error = 'The open curly bracket of a declare statement must be the last code on the line';
                 $fix   = $phpcsFile->addFixableError($error, $token, 'CodeFoundAfterCurlyBracket');

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -44,7 +44,7 @@ class FileHeaderSniff implements Sniff
 
         $possibleHeaders = [];
 
-        $searchFor = Tokens::$ooScopeTokens;
+        $searchFor = Tokens::OO_SCOPE_TOKENS;
         $searchFor[T_OPEN_TAG] = T_OPEN_TAG;
 
         $openTag = $stackPtr;
@@ -61,7 +61,7 @@ class FileHeaderSniff implements Sniff
             }
 
             $next = $phpcsFile->findNext($searchFor, ($openTag + 1));
-            if (isset(Tokens::$ooScopeTokens[$tokens[$next]['code']]) === true) {
+            if (isset(Tokens::OO_SCOPE_TOKENS[$tokens[$next]['code']]) === true) {
                 // Once we find an OO token, the file content has
                 // definitely started.
                 break;
@@ -146,7 +146,7 @@ class FileHeaderSniff implements Sniff
 
         $foundDocblock = false;
 
-        $commentOpeners = Tokens::$scopeOpeners;
+        $commentOpeners = Tokens::SCOPE_OPENERS;
         unset($commentOpeners[T_NAMESPACE]);
         unset($commentOpeners[T_DECLARE]);
         unset($commentOpeners[T_USE]);
@@ -168,7 +168,7 @@ class FileHeaderSniff implements Sniff
                 // Make sure this is not a code-level docblock.
                 $end = $tokens[$next]['comment_closer'];
                 for ($docToken = ($end + 1); $docToken < $phpcsFile->numTokens; $docToken++) {
-                    if (isset(Tokens::$emptyTokens[$tokens[$docToken]['code']]) === true) {
+                    if (isset(Tokens::EMPTY_TOKENS[$tokens[$docToken]['code']]) === true) {
                         continue;
                     }
 
@@ -187,7 +187,7 @@ class FileHeaderSniff implements Sniff
                 }
 
                 if (isset($commentOpeners[$tokens[$docToken]['code']]) === false
-                    && isset(Tokens::$methodPrefixes[$tokens[$docToken]['code']]) === false
+                    && isset(Tokens::METHOD_MODIFIERS[$tokens[$docToken]['code']]) === false
                     && $tokens[$docToken]['code'] !== T_READONLY
                 ) {
                     // Check for an @var annotation.
@@ -234,7 +234,7 @@ class FileHeaderSniff implements Sniff
                 break;
             case T_USE:
                 $type    = 'use';
-                $useType = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                $useType = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
                 if ($useType !== false && $tokens[$useType]['code'] === T_STRING) {
                     $content = strtolower($tokens[$useType]['content']);
                     if ($content === 'function' || $content === 'const') {
@@ -254,8 +254,8 @@ class FileHeaderSniff implements Sniff
                 break;
             default:
                 // Skip comments as PSR-12 doesn't say if these are allowed or not.
-                if (isset(Tokens::$commentTokens[$tokens[$next]['code']]) === true) {
-                    $next = $phpcsFile->findNext(Tokens::$commentTokens, ($next + 1), null, true);
+                if (isset(Tokens::COMMENT_TOKENS[$tokens[$next]['code']]) === true) {
+                    $next = $phpcsFile->findNext(Tokens::COMMENT_TOKENS, ($next + 1), null, true);
                     if ($next === false) {
                         // We reached the end of the file.
                         break(2);

--- a/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
@@ -47,17 +47,17 @@ class ImportStatementSniff implements Sniff
             return;
         }
 
-        if ($phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens) === true) {
+        if ($phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS) === true) {
             // This rule only applies to import statements.
             return;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($tokens[$next]['code'] === T_STRING
             && (strtolower($tokens[$next]['content']) === 'function'
             || strtolower($tokens[$next]['content']) === 'const')
         ) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
         }
 
         if ($tokens[$next]['code'] !== T_NAME_FULLY_QUALIFIED) {

--- a/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
@@ -26,10 +26,10 @@ class OperatorSpacingSniff extends SquizOperatorSpacingSniff
     {
         parent::register();
 
-        $targets   = Tokens::$comparisonTokens;
-        $targets  += Tokens::$operators;
-        $targets  += Tokens::$assignmentTokens;
-        $targets  += Tokens::$booleanOperators;
+        $targets   = Tokens::COMPARISON_TOKENS;
+        $targets  += Tokens::OPERATORS;
+        $targets  += Tokens::ASSIGNMENT_TOKENS;
+        $targets  += Tokens::BOOLEAN_OPERATORS;
         $targets[] = T_INLINE_THEN;
         $targets[] = T_INLINE_ELSE;
         $targets[] = T_STRING_CONCAT;

--- a/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
+++ b/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
@@ -43,15 +43,15 @@ class ConstantVisibilitySniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Make sure this is a class constant.
-        if ($phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens) === false) {
+        if ($phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS) === false) {
             return;
         }
 
-        $ignore   = Tokens::$emptyTokens;
+        $ignore   = Tokens::EMPTY_TOKENS;
         $ignore[] = T_FINAL;
 
         $prev = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
-        if (isset(Tokens::$scopeModifiers[$tokens[$prev]['code']]) === true) {
+        if (isset(Tokens::SCOPE_MODIFIERS[$tokens[$prev]['code']]) === true) {
             return;
         }
 

--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -45,7 +45,7 @@ class UseDeclarationSniff implements Sniff
         // Needs to be a use statement directly inside a class.
         $conditions = $tokens[$stackPtr]['conditions'];
         end($conditions);
-        if (isset(Tokens::$ooScopeTokens[current($conditions)]) === false) {
+        if (isset(Tokens::OO_SCOPE_TOKENS[current($conditions)]) === false) {
             return;
         }
 
@@ -81,7 +81,7 @@ class UseDeclarationSniff implements Sniff
                         continue;
                     }
 
-                    if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                    if (isset(Tokens::COMMENT_TOKENS[$tokens[$i]['code']]) === true) {
                         if ($tokens[$i]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
                             // Skip past the comment.
                             $i = $tokens[$i]['comment_opener'];
@@ -100,7 +100,7 @@ class UseDeclarationSniff implements Sniff
                     $data  = [strtolower($tokens[$ooToken]['content'])];
 
                     // Figure out if we can fix this error.
-                    $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($useToken - 1), ($opener - 1), true);
+                    $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($useToken - 1), ($opener - 1), true);
                     if ($tokens[$prev]['line'] === $tokens[$opener]['line']) {
                         $fix = $phpcsFile->addFixableError($error, $useToken, 'UseAfterBrace', $data);
                         if ($fix === true) {
@@ -123,7 +123,7 @@ class UseDeclarationSniff implements Sniff
                                     $phpcsFile->fixer->replaceToken($i, '');
                                 }
 
-                                if (isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true) {
+                                if (isset(Tokens::COMMENT_TOKENS[$tokens[$i]['code']]) === true) {
                                     if ($tokens[$i]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
                                         // Skip past the comment.
                                         $i = $tokens[$i]['comment_opener'];
@@ -141,7 +141,7 @@ class UseDeclarationSniff implements Sniff
                 }//end if
             } else {
                 // Make sure this use statement is not on the same line as the previous one.
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($useToken - 1), null, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($useToken - 1), null, true);
                 if ($prev !== false && $tokens[$prev]['line'] === $tokens[$useToken]['line']) {
                     $error     = 'Each imported trait must be on its own line';
                     $prevNonWs = $phpcsFile->findPrevious(T_WHITESPACE, ($useToken - 1), null, true);
@@ -261,7 +261,7 @@ class UseDeclarationSniff implements Sniff
                             continue;
                         }
 
-                        if (isset(Tokens::$commentTokens[$tokens[$next]['code']]) === true
+                        if (isset(Tokens::COMMENT_TOKENS[$tokens[$next]['code']]) === true
                             && $tokens[$next]['line'] === $tokens[$end]['line']
                         ) {
                             continue;
@@ -290,7 +290,7 @@ class UseDeclarationSniff implements Sniff
                 }//end if
             } else {
                 // Ensure use statements are grouped.
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
                 if ($next !== $useTokens[($usePos + 1)]) {
                     $error = 'Imported traits must be grouped together';
                     $phpcsFile->addError($error, $useTokens[($usePos + 1)], 'NotGrouped');
@@ -382,7 +382,7 @@ class UseDeclarationSniff implements Sniff
             }
         }//end if
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), ($closer - 1), true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($opener + 1), ($closer - 1), true);
         if ($next !== false && $tokens[$next]['line'] !== ($tokens[$opener]['line'] + 1)) {
             $error     = 'First trait conflict resolution statement must be on the line after the opening brace';
             $nextNonWs = $phpcsFile->findNext(T_WHITESPACE, ($opener + 1), ($closer - 1), true);
@@ -473,7 +473,7 @@ class UseDeclarationSniff implements Sniff
 
                     $data = [$found];
 
-                    $prevNonWs = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $opener, true);
+                    $prevNonWs = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), $opener, true);
                     if ($prevNonWs !== $prev) {
                         $phpcsFile->addError($error, $i, 'SpaceBeforeInsteadof', $data);
                     } else {
@@ -511,7 +511,7 @@ class UseDeclarationSniff implements Sniff
 
                     $data = [$found];
 
-                    $nextNonWs = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closer, true);
+                    $nextNonWs = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), $closer, true);
                     if ($nextNonWs !== $next) {
                         $phpcsFile->addError($error, $i, 'SpaceAfterInsteadof', $data);
                     } else {
@@ -551,7 +551,7 @@ class UseDeclarationSniff implements Sniff
 
                     $data = [$found];
 
-                    $prevNonWs = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $opener, true);
+                    $prevNonWs = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), $opener, true);
                     if ($prevNonWs !== $prev) {
                         $phpcsFile->addError($error, $i, 'SpaceBeforeAs', $data);
                     } else {
@@ -589,7 +589,7 @@ class UseDeclarationSniff implements Sniff
 
                     $data = [$found];
 
-                    $nextNonWs = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closer, true);
+                    $nextNonWs = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), $closer, true);
                     if ($nextNonWs !== $next) {
                         $phpcsFile->addError($error, $i, 'SpaceAfterAs', $data);
                     } else {
@@ -621,7 +621,7 @@ class UseDeclarationSniff implements Sniff
                     }
                 }
 
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), ($closer - 1), true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), ($closer - 1), true);
                 if ($next !== false && $tokens[$next]['line'] === $tokens[$i]['line']) {
                     $error     = 'Each trait conflict resolution statement must be on a line by itself';
                     $nextNonWs = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), ($closer - 1), true);
@@ -643,7 +643,7 @@ class UseDeclarationSniff implements Sniff
             }//end if
         }//end for
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), ($opener + 1), true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closer - 1), ($opener + 1), true);
         if ($prev !== false && $tokens[$prev]['line'] !== ($tokens[$closer]['line'] - 1)) {
             $error     = 'Closing brace must be on the line after the last trait conflict resolution statement';
             $prevNonWs = $phpcsFile->findPrevious(T_WHITESPACE, ($closer - 1), ($opener + 1), true);

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -72,7 +72,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         ];
 
         $prevNonSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         if (isset($classModifiers[$tokens[$prevNonEmpty]['code']]) === true) {
             $spaces    = 0;
@@ -274,13 +274,13 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         $implements          = $phpcsFile->findNext($keywordTokenType, ($stackPtr + 1), $openingBrace);
         $multiLineImplements = false;
         if ($implements !== false) {
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openingBrace - 1), $implements, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($openingBrace - 1), $implements, true);
             if ($tokens[$prev]['line'] !== $tokens[$implements]['line']) {
                 $multiLineImplements = true;
             }
         }
 
-        $find = Tokens::$nameTokens;
+        $find = Tokens::NAME_TOKENS;
         $find[$keywordTokenType] = $keywordTokenType;
 
         if ($className !== null) {
@@ -339,7 +339,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         $phpcsFile->fixer->addNewline($prev);
                         $phpcsFile->fixer->endChangeset();
                     }
-                } else if ((isset(Tokens::$commentTokens[$tokens[$prev]['code']]) === false
+                } else if ((isset(Tokens::COMMENT_TOKENS[$tokens[$prev]['code']]) === false
                     && $tokens[$prev]['line'] !== ($tokens[$className]['line'] - 1))
                     || $tokens[$prev]['line'] === $tokens[$className]['line']
                 ) {
@@ -499,7 +499,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         if ($tokens[$stackPtr]['code'] !== T_ANON_CLASS) {
             // Check the closing brace is on it's own line, but allow
             // for comments like "//end class".
-            $ignoreTokens   = Tokens::$phpcsCommentTokens;
+            $ignoreTokens   = Tokens::PHPCS_ANNOTATION_TOKENS;
             $ignoreTokens[] = T_WHITESPACE;
             $ignoreTokens[] = T_COMMENT;
             $ignoreTokens[] = T_SEMICOLON;

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -24,7 +24,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
      */
     public function __construct()
     {
-        AbstractScopeSniff::__construct(Tokens::$ooScopeTokens, [T_VARIABLE], false);
+        AbstractScopeSniff::__construct(Tokens::OO_SCOPE_TOKENS, [T_VARIABLE], false);
 
     }//end __construct()
 
@@ -57,7 +57,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         // Detect multiple properties defined at the same time. Throw an error
         // for this, but also only process the first property in the list so we don't
         // repeat errors.
-        $find   = Tokens::$scopeModifiers;
+        $find   = Tokens::SCOPE_MODIFIERS;
         $find[] = T_VARIABLE;
         $find[] = T_VAR;
         $find[] = T_READONLY;
@@ -100,7 +100,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
 
                 $data = [$found];
 
-                $nextNonWs = $phpcsFile->findNext(Tokens::$emptyTokens, ($typeToken + 1), null, true);
+                $nextNonWs = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($typeToken + 1), null, true);
                 if ($nextNonWs !== $next) {
                     $phpcsFile->addError($error, $typeToken, 'SpacingAfterType', $data);
                 } else {
@@ -145,7 +145,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
          */
 
         if ($propertyInfo['scope_specified'] === true && $propertyInfo['is_final'] === true) {
-            $scopePtr = $phpcsFile->findPrevious(Tokens::$scopeModifiers, ($stackPtr - 1));
+            $scopePtr = $phpcsFile->findPrevious(Tokens::SCOPE_MODIFIERS, ($stackPtr - 1));
             $finalPtr = $phpcsFile->findPrevious(T_FINAL, ($stackPtr - 1));
             if ($finalPtr > $scopePtr) {
                 $error = 'The final declaration must come before the visibility declaration';
@@ -170,7 +170,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         }//end if
 
         if ($propertyInfo['scope_specified'] === true && $propertyInfo['is_static'] === true) {
-            $scopePtr  = $phpcsFile->findPrevious(Tokens::$scopeModifiers, ($stackPtr - 1));
+            $scopePtr  = $phpcsFile->findPrevious(Tokens::SCOPE_MODIFIERS, ($stackPtr - 1));
             $staticPtr = $phpcsFile->findPrevious(T_STATIC, ($stackPtr - 1));
             if ($scopePtr > $staticPtr) {
                 $error = 'The static declaration must come after the visibility declaration';
@@ -195,7 +195,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         }//end if
 
         if ($propertyInfo['scope_specified'] === true && $propertyInfo['is_readonly'] === true) {
-            $scopePtr    = $phpcsFile->findPrevious(Tokens::$scopeModifiers, ($stackPtr - 1));
+            $scopePtr    = $phpcsFile->findPrevious(Tokens::SCOPE_MODIFIERS, ($stackPtr - 1));
             $readonlyPtr = $phpcsFile->findPrevious(T_READONLY, ($stackPtr - 1));
             if ($scopePtr > $readonlyPtr) {
                 $error = 'The readonly declaration must come after the visibility declaration';

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -76,7 +76,7 @@ class ControlStructureSpacingSniff implements Sniff
         $parenOpener = $tokens[$stackPtr]['parenthesis_opener'];
         $parenCloser = $tokens[$stackPtr]['parenthesis_closer'];
         $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($parenOpener + 1), null, true);
-        if (in_array($tokens[$nextContent]['code'], Tokens::$commentTokens, true) === false) {
+        if (in_array($tokens[$nextContent]['code'], Tokens::COMMENT_TOKENS, true) === false) {
             $spaceAfterOpen = 0;
             if ($tokens[($parenOpener + 1)]['code'] === T_WHITESPACE) {
                 if (strpos($tokens[($parenOpener + 1)]['content'], $phpcsFile->eolChar) !== false) {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -108,8 +108,8 @@ class SwitchDeclarationSniff implements Sniff
                 }
 
                 for ($next = ($opener + 1); $next < $nextCloser; $next++) {
-                    if (isset(Tokens::$emptyTokens[$tokens[$next]['code']]) === false
-                        || (isset(Tokens::$commentTokens[$tokens[$next]['code']]) === true
+                    if (isset(Tokens::EMPTY_TOKENS[$tokens[$next]['code']]) === false
+                        || (isset(Tokens::COMMENT_TOKENS[$tokens[$next]['code']]) === true
                         && $tokens[$next]['line'] !== $tokens[$opener]['line'])
                     ) {
                         break;
@@ -190,7 +190,7 @@ class SwitchDeclarationSniff implements Sniff
                 $nextCode = $this->findNextCase($phpcsFile, ($opener + 1), $nextCloser);
                 if ($nextCode !== false) {
                     $prevCode = $phpcsFile->findPrevious(T_WHITESPACE, ($nextCode - 1), $nextCase, true);
-                    if (isset(Tokens::$commentTokens[$tokens[$prevCode]['code']]) === false
+                    if (isset(Tokens::COMMENT_TOKENS[$tokens[$prevCode]['code']]) === false
                         && $this->findNestedTerminator($phpcsFile, ($opener + 1), $nextCode) === false
                     ) {
                         $error = 'There must be a comment when fall-through is intentional in a non-empty case body';
@@ -247,7 +247,7 @@ class SwitchDeclarationSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $lastToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($end - 1), $stackPtr, true);
+        $lastToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($end - 1), $stackPtr, true);
         if ($lastToken === false) {
             return false;
         }
@@ -267,7 +267,7 @@ class SwitchDeclarationSniff implements Sniff
                 $scopeOpener = $tokens[$currentCloser]['scope_opener'];
                 $scopeCloser = $tokens[$currentCloser]['scope_closer'];
 
-                $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($scopeOpener - 1), $stackPtr, true);
+                $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($scopeOpener - 1), $stackPtr, true);
                 if ($prevToken === false) {
                     return false;
                 }
@@ -295,7 +295,7 @@ class SwitchDeclarationSniff implements Sniff
                         return false;
                     }
 
-                    $currentCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), $stackPtr, true);
+                    $currentCloser = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), $stackPtr, true);
                     if ($tokens[$prevToken]['code'] === T_ELSE) {
                         $hasElseBlock = true;
                     }
@@ -308,7 +308,7 @@ class SwitchDeclarationSniff implements Sniff
                     }
 
                     // Otherwise, we continue with the previous TRY or CATCH clause.
-                    $currentCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), $stackPtr, true);
+                    $currentCloser = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), $stackPtr, true);
                 } else if ($tokens[$prevToken]['code'] === T_TRY) {
                     // If we've seen CATCH blocks without terminator statement and
                     // have not seen a FINALLY *with* a terminator statement, we
@@ -327,7 +327,7 @@ class SwitchDeclarationSniff implements Sniff
                         $hasCatchWithoutTerminator = true;
                     }
 
-                    $currentCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), $stackPtr, true);
+                    $currentCloser = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), $stackPtr, true);
                 } else if ($tokens[$prevToken]['code'] === T_SWITCH) {
                     $hasDefaultBlock = false;
                     $endOfSwitch     = $tokens[$prevToken]['scope_closer'];
@@ -341,7 +341,7 @@ class SwitchDeclarationSniff implements Sniff
 
                         $opener = $tokens[$nextCase]['scope_opener'];
 
-                        $nextCode = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), $endOfSwitch, true);
+                        $nextCode = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($opener + 1), $endOfSwitch, true);
                         if ($tokens[$nextCode]['code'] === T_CASE || $tokens[$nextCode]['code'] === T_DEFAULT) {
                             // This case statement has no content, so skip it.
                             continue;

--- a/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
@@ -64,7 +64,7 @@ class ClosingTagSniff implements Sniff
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
                 $phpcsFile->fixer->replaceToken($last, $phpcsFile->eolChar);
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($last - 1), null, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($last - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_SEMICOLON
                     && $tokens[$prev]['code'] !== T_CLOSE_CURLY_BRACKET
                     && $tokens[$prev]['code'] !== T_OPEN_TAG

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -41,7 +41,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
     {
         // If the first argument is on a new line, this is a multi-line
         // function call, even if there is only one argument.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
         if ($tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
             return true;
         }
@@ -52,7 +52,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
         while ($tokens[$end]['code'] === T_COMMA) {
             // If the next bit of code is not on the same line, this is a
             // multi-line function call.
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), $closeBracket, true);
             if ($next === false) {
                 return false;
             }
@@ -66,7 +66,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
 
         // We've reached the last argument, so see if the next content
         // (should be the close bracket) is also on the same line.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), $closeBracket, true);
         if ($next !== false && $tokens[$next]['line'] !== $tokens[$end]['line']) {
             return true;
         }

--- a/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -22,7 +22,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION]);
+        parent::__construct(Tokens::OO_SCOPE_TOKENS, [T_FUNCTION]);
 
     }//end __construct()
 
@@ -65,11 +65,11 @@ class MethodDeclarationSniff extends AbstractScopeSniff
         $abstract   = 0;
         $final      = 0;
 
-        $find = (Tokens::$methodPrefixes + Tokens::$emptyTokens);
+        $find = (Tokens::METHOD_MODIFIERS + Tokens::EMPTY_TOKENS);
         $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
 
         $prefix = $stackPtr;
-        while (($prefix = $phpcsFile->findPrevious(Tokens::$methodPrefixes, ($prefix - 1), $prev)) !== false) {
+        while (($prefix = $phpcsFile->findPrevious(Tokens::METHOD_MODIFIERS, ($prefix - 1), $prev)) !== false) {
             switch ($tokens[$prefix]['code']) {
             case T_STATIC:
                 $static = $prefix;

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -107,7 +107,7 @@ class UseDeclarationSniff implements Sniff
 
                         // Convert grouped use statements into full use statements.
                         do {
-                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), $closingCurly, true);
                             if ($next === false) {
                                 // Group use statement with trailing comma after last item.
                                 break;
@@ -125,7 +125,7 @@ class UseDeclarationSniff implements Sniff
 
                             if ($tokens[$next]['content'] === 'const' || $tokens[$next]['content'] === 'function') {
                                 $phpcsFile->fixer->addContentBefore($next, 'use ');
-                                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), $closingCurly, true);
                                 $phpcsFile->fixer->addContentBefore($next, str_replace('use ', '', $baseUse));
                             } else {
                                 $phpcsFile->fixer->addContentBefore($next, $baseUse);
@@ -133,7 +133,7 @@ class UseDeclarationSniff implements Sniff
 
                             $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $closingCurly);
                             if ($next !== false) {
-                                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), $closingCurly, true);
                                 if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['line'] === $tokens[$next]['line']) {
                                     $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextNonEmpty - 1), $next, true);
                                     if ($prevNonWhitespace === $next) {
@@ -153,7 +153,7 @@ class UseDeclarationSniff implements Sniff
                         } while ($next !== false);
 
                         // Remove closing curly, semicolon and any whitespace between last child and closing curly.
-                        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
+                        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closingCurly + 1), null, true);
                         if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
                             // Parse error, forgotten semicolon.
                             $next = $closingCurly;
@@ -198,7 +198,7 @@ class UseDeclarationSniff implements Sniff
         }
 
         if ($tokens[$end]['code'] === T_CLOSE_USE_GROUP) {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
             if ($tokens[$nextNonEmpty]['code'] === T_SEMICOLON) {
                 $end = $nextNonEmpty;
             }
@@ -207,7 +207,7 @@ class UseDeclarationSniff implements Sniff
         // Find either the start of the next line or the beginning of the next statement,
         // whichever comes first.
         for ($end = ++$end; $end < $phpcsFile->numTokens; $end++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$end]['code']]) === false) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$end]['code']]) === false) {
                 break;
             }
 
@@ -220,7 +220,7 @@ class UseDeclarationSniff implements Sniff
         --$end;
 
         if (($tokens[$end]['code'] === T_COMMENT
-            || isset(Tokens::$phpcsCommentTokens[$tokens[$end]['code']]) === true)
+            || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$end]['code']]) === true)
             && substr($tokens[$end]['content'], 0, 2) === '/*'
             && substr($tokens[$end]['content'], -2) !== '*/'
         ) {
@@ -284,7 +284,7 @@ class UseDeclarationSniff implements Sniff
         }
 
         // Ignore USE keywords during live coding.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($next === false) {
             return true;
         }

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -97,7 +97,7 @@ class ArrayDeclarationSniff implements Sniff
                 $error = 'There must be no space between the "array" keyword and the opening parenthesis';
 
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $arrayStart, true);
-                if (isset(Tokens::$commentTokens[$tokens[$next]['code']]) === true) {
+                if (isset(Tokens::COMMENT_TOKENS[$tokens[$next]['code']]) === true) {
                     // We don't have anywhere to put the comment, so don't attempt to fix it.
                     $phpcsFile->addError($error, $stackPtr, 'SpaceAfterKeyword');
                 } else {
@@ -456,7 +456,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
-                    $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($lastToken + 1), null, true);
+                    $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($lastToken + 1), null, true);
                     // Allow for PHP 7.4+ array unpacking within an array declaration.
                     if ($tokens[$nextToken]['code'] !== T_ELLIPSIS) {
                         $error = 'No key specified for array entry; first entry specifies key';
@@ -467,7 +467,7 @@ class ArrayDeclarationSniff implements Sniff
 
                 if ($keyUsed === false) {
                     if ($tokens[($nextToken - 1)]['code'] === T_WHITESPACE) {
-                        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextToken - 1), null, true);
+                        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($nextToken - 1), null, true);
                         if (($tokens[$prev]['code'] !== T_END_HEREDOC
                             && $tokens[$prev]['code'] !== T_END_NOWDOC)
                             || $tokens[($nextToken - 1)]['line'] === $tokens[$nextToken]['line']
@@ -494,7 +494,7 @@ class ArrayDeclarationSniff implements Sniff
                     }//end if
 
                     $valueContent = $phpcsFile->findNext(
-                        Tokens::$emptyTokens,
+                        Tokens::EMPTY_TOKENS,
                         ($lastToken + 1),
                         $nextToken,
                         true
@@ -502,7 +502,7 @@ class ArrayDeclarationSniff implements Sniff
 
                     $indices[]          = ['value' => $valueContent];
                     $usesArrayUnpacking = $phpcsFile->findPrevious(
-                        Tokens::$emptyTokens,
+                        Tokens::EMPTY_TOKENS,
                         ($nextToken - 2),
                         null,
                         true
@@ -551,7 +551,7 @@ class ArrayDeclarationSniff implements Sniff
 
                 // Find the value of this index.
                 $nextContent = $phpcsFile->findNext(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($nextToken + 1),
                     $arrayEnd,
                     true
@@ -570,7 +570,7 @@ class ArrayDeclarationSniff implements Sniff
             $singleValue = true;
         } else if (count($indices) === 1 && $tokens[$lastToken]['code'] === T_COMMA) {
             // There may be another array value without a comma.
-            $exclude     = Tokens::$emptyTokens;
+            $exclude     = Tokens::EMPTY_TOKENS;
             $exclude[]   = T_COMMA;
             $nextContent = $phpcsFile->findNext($exclude, ($indices[0]['value'] + 1), $arrayEnd, true);
             if ($nextContent === false) {
@@ -580,14 +580,14 @@ class ArrayDeclarationSniff implements Sniff
 
         if ($singleValue === true) {
             // Before we complain, make sure the single value isn't a here/nowdoc.
-            $next = $phpcsFile->findNext(Tokens::$heredocTokens, ($arrayStart + 1), ($arrayEnd - 1));
+            $next = $phpcsFile->findNext(Tokens::HEREDOC_TOKENS, ($arrayStart + 1), ($arrayEnd - 1));
             if ($next === false) {
                 // Array cannot be empty, so this is a multi-line array with
                 // a single value. It should be defined on single line.
                 $error     = 'Multi-line array contains a single value; use single-line array instead';
                 $errorCode = 'MultiLineNotAllowed';
 
-                $find    = Tokens::$phpcsCommentTokens;
+                $find    = Tokens::PHPCS_ANNOTATION_TOKENS;
                 $find[]  = T_COMMENT;
                 $comment = $phpcsFile->findNext($find, ($arrayStart + 1), $arrayEnd);
                 if ($comment === false) {
@@ -638,7 +638,7 @@ class ArrayDeclarationSniff implements Sniff
             $lastIndex = $indices[($count - 1)]['value'];
 
             $trailingContent = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($arrayEnd - 1),
                 $lastIndex,
                 true
@@ -669,7 +669,7 @@ class ArrayDeclarationSniff implements Sniff
                     T_WHITESPACE => T_WHITESPACE,
                     T_COMMA      => T_COMMA,
                 ];
-                $ignoreTokens += Tokens::$castTokens;
+                $ignoreTokens += Tokens::CAST_TOKENS;
 
                 if ($tokens[$valuePointer]['code'] === T_CLOSURE
                     || $tokens[$valuePointer]['code'] === T_FN
@@ -898,11 +898,11 @@ class ArrayDeclarationSniff implements Sniff
             if ($end === false) {
                 $valueEnd = $valueStart;
             } else if ($tokens[$end]['code'] === T_COMMA) {
-                $valueEnd  = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($end - 1), $valueStart, true);
+                $valueEnd  = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($end - 1), $valueStart, true);
                 $nextComma = $end;
             } else {
                 $valueEnd = $end;
-                $next     = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), $arrayEnd, true);
+                $next     = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), $arrayEnd, true);
                 if ($next !== false && $tokens[$next]['code'] === T_COMMA) {
                     $nextComma = $next;
                 }
@@ -938,7 +938,7 @@ class ArrayDeclarationSniff implements Sniff
             // Check that there is no space before the comma.
             if ($nextComma !== false && $tokens[($nextComma - 1)]['code'] === T_WHITESPACE) {
                 // Here/nowdoc closing tags must have the comma on the next line.
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextComma - 1), null, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($nextComma - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_END_HEREDOC && $tokens[$prev]['code'] !== T_END_NOWDOC) {
                     $content     = $tokens[($nextComma - 2)]['content'];
                     $spaceLength = $tokens[($nextComma - 1)]['length'];

--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -111,7 +111,7 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
             if ($tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']
                 && ($tokens[$nextContent]['code'] === T_WHITESPACE
                 || $tokens[$nextContent]['code'] === T_COMMENT
-                || isset(Tokens::$phpcsCommentTokens[$tokens[$nextContent]['code']]) === true)
+                || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$nextContent]['code']]) === true)
             ) {
                 continue;
             }

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -24,7 +24,7 @@ class ClassFileNameSniff implements Sniff
      */
     public function register()
     {
-        $targets = Tokens::$ooScopeTokens;
+        $targets = Tokens::OO_SCOPE_TOKENS;
         unset($targets[T_ANON_CLASS]);
 
         return $targets;

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -24,7 +24,7 @@ class LowercaseClassKeywordsSniff implements Sniff
      */
     public function register()
     {
-        $targets   = Tokens::$ooScopeTokens;
+        $targets   = Tokens::OO_SCOPE_TOKENS;
         $targets[] = T_EXTENDS;
         $targets[] = T_IMPLEMENTS;
         $targets[] = T_ABSTRACT;

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -58,7 +58,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
             return;
         }
 
-        $calledClassName = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $calledClassName = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($calledClassName === false) {
             // Parse error.
             return;
@@ -75,7 +75,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
 
                 return;
             }
-        } else if (isset(Tokens::$nameTokens[$tokens[$calledClassName]['code']]) === true) {
+        } else if (isset(Tokens::NAME_TOKENS[$tokens[$calledClassName]['code']]) === true) {
             // Work out the fully qualified name for both the class declaration
             // as well as the class usage to see if they match.
             $namespaceName = $this->getNamespaceName($phpcsFile, $currScope);
@@ -187,7 +187,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
 
         if ($namespaceDeclaration !== false) {
             $tokens       = $phpcsFile->getTokens();
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($namespaceDeclaration + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($namespaceDeclaration + 1), null, true);
             if ($nextNonEmpty !== false
                 && ($tokens[$nextNonEmpty]['code'] === T_NAME_QUALIFIED
                 || $tokens[$nextNonEmpty]['code'] === T_STRING)

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -57,8 +57,8 @@ class ValidClassNameSniff implements Sniff
         // simply look for the first T_STRING because a class name
         // starting with the number will be multiple tokens.
         $opener    = $tokens[$stackPtr]['scope_opener'];
-        $nameStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $opener, true);
-        $nameEnd   = $phpcsFile->findNext((Tokens::$emptyTokens + [T_COLON => T_COLON]), $nameStart, $opener);
+        $nameStart = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), $opener, true);
+        $nameEnd   = $phpcsFile->findNext((Tokens::EMPTY_TOKENS + [T_COLON => T_COLON]), $nameStart, $opener);
         if ($nameEnd === false) {
             $name = $tokens[$nameStart]['content'];
         } else {

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -71,7 +71,7 @@ class BlockCommentSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
             $nextToken = $stackPtr;
             do {
-                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextToken + 1), null, true);
+                $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextToken + 1), null, true);
                 if ($tokens[$nextToken]['code'] === T_ATTRIBUTE) {
                     $nextToken = $tokens[$nextToken]['attribute_closer'];
                     continue;
@@ -100,7 +100,7 @@ class BlockCommentSniff implements Sniff
                 return;
             }
 
-            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
                 return;
             }
@@ -131,7 +131,7 @@ class BlockCommentSniff implements Sniff
         // Construct the comment into an array.
         while (($nextComment = $phpcsFile->findNext(T_WHITESPACE, ($nextComment + 1), null, true)) !== false) {
             if ($tokens[$nextComment]['code'] !== $tokens[$stackPtr]['code']
-                && isset(Tokens::$phpcsCommentTokens[$tokens[$nextComment]['code']]) === false
+                && isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$nextComment]['code']]) === false
             ) {
                 // Found the next bit of code.
                 break;
@@ -175,7 +175,7 @@ class BlockCommentSniff implements Sniff
             $error = 'Single line block comment not allowed; use inline ("// text") comment instead';
 
             // Only fix comments when they are the last token on a line.
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
                 $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SingleLine');
                 if ($fix === true) {

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -43,7 +43,7 @@ class DocCommentAlignmentSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         // We are only interested in function/class/interface doc block comments.
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         $ignore    = [
             T_CLASS     => true,
             T_INTERFACE => true,
@@ -62,7 +62,7 @@ class DocCommentAlignmentSniff implements Sniff
 
         if ($nextToken === false || isset($ignore[$tokens[$nextToken]['code']]) === false) {
             // Could be a file comment.
-            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$prevToken]['code'] !== T_OPEN_TAG) {
                 return;
             }

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -47,7 +47,7 @@ class FunctionCommentThrowTagSniff implements Sniff
             return;
         }
 
-        $ignore = Tokens::$methodPrefixes;
+        $ignore = Tokens::METHOD_MODIFIERS;
         $ignore[T_WHITESPACE] = T_WHITESPACE;
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
@@ -104,13 +104,13 @@ class FunctionCommentThrowTagSniff implements Sniff
                 don't know the exception class.
             */
 
-            $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($currPos + 1), null, true);
+            $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($currPos + 1), null, true);
             if ($tokens[$nextToken]['code'] === T_NEW
-                || isset(Tokens::$nameTokens[$tokens[$nextToken]['code']]) === true
+                || isset(Tokens::NAME_TOKENS[$tokens[$nextToken]['code']]) === true
             ) {
                 if ($tokens[$nextToken]['code'] === T_NEW) {
                     $currException = $phpcsFile->findNext(
-                        Tokens::$emptyTokens,
+                        Tokens::EMPTY_TOKENS,
                         ($nextToken + 1),
                         $stackPtrEnd,
                         true
@@ -120,7 +120,7 @@ class FunctionCommentThrowTagSniff implements Sniff
                 }
 
                 if ($currException !== false
-                    && isset(Tokens::$nameTokens[$tokens[$currException]['code']]) === true
+                    && isset(Tokens::NAME_TOKENS[$tokens[$currException]['code']]) === true
                 ) {
                     if ($tokens[$currException]['code'] === T_NAME_RELATIVE) {
                         // Strip the `namespace\` prefix off the exception name

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -51,7 +51,7 @@ class InlineCommentSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
             $nextToken = $stackPtr;
             do {
-                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextToken + 1), null, true);
+                $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextToken + 1), null, true);
                 if ($tokens[$nextToken]['code'] === T_ATTRIBUTE) {
                     $nextToken = $tokens[$nextToken]['attribute_closer'];
                     continue;
@@ -86,7 +86,7 @@ class InlineCommentSniff implements Sniff
             }
 
             $prevToken = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($stackPtr - 1),
                 null,
                 true

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -24,7 +24,7 @@ class VariableCommentSniff extends AbstractVariableSniff
      */
     public function __construct()
     {
-        AbstractScopeSniff::__construct(Tokens::$ooScopeTokens, [T_VARIABLE], false);
+        AbstractScopeSniff::__construct(Tokens::OO_SCOPE_TOKENS, [T_VARIABLE], false);
 
     }//end __construct()
 
@@ -42,8 +42,8 @@ class VariableCommentSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore  = Tokens::$scopeModifiers;
-        $ignore += Tokens::$nameTokens;
+        $ignore  = Tokens::SCOPE_MODIFIERS;
+        $ignore += Tokens::NAME_TOKENS;
         $ignore += [
             T_VAR                    => T_VAR,
             T_STATIC                 => T_STATIC,

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -62,7 +62,7 @@ class ControlSignatureSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }
@@ -203,7 +203,7 @@ class ControlSignatureSniff implements Sniff
 
                 // Skip all empty tokens on the same line as the opener.
                 if ($tokens[$next]['line'] === $tokens[$opener]['line']
-                    && (isset(Tokens::$emptyTokens[$code]) === true
+                    && (isset(Tokens::EMPTY_TOKENS[$code]) === true
                     || $code === T_CLOSE_TAG)
                 ) {
                     continue;
@@ -235,7 +235,7 @@ class ControlSignatureSniff implements Sniff
         } else if ($tokens[$stackPtr]['code'] === T_WHILE) {
             // Zero spaces after parenthesis closer, but only if followed by a semicolon.
             $closer       = $tokens[$stackPtr]['parenthesis_closer'];
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closer + 1), null, true);
             if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_SEMICOLON) {
                 $found = 0;
                 if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
@@ -263,7 +263,7 @@ class ControlSignatureSniff implements Sniff
                 return;
             }
 
-            $closer = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $closer = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($closer === false
                 || $tokens[$closer]['code'] !== T_CLOSE_CURLY_BRACKET
                 || $tokens[$tokens[$closer]['scope_condition']]['code'] !== T_DO
@@ -283,7 +283,7 @@ class ControlSignatureSniff implements Sniff
                 return;
             }
 
-            $closer = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $closer = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($closer === false || $tokens[$closer]['code'] !== T_CLOSE_CURLY_BRACKET) {
                 return;
             }
@@ -305,7 +305,7 @@ class ControlSignatureSniff implements Sniff
             $error = 'Expected 1 space after closing brace; %s found';
             $data  = [$found];
 
-            if ($phpcsFile->findNext(Tokens::$commentTokens, ($closer + 1), $stackPtr) !== false) {
+            if ($phpcsFile->findNext(Tokens::COMMENT_TOKENS, ($closer + 1), $stackPtr) !== false) {
                 // Comment found between closing brace and keyword, don't auto-fix.
                 $phpcsFile->addError($error, $closer, 'SpaceAfterCloseBrace', $data);
                 return;

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -134,7 +134,7 @@ class ForLoopDeclarationSniff implements Sniff
         $prevNonWhiteSpace  = $phpcsFile->findPrevious(T_WHITESPACE, ($closingBracket - 1), $openingBracket, true);
         $beforeClosefixable = true;
         if ($tokens[$prevNonWhiteSpace]['line'] !== $tokens[$closingBracket]['line']
-            && isset(Tokens::$emptyTokens[$tokens[$prevNonWhiteSpace]['code']]) === true
+            && isset(Tokens::EMPTY_TOKENS[$tokens[$prevNonWhiteSpace]['code']]) === true
         ) {
             $beforeClosefixable = false;
         }

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -239,7 +239,7 @@ class SwitchDeclarationSniff implements Sniff
                                 continue;
                             }
 
-                            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+                            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === false) {
                                 $foundContent = true;
                                 break;
                             }

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -24,7 +24,7 @@ class OperatorBracketSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$operators;
+        return Tokens::OPERATORS;
 
     }//end register()
 
@@ -51,7 +51,7 @@ class OperatorBracketSniff implements Sniff
         // the minus sign being used to assign a negative number to a variable.
         if ($tokens[$stackPtr]['code'] === T_MINUS) {
             // Check to see if we are trying to return -n.
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$prev]['code'] === T_RETURN) {
                 return;
             }
@@ -60,10 +60,10 @@ class OperatorBracketSniff implements Sniff
             if ($tokens[$number]['code'] === T_LNUMBER || $tokens[$number]['code'] === T_DNUMBER) {
                 $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
                 if ($previous !== false) {
-                    $isAssignment = isset(Tokens::$assignmentTokens[$tokens[$previous]['code']]);
-                    $isEquality   = isset(Tokens::$equalityTokens[$tokens[$previous]['code']]);
-                    $isComparison = isset(Tokens::$comparisonTokens[$tokens[$previous]['code']]);
-                    $isUnary      = isset(Tokens::$operators[$tokens[$previous]['code']]);
+                    $isAssignment = isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$previous]['code']]);
+                    $isEquality   = isset(Tokens::EQUALITY_TOKENS[$tokens[$previous]['code']]);
+                    $isComparison = isset(Tokens::COMPARISON_TOKENS[$tokens[$previous]['code']]);
+                    $isUnary      = isset(Tokens::OPERATORS[$tokens[$previous]['code']]);
                     if ($isAssignment === true || $isEquality === true || $isComparison === true || $isUnary === true) {
                         // This is a negative assignment or comparison.
                         // We need to check that the minus and the number are
@@ -115,8 +115,8 @@ class OperatorBracketSniff implements Sniff
         }
 
         // Tokens that are allowed inside a bracketed operation.
-        $allowed  = Tokens::$nameTokens;
-        $allowed += Tokens::$operators;
+        $allowed  = Tokens::NAME_TOKENS;
+        $allowed += Tokens::OPERATORS;
         $allowed += [
             T_VARIABLE                 => T_VARIABLE,
             T_LNUMBER                  => T_LNUMBER,
@@ -147,7 +147,7 @@ class OperatorBracketSniff implements Sniff
                     break;
                 }
 
-                if (isset(Tokens::$nameTokens[$prevCode]) === true
+                if (isset(Tokens::NAME_TOKENS[$prevCode]) === true
                     || $prevCode === T_SWITCH
                     || $prevCode === T_MATCH
                 ) {
@@ -186,7 +186,7 @@ class OperatorBracketSniff implements Sniff
                     }
                 }//end if
 
-                if (in_array($prevCode, Tokens::$scopeOpeners, true) === true) {
+                if (in_array($prevCode, Tokens::SCOPE_OPENERS, true) === true) {
                     // This operation is inside a control structure like FOREACH
                     // or IF, but has no bracket of it's own.
                     // The only control structures allowed to do this are SWITCH and MATCH.
@@ -236,7 +236,7 @@ class OperatorBracketSniff implements Sniff
             return;
         }//end if
 
-        $lastAssignment = $phpcsFile->findPrevious(Tokens::$assignmentTokens, $stackPtr, null, false, null, true);
+        $lastAssignment = $phpcsFile->findPrevious(Tokens::ASSIGNMENT_TOKENS, $stackPtr, null, false, null, true);
         if ($lastAssignment !== false && $lastAssignment > $lastBracket) {
             $this->addMissingBracketsError($phpcsFile, $stackPtr);
         }
@@ -277,10 +277,10 @@ class OperatorBracketSniff implements Sniff
 
         // Find the first token in the expression.
         for ($before = ($stackPtr - 1); $before > 0; $before--) {
-            if (isset(Tokens::$emptyTokens[$tokens[$before]['code']]) === true
-                || isset(Tokens::$operators[$tokens[$before]['code']]) === true
-                || isset(Tokens::$castTokens[$tokens[$before]['code']]) === true
-                || isset(Tokens::$nameTokens[$tokens[$before]['code']]) === true
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$before]['code']]) === true
+                || isset(Tokens::OPERATORS[$tokens[$before]['code']]) === true
+                || isset(Tokens::CAST_TOKENS[$tokens[$before]['code']]) === true
+                || isset(Tokens::NAME_TOKENS[$tokens[$before]['code']]) === true
                 || isset($allowed[$tokens[$before]['code']]) === true
             ) {
                 continue;
@@ -304,7 +304,7 @@ class OperatorBracketSniff implements Sniff
             break;
         }//end for
 
-        $before = $phpcsFile->findNext(Tokens::$emptyTokens, ($before + 1), null, true);
+        $before = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($before + 1), null, true);
 
         // A few extra tokens are allowed to be on the right side of the expression.
         $allowed[T_EQUAL] = true;
@@ -312,10 +312,10 @@ class OperatorBracketSniff implements Sniff
 
         // Find the last token in the expression.
         for ($after = ($stackPtr + 1); $after < $phpcsFile->numTokens; $after++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$after]['code']]) === true
-                || isset(Tokens::$operators[$tokens[$after]['code']]) === true
-                || isset(Tokens::$castTokens[$tokens[$after]['code']]) === true
-                || isset(Tokens::$nameTokens[$tokens[$after]['code']]) === true
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$after]['code']]) === true
+                || isset(Tokens::OPERATORS[$tokens[$after]['code']]) === true
+                || isset(Tokens::CAST_TOKENS[$tokens[$after]['code']]) === true
+                || isset(Tokens::NAME_TOKENS[$tokens[$after]['code']]) === true
                 || isset($allowed[$tokens[$after]['code']]) === true
             ) {
                 continue;
@@ -346,7 +346,7 @@ class OperatorBracketSniff implements Sniff
             break;
         }//end for
 
-        $after = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($after - 1), null, true);
+        $after = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($after - 1), null, true);
 
         $error = 'Operation must be bracketed';
         if ($before === $after || $before === $stackPtr || $after === $stackPtr) {

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -371,7 +371,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
             }
 
             if ($commaToken !== false) {
-                $endOfPreviousParam = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($commaToken - 1), null, true);
+                $endOfPreviousParam = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($commaToken - 1), null, true);
 
                 $spaceBeforeComma = 0;
                 if ($tokens[$endOfPreviousParam]['line'] !== $tokens[$commaToken]['line']) {
@@ -389,7 +389,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                     $fix = $phpcsFile->addFixableError($error, $commaToken, 'SpaceBeforeComma', $data);
                     if ($fix === true) {
-                        $startOfCurrentParam = $phpcsFile->findNext(Tokens::$emptyTokens, ($commaToken + 1), null, true);
+                        $startOfCurrentParam = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($commaToken + 1), null, true);
 
                         $phpcsFile->fixer->beginChangeset();
                         $phpcsFile->fixer->addContent($endOfPreviousParam, ',');
@@ -422,7 +422,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                 // Don't check spacing after the comma if it is the last content on the line.
                 $checkComma = true;
                 if ($multiLine === true) {
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($commaToken + 1), $closeBracket, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($commaToken + 1), $closeBracket, true);
                     if ($tokens[$next]['line'] !== $tokens[$commaToken]['line']) {
                         $checkComma = false;
                     }
@@ -436,7 +436,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                     if (isset($param['property_visibility']) === true) {
                         $typeOfNext      = 'property modifier';
                         $typeOfNextShort = 'PropertyModifier';
-                        $modifier        = $phpcsFile->findNext(Tokens::$emptyTokens, ($commaToken + 1), $param['token'], true);
+                        $modifier        = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($commaToken + 1), $param['token'], true);
                         $contentOfNext   = $tokens[$modifier]['content'];
                     } else if ($param['type_hint_token'] !== false) {
                         $typeOfNext      = 'type hint';

--- a/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
@@ -24,7 +24,7 @@ class LowercaseFunctionKeywordsSniff implements Sniff
      */
     public function register()
     {
-        $tokens   = Tokens::$methodPrefixes;
+        $tokens   = Tokens::METHOD_MODIFIERS;
         $tokens[] = T_FUNCTION;
         $tokens[] = T_CLOSURE;
         $tokens[] = T_FN;

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -44,7 +44,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
         foreach ($bracketsToCheck as $stackPtr => $openBracket) {
             // If the first argument is on a new line, this is a multi-line
             // function declaration, even if there is only one argument.
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
             if ($tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
                 return true;
             }
@@ -55,7 +55,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
             while ($tokens[$end]['code'] === T_COMMA) {
                 // If the next bit of code is not on the same line, this is a
                 // multi-line function declaration.
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), $closeBracket, true);
                 if ($next === false) {
                     continue(2);
                 }
@@ -69,7 +69,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
 
             // We've reached the last argument, so see if the next content
             // (should be the close bracket) is also on the same line.
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), $closeBracket, true);
             if ($next !== false && $tokens[$next]['line'] !== $tokens[$end]['line']) {
                 return true;
             }
@@ -106,7 +106,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
         if ($tokens[$prevNonWhiteSpace]['line'] !== $tokens[$closingBracket]['line']) {
             $error = 'There must not be a newline before the closing parenthesis of a single-line function declaration';
 
-            if (isset(Tokens::$emptyTokens[$tokens[$prevNonWhiteSpace]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$prevNonWhiteSpace]['code']]) === true) {
                 $phpcsFile->addError($error, $closingBracket, 'CloseBracketNewLine');
             } else {
                 $fix = $phpcsFile->addFixableError($error, $closingBracket, 'CloseBracketNewLine');
@@ -185,7 +185,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
 
         // The open bracket should be the last thing on the line.
         if ($tokens[$openBracket]['line'] !== $tokens[$closeBracket]['line']) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
             if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
                 $error = 'The first parameter of a multi-line '.$type.' declaration must be on the line after the opening bracket';
                 $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix.'FirstParamSpacing');
@@ -232,7 +232,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
                 continue;
             }
 
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             if ($tokens[$next]['line'] === $tokens[$i]['line']) {
                 $error = 'Multi-line '.$type.' declarations must define one parameter per line';
                 $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix.'OneParamPerLine');

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -89,7 +89,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         // check the main part of the variable name.
         $originalVarName = $varName;
         if (substr($varName, 0, 1) === '_') {
-            $inClass = $phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens);
+            $inClass = $phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS);
             if ($inClass === true) {
                 $varName = substr($varName, 1);
             }

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -42,7 +42,7 @@ class ObjectInstantiationSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $allowedTokens   = Tokens::$emptyTokens;
+        $allowedTokens   = Tokens::EMPTY_TOKENS;
         $allowedTokens[] = T_BITWISE_AND;
 
         $prev = $phpcsFile->findPrevious($allowedTokens, ($stackPtr - 1), null, true);

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -75,7 +75,7 @@ class ComparisonOperatorUsageSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['code'] === T_INLINE_THEN) {
-            $end = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $end = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$end]['code'] !== T_CLOSE_PARENTHESIS) {
                 // This inline IF statement does not have its condition
                 // bracketed, so we need to guess where it starts.
@@ -111,7 +111,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                     }//end if
                 }//end for
 
-                $start = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                $start = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             } else {
                 if (isset($tokens[$end]['parenthesis_opener']) === false) {
                     return;
@@ -163,7 +163,7 @@ class ComparisonOperatorUsageSniff implements Sniff
 
             if ($type === T_OPEN_PARENTHESIS
                 && isset($tokens[$i]['parenthesis_closer']) === true
-                && isset(Tokens::$functionNameTokens[$tokens[$lastNonEmpty]['code']]) === true
+                && isset(Tokens::FUNCTION_NAME_TOKENS[$tokens[$lastNonEmpty]['code']]) === true
             ) {
                 $i            = $tokens[$i]['parenthesis_closer'];
                 $lastNonEmpty = $i;
@@ -196,7 +196,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                 }
             }
 
-            if (isset(Tokens::$emptyTokens[$type]) === false) {
+            if (isset(Tokens::EMPTY_TOKENS[$type]) === false) {
                 $lastNonEmpty = $i;
             }
         }//end for

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -82,18 +82,18 @@ class IncrementDecrementUsageSniff implements Sniff
             $start = ($stackPtr + 2);
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, null, true);
         if ($next === false) {
             return;
         }
 
-        if (isset(Tokens::$arithmeticTokens[$tokens[$next]['code']]) === true) {
+        if (isset(Tokens::ARITHMETIC_TOKENS[$tokens[$next]['code']]) === true) {
             $error = 'Increment and decrement operators cannot be used in an arithmetic operation';
             $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
             return;
         }
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($start - 3), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($start - 3), null, true);
         if ($prev === false) {
             return;
         }
@@ -120,7 +120,7 @@ class IncrementDecrementUsageSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $assignedVar = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $assignedVar = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         // Not an assignment, return.
         if ($tokens[$assignedVar]['code'] !== T_VARIABLE) {
             return;
@@ -129,7 +129,7 @@ class IncrementDecrementUsageSniff implements Sniff
         $statementEnd = $phpcsFile->findNext([T_SEMICOLON, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET, T_CLOSE_CURLY_BRACKET], $stackPtr);
 
         // If there is anything other than variables, numbers, spaces or operators we need to return.
-        $find   = Tokens::$emptyTokens;
+        $find   = Tokens::EMPTY_TOKENS;
         $find[] = T_LNUMBER;
         $find[] = T_VARIABLE;
         $find[] = T_PLUS;

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -67,7 +67,7 @@ class CommentedOutCodeSniff implements Sniff
 
         $lastCommentBlockToken = $stackPtr;
         for ($i = $stackPtr; $i < $phpcsFile->numTokens; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === false) {
                 break;
             }
 
@@ -75,7 +75,7 @@ class CommentedOutCodeSniff implements Sniff
                 continue;
             }
 
-            if (isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$i]['code']]) === true) {
                 $lastLineSeen = $tokens[$i]['line'];
                 continue;
             }
@@ -215,7 +215,7 @@ class CommentedOutCodeSniff implements Sniff
 
         // The second last token is always whitespace or a comment, depending
         // on the code inside the comment.
-        if (isset(Tokens::$emptyTokens[$stringTokens[($numTokens - 1)]['code']]) === false) {
+        if (isset(Tokens::EMPTY_TOKENS[$stringTokens[($numTokens - 1)]['code']]) === false) {
             return ($lastCommentBlockToken + 1);
         }
 
@@ -232,7 +232,7 @@ class CommentedOutCodeSniff implements Sniff
             T_NONE                    => true,
             T_COMMENT                 => true,
         ];
-        $emptyTokens += Tokens::$phpcsCommentTokens;
+        $emptyTokens += Tokens::PHPCS_ANNOTATION_TOKENS;
 
         $numCode          = 0;
         $numNonWhitespace = 0;
@@ -242,8 +242,8 @@ class CommentedOutCodeSniff implements Sniff
             if (isset($emptyTokens[$stringTokens[$i]['code']]) === false
                 // Commented out HTML/XML and other docs contain a lot of these
                 // characters, so it is best to not use them directly.
-                && isset(Tokens::$comparisonTokens[$stringTokens[$i]['code']]) === false
-                && isset(Tokens::$arithmeticTokens[$stringTokens[$i]['code']]) === false
+                && isset(Tokens::COMPARISON_TOKENS[$stringTokens[$i]['code']]) === false
+                && isset(Tokens::ARITHMETIC_TOKENS[$stringTokens[$i]['code']]) === false
                 && $stringTokens[$i]['code'] !== T_GOTO_LABEL
             ) {
                 // Looks like code.

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
@@ -24,7 +24,7 @@ class DisallowBooleanStatementSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$booleanOperators;
+        return Tokens::BOOLEAN_OPERATORS;
 
     }//end register()
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
@@ -54,7 +54,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
 
         // Ignore values in array definitions or match structures.
         $nextNonEmpty = $phpcsFile->findNext(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($stackPtr + 1),
             null,
             true
@@ -68,7 +68,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
         }
 
         // Ignore function calls.
-        $ignore   = Tokens::$nameTokens;
+        $ignore   = Tokens::NAME_TOKENS;
         $ignore[] = T_NULLSAFE_OBJECT_OPERATOR;
         $ignore[] = T_OBJECT_OPERATOR;
         $ignore[] = T_VARIABLE;
@@ -77,7 +77,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
         $next = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true);
         if ($tokens[$next]['code'] === T_CLOSURE
             || ($tokens[$next]['code'] === T_OPEN_PARENTHESIS
-            && isset(Tokens::$nameTokens[$tokens[($next - 1)]['code']]) === true)
+            && isset(Tokens::NAME_TOKENS[$tokens[($next - 1)]['code']]) === true)
         ) {
             // Code will look like: $var = myFunction(
             // and will be ignored.
@@ -86,7 +86,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
 
         $endStatement = $phpcsFile->findEndOfStatement($stackPtr);
         for ($i = ($stackPtr + 1); $i < $endStatement; $i++) {
-            if ((isset(Tokens::$comparisonTokens[$tokens[$i]['code']]) === true
+            if ((isset(Tokens::COMPARISON_TOKENS[$tokens[$i]['code']]) === true
                 && $tokens[$i]['code'] !== T_COALESCE)
                 || $tokens[$i]['code'] === T_INLINE_THEN
             ) {
@@ -95,7 +95,7 @@ class DisallowComparisonAssignmentSniff implements Sniff
                 break;
             }
 
-            if (isset(Tokens::$booleanOperators[$tokens[$i]['code']]) === true
+            if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === T_BOOLEAN_NOT
             ) {
                 $error = 'The value of a boolean operation must not be assigned to a variable';

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -74,7 +74,7 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             $conditions = $tokens[$stackPtr]['conditions'];
             end($conditions);
             $deepestScope = key($conditions);
-            if (isset(Tokens::$ooScopeTokens[$tokens[$deepestScope]['code']]) === true) {
+            if (isset(Tokens::OO_SCOPE_TOKENS[$tokens[$deepestScope]['code']]) === true) {
                 return;
             }
         }
@@ -105,7 +105,7 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             }
 
             if ($tokens[$varToken]['code'] === T_VARIABLE) {
-                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($varToken - 1), null, true);
+                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($varToken - 1), null, true);
                 if ($tokens[$prevNonEmpty]['code'] === T_OBJECT_OPERATOR) {
                     // Dynamic property access, the real "start" variable still needs to be found.
                     $varToken = $prevNonEmpty;
@@ -124,8 +124,8 @@ class DisallowMultipleAssignmentsSniff implements Sniff
 
         $start = $phpcsFile->findStartOfStatement($varToken);
 
-        $allowed  = Tokens::$emptyTokens;
-        $allowed += Tokens::$nameTokens;
+        $allowed  = Tokens::EMPTY_TOKENS;
+        $allowed += Tokens::NAME_TOKENS;
 
         $allowed[T_DOUBLE_COLON] = T_DOUBLE_COLON;
         $allowed[T_ASPERAND]     = T_ASPERAND;

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -292,7 +292,7 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         // Check for a blank line at the bottom.
-        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closingTag - 1), ($stackPtr + 1), true);
+        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closingTag - 1), ($stackPtr + 1), true);
         if ((isset($tokens[$lastNonEmpty]['scope_closer']) === false
             || $tokens[$lastNonEmpty]['scope_closer'] !== $lastNonEmpty)
             && $tokens[$lastContent]['line'] < ($tokens[$closingTag]['line'] - 1)
@@ -367,7 +367,7 @@ class EmbeddedPhpSniff implements Sniff
             }
         }
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closeTag - 1), $stackPtr, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closeTag - 1), $stackPtr, true);
         if ($prev !== $stackPtr) {
             if ((isset($tokens[$prev]['scope_opener']) === false
                 || $tokens[$prev]['scope_opener'] !== $prev)
@@ -405,7 +405,7 @@ class EmbeddedPhpSniff implements Sniff
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {
             $trailingSpace = $tokens[($closeTag - 1)]['length'];
         } else if (($tokens[($closeTag - 1)]['code'] === T_COMMENT
-            || isset(Tokens::$phpcsCommentTokens[$tokens[($closeTag - 1)]['code']]) === true)
+            || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[($closeTag - 1)]['code']]) === true)
             && substr($tokens[($closeTag - 1)]['content'], -1) === ' '
         ) {
             $trailingSpace = (strlen($tokens[($closeTag - 1)]['content']) - strlen(rtrim($tokens[($closeTag - 1)]['content'])));
@@ -419,7 +419,7 @@ class EmbeddedPhpSniff implements Sniff
                 if ($trailingSpace === 0) {
                     $phpcsFile->fixer->addContentBefore($closeTag, ' ');
                 } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT
-                    || isset(Tokens::$phpcsCommentTokens[$tokens[($closeTag - 1)]['code']]) === true
+                    || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[($closeTag - 1)]['code']]) === true
                 ) {
                     $phpcsFile->fixer->replaceToken(($closeTag - 1), rtrim($tokens[($closeTag - 1)]['content']).' ');
                 } else {

--- a/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
@@ -56,7 +56,7 @@ class InnerFunctionsSniff implements Sniff
                 break;
             }
 
-            if (array_key_exists($condition, Tokens::$ooScopeTokens) === true) {
+            if (array_key_exists($condition, Tokens::OO_SCOPE_TOKENS) === true) {
                 // Ignore methods in OOP structures defined within functions.
                 return;
             }

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -87,16 +87,16 @@ class LowercasePHPFunctionsSniff implements Sniff
             return;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($next === false) {
             // Not a function call.
             return;
         }
 
-        $ignore   = Tokens::$emptyTokens;
+        $ignore   = Tokens::EMPTY_TOKENS;
         $ignore[] = T_BITWISE_AND;
         $prev     = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
-        $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+        $prevPrev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prev - 1), null, true);
 
         if ($tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
             // Is this a use statement importing a PHP native function ?

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -65,14 +65,14 @@ class NonExecutableCodeSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         // Tokens which can be used in inline expressions need special handling.
         if (isset($this->expressionTokens[$tokens[$stackPtr]['code']]) === true) {
             // If this token is preceded by a logical operator, it only relates to one line
             // and should be ignored. For example: fopen() or die().
             // Note: There is one exception: throw expressions can not be used with xor.
-            if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true
+            if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$prev]['code']]) === true
                 && ($tokens[$stackPtr]['code'] === T_THROW && $tokens[$prev]['code'] === T_LOGICAL_XOR) === false
             ) {
                 return;
@@ -106,9 +106,9 @@ class NonExecutableCodeSniff implements Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === T_RETURN) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($tokens[$next]['code'] === T_SEMICOLON) {
-                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
                 if ($tokens[$next]['code'] === T_CLOSE_CURLY_BRACKET) {
                     // If this is the closing brace of a function
                     // then this return statement doesn't return anything
@@ -145,7 +145,7 @@ class NonExecutableCodeSniff implements Sniff
                 if ($next !== false) {
                     $lastLine = $tokens[$end]['line'];
                     for ($i = ($stackPtr + 1); $i < $next; $i++) {
-                        if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                        if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                             continue;
                         }
 
@@ -252,8 +252,8 @@ class NonExecutableCodeSniff implements Sniff
 
         $lastLine = $tokens[$start]['line'];
         for ($i = ($start + 1); $i < $end; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true
-                || isset(Tokens::$bracketTokens[$tokens[$i]['code']]) === true
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true
+                || isset(Tokens::BRACKET_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === T_SEMICOLON
             ) {
                 continue;
@@ -261,7 +261,7 @@ class NonExecutableCodeSniff implements Sniff
 
             // Skip whole functions and classes/interfaces because they are not
             // technically executed code, but rather declarations that may be used.
-            if (isset(Tokens::$ooScopeTokens[$tokens[$i]['code']]) === true
+            if (isset(Tokens::OO_SCOPE_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === T_FUNCTION
                 || $tokens[$i]['code'] === T_CLOSURE
             ) {

--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -24,7 +24,7 @@ class MemberVarScopeSniff extends AbstractVariableSniff
      */
     public function __construct()
     {
-        AbstractScopeSniff::__construct(Tokens::$ooScopeTokens, [T_VARIABLE], false);
+        AbstractScopeSniff::__construct(Tokens::OO_SCOPE_TOKENS, [T_VARIABLE], false);
 
     }//end __construct()
 

--- a/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -22,7 +22,7 @@ class MethodScopeSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION]);
+        parent::__construct(Tokens::OO_SCOPE_TOKENS, [T_FUNCTION]);
 
     }//end __construct()
 

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -54,7 +54,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
             return;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] !== T_STRING) {
             // Not a function declaration, or incomplete.
             return;

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -61,7 +61,7 @@ class ConcatenationSpacingSniff implements Sniff
         }
 
         $ignoreBefore = false;
-        $prev         = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev         = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prev]['code'] === T_END_HEREDOC || $tokens[$prev]['code'] === T_END_NOWDOC) {
             // Spacing before must be preserved due to the here/nowdoc closing tag.
             $ignoreBefore = true;

--- a/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
@@ -66,7 +66,7 @@ class EchoedStringsSniff implements Sniff
 
         $phpcsFile->recordMetric($stackPtr, 'Brackets around echoed strings', 'yes');
 
-        if (($phpcsFile->findNext(Tokens::$operators, $stackPtr, $end, false)) === false) {
+        if (($phpcsFile->findNext(Tokens::OPERATORS, $stackPtr, $end, false)) === false) {
             // There are no arithmetic operators in this.
             $error = 'Echoed strings should not be bracketed';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'HasBracket');

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
@@ -24,7 +24,7 @@ class CastSpacingSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$castTokens;
+        return Tokens::CAST_TOKENS;
 
     }//end register()
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -120,7 +120,7 @@ class ControlStructureSpacingSniff implements Sniff
 
             // Skip all empty tokens on the same line as the opener.
             if ($tokens[$firstContent]['line'] === $tokens[$scopeOpener]['line']
-                && (isset(Tokens::$emptyTokens[$code]) === true
+                && (isset(Tokens::EMPTY_TOKENS[$code]) === true
                 || $code === T_CLOSE_TAG)
             ) {
                 continue;
@@ -175,7 +175,7 @@ class ControlStructureSpacingSniff implements Sniff
             );
 
             $lastNonEmptyContent = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($scopeCloser - 1),
                 null,
                 true
@@ -226,7 +226,7 @@ class ControlStructureSpacingSniff implements Sniff
 
         if ($tokens[$stackPtr]['code'] === T_MATCH) {
             // Move the scope closer to the semicolon/comma.
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($scopeCloser + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($scopeCloser + 1), null, true);
             if ($next !== false
                 && ($tokens[$next]['code'] === T_SEMICOLON || $tokens[$next]['code'] === T_COMMA)
             ) {
@@ -242,12 +242,12 @@ class ControlStructureSpacingSniff implements Sniff
         );
 
         if ($tokens[$trailingContent]['code'] === T_COMMENT
-            || isset(Tokens::$phpcsCommentTokens[$tokens[$trailingContent]['code']]) === true
+            || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$trailingContent]['code']]) === true
         ) {
             // Special exception for code where the comment about
             // an ELSE or ELSEIF is written between the control structures.
             $nextCode = $phpcsFile->findNext(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($scopeCloser + 1),
                 null,
                 true
@@ -333,7 +333,7 @@ class ControlStructureSpacingSniff implements Sniff
                 );
 
                 if (($tokens[$trailingContent]['code'] === T_COMMENT
-                    || isset(Tokens::$phpcsCommentTokens[$tokens[$trailingContent]['code']]) === true)
+                    || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$trailingContent]['code']]) === true)
                     && $tokens[$trailingContent]['line'] === $tokens[$scopeCloser]['line']
                 ) {
                     $phpcsFile->fixer->addNewline($trailingContent);

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -69,7 +69,7 @@ class FunctionSpacingSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens           = $phpcsFile->getTokens();
-        $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $previousNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($previousNonEmpty !== false
             && $tokens[$previousNonEmpty]['code'] === T_OPEN_TAG
             && $tokens[$previousNonEmpty]['line'] !== 1
@@ -112,7 +112,7 @@ class FunctionSpacingSniff implements Sniff
         $isFirst = false;
         $isLast  = false;
 
-        $ignore = ([T_WHITESPACE => T_WHITESPACE] + Tokens::$methodPrefixes);
+        $ignore = ([T_WHITESPACE => T_WHITESPACE] + Tokens::METHOD_MODIFIERS);
 
         $prev = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
 
@@ -156,7 +156,7 @@ class FunctionSpacingSniff implements Sniff
         }
 
         $next = $phpcsFile->findNext($ignore, ($closer + 1), null, true);
-        if (isset(Tokens::$emptyTokens[$tokens[$next]['code']]) === true
+        if (isset(Tokens::EMPTY_TOKENS[$tokens[$next]['code']]) === true
             && $tokens[$next]['line'] === $tokens[$closer]['line']
         ) {
             // Skip past "end" comments.
@@ -270,7 +270,7 @@ class FunctionSpacingSniff implements Sniff
         } else {
             $firstBefore = $phpcsFile->findPrevious(T_WHITESPACE, ($startOfDeclarationLine - 1), null, true);
             if ($tokens[$firstBefore]['code'] === T_COMMENT
-                || isset(Tokens::$phpcsCommentTokens[$tokens[$firstBefore]['code']]) === true
+                || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$firstBefore]['code']]) === true
             ) {
                 // Ignore comments as they can have different spacing rules, and this
                 // isn't a proper function comment anyway.

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
@@ -24,7 +24,7 @@ class LogicalOperatorSpacingSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$booleanOperators;
+        return Tokens::BOOLEAN_OPERATORS;
 
     }//end register()
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -37,7 +37,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
      */
     public function __construct()
     {
-        AbstractScopeSniff::__construct(Tokens::$ooScopeTokens, [T_VARIABLE], false);
+        AbstractScopeSniff::__construct(Tokens::OO_SCOPE_TOKENS, [T_VARIABLE], false);
 
     }//end __construct()
 
@@ -64,7 +64,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $endOfPreviousStatement = $phpcsFile->findPrevious($stopPoints, ($stackPtr - 1), null, false, null, true);
 
-        $validPrefixes   = Tokens::$methodPrefixes;
+        $validPrefixes   = Tokens::METHOD_MODIFIERS;
         $validPrefixes[] = T_VAR;
         $validPrefixes[] = T_READONLY;
 
@@ -95,9 +95,9 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         if ($tokens[$prev]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
             $start = $prev;
-        } else if (isset(Tokens::$commentTokens[$tokens[$prev]['code']]) === true) {
+        } else if (isset(Tokens::COMMENT_TOKENS[$tokens[$prev]['code']]) === true) {
             // Assume the comment belongs to the member var if it is on a line by itself.
-            $prevContent = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+            $prevContent = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prev - 1), null, true);
             if ($tokens[$prevContent]['line'] !== $tokens[$prev]['line']) {
                 $start = $prev;
             }
@@ -114,7 +114,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
                 || $tokens[$i]['code'] !== T_WHITESPACE
                 || $tokens[$i]['line'] === $tokens[($i + 1)]['line']
                 // Do not report blank lines after a PHPCS annotation as removing the blank lines could change the meaning.
-                || isset(Tokens::$phpcsCommentTokens[$tokens[($i - 1)]['code']]) === true
+                || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[($i - 1)]['code']]) === true
             ) {
                 continue;
             }
@@ -147,15 +147,15 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         // There needs to be n blank lines before the var, not counting comments.
         if ($start === $startOfStatement) {
             // No comment found.
-            $first = $phpcsFile->findFirstOnLine(Tokens::$emptyTokens, $start, true);
+            $first = $phpcsFile->findFirstOnLine(Tokens::EMPTY_TOKENS, $start, true);
             if ($first === false) {
                 $first = $start;
             }
         } else if ($tokens[$start]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
             $first = $tokens[$start]['comment_opener'];
         } else {
-            $first = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($start - 1), null, true);
-            $first = $phpcsFile->findNext(array_merge(Tokens::$commentTokens, [T_ATTRIBUTE]), ($first + 1));
+            $first = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($start - 1), null, true);
+            $first = $phpcsFile->findNext(array_merge(Tokens::COMMENT_TOKENS, [T_ATTRIBUTE]), ($first + 1));
         }
 
         // Determine if this is the first member var.
@@ -168,7 +168,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         }
 
         if ($tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET
-            && isset(Tokens::$ooScopeTokens[$tokens[$tokens[$prev]['scope_condition']]['code']]) === true
+            && isset(Tokens::OO_SCOPE_TOKENS[$tokens[$tokens[$prev]['scope_condition']]['code']]) === true
         ) {
             $errorMsg  = 'Expected %s blank line(s) before first member var; %s found';
             $errorCode = 'FirstIncorrect';

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -54,16 +54,16 @@ class OperatorSpacingSniff implements Sniff
         */
 
         // Trying to operate on a negative value; eg. ($var * -1).
-        $this->nonOperandTokens = Tokens::$operators;
+        $this->nonOperandTokens = Tokens::OPERATORS;
 
         // Trying to compare a negative value; eg. ($var === -1).
-        $this->nonOperandTokens += Tokens::$comparisonTokens;
+        $this->nonOperandTokens += Tokens::COMPARISON_TOKENS;
 
         // Trying to compare a negative value; eg. ($var || -1 === $b).
-        $this->nonOperandTokens += Tokens::$booleanOperators;
+        $this->nonOperandTokens += Tokens::BOOLEAN_OPERATORS;
 
         // Trying to assign a negative value; eg. ($var = -1).
-        $this->nonOperandTokens += Tokens::$assignmentTokens;
+        $this->nonOperandTokens += Tokens::ASSIGNMENT_TOKENS;
 
         // Returning/printing a negative value; eg. (return -1).
         $this->nonOperandTokens += [
@@ -91,15 +91,15 @@ class OperatorSpacingSniff implements Sniff
         ];
 
         // Casting a negative value; eg. (array) -$a.
-        $this->nonOperandTokens += Tokens::$castTokens;
+        $this->nonOperandTokens += Tokens::CAST_TOKENS;
 
         /*
             These are the tokens the sniff is looking for.
         */
 
-        $targets   = Tokens::$comparisonTokens;
-        $targets  += Tokens::$operators;
-        $targets  += Tokens::$assignmentTokens;
+        $targets   = Tokens::COMPARISON_TOKENS;
+        $targets  += Tokens::OPERATORS;
+        $targets  += Tokens::ASSIGNMENT_TOKENS;
         $targets[] = T_INLINE_THEN;
         $targets[] = T_INLINE_ELSE;
         $targets[] = T_INSTANCEOF;
@@ -223,7 +223,7 @@ class OperatorSpacingSniff implements Sniff
             }
 
             $phpcsFile->recordMetric($stackPtr, 'Space before operator', 0);
-        } else if (isset(Tokens::$assignmentTokens[$tokens[$stackPtr]['code']]) === false
+        } else if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$stackPtr]['code']]) === false
             || $this->ignoreSpacingBeforeAssignments === false
         ) {
             // Throw an error for assignments only if enabled using the sniff property
@@ -245,7 +245,7 @@ class OperatorSpacingSniff implements Sniff
                     $found,
                 ];
 
-                if (isset(Tokens::$commentTokens[$tokens[$prevNonWhitespace]['code']]) === true) {
+                if (isset(Tokens::COMMENT_TOKENS[$tokens[$prevNonWhitespace]['code']]) === true) {
                     // Throw a non-fixable error if the token on the previous line is a comment token,
                     // as in that case it's not for the sniff to decide where the comment should be moved to
                     // and it would get us into unfixable situations as the new line char is included
@@ -312,7 +312,7 @@ class OperatorSpacingSniff implements Sniff
 
                 $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
                 if ($nextNonWhitespace !== false
-                    && isset(Tokens::$commentTokens[$tokens[$nextNonWhitespace]['code']]) === true
+                    && isset(Tokens::COMMENT_TOKENS[$tokens[$nextNonWhitespace]['code']]) === true
                     && $found === 'newline'
                 ) {
                     // Don't auto-fix when it's a comment or PHPCS annotation on a new line as
@@ -385,7 +385,7 @@ class OperatorSpacingSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_MINUS || $tokens[$stackPtr]['code'] === T_PLUS) {
             // Check minus spacing, but make sure we aren't just assigning
             // a minus value or returning one.
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if (isset($this->nonOperandTokens[$tokens[$prev]['code']]) === true) {
                 return false;
             }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -24,7 +24,7 @@ class ScopeClosingBraceSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$scopeOpeners;
+        return Tokens::SCOPE_OPENERS;
 
     }//end register()
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -24,7 +24,7 @@ class ScopeKeywordSpacingSniff implements Sniff
      */
     public function register()
     {
-        $register   = Tokens::$methodPrefixes;
+        $register   = Tokens::METHOD_MODIFIERS;
         $register[] = T_READONLY;
         return $register;
 
@@ -50,8 +50,8 @@ class ScopeKeywordSpacingSniff implements Sniff
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
         if ($tokens[$stackPtr]['code'] === T_STATIC) {
             if (($nextToken === false || $tokens[$nextToken]['code'] === T_DOUBLE_COLON)
@@ -79,7 +79,7 @@ class ScopeKeywordSpacingSniff implements Sniff
             if ($prevToken !== false
                 && $tokens[$prevToken]['code'] === T_COLON
             ) {
-                $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+                $prevPrevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), null, true);
                 if ($prevPrevToken !== false
                     && $tokens[$prevPrevToken]['code'] === T_CLOSE_PARENTHESIS
                 ) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -43,11 +43,11 @@ class SemicolonSpacingSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         $prevType = $tokens[($stackPtr - 1)]['code'];
-        if (isset(Tokens::$emptyTokens[$prevType]) === false) {
+        if (isset(Tokens::EMPTY_TOKENS[$prevType]) === false) {
             return;
         }
 
-        $nonSpace = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 2), null, true);
+        $nonSpace = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 2), null, true);
 
         // Detect whether this is a semicolon for a condition in a `for()` control structure.
         $forCondition = false;

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -54,7 +54,7 @@ class ClosingTagSniff implements Sniff
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
                 $phpcsFile->fixer->replaceToken($last, $phpcsFile->eolChar);
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($last - 1), null, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($last - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_SEMICOLON
                     && $tokens[$prev]['code'] !== T_CLOSE_CURLY_BRACKET
                     && $tokens[$prev]['code'] !== T_OPEN_TAG

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -83,7 +83,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
                 // this: MyClass::$_variable, so we don't know its scope.
                 $inClass = true;
             } else {
-                $inClass = $phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens);
+                $inClass = $phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS);
             }
 
             if ($inClass === true) {

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -577,7 +577,7 @@ class PHP extends Tokenizer
             }//end if
 
             if ($newStackPtr > 0
-                && isset(Tokens::$emptyTokens[$finalTokens[($newStackPtr - 1)]['code']]) === false
+                && isset(Tokens::EMPTY_TOKENS[$finalTokens[($newStackPtr - 1)]['code']]) === false
             ) {
                 $lastNotEmptyToken = ($newStackPtr - 1);
             }
@@ -622,7 +622,7 @@ class PHP extends Tokenizer
             */
 
             if ($tokenIsArray === true
-                && isset(Tokens::$contextSensitiveKeywords[$token[0]]) === true
+                && isset(Tokens::CONTEXT_SENSITIVE_KEYWORDS[$token[0]]) === true
                 && (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
                 || $finalTokens[$lastNotEmptyToken]['content'] === '&'
                 || $insideConstDeclaration === true)
@@ -644,7 +644,7 @@ class PHP extends Tokenizer
                     ) {
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === false
-                                || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                                || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                             ) {
                                 break;
                             }
@@ -669,7 +669,7 @@ class PHP extends Tokenizer
                                 break;
                             }
 
-                            if (isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true) {
+                            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true) {
                                 continue;
                             }
 
@@ -692,7 +692,7 @@ class PHP extends Tokenizer
                     // Find the next non-empty token.
                     for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                         if (is_array($tokens[$i]) === true
-                            && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                            && isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true
                         ) {
                             continue;
                         }
@@ -710,7 +710,7 @@ class PHP extends Tokenizer
                     $preserveKeyword = true;
 
                     for ($i = ($lastNotEmptyToken - 1); $i >= 0; $i--) {
-                        if (isset(Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
+                        if (isset(Tokens::EMPTY_TOKENS[$finalTokens[$i]['code']]) === true) {
                             continue;
                         }
 
@@ -772,7 +772,7 @@ class PHP extends Tokenizer
             ) {
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === true
-                        && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                        && isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true
                     ) {
                         continue;
                     }
@@ -1217,7 +1217,7 @@ class PHP extends Tokenizer
                 // Get the next non-empty token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1320,7 +1320,7 @@ class PHP extends Tokenizer
                 || ($token[0] === T_NS_SEPARATOR
                 && isset($tokens[($stackPtr + 1)]) === true
                 && is_array($tokens[($stackPtr + 1)]) === true
-                && isset(Tokens::$emptyTokens[$tokens[($stackPtr + 1)][0]]) === false
+                && isset(Tokens::EMPTY_TOKENS[$tokens[($stackPtr + 1)][0]]) === false
                 && preg_match(self::PHP_LABEL_REGEX, $tokens[($stackPtr + 1)][1]) === 1))
             ) {
                 $nameStart = $stackPtr;
@@ -1342,7 +1342,7 @@ class PHP extends Tokenizer
                     $newToken['type'] = 'T_NAME_FULLY_QUALIFIED';
 
                     if (is_array($tokens[($i - 1)]) === true
-                        && isset(Tokens::$emptyTokens[$tokens[($i - 1)][0]]) === false
+                        && isset(Tokens::EMPTY_TOKENS[$tokens[($i - 1)][0]]) === false
                         && preg_match(self::PHP_LABEL_REGEX, $tokens[($i - 1)][1]) === 1
                     ) {
                         // The namespaced name starts with a reserved keyword. Move one token back.
@@ -1362,7 +1362,7 @@ class PHP extends Tokenizer
                 while (isset($tokens[($i + 1)], $tokens[($i + 2)]) === true
                     && is_array($tokens[($i + 1)]) === true && $tokens[($i + 1)][0] === T_NS_SEPARATOR
                     && is_array($tokens[($i + 2)]) === true
-                    && isset(Tokens::$emptyTokens[$tokens[($i + 2)][0]]) === false
+                    && isset(Tokens::EMPTY_TOKENS[$tokens[($i + 2)][0]]) === false
                     && preg_match(self::PHP_LABEL_REGEX, $tokens[($i + 2)][1]) === 1
                 ) {
                     $newToken['content'] .= $tokens[($i + 1)][1].$tokens[($i + 2)][1];
@@ -1446,7 +1446,7 @@ class PHP extends Tokenizer
                 // Get the next non-empty token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1459,7 +1459,7 @@ class PHP extends Tokenizer
                     // Get the previous non-empty token.
                     for ($j = ($stackPtr - 1); $j > 0; $j--) {
                         if (is_array($tokens[$j]) === false
-                            || isset(Tokens::$emptyTokens[$tokens[$j][0]]) === false
+                            || isset(Tokens::EMPTY_TOKENS[$tokens[$j][0]]) === false
                         ) {
                             break;
                         }
@@ -1503,7 +1503,7 @@ class PHP extends Tokenizer
                 // Get the next non-whitespace token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === false
-                        || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                        || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                     ) {
                         break;
                     }
@@ -1533,7 +1533,7 @@ class PHP extends Tokenizer
                             $tokenType = $tokens[$i];
                         }
 
-                        if (isset(Tokens::$emptyTokens[$tokenType]) === true) {
+                        if (isset(Tokens::EMPTY_TOKENS[$tokenType]) === true) {
                             continue;
                         }
 
@@ -1876,7 +1876,7 @@ class PHP extends Tokenizer
             ) {
                 $isMatch = false;
                 for ($x = ($stackPtr + 1); $x < $numTokens; $x++) {
-                    if (isset($tokens[$x][0], Tokens::$emptyTokens[$tokens[$x][0]]) === true) {
+                    if (isset($tokens[$x][0], Tokens::EMPTY_TOKENS[$tokens[$x][0]]) === true) {
                         continue;
                     }
 
@@ -1941,7 +1941,7 @@ class PHP extends Tokenizer
                     }
 
                     if (is_array($tokens[$x]) === false
-                        || isset(Tokens::$emptyTokens[$tokens[$x][0]]) === false
+                        || isset(Tokens::EMPTY_TOKENS[$tokens[$x][0]]) === false
                     ) {
                         // Non-empty, non-comma content.
                         break;
@@ -2014,11 +2014,11 @@ class PHP extends Tokenizer
                         $tokenType = $tokens[$i];
                     }
 
-                    if (isset(Tokens::$emptyTokens[$tokenType]) === true) {
+                    if (isset(Tokens::EMPTY_TOKENS[$tokenType]) === true) {
                         continue;
                     }
 
-                    if (isset(Tokens::$nameTokens[$tokenType]) === true
+                    if (isset(Tokens::NAME_TOKENS[$tokenType]) === true
                         || $tokenType === T_ARRAY
                         || $tokenType === T_NAMESPACE
                         || $tokenType === T_NS_SEPARATOR
@@ -2031,7 +2031,7 @@ class PHP extends Tokenizer
                         && isset($lastRelevantNonEmpty) === false)
                         || ($lastRelevantNonEmpty === T_ARRAY
                         && $tokenType === '(')
-                        || (isset(Tokens::$nameTokens[$lastRelevantNonEmpty]) === true
+                        || (isset(Tokens::NAME_TOKENS[$lastRelevantNonEmpty]) === true
                         && ($tokenType === T_DOUBLE_COLON
                         || $tokenType === '('
                         || $tokenType === ':'))
@@ -2077,7 +2077,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($prevNonEmpty === null
-                        && isset(Tokens::$emptyTokens[$tokenType]) === false
+                        && isset(Tokens::EMPTY_TOKENS[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
                         if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
@@ -2096,7 +2096,7 @@ class PHP extends Tokenizer
 
                     if ($tokenType === T_FUNCTION
                         || $tokenType === T_FN
-                        || isset(Tokens::$methodPrefixes[$tokenType]) === true
+                        || isset(Tokens::METHOD_MODIFIERS[$tokenType]) === true
                         || $tokenType === T_VAR
                         || $tokenType === T_READONLY
                     ) {
@@ -2119,7 +2119,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset(Tokens::$emptyTokens[$tokenType]) === false) {
+                    if (isset(Tokens::EMPTY_TOKENS[$tokenType]) === false) {
                         $lastSeenNonEmpty = $tokenType;
                     }
                 }//end for
@@ -2142,7 +2142,7 @@ class PHP extends Tokenizer
                 && $token[0] !== T_STRING
                 && $token[0] !== T_VARIABLE
                 && $token[0] !== T_DOLLAR
-                && isset(Tokens::$emptyTokens[$token[0]]) === false
+                && isset(Tokens::EMPTY_TOKENS[$token[0]]) === false
             ) {
                 $newToken            = [];
                 $newToken['code']    = T_STRING;
@@ -2202,7 +2202,7 @@ class PHP extends Tokenizer
                 if ($parenthesisCloser !== false) {
                     for ($x = ($parenthesisCloser + 1); $x < $numTokens; $x++) {
                         if (is_array($tokens[$x]) === false
-                            || isset(Tokens::$emptyTokens[$tokens[$x][0]]) === false
+                            || isset(Tokens::EMPTY_TOKENS[$tokens[$x][0]]) === false
                         ) {
                             // Non-empty content.
                             if (is_array($tokens[$x]) === true && $tokens[$x][0] === T_USE) {
@@ -2225,7 +2225,7 @@ class PHP extends Tokenizer
                         // Find the start of the return type.
                         for ($x += 1; $x < $numTokens; $x++) {
                             if (is_array($tokens[$x]) === true
-                                && isset(Tokens::$emptyTokens[$tokens[$x][0]]) === true
+                                && isset(Tokens::EMPTY_TOKENS[$tokens[$x][0]]) === true
                             ) {
                                 // Whitespace or comments before the return type.
                                 continue;
@@ -2269,7 +2269,7 @@ class PHP extends Tokenizer
                 // Find next non-empty token.
                 for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                     if (is_array($tokens[$i]) === true
-                        && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                        && isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true
                     ) {
                         continue;
                     }
@@ -2371,7 +2371,7 @@ class PHP extends Tokenizer
                         // Find the next non-empty token.
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === true
-                                && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                                && isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true
                             ) {
                                 continue;
                             }
@@ -2399,7 +2399,7 @@ class PHP extends Tokenizer
                     } else if ($finalTokens[$lastNotEmptyToken]['content'] === '&') {
                         // Function names for functions declared to return by reference.
                         for ($i = ($lastNotEmptyToken - 1); $i >= 0; $i--) {
-                            if (isset(Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
+                            if (isset(Tokens::EMPTY_TOKENS[$finalTokens[$i]['code']]) === true) {
                                 continue;
                             }
 
@@ -2413,7 +2413,7 @@ class PHP extends Tokenizer
                         // Keywords with special PHPCS token when used as a function call.
                         for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                             if (is_array($tokens[$i]) === true
-                                && isset(Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                                && isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === true
                             ) {
                                 continue;
                             }
@@ -2470,7 +2470,7 @@ class PHP extends Tokenizer
                     // Get the previous non-empty token.
                     for ($i = ($stackPtr - 1); $i > 0; $i--) {
                         if (is_array($tokens[$i]) === false
-                            || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                            || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                         ) {
                             break;
                         }
@@ -2577,7 +2577,7 @@ class PHP extends Tokenizer
                 if ($newToken['code'] === T_ARRAY) {
                     for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
                         if (is_array($tokens[$i]) === false
-                            || isset(Tokens::$emptyTokens[$tokens[$i][0]]) === false
+                            || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                         ) {
                             // Non-empty content.
                             break;
@@ -2671,7 +2671,7 @@ class PHP extends Tokenizer
 
                 if (isset($this->tokens[$i]['scope_opener']) === true) {
                     for ($x = ($i + 1); $x < $numTokens; $x++) {
-                        if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
+                        if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false
                             && $this->tokens[$x]['code'] !== T_BITWISE_AND
                         ) {
                             break;
@@ -2707,7 +2707,7 @@ class PHP extends Tokenizer
                 */
 
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false) {
                         break;
                     }
                 }
@@ -2758,7 +2758,7 @@ class PHP extends Tokenizer
             } else if ($this->tokens[$i]['code'] === T_FN && isset($this->tokens[($i + 1)]) === true) {
                 // Possible arrow function.
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false
                         && $this->tokens[$x]['code'] !== T_BITWISE_AND
                     ) {
                         // Non-whitespace content.
@@ -2770,8 +2770,8 @@ class PHP extends Tokenizer
                     && $this->tokens[$x]['code'] === T_OPEN_PARENTHESIS
                     && isset($this->tokens[$x]['parenthesis_closer']) === true
                 ) {
-                    $ignore  = Tokens::$emptyTokens;
-                    $ignore += Tokens::$nameTokens;
+                    $ignore  = Tokens::EMPTY_TOKENS;
+                    $ignore += Tokens::NAME_TOKENS;
                     $ignore += [
                         T_ARRAY                  => T_ARRAY,
                         T_CALLABLE               => T_CALLABLE,
@@ -2831,7 +2831,7 @@ class PHP extends Tokenizer
                                 }
 
                                 for ($lastNonEmpty = ($scopeCloser - 1); $lastNonEmpty > $arrow; $lastNonEmpty--) {
-                                    if (isset(Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
+                                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$lastNonEmpty]['code']]) === false) {
                                         $scopeCloser = $lastNonEmpty;
                                         break 2;
                                     }
@@ -2846,7 +2846,7 @@ class PHP extends Tokenizer
                                     && $this->tokens[$scopeCloser]['bracket_opener'] < $arrow))
                                 ) {
                                     for ($lastNonEmpty = ($scopeCloser - 1); $lastNonEmpty > $arrow; $lastNonEmpty--) {
-                                        if (isset(Tokens::$emptyTokens[$this->tokens[$lastNonEmpty]['code']]) === false) {
+                                        if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$lastNonEmpty]['code']]) === false) {
                                             $scopeCloser = $lastNonEmpty;
                                             break;
                                         }
@@ -2964,7 +2964,7 @@ class PHP extends Tokenizer
                 // Unless there is a variable or a bracket before this token,
                 // it is the start of an array being defined using the short syntax.
                 $isShortArray = false;
-                $allowed      = Tokens::$nameTokens;
+                $allowed      = Tokens::NAME_TOKENS;
                 $allowed     += [
                     T_CLOSE_SQUARE_BRACKET     => T_CLOSE_SQUARE_BRACKET,
                     T_CLOSE_CURLY_BRACKET      => T_CLOSE_CURLY_BRACKET,
@@ -2975,7 +2975,7 @@ class PHP extends Tokenizer
                     T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
                     T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
                 ];
-                $allowed     += Tokens::$magicConstants;
+                $allowed     += Tokens::MAGIC_CONSTANTS;
 
                 for ($x = ($i - 1); $x >= 0; $x--) {
                     // If we hit a scope opener, the statement has ended
@@ -2986,11 +2986,11 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false) {
                         // Allow for control structures without braces.
                         if (($this->tokens[$x]['code'] === T_CLOSE_PARENTHESIS
                             && isset($this->tokens[$x]['parenthesis_owner']) === true
-                            && isset(Tokens::$scopeOpeners[$this->tokens[$this->tokens[$x]['parenthesis_owner']]['code']]) === true)
+                            && isset(Tokens::SCOPE_OPENERS[$this->tokens[$this->tokens[$x]['parenthesis_owner']]['code']]) === true)
                             || isset($allowed[$this->tokens[$x]['code']]) === false
                         ) {
                             $isShortArray = true;
@@ -3052,7 +3052,7 @@ class PHP extends Tokenizer
                         T_OPEN_SHORT_ARRAY    => T_OPEN_SHORT_ARRAY,
                         T_DOUBLE_ARROW        => T_DOUBLE_ARROW,
                     ];
-                    $searchFor += Tokens::$scopeOpeners;
+                    $searchFor += Tokens::SCOPE_OPENERS;
 
                     for ($x = ($this->tokens[$i]['scope_opener'] + 1); $x < $this->tokens[$i]['scope_closer']; $x++) {
                         if (isset($searchFor[$this->tokens[$x]['code']]) === false) {
@@ -3105,7 +3105,7 @@ class PHP extends Tokenizer
                     All type related tokens will be converted in one go as soon as this section is hit.
                 */
 
-                $allowed  = Tokens::$nameTokens;
+                $allowed  = Tokens::NAME_TOKENS;
                 $allowed += [
                     T_CALLABLE => T_CALLABLE,
                     T_SELF     => T_SELF,
@@ -3120,7 +3120,7 @@ class PHP extends Tokenizer
                 $typeTokenCountAfter = 0;
 
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === true) {
                         continue;
                     }
 
@@ -3198,7 +3198,7 @@ class PHP extends Tokenizer
                 }
 
                 for ($x = ($i - 1); $x >= 0; $x--) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === true) {
                         continue;
                     }
 
@@ -3230,7 +3230,7 @@ class PHP extends Tokenizer
                         } else {
                             // This may still be an arrow function which hasn't been handled yet.
                             for ($y = ($x - 1); $y > 0; $y--) {
-                                if (isset(Tokens::$emptyTokens[$this->tokens[$y]['code']]) === false
+                                if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$y]['code']]) === false
                                     && $this->tokens[$y]['code'] !== T_BITWISE_AND
                                 ) {
                                     // Non-whitespace content.
@@ -3277,7 +3277,7 @@ class PHP extends Tokenizer
                     if ($suspectedType === 'return' && $this->tokens[$x]['code'] === T_COLON) {
                         // Make sure this is the colon for a return type.
                         for ($y = ($x - 1); $y > 0; $y--) {
-                            if (isset(Tokens::$emptyTokens[$this->tokens[$y]['code']]) === false) {
+                            if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$y]['code']]) === false) {
                                 break;
                             }
                         }
@@ -3302,7 +3302,7 @@ class PHP extends Tokenizer
                         // Arrow functions may not have the parenthesis_owner set correctly yet.
                         if (isset($this->tokens[$y]['parenthesis_opener']) === true) {
                             for ($z = ($this->tokens[$y]['parenthesis_opener'] - 1); $z > 0; $z--) {
-                                if (isset(Tokens::$emptyTokens[$this->tokens[$z]['code']]) === false) {
+                                if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$z]['code']]) === false) {
                                     break;
                                 }
                             }
@@ -3321,7 +3321,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($suspectedType === 'property or parameter'
-                        && (isset(Tokens::$scopeModifiers[$this->tokens[$x]['code']]) === true
+                        && (isset(Tokens::SCOPE_MODIFIERS[$this->tokens[$x]['code']]) === true
                         || $this->tokens[$x]['code'] === T_VAR
                         || $this->tokens[$x]['code'] === T_STATIC
                         || $this->tokens[$x]['code'] === T_READONLY
@@ -3353,7 +3353,7 @@ class PHP extends Tokenizer
                         // had additional processing done.
                         if (isset($this->tokens[$last]['parenthesis_opener']) === true) {
                             for ($x = ($this->tokens[$last]['parenthesis_opener'] - 1); $x >= 0; $x--) {
-                                if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                                if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === true) {
                                     continue;
                                 }
 
@@ -3362,7 +3362,7 @@ class PHP extends Tokenizer
 
                             if ($this->tokens[$x]['code'] === T_FN) {
                                 for (--$x; $x >= 0; $x--) {
-                                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true
+                                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === true
                                         || $this->tokens[$x]['code'] === T_BITWISE_AND
                                     ) {
                                         continue;
@@ -3438,7 +3438,7 @@ class PHP extends Tokenizer
                 || $this->tokens[$i]['code'] === T_NULL
             ) {
                 for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                    if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false) {
                         // Non-whitespace content.
                         break;
                     }
@@ -3474,7 +3474,7 @@ class PHP extends Tokenizer
             // opening this case statement and the opener and closer are
             // probably set incorrectly.
             for ($x = ($scopeOpener + 1); $x < $numTokens; $x++) {
-                if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
+                if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === false) {
                     // Non-whitespace content.
                     break;
                 }

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -635,9 +635,9 @@ abstract class Tokenizer
                 Parenthesis mapping.
             */
 
-            if (isset(Tokens::$parenthesisOpeners[$this->tokens[$i]['code']]) === true) {
+            if (isset(Tokens::PARENTHESIS_OPENERS[$this->tokens[$i]['code']]) === true) {
                 // Find the next non-empty token.
-                $find = Tokens::$emptyTokens;
+                $find = Tokens::EMPTY_TOKENS;
                 if ($this->tokens[$i]['code'] === T_FUNCTION) {
                     $find[T_STRING]      = T_STRING;
                     $find[T_BITWISE_AND] = T_BITWISE_AND;
@@ -1234,13 +1234,13 @@ abstract class Tokenizer
                         // Make sure this is actually an opener and not a
                         // string offset (e.g., $var{0}).
                         for ($x = ($i - 1); $x > 0; $x--) {
-                            if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === true) {
+                            if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$x]['code']]) === true) {
                                 continue;
                             } else {
                                 // If the first non-whitespace/comment token looks like this
                                 // brace is a string offset, or this brace is mid-way through
                                 // a new statement, it isn't a scope opener.
-                                $disallowed  = Tokens::$assignmentTokens;
+                                $disallowed  = Tokens::ASSIGNMENT_TOKENS;
                                 $disallowed += [
                                     T_DOLLAR                   => true,
                                     T_VARIABLE                 => true,
@@ -1304,7 +1304,7 @@ abstract class Tokenizer
             } else if ($tokenType === T_OPEN_PARENTHESIS) {
                 if (isset($this->tokens[$i]['parenthesis_owner']) === true) {
                     $owner = $this->tokens[$i]['parenthesis_owner'];
-                    if (isset(Tokens::$scopeOpeners[$this->tokens[$owner]['code']]) === true
+                    if (isset(Tokens::SCOPE_OPENERS[$this->tokens[$owner]['code']]) === true
                         && isset($this->tokens[$i]['parenthesis_closer']) === true
                     ) {
                         // If we get into here, then we opened a parenthesis for
@@ -1341,7 +1341,7 @@ abstract class Tokenizer
                 // token was empty (in which case we'll just confirm there is
                 // more code in this file and not just a big comment).
                 if ($this->tokens[$i]['line'] >= ($startLine + 30)
-                    && isset(Tokens::$emptyTokens[$this->tokens[($i - 1)]['code']]) === false
+                    && isset(Tokens::EMPTY_TOKENS[$this->tokens[($i - 1)]['code']]) === false
                 ) {
                     if ($this->scopeOpeners[$currType]['strict'] === true) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -860,15 +860,6 @@ final class Tokens
     public static $heredocTokens = self::HEREDOC_TOKENS;
 
     /**
-     * Tokens used for "names", be it namespace, OO, function or constant names.
-     *
-     * @deprecated 4.0 Use the Tokens::NAME_TOKENS constant instead.
-     *
-     * @var array<int|string, int|string>
-     */
-    public static $nameTokens = self::NAME_TOKENS;
-
-    /**
      * Tokens that represent the names of called functions.
      *
      * Mostly, these are just strings. But PHP tokenizes some language

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -148,11 +148,449 @@ final class Tokens
 {
 
     /**
+     * Tokens that represent assignments.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const ASSIGNMENT_TOKENS = [
+        T_EQUAL          => T_EQUAL,
+        T_AND_EQUAL      => T_AND_EQUAL,
+        T_OR_EQUAL       => T_OR_EQUAL,
+        T_CONCAT_EQUAL   => T_CONCAT_EQUAL,
+        T_DIV_EQUAL      => T_DIV_EQUAL,
+        T_MINUS_EQUAL    => T_MINUS_EQUAL,
+        T_POW_EQUAL      => T_POW_EQUAL,
+        T_MOD_EQUAL      => T_MOD_EQUAL,
+        T_MUL_EQUAL      => T_MUL_EQUAL,
+        T_PLUS_EQUAL     => T_PLUS_EQUAL,
+        T_XOR_EQUAL      => T_XOR_EQUAL,
+        T_DOUBLE_ARROW   => T_DOUBLE_ARROW,
+        T_SL_EQUAL       => T_SL_EQUAL,
+        T_SR_EQUAL       => T_SR_EQUAL,
+        T_COALESCE_EQUAL => T_COALESCE_EQUAL,
+    ];
+
+    /**
+     * Tokens that represent equality comparisons.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const EQUALITY_TOKENS = [
+        T_IS_EQUAL            => T_IS_EQUAL,
+        T_IS_NOT_EQUAL        => T_IS_NOT_EQUAL,
+        T_IS_IDENTICAL        => T_IS_IDENTICAL,
+        T_IS_NOT_IDENTICAL    => T_IS_NOT_IDENTICAL,
+        T_IS_SMALLER_OR_EQUAL => T_IS_SMALLER_OR_EQUAL,
+        T_IS_GREATER_OR_EQUAL => T_IS_GREATER_OR_EQUAL,
+    ];
+
+    /**
+     * Tokens that represent comparison operator.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const COMPARISON_TOKENS = (self::EQUALITY_TOKENS + [
+        T_LESS_THAN    => T_LESS_THAN,
+        T_GREATER_THAN => T_GREATER_THAN,
+        T_SPACESHIP    => T_SPACESHIP,
+        T_COALESCE     => T_COALESCE,
+    ]);
+
+    /**
+     * Tokens that represent arithmetic operators.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const ARITHMETIC_TOKENS = [
+        T_PLUS     => T_PLUS,
+        T_MINUS    => T_MINUS,
+        T_MULTIPLY => T_MULTIPLY,
+        T_DIVIDE   => T_DIVIDE,
+        T_MODULUS  => T_MODULUS,
+        T_POW      => T_POW,
+    ];
+
+    /**
+     * Tokens that perform operations.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const OPERATORS = (self::ARITHMETIC_TOKENS + [
+        T_SPACESHIP   => T_SPACESHIP,
+        T_COALESCE    => T_COALESCE,
+        T_BITWISE_AND => T_BITWISE_AND,
+        T_BITWISE_OR  => T_BITWISE_OR,
+        T_BITWISE_XOR => T_BITWISE_XOR,
+        T_SL          => T_SL,
+        T_SR          => T_SR,
+    ]);
+
+    /**
+     * Tokens that perform boolean operations.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const BOOLEAN_OPERATORS = [
+        T_BOOLEAN_AND => T_BOOLEAN_AND,
+        T_BOOLEAN_OR  => T_BOOLEAN_OR,
+        T_LOGICAL_AND => T_LOGICAL_AND,
+        T_LOGICAL_OR  => T_LOGICAL_OR,
+        T_LOGICAL_XOR => T_LOGICAL_XOR,
+    ];
+
+    /**
+     * Tokens that represent casting.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const CAST_TOKENS = [
+        T_INT_CAST    => T_INT_CAST,
+        T_STRING_CAST => T_STRING_CAST,
+        T_DOUBLE_CAST => T_DOUBLE_CAST,
+        T_ARRAY_CAST  => T_ARRAY_CAST,
+        T_BOOL_CAST   => T_BOOL_CAST,
+        T_OBJECT_CAST => T_OBJECT_CAST,
+        T_UNSET_CAST  => T_UNSET_CAST,
+        T_BINARY_CAST => T_BINARY_CAST,
+    ];
+
+    /**
+     * Token types that open parenthesis.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const PARENTHESIS_OPENERS = [
+        T_ARRAY      => T_ARRAY,
+        T_LIST       => T_LIST,
+        T_FUNCTION   => T_FUNCTION,
+        T_CLOSURE    => T_CLOSURE,
+        T_USE        => T_USE,
+        T_ANON_CLASS => T_ANON_CLASS,
+        T_WHILE      => T_WHILE,
+        T_FOR        => T_FOR,
+        T_FOREACH    => T_FOREACH,
+        T_SWITCH     => T_SWITCH,
+        T_IF         => T_IF,
+        T_ELSEIF     => T_ELSEIF,
+        T_CATCH      => T_CATCH,
+        T_DECLARE    => T_DECLARE,
+        T_MATCH      => T_MATCH,
+        T_ISSET      => T_ISSET,
+        T_EMPTY      => T_EMPTY,
+        T_UNSET      => T_UNSET,
+        T_EVAL       => T_EVAL,
+        T_EXIT       => T_EXIT,
+    ];
+
+    /**
+     * Tokens that are allowed to open scopes.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const SCOPE_OPENERS = [
+        T_CLASS      => T_CLASS,
+        T_ANON_CLASS => T_ANON_CLASS,
+        T_INTERFACE  => T_INTERFACE,
+        T_TRAIT      => T_TRAIT,
+        T_ENUM       => T_ENUM,
+        T_NAMESPACE  => T_NAMESPACE,
+        T_FUNCTION   => T_FUNCTION,
+        T_CLOSURE    => T_CLOSURE,
+        T_IF         => T_IF,
+        T_SWITCH     => T_SWITCH,
+        T_CASE       => T_CASE,
+        T_DECLARE    => T_DECLARE,
+        T_DEFAULT    => T_DEFAULT,
+        T_WHILE      => T_WHILE,
+        T_ELSE       => T_ELSE,
+        T_ELSEIF     => T_ELSEIF,
+        T_FOR        => T_FOR,
+        T_FOREACH    => T_FOREACH,
+        T_DO         => T_DO,
+        T_TRY        => T_TRY,
+        T_CATCH      => T_CATCH,
+        T_FINALLY    => T_FINALLY,
+        T_USE        => T_USE,
+        T_MATCH      => T_MATCH,
+    ];
+
+    /**
+     * Tokens that represent scope modifiers.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const SCOPE_MODIFIERS = [
+        T_PRIVATE   => T_PRIVATE,
+        T_PUBLIC    => T_PUBLIC,
+        T_PROTECTED => T_PROTECTED,
+    ];
+
+    /**
+     * Tokens that can prefix a method name
+     *
+     * @var array<int|string, int|string>
+     */
+    public const METHOD_MODIFIERS = (self::SCOPE_MODIFIERS + [
+        T_ABSTRACT => T_ABSTRACT,
+        T_STATIC   => T_STATIC,
+        T_FINAL    => T_FINAL,
+    ]);
+
+    /**
+     * Tokens that open code blocks.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const BLOCK_OPENERS = [
+        T_OPEN_CURLY_BRACKET  => T_OPEN_CURLY_BRACKET,
+        T_OPEN_SQUARE_BRACKET => T_OPEN_SQUARE_BRACKET,
+        T_OPEN_PARENTHESIS    => T_OPEN_PARENTHESIS,
+    ];
+
+    /**
+     * Tokens that represent brackets and parenthesis.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const BRACKET_TOKENS = (self::BLOCK_OPENERS + [
+        T_CLOSE_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
+        T_CLOSE_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
+        T_CLOSE_PARENTHESIS    => T_CLOSE_PARENTHESIS,
+    ]);
+
+    /**
+     * Tokens that don't represent code.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const EMPTY_TOKENS = (self::COMMENT_TOKENS + [T_WHITESPACE => T_WHITESPACE]);
+
+    /**
+     * Tokens that are comments.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const COMMENT_TOKENS = (self::PHPCS_ANNOTATION_TOKENS + [
+        T_COMMENT                => T_COMMENT,
+        T_DOC_COMMENT            => T_DOC_COMMENT,
+        T_DOC_COMMENT_STAR       => T_DOC_COMMENT_STAR,
+        T_DOC_COMMENT_WHITESPACE => T_DOC_COMMENT_WHITESPACE,
+        T_DOC_COMMENT_TAG        => T_DOC_COMMENT_TAG,
+        T_DOC_COMMENT_OPEN_TAG   => T_DOC_COMMENT_OPEN_TAG,
+        T_DOC_COMMENT_CLOSE_TAG  => T_DOC_COMMENT_CLOSE_TAG,
+        T_DOC_COMMENT_STRING     => T_DOC_COMMENT_STRING,
+    ]);
+
+    /**
+     * Tokens that are comments containing PHPCS instructions.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const PHPCS_ANNOTATION_TOKENS = [
+        T_PHPCS_ENABLE      => T_PHPCS_ENABLE,
+        T_PHPCS_DISABLE     => T_PHPCS_DISABLE,
+        T_PHPCS_SET         => T_PHPCS_SET,
+        T_PHPCS_IGNORE      => T_PHPCS_IGNORE,
+        T_PHPCS_IGNORE_FILE => T_PHPCS_IGNORE_FILE,
+    ];
+
+    /**
+     * Tokens that represent strings.
+     *
+     * Note that T_STRINGS are NOT represented in this list.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const STRING_TOKENS = [
+        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+        T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
+    ];
+
+    /**
+     * Tokens that represent text strings.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const TEXT_STRING_TOKENS = (self::STRING_TOKENS + [
+        T_INLINE_HTML => T_INLINE_HTML,
+        T_HEREDOC     => T_HEREDOC,
+        T_NOWDOC      => T_NOWDOC,
+    ]);
+
+    /**
+     * Tokens that make up a heredoc string.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const HEREDOC_TOKENS = [
+        T_START_HEREDOC => T_START_HEREDOC,
+        T_END_HEREDOC   => T_END_HEREDOC,
+        T_HEREDOC       => T_HEREDOC,
+        T_START_NOWDOC  => T_START_NOWDOC,
+        T_END_NOWDOC    => T_END_NOWDOC,
+        T_NOWDOC        => T_NOWDOC,
+    ];
+
+    /**
+     * Tokens that include files.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const INCLUDE_TOKENS = [
+        T_REQUIRE_ONCE => T_REQUIRE_ONCE,
+        T_REQUIRE      => T_REQUIRE,
+        T_INCLUDE_ONCE => T_INCLUDE_ONCE,
+        T_INCLUDE      => T_INCLUDE,
+    ];
+
+    /**
+     * Tokens used for "names", be it namespace, OO, function or constant names.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const NAME_TOKENS = [
+        T_STRING               => T_STRING,
+        T_NAME_QUALIFIED       => T_NAME_QUALIFIED,
+        T_NAME_FULLY_QUALIFIED => T_NAME_FULLY_QUALIFIED,
+        T_NAME_RELATIVE        => T_NAME_RELATIVE,
+    ];
+
+    /**
+     * Tokens that represent the names of called functions.
+     *
+     * Mostly, these are just strings. But PHP tokenizes some language
+     * constructs and functions using their own tokens.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const FUNCTION_NAME_TOKENS = (self::INCLUDE_TOKENS + self::NAME_TOKENS + [
+        T_EVAL   => T_EVAL,
+        T_EXIT   => T_EXIT,
+        T_ISSET  => T_ISSET,
+        T_UNSET  => T_UNSET,
+        T_EMPTY  => T_EMPTY,
+        T_SELF   => T_SELF,
+        T_PARENT => T_PARENT,
+        T_STATIC => T_STATIC,
+    ]);
+
+    /**
+     * Tokens that open class and object scopes.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const OO_SCOPE_TOKENS = [
+        T_CLASS      => T_CLASS,
+        T_ANON_CLASS => T_ANON_CLASS,
+        T_INTERFACE  => T_INTERFACE,
+        T_TRAIT      => T_TRAIT,
+        T_ENUM       => T_ENUM,
+    ];
+
+    /**
+     * Tokens representing PHP magic constants.
+     *
+     * @var array <int|string> => <int|string>
+     *
+     * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
+     */
+    public const MAGIC_CONSTANTS = [
+        T_CLASS_C  => T_CLASS_C,
+        T_DIR      => T_DIR,
+        T_FILE     => T_FILE,
+        T_FUNC_C   => T_FUNC_C,
+        T_LINE     => T_LINE,
+        T_METHOD_C => T_METHOD_C,
+        T_NS_C     => T_NS_C,
+        T_TRAIT_C  => T_TRAIT_C,
+    ];
+
+    /**
+     * Tokens representing context sensitive keywords in PHP.
+     *
+     * @var array<int|string, int|string>
+     *
+     * https://wiki.php.net/rfc/context_sensitive_lexer
+     */
+    public const CONTEXT_SENSITIVE_KEYWORDS = [
+        T_ABSTRACT     => T_ABSTRACT,
+        T_ARRAY        => T_ARRAY,
+        T_AS           => T_AS,
+        T_BREAK        => T_BREAK,
+        T_CALLABLE     => T_CALLABLE,
+        T_CASE         => T_CASE,
+        T_CATCH        => T_CATCH,
+        T_CLASS        => T_CLASS,
+        T_CLONE        => T_CLONE,
+        T_CONST        => T_CONST,
+        T_CONTINUE     => T_CONTINUE,
+        T_DECLARE      => T_DECLARE,
+        T_DEFAULT      => T_DEFAULT,
+        T_DO           => T_DO,
+        T_ECHO         => T_ECHO,
+        T_ELSE         => T_ELSE,
+        T_ELSEIF       => T_ELSEIF,
+        T_EMPTY        => T_EMPTY,
+        T_ENDDECLARE   => T_ENDDECLARE,
+        T_ENDFOR       => T_ENDFOR,
+        T_ENDFOREACH   => T_ENDFOREACH,
+        T_ENDIF        => T_ENDIF,
+        T_ENDSWITCH    => T_ENDSWITCH,
+        T_ENDWHILE     => T_ENDWHILE,
+        T_ENUM         => T_ENUM,
+        T_EVAL         => T_EVAL,
+        T_EXIT         => T_EXIT,
+        T_EXTENDS      => T_EXTENDS,
+        T_FINAL        => T_FINAL,
+        T_FINALLY      => T_FINALLY,
+        T_FN           => T_FN,
+        T_FOR          => T_FOR,
+        T_FOREACH      => T_FOREACH,
+        T_FUNCTION     => T_FUNCTION,
+        T_GLOBAL       => T_GLOBAL,
+        T_GOTO         => T_GOTO,
+        T_IF           => T_IF,
+        T_IMPLEMENTS   => T_IMPLEMENTS,
+        T_INCLUDE      => T_INCLUDE,
+        T_INCLUDE_ONCE => T_INCLUDE_ONCE,
+        T_INSTANCEOF   => T_INSTANCEOF,
+        T_INSTEADOF    => T_INSTEADOF,
+        T_INTERFACE    => T_INTERFACE,
+        T_ISSET        => T_ISSET,
+        T_LIST         => T_LIST,
+        T_LOGICAL_AND  => T_LOGICAL_AND,
+        T_LOGICAL_OR   => T_LOGICAL_OR,
+        T_LOGICAL_XOR  => T_LOGICAL_XOR,
+        T_MATCH        => T_MATCH,
+        T_NAMESPACE    => T_NAMESPACE,
+        T_NEW          => T_NEW,
+        T_PRINT        => T_PRINT,
+        T_PRIVATE      => T_PRIVATE,
+        T_PROTECTED    => T_PROTECTED,
+        T_PUBLIC       => T_PUBLIC,
+        T_READONLY     => T_READONLY,
+        T_REQUIRE      => T_REQUIRE,
+        T_REQUIRE_ONCE => T_REQUIRE_ONCE,
+        T_RETURN       => T_RETURN,
+        T_STATIC       => T_STATIC,
+        T_SWITCH       => T_SWITCH,
+        T_THROW        => T_THROW,
+        T_TRAIT        => T_TRAIT,
+        T_TRY          => T_TRY,
+        T_UNSET        => T_UNSET,
+        T_USE          => T_USE,
+        T_VAR          => T_VAR,
+        T_WHILE        => T_WHILE,
+        T_YIELD        => T_YIELD,
+        T_YIELD_FROM   => T_YIELD_FROM,
+    ];
+
+    /**
      * The token weightings.
      *
      * @var array<int|string, int>
      */
-    public static $weightings = [
+    private const WEIGHTINGS = [
         T_CLASS               => 1000,
         T_INTERFACE           => 1000,
         T_TRAIT               => 1000,
@@ -231,352 +669,204 @@ final class Tokens
     ];
 
     /**
+     * The token weightings.
+     *
+     * @deprecated 4.0 Use the Tokens::getHighestWeightedToken() method instead.
+     *
+     * @var array<int|string, int>
+     */
+    public static $weightings = self::WEIGHTINGS;
+
+    /**
      * Tokens that represent assignments.
+     *
+     * @deprecated 4.0 Use the Tokens::ASSIGNMENT_TOKENS constant instead.
      *
      * @var array<int|string, int|string>
      */
-    public static $assignmentTokens = [
-        T_EQUAL          => T_EQUAL,
-        T_AND_EQUAL      => T_AND_EQUAL,
-        T_OR_EQUAL       => T_OR_EQUAL,
-        T_CONCAT_EQUAL   => T_CONCAT_EQUAL,
-        T_DIV_EQUAL      => T_DIV_EQUAL,
-        T_MINUS_EQUAL    => T_MINUS_EQUAL,
-        T_POW_EQUAL      => T_POW_EQUAL,
-        T_MOD_EQUAL      => T_MOD_EQUAL,
-        T_MUL_EQUAL      => T_MUL_EQUAL,
-        T_PLUS_EQUAL     => T_PLUS_EQUAL,
-        T_XOR_EQUAL      => T_XOR_EQUAL,
-        T_DOUBLE_ARROW   => T_DOUBLE_ARROW,
-        T_SL_EQUAL       => T_SL_EQUAL,
-        T_SR_EQUAL       => T_SR_EQUAL,
-        T_COALESCE_EQUAL => T_COALESCE_EQUAL,
-    ];
+    public static $assignmentTokens = self::ASSIGNMENT_TOKENS;
 
     /**
      * Tokens that represent equality comparisons.
      *
+     * @deprecated 4.0 Use the Tokens::EQUALITY_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $equalityTokens = [
-        T_IS_EQUAL            => T_IS_EQUAL,
-        T_IS_NOT_EQUAL        => T_IS_NOT_EQUAL,
-        T_IS_IDENTICAL        => T_IS_IDENTICAL,
-        T_IS_NOT_IDENTICAL    => T_IS_NOT_IDENTICAL,
-        T_IS_SMALLER_OR_EQUAL => T_IS_SMALLER_OR_EQUAL,
-        T_IS_GREATER_OR_EQUAL => T_IS_GREATER_OR_EQUAL,
-    ];
+    public static $equalityTokens = self::EQUALITY_TOKENS;
 
     /**
      * Tokens that represent comparison operator.
      *
+     * @deprecated 4.0 Use the Tokens::COMPARISON_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $comparisonTokens = [
-        T_IS_EQUAL            => T_IS_EQUAL,
-        T_IS_IDENTICAL        => T_IS_IDENTICAL,
-        T_IS_NOT_EQUAL        => T_IS_NOT_EQUAL,
-        T_IS_NOT_IDENTICAL    => T_IS_NOT_IDENTICAL,
-        T_LESS_THAN           => T_LESS_THAN,
-        T_GREATER_THAN        => T_GREATER_THAN,
-        T_IS_SMALLER_OR_EQUAL => T_IS_SMALLER_OR_EQUAL,
-        T_IS_GREATER_OR_EQUAL => T_IS_GREATER_OR_EQUAL,
-        T_SPACESHIP           => T_SPACESHIP,
-        T_COALESCE            => T_COALESCE,
-    ];
+    public static $comparisonTokens = self::COMPARISON_TOKENS;
 
     /**
      * Tokens that represent arithmetic operators.
      *
+     * @deprecated 4.0 Use the Tokens::ARITHMETIC_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $arithmeticTokens = [
-        T_PLUS     => T_PLUS,
-        T_MINUS    => T_MINUS,
-        T_MULTIPLY => T_MULTIPLY,
-        T_DIVIDE   => T_DIVIDE,
-        T_MODULUS  => T_MODULUS,
-        T_POW      => T_POW,
-    ];
+    public static $arithmeticTokens = self::ARITHMETIC_TOKENS;
 
     /**
      * Tokens that perform operations.
      *
+     * @deprecated 4.0 Use the Tokens::OPERATORS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $operators = [
-        T_MINUS       => T_MINUS,
-        T_PLUS        => T_PLUS,
-        T_MULTIPLY    => T_MULTIPLY,
-        T_DIVIDE      => T_DIVIDE,
-        T_MODULUS     => T_MODULUS,
-        T_POW         => T_POW,
-        T_SPACESHIP   => T_SPACESHIP,
-        T_COALESCE    => T_COALESCE,
-        T_BITWISE_AND => T_BITWISE_AND,
-        T_BITWISE_OR  => T_BITWISE_OR,
-        T_BITWISE_XOR => T_BITWISE_XOR,
-        T_SL          => T_SL,
-        T_SR          => T_SR,
-    ];
+    public static $operators = self::OPERATORS;
 
     /**
      * Tokens that perform boolean operations.
      *
+     * @deprecated 4.0 Use the Tokens::BOOLEAN_OPERATORS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $booleanOperators = [
-        T_BOOLEAN_AND => T_BOOLEAN_AND,
-        T_BOOLEAN_OR  => T_BOOLEAN_OR,
-        T_LOGICAL_AND => T_LOGICAL_AND,
-        T_LOGICAL_OR  => T_LOGICAL_OR,
-        T_LOGICAL_XOR => T_LOGICAL_XOR,
-    ];
+    public static $booleanOperators = self::BOOLEAN_OPERATORS;
 
     /**
      * Tokens that represent casting.
      *
+     * @deprecated 4.0 Use the Tokens::CAST_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $castTokens = [
-        T_INT_CAST    => T_INT_CAST,
-        T_STRING_CAST => T_STRING_CAST,
-        T_DOUBLE_CAST => T_DOUBLE_CAST,
-        T_ARRAY_CAST  => T_ARRAY_CAST,
-        T_BOOL_CAST   => T_BOOL_CAST,
-        T_OBJECT_CAST => T_OBJECT_CAST,
-        T_UNSET_CAST  => T_UNSET_CAST,
-        T_BINARY_CAST => T_BINARY_CAST,
-    ];
+    public static $castTokens = self::CAST_TOKENS;
 
     /**
      * Token types that open parenthesis.
      *
+     * @deprecated 4.0 Use the Tokens::PARENTHESIS_OPENERS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $parenthesisOpeners = [
-        T_ARRAY      => T_ARRAY,
-        T_LIST       => T_LIST,
-        T_FUNCTION   => T_FUNCTION,
-        T_CLOSURE    => T_CLOSURE,
-        T_USE        => T_USE,
-        T_ANON_CLASS => T_ANON_CLASS,
-        T_WHILE      => T_WHILE,
-        T_FOR        => T_FOR,
-        T_FOREACH    => T_FOREACH,
-        T_SWITCH     => T_SWITCH,
-        T_IF         => T_IF,
-        T_ELSEIF     => T_ELSEIF,
-        T_CATCH      => T_CATCH,
-        T_DECLARE    => T_DECLARE,
-        T_MATCH      => T_MATCH,
-        T_ISSET      => T_ISSET,
-        T_EMPTY      => T_EMPTY,
-        T_UNSET      => T_UNSET,
-        T_EVAL       => T_EVAL,
-        T_EXIT       => T_EXIT,
-    ];
+    public static $parenthesisOpeners = self::PARENTHESIS_OPENERS;
 
     /**
      * Tokens that are allowed to open scopes.
      *
+     * @deprecated 4.0 Use the Tokens::SCOPE_OPENERS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $scopeOpeners = [
-        T_CLASS      => T_CLASS,
-        T_ANON_CLASS => T_ANON_CLASS,
-        T_INTERFACE  => T_INTERFACE,
-        T_TRAIT      => T_TRAIT,
-        T_ENUM       => T_ENUM,
-        T_NAMESPACE  => T_NAMESPACE,
-        T_FUNCTION   => T_FUNCTION,
-        T_CLOSURE    => T_CLOSURE,
-        T_IF         => T_IF,
-        T_SWITCH     => T_SWITCH,
-        T_CASE       => T_CASE,
-        T_DECLARE    => T_DECLARE,
-        T_DEFAULT    => T_DEFAULT,
-        T_WHILE      => T_WHILE,
-        T_ELSE       => T_ELSE,
-        T_ELSEIF     => T_ELSEIF,
-        T_FOR        => T_FOR,
-        T_FOREACH    => T_FOREACH,
-        T_DO         => T_DO,
-        T_TRY        => T_TRY,
-        T_CATCH      => T_CATCH,
-        T_FINALLY    => T_FINALLY,
-        T_USE        => T_USE,
-        T_MATCH      => T_MATCH,
-    ];
+    public static $scopeOpeners = self::SCOPE_OPENERS;
 
     /**
      * Tokens that represent scope modifiers.
      *
+     * @deprecated 4.0 Use the Tokens::SCOPE_MODIFIERS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $scopeModifiers = [
-        T_PRIVATE   => T_PRIVATE,
-        T_PUBLIC    => T_PUBLIC,
-        T_PROTECTED => T_PROTECTED,
-    ];
+    public static $scopeModifiers = self::SCOPE_MODIFIERS;
 
     /**
      * Tokens that can prefix a method name
      *
+     * @deprecated 4.0 Use the Tokens::METHOD_MODIFIERS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $methodPrefixes = [
-        T_PRIVATE   => T_PRIVATE,
-        T_PUBLIC    => T_PUBLIC,
-        T_PROTECTED => T_PROTECTED,
-        T_ABSTRACT  => T_ABSTRACT,
-        T_STATIC    => T_STATIC,
-        T_FINAL     => T_FINAL,
-    ];
+    public static $methodPrefixes = self::METHOD_MODIFIERS;
 
     /**
      * Tokens that open code blocks.
      *
+     * @deprecated 4.0 Use the Tokens::BLOCK_OPENERS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $blockOpeners = [
-        T_OPEN_CURLY_BRACKET  => T_OPEN_CURLY_BRACKET,
-        T_OPEN_SQUARE_BRACKET => T_OPEN_SQUARE_BRACKET,
-        T_OPEN_PARENTHESIS    => T_OPEN_PARENTHESIS,
-    ];
+    public static $blockOpeners = self::BLOCK_OPENERS;
 
     /**
      * Tokens that don't represent code.
      *
+     * @deprecated 4.0 Use the Tokens::EMPTY_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $emptyTokens = [
-        T_WHITESPACE             => T_WHITESPACE,
-        T_COMMENT                => T_COMMENT,
-        T_DOC_COMMENT            => T_DOC_COMMENT,
-        T_DOC_COMMENT_STAR       => T_DOC_COMMENT_STAR,
-        T_DOC_COMMENT_WHITESPACE => T_DOC_COMMENT_WHITESPACE,
-        T_DOC_COMMENT_TAG        => T_DOC_COMMENT_TAG,
-        T_DOC_COMMENT_OPEN_TAG   => T_DOC_COMMENT_OPEN_TAG,
-        T_DOC_COMMENT_CLOSE_TAG  => T_DOC_COMMENT_CLOSE_TAG,
-        T_DOC_COMMENT_STRING     => T_DOC_COMMENT_STRING,
-        T_PHPCS_ENABLE           => T_PHPCS_ENABLE,
-        T_PHPCS_DISABLE          => T_PHPCS_DISABLE,
-        T_PHPCS_SET              => T_PHPCS_SET,
-        T_PHPCS_IGNORE           => T_PHPCS_IGNORE,
-        T_PHPCS_IGNORE_FILE      => T_PHPCS_IGNORE_FILE,
-    ];
+    public static $emptyTokens = self::EMPTY_TOKENS;
 
     /**
      * Tokens that are comments.
      *
+     * @deprecated 4.0 Use the Tokens::COMMENT_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $commentTokens = [
-        T_COMMENT                => T_COMMENT,
-        T_DOC_COMMENT            => T_DOC_COMMENT,
-        T_DOC_COMMENT_STAR       => T_DOC_COMMENT_STAR,
-        T_DOC_COMMENT_WHITESPACE => T_DOC_COMMENT_WHITESPACE,
-        T_DOC_COMMENT_TAG        => T_DOC_COMMENT_TAG,
-        T_DOC_COMMENT_OPEN_TAG   => T_DOC_COMMENT_OPEN_TAG,
-        T_DOC_COMMENT_CLOSE_TAG  => T_DOC_COMMENT_CLOSE_TAG,
-        T_DOC_COMMENT_STRING     => T_DOC_COMMENT_STRING,
-        T_PHPCS_ENABLE           => T_PHPCS_ENABLE,
-        T_PHPCS_DISABLE          => T_PHPCS_DISABLE,
-        T_PHPCS_SET              => T_PHPCS_SET,
-        T_PHPCS_IGNORE           => T_PHPCS_IGNORE,
-        T_PHPCS_IGNORE_FILE      => T_PHPCS_IGNORE_FILE,
-    ];
+    public static $commentTokens = self::COMMENT_TOKENS;
 
     /**
      * Tokens that are comments containing PHPCS instructions.
      *
+     * @deprecated 4.0 Use the Tokens::PHPCS_ANNOTATION_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $phpcsCommentTokens = [
-        T_PHPCS_ENABLE      => T_PHPCS_ENABLE,
-        T_PHPCS_DISABLE     => T_PHPCS_DISABLE,
-        T_PHPCS_SET         => T_PHPCS_SET,
-        T_PHPCS_IGNORE      => T_PHPCS_IGNORE,
-        T_PHPCS_IGNORE_FILE => T_PHPCS_IGNORE_FILE,
-    ];
+    public static $phpcsCommentTokens = self::PHPCS_ANNOTATION_TOKENS;
 
     /**
      * Tokens that represent strings.
      *
      * Note that T_STRINGS are NOT represented in this list.
      *
+     * @deprecated 4.0 Use the Tokens::STRING_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $stringTokens = [
-        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
-        T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
-    ];
+    public static $stringTokens = self::STRING_TOKENS;
 
     /**
      * Tokens that represent text strings.
      *
+     * @deprecated 4.0 Use the Tokens::TEXT_STRINGS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $textStringTokens = [
-        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
-        T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
-        T_INLINE_HTML              => T_INLINE_HTML,
-        T_HEREDOC                  => T_HEREDOC,
-        T_NOWDOC                   => T_NOWDOC,
-    ];
+    public static $textStringTokens = self::TEXT_STRING_TOKENS;
 
     /**
      * Tokens that represent brackets and parenthesis.
      *
+     * @deprecated 4.0 Use the Tokens::BRACKET_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $bracketTokens = [
-        T_OPEN_CURLY_BRACKET   => T_OPEN_CURLY_BRACKET,
-        T_CLOSE_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
-        T_OPEN_SQUARE_BRACKET  => T_OPEN_SQUARE_BRACKET,
-        T_CLOSE_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
-        T_OPEN_PARENTHESIS     => T_OPEN_PARENTHESIS,
-        T_CLOSE_PARENTHESIS    => T_CLOSE_PARENTHESIS,
-    ];
+    public static $bracketTokens = self::BRACKET_TOKENS;
 
     /**
      * Tokens that include files.
      *
+     * @deprecated 4.0 Use the Tokens::INCLUDE_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $includeTokens = [
-        T_REQUIRE_ONCE => T_REQUIRE_ONCE,
-        T_REQUIRE      => T_REQUIRE,
-        T_INCLUDE_ONCE => T_INCLUDE_ONCE,
-        T_INCLUDE      => T_INCLUDE,
-    ];
+    public static $includeTokens = self::INCLUDE_TOKENS;
 
     /**
      * Tokens that make up a heredoc string.
      *
+     * @deprecated 4.0 Use the Tokens::HEREDOC_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $heredocTokens = [
-        T_START_HEREDOC => T_START_HEREDOC,
-        T_END_HEREDOC   => T_END_HEREDOC,
-        T_HEREDOC       => T_HEREDOC,
-        T_START_NOWDOC  => T_START_NOWDOC,
-        T_END_NOWDOC    => T_END_NOWDOC,
-        T_NOWDOC        => T_NOWDOC,
-    ];
+    public static $heredocTokens = self::HEREDOC_TOKENS;
 
     /**
      * Tokens used for "names", be it namespace, OO, function or constant names.
      *
+     * @deprecated 4.0 Use the Tokens::NAME_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $nameTokens = [
-        T_STRING               => T_STRING,
-        T_NAME_QUALIFIED       => T_NAME_QUALIFIED,
-        T_NAME_FULLY_QUALIFIED => T_NAME_FULLY_QUALIFIED,
-        T_NAME_RELATIVE        => T_NAME_RELATIVE,
-    ];
+    public static $nameTokens = self::NAME_TOKENS;
 
     /**
      * Tokens that represent the names of called functions.
@@ -584,137 +874,42 @@ final class Tokens
      * Mostly, these are just strings. But PHP tokenizes some language
      * constructs and functions using their own tokens.
      *
+     * @deprecated 4.0 Use the Tokens::FUNCTION_NAME_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $functionNameTokens = [
-        T_STRING               => T_STRING,
-        T_NAME_QUALIFIED       => T_NAME_QUALIFIED,
-        T_NAME_FULLY_QUALIFIED => T_NAME_FULLY_QUALIFIED,
-        T_NAME_RELATIVE        => T_NAME_RELATIVE,
-        T_EVAL                 => T_EVAL,
-        T_EXIT                 => T_EXIT,
-        T_INCLUDE              => T_INCLUDE,
-        T_INCLUDE_ONCE         => T_INCLUDE_ONCE,
-        T_REQUIRE              => T_REQUIRE,
-        T_REQUIRE_ONCE         => T_REQUIRE_ONCE,
-        T_ISSET                => T_ISSET,
-        T_UNSET                => T_UNSET,
-        T_EMPTY                => T_EMPTY,
-        T_SELF                 => T_SELF,
-        T_PARENT               => T_PARENT,
-        T_STATIC               => T_STATIC,
-    ];
+    public static $functionNameTokens = self::FUNCTION_NAME_TOKENS;
 
     /**
      * Tokens that open class and object scopes.
      *
+     * @deprecated 4.0 Use the Tokens::OO_SCOPE_TOKENS constant instead.
+     *
      * @var array<int|string, int|string>
      */
-    public static $ooScopeTokens = [
-        T_CLASS      => T_CLASS,
-        T_ANON_CLASS => T_ANON_CLASS,
-        T_INTERFACE  => T_INTERFACE,
-        T_TRAIT      => T_TRAIT,
-        T_ENUM       => T_ENUM,
-    ];
+    public static $ooScopeTokens = self::OO_SCOPE_TOKENS;
 
     /**
      * Tokens representing PHP magic constants.
+     *
+     * @deprecated 4.0 Use the Tokens::MAGIC_CONSTANTS constant instead.
      *
      * @var array <int|string> => <int|string>
      *
      * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
      */
-    public static $magicConstants = [
-        T_CLASS_C  => T_CLASS_C,
-        T_DIR      => T_DIR,
-        T_FILE     => T_FILE,
-        T_FUNC_C   => T_FUNC_C,
-        T_LINE     => T_LINE,
-        T_METHOD_C => T_METHOD_C,
-        T_NS_C     => T_NS_C,
-        T_TRAIT_C  => T_TRAIT_C,
-    ];
+    public static $magicConstants = self::MAGIC_CONSTANTS;
 
     /**
      * Tokens representing context sensitive keywords in PHP.
      *
+     * @deprecated 4.0 Use the Tokens::CONTEXT_SENSITIVE_KEYWORDS constant instead.
+     *
      * @var array<int|string, int|string>
      *
-     * https://wiki.php.net/rfc/context_sensitive_lexer
+     * @link https://wiki.php.net/rfc/context_sensitive_lexer
      */
-    public static $contextSensitiveKeywords = [
-        T_ABSTRACT     => T_ABSTRACT,
-        T_ARRAY        => T_ARRAY,
-        T_AS           => T_AS,
-        T_BREAK        => T_BREAK,
-        T_CALLABLE     => T_CALLABLE,
-        T_CASE         => T_CASE,
-        T_CATCH        => T_CATCH,
-        T_CLASS        => T_CLASS,
-        T_CLONE        => T_CLONE,
-        T_CONST        => T_CONST,
-        T_CONTINUE     => T_CONTINUE,
-        T_DECLARE      => T_DECLARE,
-        T_DEFAULT      => T_DEFAULT,
-        T_DO           => T_DO,
-        T_ECHO         => T_ECHO,
-        T_ELSE         => T_ELSE,
-        T_ELSEIF       => T_ELSEIF,
-        T_EMPTY        => T_EMPTY,
-        T_ENDDECLARE   => T_ENDDECLARE,
-        T_ENDFOR       => T_ENDFOR,
-        T_ENDFOREACH   => T_ENDFOREACH,
-        T_ENDIF        => T_ENDIF,
-        T_ENDSWITCH    => T_ENDSWITCH,
-        T_ENDWHILE     => T_ENDWHILE,
-        T_ENUM         => T_ENUM,
-        T_EVAL         => T_EVAL,
-        T_EXIT         => T_EXIT,
-        T_EXTENDS      => T_EXTENDS,
-        T_FINAL        => T_FINAL,
-        T_FINALLY      => T_FINALLY,
-        T_FN           => T_FN,
-        T_FOR          => T_FOR,
-        T_FOREACH      => T_FOREACH,
-        T_FUNCTION     => T_FUNCTION,
-        T_GLOBAL       => T_GLOBAL,
-        T_GOTO         => T_GOTO,
-        T_IF           => T_IF,
-        T_IMPLEMENTS   => T_IMPLEMENTS,
-        T_INCLUDE      => T_INCLUDE,
-        T_INCLUDE_ONCE => T_INCLUDE_ONCE,
-        T_INSTANCEOF   => T_INSTANCEOF,
-        T_INSTEADOF    => T_INSTEADOF,
-        T_INTERFACE    => T_INTERFACE,
-        T_ISSET        => T_ISSET,
-        T_LIST         => T_LIST,
-        T_LOGICAL_AND  => T_LOGICAL_AND,
-        T_LOGICAL_OR   => T_LOGICAL_OR,
-        T_LOGICAL_XOR  => T_LOGICAL_XOR,
-        T_MATCH        => T_MATCH,
-        T_NAMESPACE    => T_NAMESPACE,
-        T_NEW          => T_NEW,
-        T_PRINT        => T_PRINT,
-        T_PRIVATE      => T_PRIVATE,
-        T_PROTECTED    => T_PROTECTED,
-        T_PUBLIC       => T_PUBLIC,
-        T_READONLY     => T_READONLY,
-        T_REQUIRE      => T_REQUIRE,
-        T_REQUIRE_ONCE => T_REQUIRE_ONCE,
-        T_RETURN       => T_RETURN,
-        T_STATIC       => T_STATIC,
-        T_SWITCH       => T_SWITCH,
-        T_THROW        => T_THROW,
-        T_TRAIT        => T_TRAIT,
-        T_TRY          => T_TRY,
-        T_UNSET        => T_UNSET,
-        T_USE          => T_USE,
-        T_VAR          => T_VAR,
-        T_WHILE        => T_WHILE,
-        T_YIELD        => T_YIELD,
-        T_YIELD_FROM   => T_YIELD_FROM,
-    ];
+    public static $contextSensitiveKeywords = self::CONTEXT_SENSITIVE_KEYWORDS;
 
 
     /**

--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -32,7 +32,7 @@ final class FindEndOfStatementTest extends AbstractMethodTestCase
         $errors = [];
 
         for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -34,7 +34,7 @@ final class FindStartOfStatementTest extends AbstractMethodTestCase
         $errors = [];
 
         for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/tests/Core/File/GetConditionTest.php
+++ b/tests/Core/File/GetConditionTest.php
@@ -71,7 +71,7 @@ final class GetConditionTest extends AbstractMethodTestCase
      * This array is merged with expected result arrays for various unit tests
      * to make sure all possible conditions are tested.
      *
-     * This array should be kept in sync with the Tokens::$scopeOpeners array.
+     * This array should be kept in sync with the Tokens::SCOPE_OPENERS array.
      * This array isn't auto-generated based on the array in Tokens as for these
      * tests we want to have access to the token constant names, not just their values.
      *
@@ -135,7 +135,7 @@ final class GetConditionTest extends AbstractMethodTestCase
 
         if (empty(self::$markerTokens) === true) {
             foreach ($this->conditionMarkers as $marker) {
-                self::$markerTokens[$marker] = $this->getTargetToken($marker, Tokens::$scopeOpeners);
+                self::$markerTokens[$marker] = $this->getTargetToken($marker, Tokens::SCOPE_OPENERS);
             }
         }
 
@@ -171,7 +171,7 @@ final class GetConditionTest extends AbstractMethodTestCase
         $result = self::$phpcsFile->getCondition($stackPtr, T_IF);
         $this->assertFalse($result);
 
-        $result = self::$phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens);
+        $result = self::$phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS);
         $this->assertFalse($result);
 
     }//end testNonConditionalToken()
@@ -478,7 +478,7 @@ final class GetConditionTest extends AbstractMethodTestCase
             'Failed asserting that "testSeriouslyNestedMethod" does not have an anonymous class nor a closure condition'
         );
 
-        $result = self::$phpcsFile->hasCondition($stackPtr, Tokens::$ooScopeTokens);
+        $result = self::$phpcsFile->hasCondition($stackPtr, Tokens::OO_SCOPE_TOKENS);
         $this->assertTrue(
             $result,
             'Failed asserting that "testSeriouslyNestedMethod" has an OO Scope token condition'

--- a/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
@@ -141,7 +141,7 @@ final class BackfillEnumTest extends AbstractTokenizerTestCase
      */
     public function testNotEnums($testMarker, $testContent, $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_ENUM => T_ENUM];
         $target       = $this->getTargetToken($testMarker, $targetTypes, $testContent);
 

--- a/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
@@ -831,7 +831,7 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
      */
     public function testNotAnArrowFunction($testMarker, $testContent='fn', $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_FN => T_FN];
         $target       = $this->getTargetToken($testMarker, $targetTypes, $testContent);
 

--- a/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
@@ -215,7 +215,7 @@ final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
      */
     public function testNotAMatchStructure($testMarker, $testContent='match', $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_MATCH => T_MATCH];
         $target       = $this->getTargetToken($testMarker, $targetTypes, $testContent);
 
@@ -232,7 +232,7 @@ final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
         $this->assertArrayNotHasKey('parenthesis_opener', $tokenArray, 'Parenthesis opener is set');
         $this->assertArrayNotHasKey('parenthesis_closer', $tokenArray, 'Parenthesis closer is set');
 
-        $next = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($target + 1), null, true);
+        $next = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($target + 1), null, true);
         if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             $this->assertArrayNotHasKey('parenthesis_owner', $tokenArray, 'Parenthesis owner is set for opener after');
         }

--- a/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
@@ -189,7 +189,7 @@ final class BackfillReadonlyTest extends AbstractTokenizerTestCase
      */
     public function testNotReadonly($testMarker, $testContent='readonly', $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_READONLY => T_READONLY];
         $target       = $this->getTargetToken($testMarker, $targetTypes, $testContent);
 

--- a/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.php
+++ b/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsGotoTest.php
@@ -32,7 +32,7 @@ final class ContextSensitiveKeywordsGotoTest extends AbstractTokenizerTestCase
     public function testStrings($testMarker)
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING]));
+        $target     = $this->getTargetToken($testMarker, (Tokens::CONTEXT_SENSITIVE_KEYWORDS + [T_STRING]));
         $tokenArray = $tokens[$target];
 
         $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');

--- a/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsTest.php
@@ -29,7 +29,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public function testStrings($testMarker)
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING]));
+        $target     = $this->getTargetToken($testMarker, (Tokens::CONTEXT_SENSITIVE_KEYWORDS + [T_STRING]));
         $tokenArray = $tokens[$target];
 
         $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
@@ -156,7 +156,7 @@ final class ContextSensitiveKeywordsTest extends AbstractTokenizerTestCase
     public function testKeywords($testMarker, $expectedTokenType)
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_STRING]));
+        $target     = $this->getTargetToken($testMarker, (Tokens::CONTEXT_SENSITIVE_KEYWORDS + [T_ANON_CLASS, T_MATCH_DEFAULT, T_STRING]));
         $tokenArray = $tokens[$target];
 
         $this->assertSame(

--- a/tests/Core/Tokenizers/PHP/DNFTypesParseError2Test.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesParseError2Test.php
@@ -151,7 +151,7 @@ final class DNFTypesParseError2Test extends AbstractTokenizerTestCase
         $startPtr = $this->getTargetToken($testMarker, [T_OPEN_PARENTHESIS, T_TYPE_OPEN_PARENTHESIS], '(');
 
         for ($i = $startPtr; $i < $this->phpcsFile->numTokens; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/tests/Core/Tokenizers/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesTest.php
@@ -62,7 +62,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
             }
         }
 
-        $before = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($openPtr - 1), null, true);
+        $before = $this->phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($openPtr - 1), null, true);
         if ($before !== false && $tokens[$before]['content'] === '|') {
             $this->assertSame(
                 T_BITWISE_OR,
@@ -76,7 +76,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
             );
         }
 
-        $after = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($closePtr + 1), null, true);
+        $after = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closePtr + 1), null, true);
         if ($after !== false && $tokens[$after]['content'] === '|') {
             $this->assertSame(
                 T_BITWISE_OR,
@@ -330,7 +330,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
 
         $this->assertGreaterThanOrEqual(1, $intersectionCount, 'Did not find an intersection "&" between the DNF type parentheses');
 
-        $before = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($openPtr - 1), null, true);
+        $before = $this->phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($openPtr - 1), null, true);
         if ($before !== false && $tokens[$before]['content'] === '|') {
             $this->assertSame(
                 T_TYPE_UNION,
@@ -358,7 +358,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
             );
         }
 
-        $after = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($closePtr + 1), null, true);
+        $after = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closePtr + 1), null, true);
         if ($after !== false && $tokens[$after]['content'] === '|') {
             $this->assertSame(
                 T_TYPE_UNION,

--- a/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
@@ -171,7 +171,7 @@ final class DefaultKeywordTest extends AbstractTokenizerTestCase
      */
     public function testNotDefaultKeyword($testMarker, $testContent='DEFAULT', $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [
             T_MATCH_DEFAULT => T_MATCH_DEFAULT,
             T_DEFAULT       => T_DEFAULT,

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.php
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.php
@@ -115,7 +115,7 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
         $this->assertIsInt($label);
         $this->assertSame($testContent, $tokens[$label]['content']);
 
-        $next = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $next = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertIsInt($next);
         $this->assertSame(T_GOTO_COLON, $tokens[$next]['code']);
@@ -191,7 +191,7 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
      */
     public function testNotAGotoDeclaration($testMarker, $testContent, $expectedType='T_STRING')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_GOTO_LABEL => T_GOTO_LABEL];
         $expectedCode = T_STRING;
 

--- a/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
@@ -47,7 +47,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
             );
 
             // Get the next non-empty token.
-            $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+            $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
             $this->assertSame(
                 ':',
@@ -359,7 +359,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $true = $this->getTargetToken('/* testMixedPositionalAndNamedArgsWithTernary */', T_TRUE);
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -375,7 +375,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testMixedPositionalAndNamedArgsWithTernary */', T_PARAM_NAME, 'name');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -415,7 +415,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testNamedArgWithTernary */', T_PARAM_NAME, 'label');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -436,7 +436,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $true = $this->getTargetToken('/* testNamedArgWithTernary */', T_TRUE);
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -456,7 +456,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testNamedArgWithTernary */', T_PARAM_NAME, 'more');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -477,7 +477,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $true = $this->getTargetToken('/* testNamedArgWithTernary */', T_STRING, 'CONSTANT_A');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($true + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($true + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -512,7 +512,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_PARAM_NAME, 'label');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -533,7 +533,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $closeParens = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_CLOSE_PARENTHESIS);
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($closeParens + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closeParens + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -553,7 +553,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testTernaryWithFunctionCallsInThenElse */', T_PARAM_NAME, 'more');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -588,7 +588,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $constant = $this->getTargetToken('/* testTernaryWithConstantsInThenElse */', T_STRING, 'CONSTANT_NAME');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($constant + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($constant + 1), null, true);
 
         $this->assertSame(
             T_INLINE_ELSE,
@@ -618,7 +618,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testSwitchCaseWithConstant */', T_STRING, 'MY_CONSTANT');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -634,7 +634,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $label = $this->getTargetToken('/* testSwitchCaseWithClassProperty */', T_STRING, 'property');
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -650,7 +650,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         $default = $this->getTargetToken('/* testSwitchDefault */', T_DEFAULT);
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($default + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($default + 1), null, true);
 
         $this->assertSame(
             T_COLON,
@@ -691,7 +691,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         );
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',
@@ -807,7 +807,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
         );
 
         // Get the next non-empty token.
-        $colon = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($label + 1), null, true);
+        $colon = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($label + 1), null, true);
 
         $this->assertSame(
             ':',

--- a/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
@@ -104,7 +104,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
         $this->assertSame('T_INLINE_THEN', $tokens[$operator]['type'], 'Failed asserting type is inline then');
 
         if ($testObjectOperator === true) {
-            $next = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($operator + 1), null, true);
+            $next = $this->phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($operator + 1), null, true);
             $this->assertSame(T_OBJECT_OPERATOR, $tokens[$next]['code'], 'Failed asserting code is object operator');
             $this->assertSame('T_OBJECT_OPERATOR', $tokens[$next]['type'], 'Failed asserting type is object operator');
         }

--- a/tests/Core/Tokenizers/PHP/ResolveSimpleTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/ResolveSimpleTokenTest.php
@@ -403,7 +403,7 @@ final class ResolveSimpleTokenTest extends AbstractTokenizerTestCase
         $sequenceCount = count($expectedSequence);
 
         for ($i = $startPtr; $sequenceKey < $sequenceCount; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 // Ignore whitespace and comments, not interested in the tokenization of those for these tests.
                 continue;
             }

--- a/tests/Core/Tokenizers/PHP/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizers/PHP/StableCommentWhitespaceTest.php
@@ -36,7 +36,7 @@ final class StableCommentWhitespaceTest extends AbstractTokenizerTestCase
     public function testCommentTokenization($testMarker, $expectedTokens)
     {
         $tokens  = $this->phpcsFile->getTokens();
-        $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
+        $comment = $this->getTargetToken($testMarker, Tokens::COMMENT_TOKENS);
 
         foreach ($expectedTokens as $tokenInfo) {
             $this->assertSame(

--- a/tests/Core/Tokenizers/PHP/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizers/PHP/StableCommentWhitespaceWinTest.php
@@ -33,7 +33,7 @@ final class StableCommentWhitespaceWinTest extends AbstractTokenizerTestCase
     public function testCommentTokenization($testMarker, $expectedTokens)
     {
         $tokens  = $this->phpcsFile->getTokens();
-        $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
+        $comment = $this->getTargetToken($testMarker, Tokens::COMMENT_TOKENS);
 
         foreach ($expectedTokens as $tokenInfo) {
             $this->assertSame(

--- a/tests/Core/Tokenizers/PHP/TypedConstantsTest.php
+++ b/tests/Core/Tokenizers/PHP/TypedConstantsTest.php
@@ -63,7 +63,7 @@ final class TypedConstantsTest extends AbstractTokenizerTestCase
         $target = $this->getTargetToken($testMarker, T_CONST);
 
         for ($i = ($target + 1); $tokens[$i]['code'] !== T_EQUAL; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 // Ignore whitespace and comments, not interested in the tokenization of those.
                 continue;
             }
@@ -130,7 +130,7 @@ final class TypedConstantsTest extends AbstractTokenizerTestCase
 
         $current = 0;
         for ($i = ($target + 1); $tokens[$i]['code'] !== T_EQUAL; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 // Ignore whitespace and comments, not interested in the tokenization of those.
                 continue;
             }

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -358,7 +358,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      */
     public function testNotDefaultKeyword($testMarker, $testContent='DEFAULT')
     {
-        $targetTypes  = Tokens::$nameTokens;
+        $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [
             T_MATCH_DEFAULT => T_MATCH_DEFAULT,
             T_DEFAULT       => T_DEFAULT,
@@ -371,7 +371,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         // Make sure we're looking at the right token.
         $this->assertArrayHasKey(
             $tokenArray['code'],
-            Tokens::$nameTokens,
+            Tokens::NAME_TOKENS,
             sprintf('Token tokenized as %s, not identifier name (code). Marker: %s.', $tokenArray['type'], $testMarker)
         );
 


### PR DESCRIPTION
# Description
### Tokens: introduce class constants to replace the static properties 

Sniffs should always be able to rely on the token arrays declared as static properties in the `Tokens` to be stable.

These token arrays should never be changed/updated by sniffs.

However, as they are declared as properties instead of as constants, there is a risk that creative sniff writers will update the token arrays, thereby breaking sniffs from other standards, including PHPCS native sniffs.

By changing the token arrays from static properties to class constants, this risk is mitigated.

As this is a breaking change which will impact all sniffs, the static properties will remain available during the complete 4.x cycle and will, for now, be _soft_ deprecated.

If/when issue #30 has been addressed, this can be changed to a hard deprecation.


### Use the new Tokens constants 

... throughout the code base.

### Tokens: remove the $nameTokens property 

This property was only introduced in 4.0, so should only exist as the class constant, not as a property.

## Suggested changelog entry
The static token array properties in the `Tokens` class. Use the corresponding class constants on the Tokens class instead.


## Related issues/external references

Fixes #500
