### PR TITLE
Tests should pass in CBF mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,8 +222,6 @@ jobs:
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Note: The code style check is run multiple times against every PHP version
-      # as it also acts as an integration test.
       - name: 'PHPCS: set the path to PHP'
         run: php "bin/phpcs" --config-set php_path php
 
@@ -231,12 +229,21 @@ jobs:
         if: ${{ matrix.skip_tests != true }}
         run: php "vendor/bin/phpunit" tests/AllTests.php --no-coverage
 
+      # Do one test run against the complete test suite in CBF mode to ensure all tests can run in CBF mode.
+      - name: 'PHPUnit: run the full test suite without code coverage in CBF mode (PHP 8.3 only)'
+        if: ${{ matrix.php == '8.3' }}
+        run: php "vendor/bin/phpunit" tests/AllTests.php --exclude-group nothing --no-coverage
+        env:
+          PHP_CODESNIFFER_CBF: '1'
+
       - name: 'PHPUnit: run select tests in CBF mode'
-        if: ${{ matrix.skip_tests != true }}
+        if: ${{ matrix.skip_tests != true && matrix.php != '8.3' }}
         run: php "vendor/bin/phpunit" tests/AllTests.php --group CBF --exclude-group nothing --no-coverage
         env:
           PHP_CODESNIFFER_CBF: '1'
 
+      # Note: The code style check is run multiple times against every PHP version
+      # as it also acts as an integration test.
       - name: 'PHPCS: check code style without cache, no parallel'
         if: ${{ matrix.custom_ini == false }}
         run: php "bin/phpcs" --no-cache --parallel=1

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -21,6 +21,22 @@ final class GeneratorArgTest extends TestCase
 
 
     /**
+     * Skip these tests when in CBF mode.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function maybeSkipTests()
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('The `--generator` CLI flag is only supported for the `phpcs` command');
+        }
+
+    }//end maybeSkipTests()
+
+
+    /**
      * Ensure that the generator property is set when the parameter is passed a valid value.
      *
      * @param string $argumentValue         Generator name passed on the command line.

--- a/tests/Core/Config/SniffsExcludeArgsTest.php
+++ b/tests/Core/Config/SniffsExcludeArgsTest.php
@@ -34,6 +34,11 @@ final class SniffsExcludeArgsTest extends TestCase
      */
     public function testInvalid($argument, $value, $errors, $suggestion)
     {
+        $cmd = 'phpcs';
+        if (PHP_CODESNIFFER_CBF === true) {
+            $cmd = 'phpcbf';
+        }
+
         $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
         $message   = 'ERROR: The --'.$argument.' option only supports sniff codes.'.PHP_EOL;
         $message  .= 'Sniff codes are in the form "Standard.Category.Sniff".'.PHP_EOL;
@@ -47,7 +52,7 @@ final class SniffsExcludeArgsTest extends TestCase
         }
 
         $message .= PHP_EOL;
-        $message .= 'Run "phpcs --help" for usage information'.PHP_EOL;
+        $message .= "Run \"{$cmd} --help\" for usage information".PHP_EOL;
         $message .= PHP_EOL;
 
         if (method_exists($this, 'expectException') === true) {

--- a/tests/Core/Ruleset/DisplayCachedMessagesTest.php
+++ b/tests/Core/Ruleset/DisplayCachedMessagesTest.php
@@ -229,17 +229,23 @@ final class DisplayCachedMessagesTest extends AbstractRulesetTestCase
      */
     public static function dataSelectiveDisplayOfMessages()
     {
-        return [
-            'Explain mode'               => [
+        $data = [
+            'Explain mode' => [
                 'configArgs' => ['-e'],
             ],
-            'Quiet mode'                 => [
+            'Quiet mode'   => [
                 'configArgs' => ['-q'],
             ],
-            'Documentation is requested' => [
-                'configArgs' => ['--generator=text'],
-            ],
         ];
+
+        // Setting the `--generator` arg is only supported when running `phpcs`.
+        if (PHP_CODESNIFFER_CBF === false) {
+            $data['Documentation is requested'] = [
+                'configArgs' => ['--generator=text'],
+            ];
+        }
+
+        return $data;
 
     }//end dataSelectiveDisplayOfMessages()
 


### PR DESCRIPTION
# Description
### SniffsExcludeArgsTest: allow for the test to pass in CBF mode

### GeneratorArgTest: skip tests when in CBF mode

### DisplayCachedMessagesTest: allow for the tests to pass in CBF mode

### GH Actions/tests: safeguard that tests pass in CBF mode 

Some tests had sneaked in which would pass in CS mode, but not in CBF mode - at least, not without some tweaks.

CBF specific tests were already being run in CBF mode and run against every supported PHP version.

This commit now adds a test run of the complete test suite in CBF mode against one (high) PHP version to ensure that (new) tests always take both modes into account and no new issues like this can sneak in.

## Suggested changelog entry
_N/A_