### PR TITLE
Start using Timing class in more places

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -16,6 +16,7 @@ on:
       - 'src/Exceptions/RuntimeException.php'
       - 'src/Exceptions/TokenizerException.php'
       - 'src/Tokenizers/PHP.php'
+      - 'src/Util/Timing.php'
       - 'src/Util/Tokens.php'
   pull_request:
     paths:
@@ -27,6 +28,7 @@ on:
       - 'src/Exceptions/RuntimeException.php'
       - 'src/Exceptions/TokenizerException.php'
       - 'src/Tokenizers/PHP.php'
+      - 'src/Util/Timing.php'
       - 'src/Util/Tokens.php'
 
   # Allow manually triggering the workflow.

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -17,6 +17,7 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHP_CodeSniffer\Tokenizers\PHP;
+use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Tokens;
 
 error_reporting(E_ALL);
@@ -78,7 +79,7 @@ function stripWhitespaceAndComments($fullpath, $config)
 }//end stripWhitespaceAndComments()
 
 
-$startTime = microtime(true);
+Timing::startTiming();
 
 $scripts = [
     'phpcs',
@@ -170,14 +171,7 @@ foreach ($scripts as $script) {
     echo 'done'.PHP_EOL;
 }//end foreach
 
-$timeTaken = ((microtime(true) - $startTime) * 1000);
-if ($timeTaken < 1000) {
-    $timeTaken = round($timeTaken);
-    echo "DONE in {$timeTaken}ms".PHP_EOL;
-} else {
-    $timeTaken = round(($timeTaken / 1000), 2);
-    echo "DONE in $timeTaken secs".PHP_EOL;
-}
+Timing::printRunTime();
 
 echo PHP_EOL;
 echo 'Filesize generated phpcs.phar file: '.filesize(dirname(__DIR__).'/phpcs.phar').' bytes'.PHP_EOL;

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -15,6 +15,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Cbf implements Report
@@ -73,14 +74,7 @@ class Cbf implements Report
                 StatusWriter::forceWrite('DONE', 0, 0);
             }
 
-            $timeTaken = ((microtime(true) - $startTime) * 1000);
-            if ($timeTaken < 1000) {
-                $timeTaken = round($timeTaken);
-                StatusWriter::forceWrite(" in {$timeTaken}ms");
-            } else {
-                $timeTaken = round(($timeTaken / 1000), 2);
-                StatusWriter::forceWrite(" in $timeTaken secs");
-            }
+            StatusWriter::forceWrite(' in '.Timing::getHumanReadableDuration(Timing::getDurationSince($startTime)));
         }
 
         if ($fixed === true) {

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -12,6 +12,7 @@ namespace PHP_CodeSniffer\Reports;
 use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Code implements Report
@@ -65,14 +66,7 @@ class Code implements Report
             }
 
             if (PHP_CODESNIFFER_VERBOSITY === 1) {
-                $timeTaken = ((microtime(true) - $startTime) * 1000);
-                if ($timeTaken < 1000) {
-                    $timeTaken = round($timeTaken);
-                    StatusWriter::forceWrite("DONE in {$timeTaken}ms");
-                } else {
-                    $timeTaken = round(($timeTaken / 1000), 2);
-                    StatusWriter::forceWrite("DONE in $timeTaken secs");
-                }
+                StatusWriter::forceWrite('DONE in '.Timing::getHumanReadableDuration(Timing::getDurationSince($startTime)));
             }
 
             $tokens = $phpcsFile->getTokens();

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Diff implements Report
@@ -51,14 +52,7 @@ class Diff implements Report
             $phpcsFile->parse();
 
             if (PHP_CODESNIFFER_VERBOSITY === 1) {
-                $timeTaken = ((microtime(true) - $startTime) * 1000);
-                if ($timeTaken < 1000) {
-                    $timeTaken = round($timeTaken);
-                    StatusWriter::write("DONE in {$timeTaken}ms");
-                } else {
-                    $timeTaken = round(($timeTaken / 1000), 2);
-                    StatusWriter::write("DONE in $timeTaken secs");
-                }
+                StatusWriter::write('DONE in '.Timing::getHumanReadableDuration(Timing::getDurationSince($startTime)));
             }
 
             $phpcsFile->fixer->startFile($phpcsFile);

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -612,14 +612,7 @@ class Runner
             $file->process();
 
             if (PHP_CODESNIFFER_VERBOSITY > 0) {
-                $timeTaken = ((microtime(true) - $startTime) * 1000);
-                if ($timeTaken < 1000) {
-                    $timeTaken = round($timeTaken);
-                    StatusWriter::write("DONE in {$timeTaken}ms", 0, 0);
-                } else {
-                    $timeTaken = round(($timeTaken / 1000), 2);
-                    StatusWriter::write("DONE in $timeTaken secs", 0, 0);
-                }
+                StatusWriter::write('DONE in '.Timing::getHumanReadableDuration(Timing::getDurationSince($startTime)), 0, 0);
 
                 if (PHP_CODESNIFFER_CBF === true) {
                     $errors = $file->getFixableCount();

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -2,8 +2,17 @@
 /**
  * Timing functions for the run.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This class is intended for internal use only and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @internal
+ *
  * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
@@ -11,7 +20,7 @@ namespace PHP_CodeSniffer\Util;
 
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
-class Timing
+final class Timing
 {
 
     /**
@@ -29,7 +38,7 @@ class Timing
     private const SECOND_IN_MS = 1000;
 
     /**
-     * The start time of the run in microseconds.
+     * The start time of the run in seconds.
      *
      * @var float
      */
@@ -71,6 +80,20 @@ class Timing
         return ((microtime(true) - self::$startTime) * 1000);
 
     }//end getDuration()
+
+
+    /**
+     * Get the duration since a given start time up to "now".
+     *
+     * @param float $startTime Start time in microseconds.
+     *
+     * @return float Duration in milliseconds.
+     */
+    public static function getDurationSince($startTime)
+    {
+        return ((microtime(true) - $startTime) * 1000);
+
+    }//end getDurationSince()
 
 
     /**

--- a/tests/Core/Util/Timing/TimingTest.php
+++ b/tests/Core/Util/Timing/TimingTest.php
@@ -61,6 +61,24 @@ final class TimingTest extends TestCase
 
 
     /**
+     * Verify that getDurationSince() returns the time in milliseconds.
+     *
+     * @return void
+     */
+    public function testGetDurationSinceReturnsMilliseconds()
+    {
+        $startTime = microtime(true);
+        usleep(1500);
+        $duration = Timing::getDurationSince($startTime);
+
+        $this->assertIsFloat($duration);
+        $this->assertGreaterThan(1, $duration);
+        $this->assertLessThan(15, $duration);
+
+    }//end testGetDurationSinceReturnsMilliseconds()
+
+
+    /**
      * Verify that printRunTime() doesn't print anything if the timer wasn't started.
      *
      * @return void


### PR DESCRIPTION
# Description

### Timing: add new getDurationSince() method 

This method doesn't use the "system" run start time, but uses an arbitrary start time as provided via a parameter.

This allows for removing some duplicate code in various places.

Includes making the class `final` and explicitly marking this class as an internal class to allow for further changes in the future.

### Start using Timing class in more places 

... which allows for removing some duplicate code and streamlining consistent display of timing information.


## Suggested changelog entry
Changed:
- The `PHP_CodeSniffer\Util\Timing` class is now `final` and marked as an internal class.