### PR TITLE
ProcessRulesetCliArgsTest: add tests for `cache` arg

### DIFF
--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/.phpcs.xml
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/.phpcs.xml
@@ -8,6 +8,7 @@
 
     <!-- Issue squizlabs/PHP_CodeSniffer#2395: allow overruling CLI args when they have different CLI flag names. -->
     <arg name="no-colors"/>
+    <arg name="cache" value="./config/phpcs/.cache.phpcs"/>
 
     <!-- Miscellaneous other settings. -->
     <arg name="report" value="full,summary,source"/>

--- a/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/phpcs.xml.dist
+++ b/tests/Core/Ruleset/Fixtures/ProcessRulesetCliArgsTest/phpcs.xml.dist
@@ -22,6 +22,9 @@
     <arg name="extensions" value="inc,php"/>
     <arg name="tab-width" value="4"/>
 
+    <!-- Issue squizlabs/PHP_CodeSniffer#2395: second test. -->
+    <arg name="no-cache"/>
+
     <!-- Miscellaneous other settings. -->
     <arg name="report-width" value="120"/>
 

--- a/tests/Core/Ruleset/ProcessRulesetCliArgsTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetCliArgsTest.php
@@ -108,6 +108,10 @@ final class ProcessRulesetCliArgsTest extends TestCase
                 'name'     => 'warningSeverity',
                 'expected' => 5,
             ],
+            'Issue squiz#2395: "cache" set to file in parent before includes; "no-cache" set in child; parent should win [1]'        => [
+                'name'     => 'cache',
+                'expected' => true,
+            ],
             'Issue squiz#2395: "q" in child A before includes; "p" set in grandchild A, child A should win'                          => [
                 'name'     => 'showProgress',
                 'expected' => false,
@@ -194,6 +198,10 @@ final class ProcessRulesetCliArgsTest extends TestCase
                 'expected' => [
                     self::FIXTURE_DIR.'/vendor/OrgName/ExtStandard/bootstrap.php',
                 ],
+            ],
+            'Paths should be resolved based on the ruleset location: cacheFile'  => [
+                'name'     => 'cacheFile',
+                'expected' => self::FIXTURE_DIR.'/config/phpcs/.cache.phpcs',
             ],
         ];
 


### PR DESCRIPTION
# Description
Follow up on #1005

Was previously blocked by the `Config` class not allowing for the `cache` setting to be changed from within the tests, which was fixed via #1068. Also see #966


## Suggested changelog entry
_N/A_