### PR TITLE
Filter: files without extension are no longer ignored if the path is passed in directly

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,8 @@
 
     <file>autoload.php</file>
     <file>requirements.php</file>
-    <file>bin</file>
+    <file>bin/phpcs</file>
+    <file>bin/phpcbf</file>
     <file>scripts</file>
     <file>src</file>
     <file>tests</file>

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -28,6 +28,15 @@ class Filter extends RecursiveFilterIterator
     protected $basedir = null;
 
     /**
+     * Whether the basedir is a file or a directory.
+     *
+     * TRUE if the basedir is actually a directory.
+     *
+     * @var boolean
+     */
+    protected $isBasedirDir = false;
+
+    /**
      * The config data for the run.
      *
      * @var \PHP_CodeSniffer\Config
@@ -81,6 +90,10 @@ class Filter extends RecursiveFilterIterator
         $this->basedir = $basedir;
         $this->config  = $config;
         $this->ruleset = $ruleset;
+
+        if (is_dir($basedir) === true || Common::isPharFile($basedir) === true) {
+            $this->isBasedirDir = true;
+        }
 
     }//end __construct()
 
@@ -172,7 +185,17 @@ class Filter extends RecursiveFilterIterator
         $fileName  = basename($path);
         $fileParts = explode('.', $fileName);
         if ($fileParts[0] === $fileName || $fileParts[0] === '') {
-            return false;
+            if ($this->isBasedirDir === true) {
+                // We are recursing a directory, so ignore any
+                // files with no extension.
+                return false;
+            }
+
+            // We are processing a single file, so always
+            // accept files with no extension as they have been
+            // explicitly requested and there is no config setting
+            // to ignore them.
+            return true;
         }
 
         // Checking multi-part file extensions, so need to create a

--- a/tests/Core/Filters/Filter/ShouldProcessFileWithoutExtensionTest.php
+++ b/tests/Core/Filters/Filter/ShouldProcessFileWithoutExtensionTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Filters\Filter class.
+ *
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Filters\Filter;
+
+use PHP_CodeSniffer\Filters\Filter;
+use PHP_CodeSniffer\Tests\Core\Filters\AbstractFilterTestCase;
+use RecursiveArrayIterator;
+
+/**
+ * Tests handling of files without extension.
+ *
+ * @covers \PHP_CodeSniffer\Filters\Filter
+ */
+final class ShouldProcessFileWithoutExtensionTest extends AbstractFilterTestCase
+{
+
+
+    /**
+     * Verify that if a file without file extension is explicitly requested for scan, it is accepted.
+     *
+     * @return void
+     */
+    public function testFileWithoutExtensionIsAcceptedWhenExplicitlyRequested()
+    {
+        $fileWithoutExt = self::getBaseDir().'/bin/phpcs';
+
+        $fakeDI = new RecursiveArrayIterator([$fileWithoutExt]);
+        $filter = new Filter($fakeDI, $fileWithoutExt, self::$config, self::$ruleset);
+
+        $this->assertSame([$fileWithoutExt], $this->getFilteredResultsAsArray($filter));
+
+    }//end testFileWithoutExtensionIsAcceptedWhenExplicitlyRequested()
+
+
+    /**
+     * Verify that when (recursively) scanning a directory, files without extension are filtered out.
+     *
+     * @return void
+     */
+    public function testFileWithoutExtensionIsRejectedWhenRecursingDirectory()
+    {
+        $baseDir      = self::getBaseDir();
+        $fakeFileList = [
+            $baseDir.'/autoload.php',
+            $baseDir.'/bin',
+            $baseDir.'/bin/phpcs',
+            $baseDir.'/scripts',
+            $baseDir.'/scripts/build-phar.php',
+        ];
+        $fakeDI       = new RecursiveArrayIterator($fakeFileList);
+        $filter       = new Filter($fakeDI, self::getBaseDir(), self::$config, self::$ruleset);
+
+        $expectedOutput = [
+            $baseDir.'/autoload.php',
+            $baseDir.'/bin',
+            $baseDir.'/scripts',
+            $baseDir.'/scripts/build-phar.php',
+        ];
+
+        $this->assertSame($expectedOutput, $this->getFilteredResultsAsArray($filter));
+
+    }//end testFileWithoutExtensionIsRejectedWhenRecursingDirectory()
+
+
+}//end class


### PR DESCRIPTION
# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->


## Suggested changelog entry
Added:
Files without extension can now be scanned if the path is passed in directly.
    - Previously, files without extension would always be ignored.
    - Now, files with no extension are checked if explicitly passed on the command line or specified in a ruleset.
    - Files without extension will still be ignored when scanning directories recursively.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2916
