### PR TITLE
PSR1/SideEffects: fix syntax error in XML documentation code example

### DIFF
--- a/src/Standards/PSR1/Docs/Files/SideEffectsStandard.xml
+++ b/src/Standards/PSR1/Docs/Files/SideEffectsStandard.xml
@@ -20,7 +20,7 @@ class Foo
 {
 }
 
-<em>echo "Class Foo loaded."</em>
+<em>echo "Class Foo loaded.";</em>
         ]]>
         </code>
     </code_comparison>


### PR DESCRIPTION
# Description

Fix syntax error in `PSR1.Files.SideEffects` XML documentation code example.

## Suggested changelog entry

PSR1.Files.SideEffects: fix syntax error in the XML documentation

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
