### PR TITLE
Runner: error message if no files were checked during a run

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -361,6 +361,13 @@ class Runner
             }
         }//end if
 
+        $numFiles = count($todo);
+        if ($numFiles === 0) {
+            $error  = 'ERROR: No files were checked.'.PHP_EOL;
+            $error .= 'All specified files were excluded or did not match filtering rules.'.PHP_EOL.PHP_EOL;
+            throw new DeepExitException($error, 3);
+        }
+
         // Turn all sniff errors into exceptions.
         set_error_handler([$this, 'handleErrors']);
 
@@ -375,8 +382,7 @@ class Runner
             $this->config->parallel = 1;
         }
 
-        $lastDir  = '';
-        $numFiles = count($todo);
+        $lastDir = '';
 
         if ($this->config->parallel === 1) {
             // Running normally.

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetA/placeholder.inc
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetA/placeholder.inc
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetA/placeholder.phpt
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetA/placeholder.phpt
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderA.php
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderA.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderB.php
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderB.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderC.php
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderC.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderD.php
+++ b/tests/Core/Runner/Fixtures/AllFilesExcludedSetB/placeholderD.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Runner\RunAllFilesExcludedErrorTest
+ */
+
+echo 'hello';

--- a/tests/Core/Runner/RunAllFilesExcludedErrorTest.php
+++ b/tests/Core/Runner/RunAllFilesExcludedErrorTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for the "All files were excluded" error message.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Runner;
+
+use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
+
+/**
+ * Tests for the "All files were excluded" error message.
+ *
+ * @covers \PHP_CodeSniffer\Runner::run
+ */
+final class RunAllFilesExcludedErrorTest extends AbstractRunnerTestCase
+{
+
+
+    /**
+     * Verify that the "All files were excluded" error message is shown when all files are excluded (PHPCS).
+     *
+     * @param string        $sourceDir The (fixture) directory to scan for files.
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     *
+     * @dataProvider data
+     *
+     * @return void
+     */
+    public function testPhpcs($sourceDir, $extraArgs)
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+        $this->setupTest($sourceDir, $extraArgs);
+
+        $runner = new Runner();
+        $runner->runPHPCS();
+
+    }//end testPhpcs()
+
+
+    /**
+     * Verify that the "All files were excluded" error message is shown when all files are excluded (PHPCBF).
+     *
+     * @param string        $sourceDir The (fixture) directory to scan for files.
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     *
+     * @dataProvider data
+     * @group        CBF
+     *
+     * @return void
+     */
+    public function testPhpcbf($sourceDir, $extraArgs)
+    {
+        if (PHP_CODESNIFFER_CBF === false) {
+            $this->markTestSkipped('This test needs CBF mode to run');
+        }
+
+        $this->setupTest($sourceDir, $extraArgs);
+
+        $runner = new Runner();
+        $runner->runPHPCBF();
+
+    }//end testPhpcbf()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|array<string>>>
+     */
+    public static function data()
+    {
+        return [
+            'All files filtered out via extension'      => [
+                'sourceDir' => __DIR__.'/Fixtures/AllFilesExcludedSetA/',
+                'extraArgs' => ['--extensions=php'],
+            ],
+            'All files filtered out via ignore pattern' => [
+                'sourceDir' => __DIR__.'/Fixtures/AllFilesExcludedSetB/',
+                'extraArgs' => ['--ignore=/place*\.php'],
+            ],
+        ];
+
+    }//end data()
+
+
+    /**
+     * Helper method to prepare the test.
+     *
+     * @param string        $sourceDir The (fixture) directory to scan for files.
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     *
+     * @return void
+     */
+    private function setupTest($sourceDir, $extraArgs)
+    {
+        $_SERVER['argv'] = [
+            'phpcs',
+            $sourceDir,
+            '--standard=PSR1',
+            '--report-width=80',
+        ];
+
+        foreach ($extraArgs as $arg) {
+            $_SERVER['argv'][] = $arg;
+        }
+
+        $message  = 'ERROR: No files were checked.'.PHP_EOL;
+        $message .= 'All specified files were excluded or did not match filtering rules.'.PHP_EOL.PHP_EOL;
+
+        $this->expectOutputString($message);
+
+    }//end setupTest()
+
+
+}//end class


### PR DESCRIPTION
# Description
Show error message if no files were checked during a run and exit with a non-zero exit code.


Note: the tests only cover the new error message and not the situation where this message would _not_ be shown (outside the scope of this change).



## Suggested changelog entry
Added:
An error message is now displayed if no files were checked during a run.
    - This occurs when all of the specified files matched exclusion rules, or none matched filtering rules.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#1595

