### PR TITLE
Runner: use StatusWriter::writeNewline()

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -208,7 +208,7 @@ class Runner
             $this->reporter->printReports();
 
             if ($this->config->quiet === false) {
-                StatusWriter::write('');
+                StatusWriter::writeNewline();
                 Timing::printRunTime();
             }
         } catch (DeepExitException $e) {


### PR DESCRIPTION
# Description
Follow up on #1010 and #1011.

PR #1011 moved the Timing display to the `Runner` class, but didn't take the change to PR #1010, introducing the `writeNewline()` method into account. Fixed up now.


## Suggested changelog entry
_N/A_
