### PR TITLE
Reporter: remove redundant property

### DIFF
--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -61,13 +61,6 @@ class Reporter
     public $totalFixed = 0;
 
     /**
-     * When the PHPCS run started.
-     *
-     * @var float
-     */
-    public static $startTime = 0;
-
-    /**
      * A cache of report objects.
      *
      * @var array


### PR DESCRIPTION
# Description
This property was introduced in commit 9eaaccd58ed4ffa7d28bb3a1d501a77205c363ed (March 2014) and made redundant in commit f61025c5617a493b655a5f572a3e13749b3a51f8 (March 2015) by the introduction of the `Util\Timing` class. It hasn't been used since.

Time to remove this dead wood.

## Suggested changelog entry
Removed:
* Unused static `PHP_CodeSniffer\Reporter::$startTime` property.

