### PR TITLE
CS: various array formatting fixes

### DIFF
--- a/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
@@ -135,7 +135,7 @@ final class ArrayKeywordTest extends AbstractTokenizerTestCase
                 'testMarker' => '/* testFunctionDeclarationParamDNFType */',
             ],
             'closure param DNF type'     => [
-                'testMarker'  => '/* testClosureDeclarationParamDNFType */',
+                'testMarker' => '/* testClosureDeclarationParamDNFType */',
             ],
             'arrow return DNF type'      => [
                 'testMarker'  => '/* testArrowDeclarationReturnDNFType */',

--- a/tests/Core/Tokenizers/PHP/AttributesTest.php
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.php
@@ -74,7 +74,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
             'class attribute'                                                                   => [
                 'testMarker' => '/* testAttribute */',
                 'tokenCodes' => [
-                    T_STRING
+                    T_STRING,
                 ],
             ],
             'class attribute with param'                                                        => [
@@ -105,7 +105,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
             'function attribute'                                                                => [
                 'testMarker' => '/* testAttributeOnFunction */',
                 'tokenCodes' => [
-                    T_STRING
+                    T_STRING,
                 ],
             ],
             'function attribute with params'                                                    => [
@@ -389,7 +389,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
                 'testMarker' => '/* testSingleAttributeOnParameter */',
                 'position'   => 4,
                 'tokenCodes' => [
-                    T_STRING
+                    T_STRING,
                 ],
             ],
             'parameter attribute; multiple comma separated, inline' => [

--- a/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
@@ -45,10 +45,10 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
     {
         return [
             'standard'   => [
-                'testMarker'  => '/* testStandard */',
+                'testMarker' => '/* testStandard */',
             ],
             'mixed case' => [
-                'testMarker'  => '/* testMixedCase */',
+                'testMarker' => '/* testMixedCase */',
             ],
         ];
 
@@ -423,28 +423,28 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
     {
         return [
             'self'     => [
-                'testMarker'  => '/* testSelfReturnType */',
+                'testMarker' => '/* testSelfReturnType */',
             ],
             'parent'   => [
-                'testMarker'  => '/* testParentReturnType */',
+                'testMarker' => '/* testParentReturnType */',
             ],
             'callable' => [
-                'testMarker'  => '/* testCallableReturnType */',
+                'testMarker' => '/* testCallableReturnType */',
             ],
             'array'    => [
-                'testMarker'  => '/* testArrayReturnType */',
+                'testMarker' => '/* testArrayReturnType */',
             ],
             'static'   => [
-                'testMarker'  => '/* testStaticReturnType */',
+                'testMarker' => '/* testStaticReturnType */',
             ],
             'false'    => [
-                'testMarker'  => '/* testFalseReturnType */',
+                'testMarker' => '/* testFalseReturnType */',
             ],
             'true'     => [
-                'testMarker'  => '/* testTrueReturnType */',
+                'testMarker' => '/* testTrueReturnType */',
             ],
             'null'     => [
-                'testMarker'  => '/* testNullReturnType */',
+                'testMarker' => '/* testNullReturnType */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesTest.php
@@ -386,150 +386,150 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
     {
         return [
             'arrow function return type: in named parameter'              => [
-                'testMarker'  => '/* testDNFTypeArrowFnReturnInNamedParam */',
+                'testMarker' => '/* testDNFTypeArrowFnReturnInNamedParam */',
             ],
             'closure return type: in named parameter'                     => [
-                'testMarker'  => '/* testDNFTypeClosureReturnInNamedParam */',
+                'testMarker' => '/* testDNFTypeClosureReturnInNamedParam */',
             ],
 
             'OO const type: unqualified classes'                          => [
-                'testMarker'  => '/* testDNFTypeOOConstUnqualifiedClasses */',
+                'testMarker' => '/* testDNFTypeOOConstUnqualifiedClasses */',
             ],
             'OO const type: modifiers in reverse order'                   => [
-                'testMarker'  => '/* testDNFTypeOOConstReverseModifierOrder */',
+                'testMarker' => '/* testDNFTypeOOConstReverseModifierOrder */',
             ],
             'OO const type: multi-dnf part 1'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti1 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti1 */',
             ],
             'OO const type: multi-dnf part 2'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti2 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti2 */',
             ],
             'OO const type: multi-dnf part 3'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti3 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti3 */',
             ],
             'OO const type: namespace relative classes'                   => [
-                'testMarker'  => '/* testDNFTypeOOConstNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeOOConstNamespaceRelative */',
             ],
             'OO const type: partially qualified classes'                  => [
-                'testMarker'  => '/* testDNFTypeOOConstPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeOOConstPartiallyQualified */',
             ],
             'OO const type: fully qualified classes'                      => [
-                'testMarker'  => '/* testDNFTypeOOConstFullyQualified */',
+                'testMarker' => '/* testDNFTypeOOConstFullyQualified */',
             ],
 
             'OO property type: unqualified classes'                       => [
-                'testMarker'  => '/* testDNFTypePropertyUnqualifiedClasses */',
+                'testMarker' => '/* testDNFTypePropertyUnqualifiedClasses */',
             ],
             'OO property type: modifiers in reverse order'                => [
-                'testMarker'  => '/* testDNFTypePropertyReverseModifierOrder */',
+                'testMarker' => '/* testDNFTypePropertyReverseModifierOrder */',
             ],
             'OO property type: multi-dnf namespace relative classes'      => [
-                'testMarker'  => '/* testDNFTypePropertyMultiNamespaceRelative */',
+                'testMarker' => '/* testDNFTypePropertyMultiNamespaceRelative */',
             ],
             'OO property type: multi-dnf partially qualified classes'     => [
-                'testMarker'  => '/* testDNFTypePropertyMultiPartiallyQualified */',
+                'testMarker' => '/* testDNFTypePropertyMultiPartiallyQualified */',
             ],
             'OO property type: multi-dnf fully qualified classes'         => [
-                'testMarker'  => '/* testDNFTypePropertyMultiFullyQualified */',
+                'testMarker' => '/* testDNFTypePropertyMultiFullyQualified */',
             ],
             'OO property type: multi-dnf with readonly keyword 1'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithReadOnlyKeyword1 */',
+                'testMarker' => '/* testDNFTypePropertyWithReadOnlyKeyword1 */',
             ],
             'OO property type: multi-dnf with readonly keyword 2'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithReadOnlyKeyword2 */',
+                'testMarker' => '/* testDNFTypePropertyWithReadOnlyKeyword2 */',
             ],
             'OO property type: with static and readonly keywords'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithStaticAndReadOnlyKeywords */',
+                'testMarker' => '/* testDNFTypePropertyWithStaticAndReadOnlyKeywords */',
             ],
             'OO property type: with only static keyword'                  => [
-                'testMarker'  => '/* testDNFTypePropertyWithOnlyStaticKeyword */',
+                'testMarker' => '/* testDNFTypePropertyWithOnlyStaticKeyword */',
             ],
             'OO property type: with only final keyword'                   => [
-                'testMarker'  => '/* testDNFTypeWithPHP84FinalKeyword */',
+                'testMarker' => '/* testDNFTypeWithPHP84FinalKeyword */',
             ],
             'OO property type: with final and static keyword'             => [
-                'testMarker'  => '/* testDNFTypeWithPHP84FinalKeywordAndStatic */',
+                'testMarker' => '/* testDNFTypeWithPHP84FinalKeywordAndStatic */',
             ],
 
             'OO method param type: first param'                           => [
-                'testMarker'  => '/* testDNFTypeParam1WithAttribute */',
+                'testMarker' => '/* testDNFTypeParam1WithAttribute */',
             ],
             'OO method param type: second param, first DNF'               => [
-                'testMarker'  => '/* testDNFTypeParam2 */',
+                'testMarker' => '/* testDNFTypeParam2 */',
             ],
             'OO method param type: second param, second DNF'              => [
-                'testMarker'  => '/* testDNFTypeParam3 */',
+                'testMarker' => '/* testDNFTypeParam3 */',
             ],
             'OO method param type: namespace relative classes'            => [
-                'testMarker'  => '/* testDNFTypeParamNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeParamNamespaceRelative */',
             ],
             'OO method param type: partially qualified classes'           => [
-                'testMarker'  => '/* testDNFTypeParamPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeParamPartiallyQualified */',
             ],
             'OO method param type: fully qualified classes'               => [
-                'testMarker'  => '/* testDNFTypeParamFullyQualified */',
+                'testMarker' => '/* testDNFTypeParamFullyQualified */',
             ],
             'Constructor property promotion with multi DNF 1'             => [
-                'testMarker'  => '/* testDNFTypeConstructorPropertyPromotion1 */',
+                'testMarker' => '/* testDNFTypeConstructorPropertyPromotion1 */',
             ],
             'Constructor property promotion with multi DNF 2'             => [
-                'testMarker'  => '/* testDNFTypeConstructorPropertyPromotion2 */',
+                'testMarker' => '/* testDNFTypeConstructorPropertyPromotion2 */',
             ],
             'OO method return type: multi DNF 1'                          => [
-                'testMarker'  => '/* testDNFTypeReturnType1 */',
+                'testMarker' => '/* testDNFTypeReturnType1 */',
             ],
             'OO method return type: multi DNF 2'                          => [
-                'testMarker'  => '/* testDNFTypeReturnType2 */',
+                'testMarker' => '/* testDNFTypeReturnType2 */',
             ],
             'OO abstract method return type: multi DNF 1'                 => [
-                'testMarker'  => '/* testDNFTypeAbstractMethodReturnType1 */',
+                'testMarker' => '/* testDNFTypeAbstractMethodReturnType1 */',
             ],
             'OO abstract method return type: multi DNF 2'                 => [
-                'testMarker'  => '/* testDNFTypeAbstractMethodReturnType2 */',
+                'testMarker' => '/* testDNFTypeAbstractMethodReturnType2 */',
             ],
             'OO method return type: namespace relative classes'           => [
-                'testMarker'  => '/* testDNFTypeReturnTypeNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeReturnTypeNamespaceRelative */',
             ],
             'OO method return type: partially qualified classes'          => [
-                'testMarker'  => '/* testDNFTypeReturnPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeReturnPartiallyQualified */',
             ],
             'OO method return type: fully qualified classes'              => [
-                'testMarker'  => '/* testDNFTypeReturnFullyQualified */',
+                'testMarker' => '/* testDNFTypeReturnFullyQualified */',
             ],
             'function param type: with reference'                         => [
-                'testMarker'  => '/* testDNFTypeWithReference */',
+                'testMarker' => '/* testDNFTypeWithReference */',
             ],
             'function param type: with spread'                            => [
-                'testMarker'  => '/* testDNFTypeWithSpreadOperator */',
+                'testMarker' => '/* testDNFTypeWithSpreadOperator */',
             ],
             'closure param type: with illegal nullable'                   => [
-                'testMarker'  => '/* testDNFTypeClosureParamIllegalNullable */',
+                'testMarker' => '/* testDNFTypeClosureParamIllegalNullable */',
             ],
             'closure return type'                                         => [
-                'testMarker'  => '/* testDNFTypeClosureReturn */',
+                'testMarker' => '/* testDNFTypeClosureReturn */',
             ],
             'closure with use return type'                                => [
-                'testMarker'  => '/* testDNFTypeClosureWithUseReturn */',
+                'testMarker' => '/* testDNFTypeClosureWithUseReturn */',
             ],
 
             'arrow function param type'                                   => [
-                'testMarker'  => '/* testDNFTypeArrowParam */',
+                'testMarker' => '/* testDNFTypeArrowParam */',
             ],
             'arrow function return type'                                  => [
-                'testMarker'  => '/* testDNFTypeArrowReturnType */',
+                'testMarker' => '/* testDNFTypeArrowReturnType */',
             ],
             'arrow function param type with return by ref'                => [
-                'testMarker'  => '/* testDNFTypeArrowParamWithReturnByRef */',
+                'testMarker' => '/* testDNFTypeArrowParamWithReturnByRef */',
             ],
 
             'illegal syntax: unnecessary parentheses (no union)'          => [
-                'testMarker'  => '/* testDNFTypeParamIllegalUnnecessaryParens */',
+                'testMarker' => '/* testDNFTypeParamIllegalUnnecessaryParens */',
             ],
             'illegal syntax: union within parentheses, intersect outside' => [
-                'testMarker'  => '/* testDNFTypeParamIllegalIntersectUnionReversed */',
+                'testMarker' => '/* testDNFTypeParamIllegalIntersectUnionReversed */',
             ],
             'illegal syntax: nested parentheses'                          => [
-                'testMarker'  => '/* testDNFTypeParamIllegalNestedParens */',
+                'testMarker' => '/* testDNFTypeParamIllegalNestedParens */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
@@ -238,133 +238,133 @@ final class CreateParenthesisNestingMapDNFTypesTest extends AbstractTokenizerTes
     {
         return [
             'OO const type: unqualified classes'                          => [
-                'testMarker'  => '/* testDNFTypeOOConstUnqualifiedClasses */',
+                'testMarker' => '/* testDNFTypeOOConstUnqualifiedClasses */',
             ],
             'OO const type: modifiers in reverse order'                   => [
-                'testMarker'  => '/* testDNFTypeOOConstReverseModifierOrder */',
+                'testMarker' => '/* testDNFTypeOOConstReverseModifierOrder */',
             ],
             'OO const type: multi-dnf part 1'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti1 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti1 */',
             ],
             'OO const type: multi-dnf part 2'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti2 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti2 */',
             ],
             'OO const type: multi-dnf part 3'                             => [
-                'testMarker'  => '/* testDNFTypeOOConstMulti3 */',
+                'testMarker' => '/* testDNFTypeOOConstMulti3 */',
             ],
             'OO const type: namespace relative classes'                   => [
-                'testMarker'  => '/* testDNFTypeOOConstNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeOOConstNamespaceRelative */',
             ],
             'OO const type: partially qualified classes'                  => [
-                'testMarker'  => '/* testDNFTypeOOConstPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeOOConstPartiallyQualified */',
             ],
             'OO const type: fully qualified classes'                      => [
-                'testMarker'  => '/* testDNFTypeOOConstFullyQualified */',
+                'testMarker' => '/* testDNFTypeOOConstFullyQualified */',
             ],
 
             'OO property type: unqualified classes'                       => [
-                'testMarker'  => '/* testDNFTypePropertyUnqualifiedClasses */',
+                'testMarker' => '/* testDNFTypePropertyUnqualifiedClasses */',
             ],
             'OO property type: modifiers in reverse order'                => [
-                'testMarker'  => '/* testDNFTypePropertyReverseModifierOrder */',
+                'testMarker' => '/* testDNFTypePropertyReverseModifierOrder */',
             ],
             'OO property type: multi-dnf namespace relative classes'      => [
-                'testMarker'  => '/* testDNFTypePropertyMultiNamespaceRelative */',
+                'testMarker' => '/* testDNFTypePropertyMultiNamespaceRelative */',
             ],
             'OO property type: multi-dnf partially qualified classes'     => [
-                'testMarker'  => '/* testDNFTypePropertyMultiPartiallyQualified */',
+                'testMarker' => '/* testDNFTypePropertyMultiPartiallyQualified */',
             ],
             'OO property type: multi-dnf fully qualified classes'         => [
-                'testMarker'  => '/* testDNFTypePropertyMultiFullyQualified */',
+                'testMarker' => '/* testDNFTypePropertyMultiFullyQualified */',
             ],
 
             'OO property type: multi-dnf with readonly keyword 1'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithReadOnlyKeyword1 */',
+                'testMarker' => '/* testDNFTypePropertyWithReadOnlyKeyword1 */',
             ],
             'OO property type: multi-dnf with readonly keyword 2'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithReadOnlyKeyword2 */',
+                'testMarker' => '/* testDNFTypePropertyWithReadOnlyKeyword2 */',
             ],
             'OO property type: with static and readonly keywords'         => [
-                'testMarker'  => '/* testDNFTypePropertyWithStaticAndReadOnlyKeywords */',
+                'testMarker' => '/* testDNFTypePropertyWithStaticAndReadOnlyKeywords */',
             ],
             'OO property type: with only static keyword'                  => [
-                'testMarker'  => '/* testDNFTypePropertyWithOnlyStaticKeyword */',
+                'testMarker' => '/* testDNFTypePropertyWithOnlyStaticKeyword */',
             ],
             'OO method param type: first param'                           => [
-                'testMarker'  => '/* testDNFTypeParam1WithAttribute */',
+                'testMarker' => '/* testDNFTypeParam1WithAttribute */',
             ],
             'OO method param type: second param, first DNF'               => [
-                'testMarker'  => '/* testDNFTypeParam2 */',
+                'testMarker' => '/* testDNFTypeParam2 */',
             ],
             'OO method param type: second param, second DNF'              => [
-                'testMarker'  => '/* testDNFTypeParam3 */',
+                'testMarker' => '/* testDNFTypeParam3 */',
             ],
             'OO method param type: namespace relative classes'            => [
-                'testMarker'  => '/* testDNFTypeParamNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeParamNamespaceRelative */',
             ],
             'OO method param type: partially qualified classes'           => [
-                'testMarker'  => '/* testDNFTypeParamPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeParamPartiallyQualified */',
             ],
             'OO method param type: fully qualified classes'               => [
-                'testMarker'  => '/* testDNFTypeParamFullyQualified */',
+                'testMarker' => '/* testDNFTypeParamFullyQualified */',
             ],
             'Constructor property promotion with multi DNF 1'             => [
-                'testMarker'  => '/* testDNFTypeConstructorPropertyPromotion1 */',
+                'testMarker' => '/* testDNFTypeConstructorPropertyPromotion1 */',
             ],
             'Constructor property promotion with multi DNF 2'             => [
-                'testMarker'  => '/* testDNFTypeConstructorPropertyPromotion2 */',
+                'testMarker' => '/* testDNFTypeConstructorPropertyPromotion2 */',
             ],
             'OO method return type: multi DNF 1'                          => [
-                'testMarker'  => '/* testDNFTypeReturnType1 */',
+                'testMarker' => '/* testDNFTypeReturnType1 */',
             ],
             'OO method return type: multi DNF 2'                          => [
-                'testMarker'  => '/* testDNFTypeReturnType2 */',
+                'testMarker' => '/* testDNFTypeReturnType2 */',
             ],
             'OO abstract method return type: multi DNF 1'                 => [
-                'testMarker'  => '/* testDNFTypeAbstractMethodReturnType1 */',
+                'testMarker' => '/* testDNFTypeAbstractMethodReturnType1 */',
             ],
             'OO abstract method return type: multi DNF 2'                 => [
-                'testMarker'  => '/* testDNFTypeAbstractMethodReturnType2 */',
+                'testMarker' => '/* testDNFTypeAbstractMethodReturnType2 */',
             ],
             'OO method return type: namespace relative classes'           => [
-                'testMarker'  => '/* testDNFTypeReturnTypeNamespaceRelative */',
+                'testMarker' => '/* testDNFTypeReturnTypeNamespaceRelative */',
             ],
             'OO method return type: partially qualified classes'          => [
-                'testMarker'  => '/* testDNFTypeReturnPartiallyQualified */',
+                'testMarker' => '/* testDNFTypeReturnPartiallyQualified */',
             ],
             'OO method return type: fully qualified classes'              => [
-                'testMarker'  => '/* testDNFTypeReturnFullyQualified */',
+                'testMarker' => '/* testDNFTypeReturnFullyQualified */',
             ],
             'function param type: with reference'                         => [
-                'testMarker'  => '/* testDNFTypeWithReference */',
+                'testMarker' => '/* testDNFTypeWithReference */',
             ],
             'function param type: with spread'                            => [
-                'testMarker'  => '/* testDNFTypeWithSpreadOperator */',
+                'testMarker' => '/* testDNFTypeWithSpreadOperator */',
             ],
             'closure param type: with illegal nullable'                   => [
-                'testMarker'  => '/* testDNFTypeClosureParamIllegalNullable */',
+                'testMarker' => '/* testDNFTypeClosureParamIllegalNullable */',
             ],
             'closure return type'                                         => [
-                'testMarker'  => '/* testDNFTypeClosureReturn */',
+                'testMarker' => '/* testDNFTypeClosureReturn */',
             ],
             'arrow function param type'                                   => [
-                'testMarker'  => '/* testDNFTypeArrowParam */',
+                'testMarker' => '/* testDNFTypeArrowParam */',
             ],
             'arrow function return type'                                  => [
-                'testMarker'  => '/* testDNFTypeArrowReturnType */',
+                'testMarker' => '/* testDNFTypeArrowReturnType */',
             ],
             'arrow function param type with return by ref'                => [
-                'testMarker'  => '/* testDNFTypeArrowParamWithReturnByRef */',
+                'testMarker' => '/* testDNFTypeArrowParamWithReturnByRef */',
             ],
 
             'illegal syntax: unnecessary parentheses (no union)'          => [
-                'testMarker'  => '/* testDNFTypeParamIllegalUnnecessaryParens */',
+                'testMarker' => '/* testDNFTypeParamIllegalUnnecessaryParens */',
             ],
             'illegal syntax: union within parentheses, intersect outside' => [
-                'testMarker'  => '/* testDNFTypeParamIllegalIntersectUnionReversed */',
+                'testMarker' => '/* testDNFTypeParamIllegalIntersectUnionReversed */',
             ],
             'illegal syntax: nested parentheses'                          => [
-                'testMarker'  => '/* testDNFTypeParamIllegalNestedParens */',
+                'testMarker' => '/* testDNFTypeParamIllegalNestedParens */',
             ],
         ];
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
@@ -143,7 +143,7 @@ final class CreateTokenMapArrayParenthesesTest extends AbstractTokenizerTestCase
                 'testMarker' => '/* testFunctionDeclarationParamDNFType */',
             ],
             'closure param DNF type'     => [
-                'testMarker'  => '/* testClosureDeclarationParamDNFType */',
+                'testMarker' => '/* testClosureDeclarationParamDNFType */',
             ],
             'arrow return DNF type'      => [
                 'testMarker'  => '/* testArrowDeclarationReturnDNFType */',


### PR DESCRIPTION
# Description
These alignment issues were, for some unknown reason, not picking up by the PHPCS native sniffs. This may need investigating, but as it involves the `Squiz.Arrays.ArrayDeclaration` sniff, this is not really worth the time.

Fixed now anyway by locally using a few outside sniffs.


## Suggested changelog entry
_N/A_