### PR TITLE
Fixer: remove output buffering

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1047,9 +1047,7 @@ class File
             && $this->fixer->enabled === true
             && $fixable === true
         ) {
-            @ob_end_clean();
             StatusWriter::forceWrite("E: [Line $line] $message ($sniffCode)", 1);
-            ob_start();
         }
 
         return true;

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -155,13 +155,10 @@ class Fixer
 
         $this->loops = 0;
         while ($this->loops < 50) {
-            ob_start();
-
             // Only needed once file content has changed.
             $contents = $this->getContents();
 
             if (PHP_CODESNIFFER_VERBOSITY > 2) {
-                @ob_end_clean();
                 StatusWriter::forceWrite('---START FILE CONTENT---');
                 $lines = explode($this->currentFile->eolChar, $contents);
                 $max   = strlen(count($lines));
@@ -171,14 +168,12 @@ class Fixer
                 }
 
                 StatusWriter::forceWrite('--- END FILE CONTENT ---');
-                ob_start();
             }
 
             $this->inConflict = false;
             $this->currentFile->ruleset->populateTokenListeners();
             $this->currentFile->setContent($contents);
             $this->currentFile->process();
-            ob_end_clean();
 
             $this->loops++;
 
@@ -212,12 +207,7 @@ class Fixer
 
         if ($this->numFixes > 0 || $this->inConflict === true) {
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                if (ob_get_level() > 0) {
-                    ob_end_clean();
-                }
-
                 StatusWriter::write("*** Reached maximum number of loops with $this->numFixes violations left unfixed ***", 1);
-                ob_start();
             }
 
             return false;
@@ -417,9 +407,7 @@ class Fixer
 
             $line = $bt[0]['line'];
 
-            @ob_end_clean();
             StatusWriter::forceWrite("=> Changeset started by $sniff:$line", 1);
-            ob_start();
         }
 
         $this->changeset   = [];
@@ -459,15 +447,11 @@ class Fixer
             }
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                @ob_end_clean();
                 StatusWriter::forceWrite('=> Changeset failed to apply', 1);
-                ob_start();
             }
         } else if (PHP_CODESNIFFER_VERBOSITY > 1) {
             $fixes = count($this->changeset);
-            @ob_end_clean();
             StatusWriter::forceWrite("=> Changeset ended: $fixes changes applied", 1);
-            ob_start();
         }
 
         $this->changeset = [];
@@ -501,10 +485,8 @@ class Fixer
 
                 $numChanges = count($this->changeset);
 
-                @ob_end_clean();
                 StatusWriter::forceWrite("R: $sniff:$line rolled back the changeset ($numChanges changes)", 2);
                 StatusWriter::forceWrite('=> Changeset rolled back', 1);
-                ob_start();
             }
 
             $this->changeset = [];
@@ -536,9 +518,7 @@ class Fixer
             }
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                @ob_end_clean();
                 StatusWriter::forceWrite("* token $stackPtr has already been modified, skipping *", $depth);
-                ob_start();
             }
 
             return false;
@@ -573,9 +553,7 @@ class Fixer
             $this->changeset[$stackPtr] = $content;
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                @ob_end_clean();
                 StatusWriter::forceWrite("Q: $sniff:$line replaced token $stackPtr ($type on line $tokenLine) \"$oldContent\" => \"$newContent\"", 2);
-                ob_start();
             }
 
             return true;
@@ -599,7 +577,6 @@ class Fixer
 
                     $loop = $this->oldTokenValues[$stackPtr]['loop'];
 
-                    @ob_end_clean();
                     StatusWriter::forceWrite("**** $sniff:$line has possible conflict with another sniff on loop $loop; caused by the following change ****", $depth);
                     StatusWriter::forceWrite("**** replaced token $stackPtr ($type on line $tokenLine) \"$oldContent\" => \"$newContent\" ****", $depth);
                 }
@@ -609,10 +586,6 @@ class Fixer
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         StatusWriter::forceWrite('**** ignoring all changes until next loop ****', $depth);
                     }
-                }
-
-                if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    ob_start();
                 }
 
                 return false;
@@ -635,12 +608,7 @@ class Fixer
                 $depth         = 2;
             }
 
-            if (ob_get_level() > 0) {
-                ob_end_clean();
-            }
-
             StatusWriter::forceWrite($statusMessage, $depth);
-            ob_start();
         }
 
         return true;
@@ -698,9 +666,7 @@ class Fixer
                 $depth         = 2;
             }
 
-            @ob_end_clean();
             StatusWriter::forceWrite($statusMessage, $depth);
-            ob_start();
         }
 
         return true;

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -42,7 +42,6 @@ class Cbf implements Report
         $errors = $phpcsFile->getFixableCount();
         if ($errors !== 0) {
             if (PHP_CODESNIFFER_VERBOSITY > 0) {
-                ob_end_clean();
                 $startTime = microtime(true);
                 $newlines  = 0;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -103,10 +102,6 @@ class Cbf implements Report
                     StatusWriter::forceWrite('=> Fixed file written to '.basename($newFilename), 1);
                 }
             }
-        }
-
-        if (PHP_CODESNIFFER_VERBOSITY > 0) {
-            ob_start();
         }
 
         $errorCount   = $phpcsFile->getErrorCount();

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -65,7 +65,6 @@ class Diff implements Report
         }//end if
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            ob_end_clean();
             StatusWriter::write('*** START FILE FIXING ***', 1);
         }
 
@@ -73,7 +72,6 @@ class Diff implements Report
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** END FILE FIXING ***', 1);
-            ob_start();
         }
 
         if ($fixed === false) {


### PR DESCRIPTION
# Description
Now debug output is written to STDERR instead of STDOUT and the StatusWriter is paused while the Fixer is running, the output buffering during fixing can be removed.


## Suggested changelog entry
_N/A_ (internal implementation detail)