### PR TITLE
:sparkles: New Generic.WhiteSpace.GotoTargetSpacing sniff

### DIFF
--- a/src/Standards/Generic/Docs/WhiteSpace/GotoTargetSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/GotoTargetSpacingStandard.xml
@@ -1,0 +1,27 @@
+<documentation title="Goto Target Spacing">
+    <standard>
+    <![CDATA[
+    There should be no space between the label for a goto target and the colon following it.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space between the label and the colon.">
+        <![CDATA[
+goto labelA;
+echo 'Foo';
+
+<em>labelA:</em>
+echo 'Bar';
+        ]]>
+        </code>
+        <code title="Invalid: Whitespace between the label and the colon.">
+        <![CDATA[
+goto labelA;
+echo 'Foo';
+
+labelA<em>   </em>:
+echo 'Bar';
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/WhiteSpace/GotoTargetSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/GotoTargetSpacingSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Ensures there is no space between the label for a goto target and the colon following it.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class GotoTargetSpacingSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_GOTO_LABEL];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr + 1)]['code'] === T_GOTO_COLON) {
+            return;
+        }
+
+        $nextNonWhiteSpace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $nextNonEmpty      = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
+
+        if ($nextNonWhiteSpace !== $nextNonEmpty) {
+            $found = 'comment';
+        } else if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonWhiteSpace]['line']) {
+            $found = 'newline';
+        } else if ($tokens[($stackPtr + 1)]['length'] === 1) {
+            $found = '1 space';
+        } else {
+            $found = $tokens[($stackPtr + 1)]['length'].' spaces';
+        }
+
+        $error = 'There should be no space between goto label "%s" and the colon following it. Found: %s';
+        $data  = [
+            $tokens[$stackPtr]['content'],
+            $found,
+        ];
+
+        if ($nextNonWhiteSpace !== $nextNonEmpty) {
+            $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceFound', $data);
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+            for ($i = ($stackPtr + 1); $tokens[$i]['code'] === T_WHITESPACE; $i++) {
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.inc
@@ -1,0 +1,35 @@
+<?php
+
+goto spacingOkay;
+echo 'Foo';
+
+spacingOkay:
+echo 'Bar';
+
+goto OneSpace;
+echo 'Foo';
+
+OneSpace :
+echo 'Bar';
+
+goto MultiSpace;
+echo 'Foo';
+
+MultiSpace     :
+echo 'Bar';
+
+goto NewLinesAndIndent;
+echo 'Foo';
+
+NewLinesAndIndent
+
+
+
+      :
+echo 'Bar';
+
+goto TooMuchSpacePlusComment;
+echo 'Foo';
+
+TooMuchSpacePlusComment  /*comment*/  :
+echo 'Bar';

--- a/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.inc.fixed
@@ -1,0 +1,31 @@
+<?php
+
+goto spacingOkay;
+echo 'Foo';
+
+spacingOkay:
+echo 'Bar';
+
+goto OneSpace;
+echo 'Foo';
+
+OneSpace:
+echo 'Bar';
+
+goto MultiSpace;
+echo 'Foo';
+
+MultiSpace:
+echo 'Bar';
+
+goto NewLinesAndIndent;
+echo 'Foo';
+
+NewLinesAndIndent:
+echo 'Bar';
+
+goto TooMuchSpacePlusComment;
+echo 'Foo';
+
+TooMuchSpacePlusComment  /*comment*/  :
+echo 'Bar';

--- a/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/GotoTargetSpacingUnitTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Unit test class for the GotoTargetSpacing sniff.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffTestCase;
+
+/**
+ * Unit test class for the HereNowdocIdentifierSpacing sniff.
+ *
+ * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\GotoTargetSpacingSniff
+ */
+final class GotoTargetSpacingUnitTest extends AbstractSniffTestCase
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            12 => 1,
+            18 => 1,
+            24 => 1,
+            34 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
# Description
What with the colon for a goto target label no longer being tokenized to be included in the label token, let's allow for people to enforce no space between the label and the colon.

This commit introduces a new sniff to do just that.

Includes tests.
Includes documentation.


## Suggested changelog entry
Added:
New sniff `Generic.WhiteSpace.GotoTargetSpacing` to enforce no space between the label of a `goto` target and the colon following it.


## Related issues/external references

Related to #185

