### PR TITLE
Squiz/VariableComment: make errorcode for "TagNotAllowed" warning modular

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,7 +47,10 @@
     <rule ref="Squiz.Commenting.PostStatementComment">
         <exclude name="Squiz.Commenting.PostStatementComment.AnnotationFound"/>
     </rule>
-    <rule ref="Squiz.Commenting.VariableComment"/>
+    <rule ref="Squiz.Commenting.VariableComment">
+        <exclude name="Squiz.Commenting.VariableComment.DeprecatedTagNotAllowed"/>
+        <exclude name="Squiz.Commenting.VariableComment.LinkTagNotAllowed"/>
+    </rule>
     <rule ref="Squiz.Formatting.OperatorBracket"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
@@ -153,10 +156,5 @@
     <rule ref="Generic.Commenting.Todo">
         <exclude-pattern>src/Standards/Generic/Sniffs/Commenting/TodoSniff\.php</exclude-pattern>
         <exclude-pattern>src/Standards/Generic/Tests/Commenting/TodoUnitTest\.php</exclude-pattern>
-    </rule>
-
-    <!-- @see https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/122#discussion_r1414167897 -->
-    <rule ref="Squiz.Commenting.VariableComment">
-        <exclude-pattern>src/Util/Tokens\.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -111,7 +111,8 @@ class VariableCommentSniff extends AbstractVariableSniff
             } else {
                 $error = '%s tag is not allowed in member variable comment';
                 $data  = [$tokens[$tag]['content']];
-                $phpcsFile->addWarning($error, $tag, 'TagNotAllowed', $data);
+                $code  = ucwords(ltrim($tokens[$tag]['content'], '@')).'TagNotAllowed';
+                $phpcsFile->addWarning($error, $tag, $code, $data);
             }//end if
         }//end foreach
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -476,3 +476,26 @@ class PHP84FinalProperties {
      */
     final int $hasDocblock;
 }
+
+// phpcs:disable Squiz.Commenting.VariableComment.SinceTagNotAllowed
+// phpcs:disable Squiz.Commenting.VariableComment.DeprecatedTagNotAllowed
+class AllowMoreForSelectivelyIgnoringDisallowedTags {
+    /**
+     * @var string
+     *
+     * @since      3.1
+     * @deprecated 10.5
+     */
+    public string $propertyWithExtraTags;
+
+    /**
+     * @var string
+     *
+     * @link       https://example.org/some-link
+     * @api
+     * @param string This tag is not allowed.
+     */
+    public $theAboveExtraTagsAreStillNotAllowed;
+}
+
+// phpcs:enable Squiz.Commenting.VariableComment

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -476,3 +476,26 @@ class PHP84FinalProperties {
      */
     final int $hasDocblock;
 }
+
+// phpcs:disable Squiz.Commenting.VariableComment.SinceTagNotAllowed
+// phpcs:disable Squiz.Commenting.VariableComment.DeprecatedTagNotAllowed
+class AllowMoreForSelectivelyIgnoringDisallowedTags {
+    /**
+     * @var string
+     *
+     * @since      3.1
+     * @deprecated 10.5
+     */
+    public string $propertyWithExtraTags;
+
+    /**
+     * @var string
+     *
+     * @link       https://example.org/some-link
+     * @api
+     * @param string This tag is not allowed.
+     */
+    public $theAboveExtraTagsAreStillNotAllowed;
+}
+
+// phpcs:enable Squiz.Commenting.VariableComment

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -81,7 +81,12 @@ final class VariableCommentUnitTest extends AbstractSniffTestCase
      */
     public function getWarningList()
     {
-        return [93 => 1];
+        return [
+            93  => 1,
+            494 => 1,
+            495 => 1,
+            496 => 1,
+        ];
 
     }//end getWarningList()
 


### PR DESCRIPTION
# Description

### Squiz/VariableComment: make errorcode for "TagNotAllowed" warning modular

As things are, the `VariableComment` sniff only allows `@see` tags and `@var` tags in property docblocks.

This practice feels dated to me, as commonly used tags, such as `@link`, `@deprecated` etc are not allowed.

This commit replaces the generic `TagNotAllowed` error code in the sniff with a more modular `[TagName]TagNotAllowed` error code.

This allows for rulesets to selectively ignore the `TagNotAllowed` error code for specific tags the ruleset maintainer wants to allow for the code base under scan.

Includes tests.

### CS: allow @link and @deprecated in property docblocks 

... for this codebase.

## Suggested changelog entry
Changed:
- The error code `Squiz.Commenting.VariableComment.TagNotAllowed` has been replaced by a dynamic `Squiz.Commenting.VariableComment.[TagName]TagNotAllowed` error code.
    - This allows for selectively allowing specific tags by excluding the error code for that tag.
    - Example: to allow `@link` tags in property docblocks, exclude the `Squiz.Commenting.VariableComment.LinkTagNotAllowed` error code.

