### PR TITLE
Config: remove some more output buffering

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -679,11 +679,8 @@ class Config
         switch ($arg) {
         case 'h':
         case '?':
-            ob_start();
             $this->printUsage();
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException('', 0);
         case 'i' :
             ob_start();
             Standards::printInstalledStandards();
@@ -796,11 +793,8 @@ class Config
     {
         switch ($arg) {
         case 'help':
-            ob_start();
             $this->printUsage();
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException('', 0);
         case 'version':
             $output  = 'PHP_CodeSniffer version '.self::VERSION.' ('.self::STABILITY.') ';
             $output .= 'by Squiz and PHPCSStandards'.PHP_EOL;


### PR DESCRIPTION
# Description

I don't see why output buffering is needed here.
The `DeepExitException` accepts/allows an empty string as the "message", so there is no reason to collect the screen output via buffering first, only to echo it out again as soon as the exception is caught (by the `Runner` class).

## Suggested changelog entry
_N/A_