### PR TITLE
PSR2/SwitchDeclaration: improve XML documentation

### DIFF
--- a/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
+++ b/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
@@ -67,8 +67,9 @@ switch ($foo) {
         <![CDATA[
 switch ($foo) {
     case 'bar':
-    <em>// no break</em>
-    default<em></em>:
+        echo $foo;
+        <em>// no break</em>
+    default:
         break;
 }
         ]]>
@@ -77,7 +78,8 @@ switch ($foo) {
         <![CDATA[
 switch ($foo) {
     case 'bar':
-    default<em></em>:
+        echo $foo;<em></em>
+    default:
         break;
 }
         ]]>

--- a/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
+++ b/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
@@ -1,11 +1,11 @@
-<documentation title="Switch Declarations">
+<documentation title="Switch Declaration">
     <standard>
     <![CDATA[
-    Case statements should be followed by a space.  Colons in switch declarations should not be preceded by whitespace.  Break statements should be indented 4 more spaces from the case statement.  There must be a comment when falling through from one case into the next.
+    Case statements must be followed by exactly one space.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Case statement followed by 1 space.">
+        <code title="Valid: Case statement followed by one space.">
         <![CDATA[
 switch ($foo) {
     case<em> </em>'bar':
@@ -13,7 +13,7 @@ switch ($foo) {
 }
         ]]>
         </code>
-        <code title="Invalid: Case statement not followed by 1 space.">
+        <code title="Invalid: Case statement not followed by one space.">
         <![CDATA[
 switch ($foo) {
     case<em></em>'bar':
@@ -22,8 +22,13 @@ switch ($foo) {
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    There must be no whitespace between the case value or default keyword and the colon.
+    ]]>
+    </standard>
     <code_comparison>
-        <code title="Valid: Colons not prefixed by whitespace.">
+        <code title="Valid: Colons not preceded by whitespace.">
         <![CDATA[
 switch ($foo) {
     case 'bar'<em></em>:
@@ -33,7 +38,7 @@ switch ($foo) {
 }
         ]]>
         </code>
-        <code title="Invalid: Colons prefixed by whitespace.">
+        <code title="Invalid: Colons preceded by whitespace.">
         <![CDATA[
 switch ($foo) {
     case 'bar'<em> </em>:
@@ -44,6 +49,11 @@ switch ($foo) {
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    Terminating statements must be indented four more spaces from the case statement.
+    ]]>
+    </standard>
     <code_comparison>
         <code title="Valid: Break statement indented correctly.">
         <![CDATA[
@@ -53,7 +63,7 @@ switch ($foo) {
 }
         ]]>
         </code>
-        <code title="Invalid: Break statement not indented 4 spaces.">
+        <code title="Invalid: Break statement not indented four spaces.">
         <![CDATA[
 switch ($foo) {
     case 'bar':
@@ -62,8 +72,13 @@ switch ($foo) {
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    There must be a comment when fall-through is intentional in a non-empty case body.
+    ]]>
+    </standard>
     <code_comparison>
-        <code title="Valid: Comment marking intentional fall-through.">
+        <code title="Valid: Comment marking intentional fall-through in a non-empty case body.">
         <![CDATA[
 switch ($foo) {
     case 'bar':
@@ -74,7 +89,7 @@ switch ($foo) {
 }
         ]]>
         </code>
-        <code title="Invalid: No comment marking intentional fall-through.">
+        <code title="Invalid: No comment marking intentional fall-through in a non-empty case body.">
         <![CDATA[
 switch ($foo) {
     case 'bar':

--- a/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
+++ b/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
@@ -1,27 +1,9 @@
 <documentation title="Switch Declarations">
     <standard>
     <![CDATA[
-    Case statements should be indented 4 spaces from the switch keyword.  It should also be followed by a space.  Colons in switch declarations should not be preceded by whitespace.  Break statements should be indented 4 more spaces from the case statement.  There must be a comment when falling through from one case into the next.
+    Case statements should be followed by a space.  Colons in switch declarations should not be preceded by whitespace.  Break statements should be indented 4 more spaces from the case statement.  There must be a comment when falling through from one case into the next.
     ]]>
     </standard>
-    <code_comparison>
-        <code title="Valid: Case statement indented correctly.">
-        <![CDATA[
-switch ($foo) {
-<em>    </em>case 'bar':
-        break;
-}
-        ]]>
-        </code>
-        <code title="Invalid: Case statement not indented 4 spaces.">
-        <![CDATA[
-switch ($foo) {
-<em></em>case 'bar':
-    break;
-}
-        ]]>
-        </code>
-    </code_comparison>
     <code_comparison>
         <code title="Valid: Case statement followed by 1 space.">
         <![CDATA[

--- a/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
+++ b/src/Standards/PSR2/Docs/ControlStructures/SwitchDeclarationStandard.xml
@@ -1,6 +1,33 @@
 <documentation title="Switch Declaration">
     <standard>
     <![CDATA[
+    Case and default keywords must be lowercase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Keywords in lowercase.">
+        <![CDATA[
+switch ($foo) {
+    <em>case</em> 'bar':
+        break;
+    <em>default</em>:
+        break;
+}
+        ]]>
+        </code>
+        <code title="Invalid: Keywords not in lowercase.">
+        <![CDATA[
+switch ($foo) {
+    <em>CASE</em> 'bar':
+        break;
+    <em>Default</em>:
+        break;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
     Case statements must be followed by exactly one space.
     ]]>
     </standard>
@@ -51,6 +78,52 @@ switch ($foo) {
     </code_comparison>
     <standard>
     <![CDATA[
+    The case or default body must start on the line following the statement.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Body starts on the next line.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar':
+<em></em>        break;
+}
+        ]]>
+        </code>
+        <code title="Invalid: Body on the same line as the case statement.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar':<em></em> break;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Terminating statements must be on a line by themselves.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Terminating statement on its own line.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar':
+        echo $foo;
+        <em>return;</em>
+}
+        ]]>
+        </code>
+        <code title="Invalid: Terminating statement not on its own line.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar':
+        <em>echo $foo; return;</em>
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
     Terminating statements must be indented four more spaces from the case statement.
     ]]>
     </standard>
@@ -68,6 +141,34 @@ switch ($foo) {
 switch ($foo) {
     case 'bar':
 <em>    </em>break;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Case and default statements must be defined using a colon.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using a colon for case and default statements.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar'<em>:</em>
+        break;
+    default<em>:</em>
+        break;
+}
+        ]]>
+        </code>
+        <code title="Invalid: Using a semi-colon or colon followed by braces.">
+        <![CDATA[
+switch ($foo) {
+    case 'bar'<em>;</em>
+        break;
+    default: <em>{</em>
+        break;
+    <em>}</em>
 }
         ]]>
         </code>


### PR DESCRIPTION
# Description

### PSR2/SwitchDeclaration: update doc as case indentation is not checked

The sniff no longer checks `case` keyword indentation as of commit https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/4a39005f5a9314984f814f2237ed94dbe9619117, but the corresponding XML documentation was not updated. This commit aligns the documentation with the current sniff behavior by removing mentions of `case` indentation checks.

### PSR2/SwitchDeclaration: update doc as case body should be non-empty

This commit updates the valid and invalid code examples in a `<code_comparison>` block, as the `There must be a comment when fall-through is intentional in a non-empty case body` error is only triggered for non-empty `case` bodies. It also fixes the positioning of the `<em>` tags in the modified code examples.

### PSR2/SwitchDeclaration: improve XML documentation

- Documentation title should match the sniff name.
- Use different `<standard>` blocks for each error triggered by the
sniff.
- Minor changes to the text to make it more clear and consistent.

### PSR2/SwitchDeclaration: add missing errors to the XML documentation

This commit adds four sniff errors not previously documented to the `PSR2.ControlStructures.SwitchDeclaration` sniff XML documentation.

## Suggested changelog entry
PSR2.ControlStructures.SwitchDeclaration: minor fixes and improvements to the XML documentation


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
