### PR TITLE
Remark/dead URL check: skip stack overflow link

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -15,7 +15,8 @@
                 "^https?://github\\.com/PHPCSStandards/PHP_CodeSniffer/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
                 "^https?://github\\.com/[A-Za-z0-9-]+",
                 "^https?://pear\\.php\\.net/bugs/bug\\.php\\?id=[0-9]+",
-                "^https?://x\\.com/PHP_CodeSniffer"
+                "^https?://x\\.com/PHP_CodeSniffer",
+                "^https?://stackoverflow\\.com/questions/tagged/phpcodesniffer"
             ],
             "deadOrAliveOptions": {
                 "maxRetries": 3


### PR DESCRIPTION
# Description
While I'm loath to add even more URLs to the ignore list, StackOverflow is currently causing the builds to fail by returning a `403`, while manually visiting the URL, works absolutely fine (`200`).


## Suggested changelog entry
_N/A_