### PR TITLE
Generic/UnnecessaryHeredoc: 2 bug fixes involving escape sequences

### DIFF
--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
@@ -85,10 +85,22 @@ class UnnecessaryHeredocSniff implements Sniff
 
         $fix = $phpcsFile->addFixableWarning($warning, $stackPtr, 'Found');
         if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
             $identifier  = trim(ltrim($tokens[$stackPtr]['content'], '<'));
             $replaceWith = "'".trim($identifier, '"')."'";
             $replacement = str_replace($identifier, $replaceWith, $tokens[$stackPtr]['content']);
             $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+
+            for ($i = ($stackPtr + 1); $i < $closer; $i++) {
+                $content = $tokens[$i]['content'];
+                $content = str_replace(['\\$', '\\\\'], ['$', '\\'], $content);
+                if ($tokens[$i]['content'] !== $content) {
+                    $phpcsFile->fixer->replaceToken($i, $content);
+                }
+            }
+
+            $phpcsFile->fixer->endChangeset();
         }
 
     }//end process()

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
@@ -15,6 +15,35 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class UnnecessaryHeredocSniff implements Sniff
 {
 
+    /**
+     * Escape chars which are supported in heredocs, but not in nowdocs.
+     *
+     * @var array<string>
+     */
+    private $escapeChars = [
+        // Octal sequences.
+        '\0',
+        '\1',
+        '\2',
+        '\3',
+        '\4',
+        '\5',
+        '\6',
+        '\7',
+
+        // Various whitespace and the escape char.
+        '\n',
+        '\r',
+        '\t',
+        '\v',
+        '\e',
+        '\f',
+
+        // Hex and unicode sequences.
+        '\x',
+        '\u',
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -80,6 +109,13 @@ class UnnecessaryHeredocSniff implements Sniff
         }//end foreach
 
         $phpcsFile->recordMetric($stackPtr, 'Heredoc contains interpolation or expression', 'no');
+
+        // Check for escape sequences which aren't supported in nowdocs.
+        foreach ($this->escapeChars as $testChar) {
+            if (strpos($body, $testChar) !== false) {
+                return;
+            }
+        }
 
         $warning = 'Detected heredoc without interpolation or expressions. Use nowdoc syntax instead';
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc
@@ -104,5 +104,5 @@ END;
 $heredoc = <<< "END"
 some text
 some \$text
-some text
+some text \\ including a backslash
 END;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc
@@ -106,3 +106,17 @@ some text
 some \$text
 some text \\ including a backslash
 END;
+
+$heredoc = <<<EOD
+<?php
+echo 'The below line contains escape characters and should be recognized as needing heredoc';
+echo "aa\xC3\xC3	\xC3\xB8aa";
+EOD;
+
+echo <<<EOT
+This should print a capital 'A': \x41
+EOT;
+
+echo <<<EOT
+Here we should have a tab and 2 'A's: \t \101 \u{41}
+EOT;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc.fixed
@@ -103,6 +103,6 @@ END;
 
 $heredoc = <<< 'END'
 some text
-some \$text
-some text
+some $text
+some text \ including a backslash
 END;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.1.inc.fixed
@@ -106,3 +106,17 @@ some text
 some $text
 some text \ including a backslash
 END;
+
+$heredoc = <<<EOD
+<?php
+echo 'The below line contains escape characters and should be recognized as needing heredoc';
+echo "aa\xC3\xC3	\xC3\xB8aa";
+EOD;
+
+echo <<<EOT
+This should print a capital 'A': \x41
+EOT;
+
+echo <<<EOT
+Here we should have a tab and 2 'A's: \t \101 \u{41}
+EOT;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc
@@ -104,5 +104,5 @@ $heredoc = <<<END
 $heredoc = <<< "END"
     some text
     some \$text
-    some text
+    some text \\ including a backslash
     END;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc
@@ -106,3 +106,17 @@ $heredoc = <<< "END"
     some \$text
     some text \\ including a backslash
     END;
+
+$heredoc = <<<EOD
+    <?php
+    echo 'The below line contains escape characters and should be recognized as needing heredoc';
+    echo "aa\xC3\xC3	\xC3\xB8aa";
+    EOD;
+
+echo <<<EOT
+    This should print a capital 'A': \x41
+    EOT;
+
+echo <<<EOT
+    Here we should have a tab and 2 'A's: \t \101 \u{41}
+    EOT;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc.fixed
@@ -106,3 +106,17 @@ $heredoc = <<< 'END'
     some $text
     some text \ including a backslash
     END;
+
+$heredoc = <<<EOD
+    <?php
+    echo 'The below line contains escape characters and should be recognized as needing heredoc';
+    echo "aa\xC3\xC3	\xC3\xB8aa";
+    EOD;
+
+echo <<<EOT
+    This should print a capital 'A': \x41
+    EOT;
+
+echo <<<EOT
+    Here we should have a tab and 2 'A's: \t \101 \u{41}
+    EOT;

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.2.inc.fixed
@@ -103,6 +103,6 @@ $heredoc = <<<'END'
 
 $heredoc = <<< 'END'
     some text
-    some \$text
-    some text
+    some $text
+    some text \ including a backslash
     END;


### PR DESCRIPTION
# Description
### Generic/UnnecessaryHeredoc: bug fix - stray backslashes after fixing 

If the original heredoc contained an escaped variable or an escaped backslash (neither of which need heredoc), the nowdoc version of the text string would contain stray backslashes as these escapes are not needed in nowdocs, so would be interpreted as literals.

Fixed now.

Includes tests.

### Generic/UnnecessaryHeredoc: bug fix - false positives for heredoc with escape sequence

If the original heredoc contained an escape sequence, but no variable interpolation or expressions, it would be flagged as unnecessary and fixed to nowdoc, even though escape sequences are not supported in nowdocs.

Fixed now.

Includes tests.

## Suggested changelog entry
Fixed: Generic.Strings.UnnecessaryHeredoc - false positive for heredocs containing escape sequences
Fixed: Generic.Strings.UnnecessaryHeredoc - fixer would not clean up escape sequences which aren't needed in nowdocs


## Related issues/external references

Follow up on #633
