### PR TITLE
Runner: use StatusWriter for caught errors

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -126,8 +126,17 @@ class Runner
                 Timing::printRunTime();
             }
         } catch (DeepExitException $e) {
-            echo $e->getMessage();
-            return $e->getCode();
+            $exitCode = $e->getCode();
+            $message  = $e->getMessage();
+            if ($message !== '') {
+                if ($exitCode === 0) {
+                    echo $e->getMessage();
+                } else {
+                    StatusWriter::write($e->getMessage(), 0, 0);
+                }
+            }
+
+            return $exitCode;
         }//end try
 
         if ($numErrors === 0) {
@@ -212,8 +221,17 @@ class Runner
                 Timing::printRunTime();
             }
         } catch (DeepExitException $e) {
-            echo $e->getMessage();
-            return $e->getCode();
+            $exitCode = $e->getCode();
+            $message  = $e->getMessage();
+            if ($message !== '') {
+                if ($exitCode === 0) {
+                    echo $e->getMessage();
+                } else {
+                    StatusWriter::write($e->getMessage(), 0, 0);
+                }
+            }
+
+            return $exitCode;
         }//end try
 
         if ($this->reporter->totalFixed === 0) {

--- a/tests/Core/Runner/RunAllFilesExcludedErrorTest.php
+++ b/tests/Core/Runner/RunAllFilesExcludedErrorTest.php
@@ -10,6 +10,7 @@ namespace PHP_CodeSniffer\Tests\Core\Runner;
 
 use PHP_CodeSniffer\Runner;
 use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
+use PHP_CodeSniffer\Tests\Core\StatusWriterTestHelper;
 
 /**
  * Tests for the "All files were excluded" error message.
@@ -18,6 +19,7 @@ use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
  */
 final class RunAllFilesExcludedErrorTest extends AbstractRunnerTestCase
 {
+    use StatusWriterTestHelper;
 
 
     /**
@@ -40,6 +42,8 @@ final class RunAllFilesExcludedErrorTest extends AbstractRunnerTestCase
 
         $runner = new Runner();
         $runner->runPHPCS();
+
+        $this->verifyOutput();
 
     }//end testPhpcs()
 
@@ -65,6 +69,8 @@ final class RunAllFilesExcludedErrorTest extends AbstractRunnerTestCase
 
         $runner = new Runner();
         $runner->runPHPCBF();
+
+        $this->verifyOutput();
 
     }//end testPhpcbf()
 
@@ -111,12 +117,24 @@ final class RunAllFilesExcludedErrorTest extends AbstractRunnerTestCase
             $_SERVER['argv'][] = $arg;
         }
 
-        $message  = 'ERROR: No files were checked.'.PHP_EOL;
-        $message .= 'All specified files were excluded or did not match filtering rules.'.PHP_EOL.PHP_EOL;
-
-        $this->expectOutputString($message);
+        $this->expectNoStdoutOutput();
 
     }//end setupTest()
+
+
+    /**
+     * Helper method to verify the output expectation for STDERR.
+     *
+     * @return void
+     */
+    private function verifyOutput()
+    {
+        $expected  = 'ERROR: No files were checked.'.PHP_EOL;
+        $expected .= 'All specified files were excluded or did not match filtering rules.'.PHP_EOL.PHP_EOL;
+
+        $this->assertStderrOutputSameString($expected);
+
+    }//end verifyOutput()
 
 
 }//end class


### PR DESCRIPTION
# Description
Errors should go to `STDERR`. This was mostly handled in PR #1010.

However, the `Runner` class contains two `catch (DeepExitException $e)` blocks which are used to exit "early", both for legitimate requests (`--version`, `-i` etc), as well as for error output.

This commit changes how the output is handled in these catch blocks, to differentiate between legitimate requests (exit code `0`) and error output, sending legitimate output to `STDOUT` and sending error output to `STDERR`.

Includes updating a unit test to reflect the change.


## Suggested changelog entry
_N/A_ This change is covered by the changelog entry for #1010.

## Related issues/external references

Related to squizlabs/PHP_CodeSniffer#1612