### PR TITLE
Standards: introduce `prepareInstalledStandardsForDisplay()` method

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -685,10 +685,7 @@ class Config
             ob_end_clean();
             throw new DeepExitException($output, 0);
         case 'i' :
-            ob_start();
-            Standards::printInstalledStandards();
-            $output = ob_get_contents();
-            ob_end_clean();
+            $output = Standards::prepareInstalledStandardsForDisplay().PHP_EOL;
             throw new DeepExitException($output, 0);
         case 'v' :
             if ($this->quiet === true) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -258,11 +258,8 @@ class Runner
             if (Standards::isInstalledStandard($standard) === false) {
                 // They didn't select a valid coding standard, so help them
                 // out by letting them know which standards are installed.
-                $error = 'ERROR: the "'.$standard.'" coding standard is not installed. ';
-                ob_start();
-                Standards::printInstalledStandards();
-                $error .= ob_get_contents();
-                ob_end_clean();
+                $error  = 'ERROR: the "'.$standard.'" coding standard is not installed.'.PHP_EOL.PHP_EOL;
+                $error .= Standards::prepareInstalledStandardsForDisplay().PHP_EOL;
                 throw new DeepExitException($error, 3);
             }
         }

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -312,27 +312,44 @@ class Standards
 
 
     /**
+     * Prepares a list of installed coding standards for display.
+     *
+     * @return string
+     */
+    public static function prepareInstalledStandardsForDisplay()
+    {
+        $installedStandards = self::getInstalledStandards();
+        $numStandards       = count($installedStandards);
+
+        $output = '';
+        if ($numStandards === 0) {
+            $output .= 'No coding standards are installed.';
+        } else {
+            $lastStandard = array_pop($installedStandards);
+            if ($numStandards === 1) {
+                $output .= "The only coding standard installed is $lastStandard";
+            } else {
+                $standardList  = implode(', ', $installedStandards);
+                $standardList .= ' and '.$lastStandard;
+                $output       .= 'The installed coding standards are '.$standardList;
+            }
+        }
+
+        return $output;
+
+    }//end prepareInstalledStandardsForDisplay()
+
+
+    /**
      * Prints out a list of installed coding standards.
+     *
+     * @deprecated 4.0.0 Use `echo Standards::prepareInstalledStandardsForDisplay()` instead.
      *
      * @return void
      */
     public static function printInstalledStandards()
     {
-        $installedStandards = self::getInstalledStandards();
-        $numStandards       = count($installedStandards);
-
-        if ($numStandards === 0) {
-            echo 'No coding standards are installed.'.PHP_EOL;
-        } else {
-            $lastStandard = array_pop($installedStandards);
-            if ($numStandards === 1) {
-                echo "The only coding standard installed is $lastStandard".PHP_EOL;
-            } else {
-                $standardList  = implode(', ', $installedStandards);
-                $standardList .= ' and '.$lastStandard;
-                echo 'The installed coding standards are '.$standardList.PHP_EOL;
-            }
-        }
+        echo self::prepareInstalledStandardsForDisplay(), PHP_EOL;
 
     }//end printInstalledStandards()
 


### PR DESCRIPTION
# Description
This commit introduces a new `Standards::prepareInstalledStandardsForDisplay()` method. This new method only prepares the "list" into displayable phrases. It doesn't include output formatting with new lines, that's up to the actual display.

This new method allows for getting rid of some output buffering calls in select places.

Includes improving the readability of the "coding standard is not installed" error.
Includes deprecating the `Standards::printInstalledStandards()` method, which is now no longer used by PHPCS itself.


## Suggested changelog entry
Deprecated:
* `Standards::printInstalledStandards()`. Use `echo Standards::prepareInstalledStandardsForDisplay()` instead.


## Additional context

This is the readability improvement I mention above:
![image](https://github.com/user-attachments/assets/3ef945c3-5bdb-4263-a271-4f2b6b348c51)
