### PR TITLE
Colors in cacheFileReport cannot be switched off

### DIFF
--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -290,6 +290,10 @@ class Reporter
             $generatedReport = ob_get_contents();
             ob_end_clean();
 
+            if ($this->config->colors !== true) {
+                $generatedReport = Common::stripColors($generatedReport);
+            }
+
             if ($report['output'] === null) {
                 // Using a temp file.
                 if (isset($this->tmpFiles[$type]) === false) {


### PR DESCRIPTION
I am using

```
vendor/bin/phpcs --report="diff" --extensions="php" --no-colors --report-diff=var/phpcs_report_680bb28374ffe.diff
``` 

to see some progress. In this case, it was not possible to switch of colors in the diff file.

Eventually related to #787 

# Description

Allow switching of colors in report files

## Suggested changelog entry

Allow switching of colors in report files

## Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

