### PR TITLE
Generic/ScopeIndent: fix passed param type

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -30,7 +30,7 @@ final class ScopeIndentUnitTest extends AbstractSniffUnitTest
      */
     public function setCliValues($testFile, $config)
     {
-        $config->setConfigData('scope_indent_debug', false, true);
+        $config->setConfigData('scope_indent_debug', '0', true);
 
         // Tab width setting is only needed for the tabbed file.
         if ($testFile === 'ScopeIndentUnitTest.2.inc') {

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -30,7 +30,7 @@ final class ScopeIndentUnitTest extends AbstractSniffUnitTest
      */
     public function setCliValues($testFile, $config)
     {
-        $config->setConfigData('scope_indent_debug', false, true);
+        $config->setConfigData('scope_indent_debug', '0', true);
 
     }//end setCliValues()
 


### PR DESCRIPTION
# Description
Follow up on #1036.

The `Config::setConfigData()` expects a `string` for the config value, even though in this case, it will still be cast back to boolean in the ScopeIndent sniff itself.

## Suggested changelog entry
_N/A_

