### PR TITLE
Modernize: use class constants for constant arrays (public API)

### DIFF
--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -26,9 +26,9 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      *
      * Used by various naming convention sniffs.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $phpReservedVars = [
+    protected const PHP_RESERVED_VARS = [
         '_SERVER'              => true,
         '_GET'                 => true,
         '_POST'                => true,
@@ -42,6 +42,15 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
         'HTTP_RAW_POST_DATA'   => true,
         'php_errormsg'         => true,
     ];
+
+    /**
+     * List of PHP Reserved variables.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the AbstractVariableSniff::PHP_RESERVED_VARS constant instead.
+     */
+    protected $phpReservedVars = self::PHP_RESERVED_VARS;
 
 
     /**

--- a/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
@@ -21,13 +21,22 @@ class ByteOrderMarkSniff implements Sniff
      *
      * Use encoding names as keys and hex BOM representations as values.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $bomDefinitions = [
+    protected const BOM_DEFINITIONS = [
         'UTF-8'       => 'efbbbf',
         'UTF-16 (BE)' => 'feff',
         'UTF-16 (LE)' => 'fffe',
     ];
+
+    /**
+     * List of supported BOM definitions.
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.0 Use the ByteOrderMarkSniff::BOM_DEFINITIONS constant instead.
+     */
+    protected $bomDefinitions = self::BOM_DEFINITIONS;
 
 
     /**
@@ -60,7 +69,7 @@ class ByteOrderMarkSniff implements Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        foreach ($this->bomDefinitions as $bomName => $expectedBomHex) {
+        foreach (static::BOM_DEFINITIONS as $bomName => $expectedBomHex) {
             $bomByteLength = (strlen($expectedBomHex) / 2);
             $htmlBomHex    = bin2hex(substr($tokens[$stackPtr]['content'], 0, $bomByteLength));
             if ($htmlBomHex === $expectedBomHex) {

--- a/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
@@ -20,13 +20,22 @@ class InlineHTMLSniff implements Sniff
      *
      * Use encoding names as keys and hex BOM representations as values.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $bomDefinitions = [
+    protected const BOM_DEFINITIONS = [
         'UTF-8'       => 'efbbbf',
         'UTF-16 (BE)' => 'feff',
         'UTF-16 (LE)' => 'fffe',
     ];
+
+    /**
+     * List of supported BOM definitions.
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.0 Use the InlineHTMLSniff::BOM_DEFINITIONS constant instead.
+     */
+    protected $bomDefinitions = self::BOM_DEFINITIONS;
 
 
     /**
@@ -54,7 +63,7 @@ class InlineHTMLSniff implements Sniff
     {
         // Allow a byte-order mark.
         $tokens = $phpcsFile->getTokens();
-        foreach ($this->bomDefinitions as $expectedBomHex) {
+        foreach (static::BOM_DEFINITIONS as $expectedBomHex) {
             $bomByteLength = (strlen($expectedBomHex) / 2);
             $htmlBomHex    = bin2hex(substr($tokens[0]['content'], 0, $bomByteLength));
             if ($htmlBomHex === $expectedBomHex && strlen($tokens[0]['content']) === $bomByteLength) {

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -20,9 +20,9 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
     /**
      * A list of all PHP magic methods.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $magicMethods = [
+    protected const MAGIC_METHODS = [
         'construct'   => true,
         'destruct'    => true,
         'call'        => true,
@@ -47,9 +47,9 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      *
      * These come from PHP modules such as SOAPClient.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $methodsDoubleUnderscore = [
+    protected const DOUBLE_UNDERSCORE_METHODS = [
         'dorequest'              => true,
         'getcookies'             => true,
         'getfunctions'           => true,
@@ -67,9 +67,9 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
     /**
      * A list of all PHP magic functions.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $magicFunctions = ['autoload' => true];
+    protected const MAGIC_FUNCTIONS = ['autoload' => true];
 
     /**
      * If TRUE, the string must not have two capital letters next to each other.
@@ -77,6 +77,33 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      * @var boolean
      */
     public $strict = true;
+
+    /**
+     * A list of all PHP magic methods.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the CamelCapsFunctionNameSniff::MAGIC_METHODS constant instead.
+     */
+    protected $magicMethods = self::MAGIC_METHODS;
+
+    /**
+     * A list of all PHP non-magic methods starting with a double underscore.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the CamelCapsFunctionNameSniff::DOUBLE_UNDERSCORE_METHODS constant instead.
+     */
+    protected $methodsDoubleUnderscore = self::DOUBLE_UNDERSCORE_METHODS;
+
+    /**
+     * A list of all PHP magic functions.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the CamelCapsFunctionNameSniff::MAGIC_FUNCTIONS constant instead.
+     */
+    protected $magicFunctions = self::MAGIC_FUNCTIONS;
 
 
     /**
@@ -130,8 +157,8 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
         // Is this a magic method. i.e., is prefixed with "__" ?
         if (preg_match('|^__[^_]|', $methodName) !== 0) {
             $magicPart = substr($methodNameLc, 2);
-            if (isset($this->magicMethods[$magicPart]) === true
-                || isset($this->methodsDoubleUnderscore[$magicPart]) === true
+            if (isset(static::MAGIC_METHODS[$magicPart]) === true
+                || isset(static::DOUBLE_UNDERSCORE_METHODS[$magicPart]) === true
             ) {
                 return;
             }
@@ -197,7 +224,7 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
         // Is this a magic function. i.e., it is prefixed with "__".
         if (preg_match('|^__[^_]|', $functionName) !== 0) {
             $magicPart = strtolower(substr($functionName, 2));
-            if (isset($this->magicFunctions[$magicPart]) === true) {
+            if (isset(static::MAGIC_FUNCTIONS[$magicPart]) === true) {
                 return;
             }
 

--- a/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
@@ -20,13 +20,22 @@ class CharacterBeforePHPOpeningTagSniff implements Sniff
      *
      * Use encoding names as keys and hex BOM representations as values.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $bomDefinitions = [
+    protected const BOM_DEFINITIONS = [
         'UTF-8'       => 'efbbbf',
         'UTF-16 (BE)' => 'feff',
         'UTF-16 (LE)' => 'fffe',
     ];
+
+    /**
+     * List of supported BOM definitions.
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.0 Use the CharacterBeforePHPOpeningTagSniff::BOM_DEFINITIONS constant instead.
+     */
+    protected $bomDefinitions = self::BOM_DEFINITIONS;
 
 
     /**
@@ -56,7 +65,7 @@ class CharacterBeforePHPOpeningTagSniff implements Sniff
         if ($stackPtr > 0) {
             // Allow a byte-order mark.
             $tokens = $phpcsFile->getTokens();
-            foreach ($this->bomDefinitions as $expectedBomHex) {
+            foreach (static::BOM_DEFINITIONS as $expectedBomHex) {
                 $bomByteLength = (strlen($expectedBomHex) / 2);
                 $htmlBomHex    = bin2hex(substr($tokens[0]['content'], 0, $bomByteLength));
                 if ($htmlBomHex === $expectedBomHex) {

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -23,12 +23,21 @@ class SubversionPropertiesSniff implements Sniff
      * exact value the property should have or NULL if the
      * property should just be set but the value is not fixed.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $properties = [
+    protected const REQUIRED_PROPERTIES = [
         'svn:keywords'  => 'Author Id Revision',
         'svn:eol-style' => 'native',
     ];
+
+    /**
+     * The Subversion properties that should be set.
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.0 Use the SubversionPropertiesSniff::REQUIRED_PROPERTIES constant instead.
+     */
+    protected $properties = self::REQUIRED_PROPERTIES;
 
 
     /**
@@ -61,10 +70,10 @@ class SubversionPropertiesSniff implements Sniff
             return $phpcsFile->numTokens;
         }
 
-        $allProperties = ($properties + $this->properties);
+        $allProperties = ($properties + static::REQUIRED_PROPERTIES);
         foreach ($allProperties as $key => $value) {
             if (isset($properties[$key]) === true
-                && isset($this->properties[$key]) === false
+                && isset(static::REQUIRED_PROPERTIES[$key]) === false
             ) {
                 $error = 'Unexpected Subversion property "%s" = "%s"';
                 $data  = [
@@ -76,25 +85,25 @@ class SubversionPropertiesSniff implements Sniff
             }
 
             if (isset($properties[$key]) === false
-                && isset($this->properties[$key]) === true
+                && isset(static::REQUIRED_PROPERTIES[$key]) === true
             ) {
                 $error = 'Missing Subversion property "%s" = "%s"';
                 $data  = [
                     $key,
-                    $this->properties[$key],
+                    static::REQUIRED_PROPERTIES[$key],
                 ];
                 $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
                 continue;
             }
 
             if ($properties[$key] !== null
-                && $properties[$key] !== $this->properties[$key]
+                && $properties[$key] !== static::REQUIRED_PROPERTIES[$key]
             ) {
                 $error = 'Subversion property "%s" = "%s" does not match "%s"';
                 $data  = [
                     $key,
                     $properties[$key],
-                    $this->properties[$key],
+                    static::REQUIRED_PROPERTIES[$key],
                 ];
                 $phpcsFile->addError($error, $stackPtr, 'NoMatch', $data);
             }

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -19,9 +19,9 @@ class FileCommentSniff implements Sniff
     /**
      * Tags in correct order and related info.
      *
-     * @var array
+     * @var array<string, array<string, bool>>
      */
-    protected $tags = [
+    protected const EXPECTED_TAGS = [
         '@category'   => [
             'required'       => true,
             'allow_multiple' => false,
@@ -67,6 +67,15 @@ class FileCommentSniff implements Sniff
             'allow_multiple' => false,
         ],
     ];
+
+    /**
+     * Tags in correct order and related info.
+     *
+     * @var array<string, array<string, bool>>
+     *
+     * @deprecated 4.0.0 Use the FileCommentSniff::EXPECTED_TAGS constant instead.
+     */
+    protected $tags = self::EXPECTED_TAGS;
 
 
     /**
@@ -235,11 +244,11 @@ class FileCommentSniff implements Sniff
         $tagTokens = [];
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             $name = $tokens[$tag]['content'];
-            if (isset($this->tags[$name]) === false) {
+            if (isset(static::EXPECTED_TAGS[$name]) === false) {
                 continue;
             }
 
-            if ($this->tags[$name]['allow_multiple'] === false && isset($tagTokens[$name]) === true) {
+            if (static::EXPECTED_TAGS[$name]['allow_multiple'] === false && isset($tagTokens[$name]) === true) {
                 $error = 'Only one %s tag is allowed in a %s comment';
                 $data  = [
                     $name,
@@ -265,7 +274,7 @@ class FileCommentSniff implements Sniff
 
         // Check if the tags are in the correct position.
         $pos = 0;
-        foreach ($this->tags as $tag => $tagData) {
+        foreach (static::EXPECTED_TAGS as $tag => $tagData) {
             if (isset($tagTokens[$tag]) === false) {
                 if ($tagData['required'] === true) {
                     $error = 'Missing %s tag in %s comment';

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -20,9 +20,9 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
     /**
      * A list of all PHP magic methods.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $magicMethods = [
+    protected const MAGIC_METHODS = [
         'construct'   => true,
         'destruct'    => true,
         'call'        => true,
@@ -45,9 +45,27 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
     /**
      * A list of all PHP magic functions.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $magicFunctions = ['autoload' => true];
+    protected const MAGIC_FUNCTIONS = ['autoload' => true];
+
+    /**
+     * A list of all PHP magic methods.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the ValidFunctionNameSniff::MAGIC_METHODS constant instead.
+     */
+    protected $magicMethods = self::MAGIC_METHODS;
+
+    /**
+     * A list of all PHP magic functions.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the ValidFunctionNameSniff::MAGIC_FUNCTIONS constant instead.
+     */
+    protected $magicFunctions = self::MAGIC_FUNCTIONS;
 
 
     /**
@@ -101,7 +119,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         // Is this a magic method. i.e., is prefixed with "__" ?
         if (preg_match('|^__[^_]|', $methodName) !== 0) {
             $magicPart = substr($methodNameLc, 2);
-            if (isset($this->magicMethods[$magicPart]) === true) {
+            if (isset(static::MAGIC_METHODS[$magicPart]) === true) {
                 return;
             }
 
@@ -191,7 +209,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         // Is this a magic function. i.e., it is prefixed with "__".
         if (preg_match('|^__[^_]|', $functionName) !== 0) {
             $magicPart = strtolower(substr($functionName, 2));
-            if (isset($this->magicFunctions[$magicPart]) === true) {
+            if (isset(static::MAGIC_FUNCTIONS[$magicPart]) === true) {
                 return;
             }
 

--- a/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -48,8 +48,8 @@ class CamelCapsMethodNameSniff extends GenericCamelCapsFunctionNameSniff
         // Ignore magic methods.
         if (preg_match('|^__[^_]|', $methodName) !== 0) {
             $magicPart = strtolower(substr($methodName, 2));
-            if (isset($this->magicMethods[$magicPart]) === true
-                || isset($this->methodsDoubleUnderscore[$magicPart]) === true
+            if (isset(static::MAGIC_METHODS[$magicPart]) === true
+                || isset(static::DOUBLE_UNDERSCORE_METHODS[$magicPart]) === true
             ) {
                 return;
             }

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -435,7 +435,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $suggestedTypeHint = 'callable';
                 } else if (strpos($suggestedName, 'callback') !== false) {
                     $suggestedTypeHint = 'callable';
-                } else if (in_array($suggestedName, Common::$allowedTypes, true) === false) {
+                } else if (isset(Common::ALLOWED_TYPES[$suggestedName]) === false) {
                     $suggestedTypeHint = $suggestedName;
                 }
 

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -34,7 +34,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
         // If it's a php reserved var, then its ok.
-        if (isset($this->phpReservedVars[$varName]) === true) {
+        if (isset(static::PHP_RESERVED_VARS[$varName]) === true) {
             return;
         }
 
@@ -170,7 +170,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         if (preg_match_all('|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
                 // If it's a php reserved var, then its ok.
-                if (isset($this->phpReservedVars[$varName]) === true) {
+                if (isset(static::PHP_RESERVED_VARS[$varName]) === true) {
                     continue;
                 }
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
@@ -18,13 +18,22 @@ class DisallowSizeFunctionsInLoopsSniff implements Sniff
     /**
      * An array of functions we don't want in the condition of loops.
      *
-     * @var array
+     * @var array<string, true>
      */
-    protected $forbiddenFunctions = [
+    protected const FORBIDDEN_FUNCTIONS = [
         'sizeof' => true,
         'strlen' => true,
         'count'  => true,
     ];
+
+    /**
+     * An array of functions we don't want in the condition of loops.
+     *
+     * @var array<string, true>
+     *
+     * @deprecated 4.0.0 Use the DisallowSizeFunctionsInLoopsSniff::FORBIDDEN_FUNCTIONS constant instead.
+     */
+    protected $forbiddenFunctions = self::FORBIDDEN_FUNCTIONS;
 
 
     /**
@@ -68,7 +77,7 @@ class DisallowSizeFunctionsInLoopsSniff implements Sniff
 
         for ($i = ($start + 1); $i < $end; $i++) {
             if (($tokens[$i]['code'] === T_STRING || $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED)
-                && isset($this->forbiddenFunctions[ltrim($tokens[$i]['content'], '\\')]) === true
+                && isset(static::FORBIDDEN_FUNCTIONS[ltrim($tokens[$i]['content'], '\\')]) === true
             ) {
                 $functionName = $tokens[$i]['content'];
 

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -34,7 +34,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
         // If it's a php reserved var, then its ok.
-        if (isset($this->phpReservedVars[$varName]) === true) {
+        if (isset(static::PHP_RESERVED_VARS[$varName]) === true) {
             return;
         }
 
@@ -176,7 +176,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
                 // If it's a php reserved var, then its ok.
-                if (isset($this->phpReservedVars[$varName]) === true) {
+                if (isset(static::PHP_RESERVED_VARS[$varName]) === true) {
                     continue;
                 }
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -17,6 +17,32 @@ class PHP extends Tokenizer
 {
 
     /**
+     * Contexts in which keywords should always be tokenized as T_STRING.
+     *
+     * @var array<int|string, true>
+     */
+    protected const T_STRING_CONTEXTS = [
+        T_OBJECT_OPERATOR          => true,
+        T_NULLSAFE_OBJECT_OPERATOR => true,
+        T_FUNCTION                 => true,
+        T_CLASS                    => true,
+        T_INTERFACE                => true,
+        T_TRAIT                    => true,
+        T_ENUM                     => true,
+        T_ENUM_CASE                => true,
+        T_EXTENDS                  => true,
+        T_IMPLEMENTS               => true,
+        T_ATTRIBUTE                => true,
+        T_NEW                      => true,
+        T_CONST                    => true,
+        T_NS_SEPARATOR             => true,
+        T_USE                      => true,
+        T_NAMESPACE                => true,
+        T_PAAMAYIM_NEKUDOTAYIM     => true,
+        T_GOTO                     => true,
+    ];
+
+    /**
      * Regular expression to check if a given identifier name is valid for use in PHP.
      *
      * @var string
@@ -482,27 +508,10 @@ class PHP extends Tokenizer
      * Contexts in which keywords should always be tokenized as T_STRING.
      *
      * @var array
+     *
+     * @deprecated 4.0.0 Use the PHP::T_STRING_CONTEXTS constant instead.
      */
-    protected $tstringContexts = [
-        T_OBJECT_OPERATOR          => true,
-        T_NULLSAFE_OBJECT_OPERATOR => true,
-        T_FUNCTION                 => true,
-        T_CLASS                    => true,
-        T_INTERFACE                => true,
-        T_TRAIT                    => true,
-        T_ENUM                     => true,
-        T_ENUM_CASE                => true,
-        T_EXTENDS                  => true,
-        T_IMPLEMENTS               => true,
-        T_ATTRIBUTE                => true,
-        T_NEW                      => true,
-        T_CONST                    => true,
-        T_NS_SEPARATOR             => true,
-        T_USE                      => true,
-        T_NAMESPACE                => true,
-        T_PAAMAYIM_NEKUDOTAYIM     => true,
-        T_GOTO                     => true,
-    ];
+    protected $tstringContexts = self::T_STRING_CONTEXTS;
 
     /**
      * A cache of different token types, resolved into arrays.
@@ -623,11 +632,11 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && isset(Tokens::CONTEXT_SENSITIVE_KEYWORDS[$token[0]]) === true
-                && (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
+                && (isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true
                 || $finalTokens[$lastNotEmptyToken]['content'] === '&'
                 || $insideConstDeclaration === true)
             ) {
-                if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
+                if (isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
                     $preserveKeyword = false;
 
                     // `new class`, and `new static` should be preserved.
@@ -683,7 +692,7 @@ class PHP extends Tokenizer
                 }//end if
 
                 // Types in typed constants should not be touched, but the constant name should be.
-                if ((isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
+                if ((isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true
                     && $finalTokens[$lastNotEmptyToken]['code'] === T_CONST)
                     || $insideConstDeclaration === true
                 ) {
@@ -1251,7 +1260,7 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && $token[0] === T_CASE
-                && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
+                && isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === false
             ) {
                 $isEnumCase = false;
                 $scope      = 1;
@@ -1497,7 +1506,7 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && strtolower($token[1]) === 'readonly'
-                && (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
+                && (isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === false
                 || $finalTokens[$lastNotEmptyToken]['code'] === T_NEW)
             ) {
                 // Get the next non-whitespace token.
@@ -1885,7 +1894,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
+                    if (isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
                         // Also not a match expression.
                         break;
                     }
@@ -1932,7 +1941,7 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && $token[0] === T_DEFAULT
-                && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false
+                && isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === false
             ) {
                 for ($x = ($stackPtr + 1); $x < $numTokens; $x++) {
                     if ($tokens[$x] === ',') {
@@ -2364,7 +2373,7 @@ class PHP extends Tokenizer
 
                     // True/false/parent/self/static in typed constants should be fixed to their own token,
                     // but the constant name should not be.
-                    if ((isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
+                    if ((isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true
                         && $finalTokens[$lastNotEmptyToken]['code'] === T_CONST)
                         || $insideConstDeclaration === true
                     ) {
@@ -2383,7 +2392,7 @@ class PHP extends Tokenizer
                             $preserveTstring        = true;
                             $insideConstDeclaration = false;
                         }
-                    } else if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
+                    } else if (isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true
                         && $finalTokens[$lastNotEmptyToken]['code'] !== T_CONST
                     ) {
                         $preserveTstring = true;
@@ -3445,7 +3454,7 @@ class PHP extends Tokenizer
                 }
 
                 if ($x !== $numTokens
-                    && isset($this->tstringContexts[$this->tokens[$x]['code']]) === true
+                    && isset(static::T_STRING_CONTEXTS[$this->tokens[$x]['code']]) === true
                 ) {
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         $line = $this->tokens[$i]['line'];

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -18,19 +18,28 @@ class Common
     /**
      * An array of variable types for param/var we will check.
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    public static $allowedTypes = [
-        'array',
-        'boolean',
-        'float',
-        'integer',
-        'mixed',
-        'object',
-        'string',
-        'resource',
-        'callable',
+    public const ALLOWED_TYPES = [
+        'array'    => 'array',
+        'boolean'  => 'boolean',
+        'float'    => 'float',
+        'integer'  => 'integer',
+        'mixed'    => 'mixed',
+        'object'   => 'object',
+        'string'   => 'string',
+        'resource' => 'resource',
+        'callable' => 'callable',
     ];
+
+    /**
+     * An array of variable types for param/var we will check.
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.0 Use the Common::ALLOWED_TYPES constant instead.
+     */
+    public static $allowedTypes = self::ALLOWED_TYPES;
 
 
     /**
@@ -466,7 +475,7 @@ class Common
             return '';
         }
 
-        if (in_array($varType, self::$allowedTypes, true) === true) {
+        if (isset(self::ALLOWED_TYPES[$varType]) === true) {
             return $varType;
         } else {
             $lowerVarType = strtolower($varType);
@@ -512,7 +521,7 @@ class Common
                 } else {
                     return 'array';
                 }//end if
-            } else if (in_array($lowerVarType, self::$allowedTypes, true) === true) {
+            } else if (isset(self::ALLOWED_TYPES[$lowerVarType]) === true) {
                 // A valid type, but not lower cased.
                 return $lowerVarType;
             } else {

--- a/tests/Core/Util/Common/SuggestTypeTest.php
+++ b/tests/Core/Util/Common/SuggestTypeTest.php
@@ -60,7 +60,7 @@ final class SuggestTypeTest extends TestCase
     public static function dataSuggestTypeAllowedType()
     {
         $data = [];
-        foreach (Common::$allowedTypes as $type) {
+        foreach (Common::ALLOWED_TYPES as $type) {
             $data['Type: '.$type] = [$type];
         }
 
@@ -97,7 +97,7 @@ final class SuggestTypeTest extends TestCase
     public static function dataSuggestTypeAllowedTypeWrongCase()
     {
         $data = [];
-        foreach (Common::$allowedTypes as $type) {
+        foreach (Common::ALLOWED_TYPES as $type) {
             $data['Mixed case: '.$type] = [
                 'varType'  => ucfirst($type),
                 'expected' => $type,


### PR DESCRIPTION
# Description

~~:warning: This PR depends on PR #1039, which needs to be merged first. ⚠️~~

---

This PR modernizes various usages of constant arrays in the public API to use class constants instead of properties.

The properties still exist, but are now deprecated and will be removed in PHPCS 5.0.

In a separate PR, which will be pulled at a later point in time (but before the 4.0.0 release), the same will be done for additional usages of constant arrays, which are **_not_** in the public API.

---

### Modernize: Util\Common: use class constant for constant array 

As the property was in the public API, the class constant is also public and the property has been deprecated, to be removed in PHPCS 5.0.

Includes changing the array format from a list of strings to an associative array with the key and value for each entry holding the same string to allow for using `isset()` instead of `in_array()`.

### Modernize: Tokenizers\PHP: use class constant for constant array 

Note: there are a couple of other properties in this class, which only contain static information. These, by nature, should be constants. however, those properties are overloading empty array properties from the abstract parent `Tokenizer` class, so I'm leaving those alone for now.

### Modernize: AbstractVariableSniff: use class constant for constant array 

As the property was in the public API, the class constant is also `protected` and the property has been deprecated, to be removed in PHPCS 5.0.

### Modernize: Generic/CamelCapsFunctionName: use class constant for constant array

### Modernize: Generic/various sniffs: use class constant for constant array

### Modernize: Generic/SubversionProperties: use class constant for constant array

### Modernize: PEAR/FileComment: use class constant for constant array 

Note: this also affects the `PEAR.Commenting.ClassComment` sniff which extends this sniff.
That sniff doesn't access the deprecated property directly, but if other sniffs `extend` the `ClassComment` sniff, they may be affected.

### Modernize: PEAR/ValidFunctionName: use class constant for constant array 

Note: this also affects the `Squiz.NamingConventions.ValidFunctionName` sniff which extends this sniff.
That sniff doesn't access the deprecated property directly, but if other sniffs `extend` the Squiz `ValidFunctionName` sniff, they may be affected.

### Modernize: Squiz/DisallowSizeFunctionsInLoops: use class constant for constant array

## Suggested changelog entry
Deprecated:
* `PHP_CodeSniffer\Util\Common::$allowedTypes`. Use `PHP_CodeSniffer\Util\Common::ALLOWED_TYPES` instead.
* `PHP_CodeSniffer\Tokenizers\PHP::$tstringContexts`. Use `PHP_CodeSniffer\Tokenizers\PHP::T_STRING_CONTEXTS` instead.
* `PHP_CodeSniffer\Sniffs\AbstractVariableSniff::$phpReservedVars`. Use `PHP_CodeSniffer\Sniffs\AbstractVariableSniff::PHP_RESERVED_VARS` instead.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::$magicMethods`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::MAGIC_METHODS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff` class which extends the `CamelCapsFunctionNameSniff`.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::$methodsDoubleUnderscore`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::DOUBLE_UNDERSCORE_METHODS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff` class which extends the `CamelCapsFunctionNameSniff`.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::$magicFunctions`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff::MAGIC_FUNCTIONS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff` class which extends the `CamelCapsFunctionNameSniff`.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff::$bomDefinitions`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff::BOM_DEFINITIONS` instead.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\Files\InlineHTMLSniff::$bomDefinitions`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\Files\InlineHTMLSniff::BOM_DEFINITIONS` instead.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\CharacterBeforePHPOpeningTagSniff::$bomDefinitions`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\CharacterBeforePHPOpeningTagSniff::BOM_DEFINITIONS` instead.
* `PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\SubversionPropertiesSniff::$properties`. Use `PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl\SubversionPropertiesSniff::REQUIRED_PROPERTIES` instead.
* `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff::$tags`. Use `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff::EXPECTED_TAGS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff` class which extends the `FileCommentSniff`.
* `PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff::$magicMethods`. Use `PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff::MAGIC_METHODS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff` class which extends the PEAR `ValidFunctionNameSniff`.
* `PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff::$magicFunctions`. Use `PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff::MAGIC_FUNCTIONS` instead.
    - This also affects the `PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff` class which extends the PEAR `ValidFunctionNameSniff`.
* `PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowSizeFunctionsInLoopsSniff::$forbiddenFunctions`. Use `PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowSizeFunctionsInLoopsSniff::FORBIDDEN_FUNCTIONS` instead.



