### PR TITLE
Modernize: add constant visibility

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -157,4 +157,7 @@
         <exclude-pattern>src/Standards/Generic/Sniffs/Commenting/TodoSniff\.php</exclude-pattern>
         <exclude-pattern>src/Standards/Generic/Tests/Commenting/TodoUnitTest\.php</exclude-pattern>
     </rule>
+
+    <!-- Require visibility for class constants. -->
+    <rule ref="PSR12.Properties.ConstantVisibility"/>
 </ruleset>

--- a/src/Config.php
+++ b/src/Config.php
@@ -88,21 +88,21 @@ class Config
      *
      * @var string
      */
-    const VERSION = '4.0.0';
+    public const VERSION = '4.0.0';
 
     /**
      * Package stability; either stable, beta or alpha.
      *
      * @var string
      */
-    const STABILITY = 'alpha';
+    public const STABILITY = 'alpha';
 
     /**
      * Default report width when no report width is provided and 'auto' does not yield a valid width.
      *
      * @var int
      */
-    const DEFAULT_REPORT_WIDTH = 80;
+    public const DEFAULT_REPORT_WIDTH = 80;
 
     /**
      * Translation table for config settings which can be changed via multiple CLI flags.

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -28,7 +28,7 @@ class HTML extends Generator
      *
      * @var string
      */
-    const STYLESHEET = '<style>
+    private const STYLESHEET = '<style>
         body {
             background-color: #FFFFFF;
             font-size: 14px;

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -29,7 +29,7 @@ final class Help
      *
      * @var string
      */
-    const DEFAULT_SHORT_OPTIONS = '-hilnpqvw';
+    public const DEFAULT_SHORT_OPTIONS = '-hilnpqvw';
 
     /**
      * Long options which are available for both the `phpcs` as well as the `phpcbf` command.
@@ -38,7 +38,7 @@ final class Help
      *
      * @var string Comma-separated list of the option names.
      */
-    const DEFAULT_LONG_OPTIONS = 'basepath,bootstrap,colors,encoding,error-severity,exclude,extensions,file,file-list,filter,ignore,ignore-annotations,no-colors,parallel,php-ini,report-width,runtime-set,severity,sniffs,standard,stdin-path,tab-width,version,vv,vvv,warning-severity';
+    public const DEFAULT_LONG_OPTIONS = 'basepath,bootstrap,colors,encoding,error-severity,exclude,extensions,file,file-list,filter,ignore,ignore-annotations,no-colors,parallel,php-ini,report-width,runtime-set,severity,sniffs,standard,stdin-path,tab-width,version,vv,vvv,warning-severity';
 
     /**
      * Minimum screen width.
@@ -47,21 +47,21 @@ final class Help
      *
      * @var integer
      */
-    const MIN_WIDTH = 60;
+    public const MIN_WIDTH = 60;
 
     /**
      * Indent option lines.
      *
      * @var string
      */
-    const INDENT = '  ';
+    public const INDENT = '  ';
 
     /**
      * Gutter spacing for between the option argument info and the option description.
      *
      * @var string
      */
-    const GUTTER = ' ';
+    public const GUTTER = ' ';
 
     /**
      * The current PHPCS Configuration.

--- a/src/Util/MessageCollector.php
+++ b/src/Util/MessageCollector.php
@@ -33,42 +33,42 @@ final class MessageCollector
      *
      * @var int
      */
-    const ERROR = 1;
+    public const ERROR = 1;
 
     /**
      * Indicator for a warning.
      *
      * @var int
      */
-    const WARNING = 2;
+    public const WARNING = 2;
 
     /**
      * Indicator for a notice.
      *
      * @var int
      */
-    const NOTICE = 4;
+    public const NOTICE = 4;
 
     /**
      * Indicator for a deprecation notice.
      *
      * @var int
      */
-    const DEPRECATED = 8;
+    public const DEPRECATED = 8;
 
     /**
      * Indicator for ordering the messages based on severity first, order received second.
      *
      * @var string
      */
-    const ORDERBY_SEVERITY = 'severity';
+    public const ORDERBY_SEVERITY = 'severity';
 
     /**
      * Indicator for ordering the messages based on the order in which they were received.
      *
      * @var string
      */
-    const ORDERBY_RECEIVED = 'received';
+    public const ORDERBY_RECEIVED = 'received';
 
     /**
      * Collected messages.

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -19,14 +19,14 @@ class Timing
      *
      * @var int
      */
-    const MINUTE_IN_MS = 60000;
+    private const MINUTE_IN_MS = 60000;
 
     /**
      * Number of milliseconds in a second.
      *
      * @var int
      */
-    const SECOND_IN_MS = 1000;
+    private const SECOND_IN_MS = 1000;
 
     /**
      * The start time of the run in microseconds.

--- a/tests/Core/Ruleset/AbstractRulesetTestCase.php
+++ b/tests/Core/Ruleset/AbstractRulesetTestCase.php
@@ -19,7 +19,7 @@ abstract class AbstractRulesetTestCase extends TestCase
      *
      * @var string
      */
-    const RUNTIME_EXCEPTION = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+    private const RUNTIME_EXCEPTION = 'PHP_CodeSniffer\Exceptions\RuntimeException';
 
 
     /**

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -29,14 +29,14 @@ final class PropertyTypeHandlingTest extends TestCase
      *
      * @var string
      */
-    const SNIFF_CODE = 'TestStandard.SetProperty.PropertyTypeHandling';
+    private const SNIFF_CODE = 'TestStandard.SetProperty.PropertyTypeHandling';
 
     /**
      * Class name of the sniff used in these tests.
      *
      * @var string
      */
-    const SNIFF_CLASS = 'Fixtures\\TestStandard\\Sniffs\\SetProperty\\PropertyTypeHandlingSniff';
+    private const SNIFF_CLASS = 'Fixtures\\TestStandard\\Sniffs\\SetProperty\\PropertyTypeHandlingSniff';
 
 
     /**


### PR DESCRIPTION
# Description
Constant visibility is available in PHP since PHP 7.1. This commit adds the visibility to all class constants currently in the codebase and starts enforcing constant visibility being required.

In most cases, the visibility remains the same as before, i.e. `public`, however, there are a couple of exceptions, which could be considered a breaking change:
* `PHP_CodeSniffer\Generators\HTML::STYLESHEET` (was `public`, now `private`)
    - Even though the class is not `final`, the `Config` only allows for requesting a PHPCS native `Generator` class, so the chances of the class being extended are very slim.
    - On top of that, this was a function local variable until a few months ago, so chances of any external access to the constant being active are also slim based on the timing.
* `PHP_CodeSniffer\Util\Timing::MINUTE_IN_MS` and `PHP_CodeSniffer\Util\Timing::SECOND_IN_MS` (were `public`, now `private`)
    - These properties were introduced about six months ago and only ever intended for use by the class itself.

Aside from the above, there are some visibility changes for class constants which are part of the PHPCS native test suite, so not in the public API.


## Suggested changelog entry
Changed:
* The `PHP_CodeSniffer\Generators\HTML::STYLESHEET`, `PHP_CodeSniffer\Util\Timing::MINUTE_IN_MS` and `PHP_CodeSniffer\Util\Timing::SECOND_IN_MS` class constants are no longer `public`.

