### PR TITLE
PrintProgressTest: minor fix to the `tearDown()` method

### DIFF
--- a/tests/Core/Runner/PrintProgressTest.php
+++ b/tests/Core/Runner/PrintProgressTest.php
@@ -86,6 +86,9 @@ final class PrintProgressTest extends TestCase
         self::$config->showProgress = true;
         self::$fileWithoutErrorsOrWarnings->ignored = false;
 
+        // Reset all static properties on the StatusWriter class.
+        $this->resetStatusWriterProperties();
+
     }//end tearDown()
 
 


### PR DESCRIPTION
# Description
The test class defines its own `tearDown()` method, which overrules the `tearDown()` from the `StatusWriterTestHelper` class, so we need to call the `StatusWriterTestHelper::resetStatusWriterProperties()` method from our own `tearDown()`.


## Suggested changelog entry
_N/A_
