### PR TITLE
4.0 | Generators/Generator: improve error messages

### DIFF
--- a/src/Exceptions/GeneratorException.php
+++ b/src/Exceptions/GeneratorException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * An exception thrown by PHP_CodeSniffer when it encounters an error in the XML document being processed
+ * by one of the documentation Generators.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2024 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Exceptions;
+
+use DomainException;
+
+class GeneratorException extends DomainException
+{
+
+}//end class

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -15,8 +15,10 @@
 namespace PHP_CodeSniffer\Generators;
 
 use DOMDocument;
+use DOMElement;
 use DOMNode;
 use PHP_CodeSniffer\Autoload;
+use PHP_CodeSniffer\Exceptions\GeneratorException;
 use PHP_CodeSniffer\Ruleset;
 
 abstract class Generator
@@ -112,6 +114,9 @@ abstract class Generator
      *
      * @return void
      * @see    processSniff()
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\GeneratorException If there is no <documentation> element
+     *                                                        in the XML document.
      */
     public function generate()
     {
@@ -119,6 +124,12 @@ abstract class Generator
             $doc = new DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
+            if (($documentation instanceof DOMNode) === false) {
+                throw new GeneratorException(
+                    'Missing top-level <documentation> element in XML documentation file '.$file
+                );
+            }
+
             $this->processSniff($documentation);
         }
 

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -19,6 +19,7 @@ use DOMDocument;
 use DOMElement;
 use DOMNode;
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\GeneratorException;
 
 class HTML extends Generator
 {
@@ -126,6 +127,9 @@ class HTML extends Generator
      *
      * @return void
      * @see    processSniff()
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\GeneratorException If there is no <documentation> element
+     *                                                        in the XML document.
      */
     public function generate()
     {
@@ -134,10 +138,18 @@ class HTML extends Generator
         }
 
         ob_start();
-        parent::generate();
+        try {
+            parent::generate();
+            $content = ob_get_clean();
+        } catch (GeneratorException $e) {
+            ob_end_clean();
+            $content = '';
+        }
 
-        $content = ob_get_contents();
-        ob_end_clean();
+        // If an exception was caught, rethrow it outside of the output buffer.
+        if (isset($e) === true) {
+            throw $e;
+        }
 
         // Clear anchor cache after Documentation generation.
         // The anchor generation for the TOC anchor links will use the same logic, so should end up with the same unique slugs.

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -14,6 +14,7 @@ namespace PHP_CodeSniffer\Generators;
 use DOMElement;
 use DOMNode;
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\GeneratorException;
 
 class Markdown extends Generator
 {
@@ -24,6 +25,9 @@ class Markdown extends Generator
      *
      * @return void
      * @see    processSniff()
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\GeneratorException If there is no <documentation> element
+     *                                                        in the XML document.
      */
     public function generate()
     {
@@ -32,10 +36,18 @@ class Markdown extends Generator
         }
 
         ob_start();
-        parent::generate();
+        try {
+            parent::generate();
+            $content = ob_get_clean();
+        } catch (GeneratorException $e) {
+            ob_end_clean();
+            $content = '';
+        }
 
-        $content = ob_get_contents();
-        ob_end_clean();
+        // If an exception was caught, rethrow it outside of the output buffer.
+        if (isset($e) === true) {
+            throw $e;
+        }
 
         if (trim($content) !== '') {
             echo $this->getFormattedHeader();

--- a/tests/Core/Generators/GeneratorTest.php
+++ b/tests/Core/Generators/GeneratorTest.php
@@ -8,6 +8,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Generators;
 
+use PHP_CodeSniffer\Exceptions\GeneratorException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\MockGenerator;
@@ -94,8 +95,6 @@ final class GeneratorTest extends TestCase
     /**
      * Verify that an XML doc which isn't valid documentation yields an Exception to warn devs.
      *
-     * This should not be hidden via defensive coding!
-     *
      * @return void
      */
     public function testGeneratingInvalidDocsResultsInException()
@@ -105,14 +104,8 @@ final class GeneratorTest extends TestCase
         $config   = new ConfigDouble(["--standard=$standard"]);
         $ruleset  = new Ruleset($config);
 
-        if (PHP_VERSION_ID >= 80000) {
-            $message = 'processSniff(): Argument #1 ($doc) must be of type DOMNode, null given';
-        } else {
-            $message = 'processSniff() must be an instance of DOMNode, null given';
-        }
-
-        $this->expectException('TypeError');
-        $this->expectExceptionMessage($message);
+        $this->expectException(GeneratorException::class);
+        $this->expectExceptionMessage('Missing top-level <documentation> element in XML documentation file');
 
         $generator = new MockGenerator($ruleset);
         $generator->generate();

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -8,6 +8,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Generators;
 
+use PHP_CodeSniffer\Exceptions\GeneratorException;
+use PHP_CodeSniffer\Generators\HTML;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\HTMLDouble;
@@ -21,6 +23,27 @@ use PHPUnit\Framework\TestCase;
  */
 final class HTMLTest extends TestCase
 {
+
+
+    /**
+     * Verify that an XML doc which isn't valid documentation yields an Exception to warn devs.
+     *
+     * @return void
+     */
+    public function testGeneratingInvalidDocsResultsInException()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/NoValidDocsTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $this->expectException(GeneratorException::class);
+        $this->expectExceptionMessage('Missing top-level <documentation> element in XML documentation file');
+
+        $generator = new HTML($ruleset);
+        $generator->generate();
+
+    }//end testGeneratingInvalidDocsResultsInException()
 
 
     /**

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -8,6 +8,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Generators;
 
+use PHP_CodeSniffer\Exceptions\GeneratorException;
+use PHP_CodeSniffer\Generators\Markdown;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\MarkdownDouble;
@@ -21,6 +23,27 @@ use PHPUnit\Framework\TestCase;
  */
 final class MarkdownTest extends TestCase
 {
+
+
+    /**
+     * Verify that an XML doc which isn't valid documentation yields an Exception to warn devs.
+     *
+     * @return void
+     */
+    public function testGeneratingInvalidDocsResultsInException()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/NoValidDocsTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $this->expectException(GeneratorException::class);
+        $this->expectExceptionMessage('Missing top-level <documentation> element in XML documentation file');
+
+        $generator = new Markdown($ruleset);
+        $generator->generate();
+
+    }//end testGeneratingInvalidDocsResultsInException()
 
 
     /**


### PR DESCRIPTION
# Description
Make errors encountered when processing XML documentation more informative by providing more specific error messages via a dedicated `GeneratorException`, which extends the PHP native `DomainException`.

Ref:
* https://www.php.net/class.domainexception


## Suggested changelog entry
The `Generator` classes will now throw a `PHP_CodeSniffer\Exceptions\GeneratorException` when encountering errors in the documentation XML.

