### PR TITLE
Config: bug fix - "reports" could get set incorrectly when in CBF mode

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1010,8 +1010,8 @@ class Config
                 }
 
                 self::$overriddenDefaults['stdinPath'] = true;
-            } else if (PHP_CODESNIFFER_CBF === false && substr($arg, 0, 12) === 'report-file=') {
-                if (isset(self::$overriddenDefaults['reportFile']) === true) {
+            } else if (substr($arg, 0, 12) === 'report-file=') {
+                if (PHP_CODESNIFFER_CBF === true || isset(self::$overriddenDefaults['reportFile']) === true) {
                     break;
                 }
 

--- a/tests/Core/Config/ReportArgsTest.php
+++ b/tests/Core/Config/ReportArgsTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Config --report, --report-file and --report-* arguments.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Config --report, --report-file and --report-* arguments.
+ *
+ * @covers \PHP_CodeSniffer\Config::processLongArgument
+ */
+final class ReportArgsTest extends TestCase
+{
+
+
+    /**
+     * [CS mode] Verify that passing `--report-file` does not influence *which* reports get activated.
+     *
+     * @return void
+     */
+    public function testReportFileDoesNotSetReportsCs()
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+        $config = new ConfigDouble(['--report-file='.__DIR__.'/report.txt']);
+
+        $this->assertTrue(is_string($config->reportFile));
+        $this->assertStringEndsWith('/report.txt', $config->reportFile);
+        $this->assertSame(['full' => null], $config->reports);
+
+    }//end testReportFileDoesNotSetReportsCs()
+
+
+    /**
+     * [CBF mode] Verify that passing `--report-file` does not influence *which* reports get activated.
+     *
+     * @group CBF
+     *
+     * @return void
+     */
+    public function testReportFileDoesNotSetReportsCbf()
+    {
+        if (PHP_CODESNIFFER_CBF === false) {
+            $this->markTestSkipped('This test needs CBF mode to run');
+        }
+
+        $config = new ConfigDouble(['--report-file='.__DIR__.'/report.txt']);
+
+        $this->assertNull($config->reportFile);
+        $this->assertSame(['full' => null], $config->reports);
+
+    }//end testReportFileDoesNotSetReportsCbf()
+
+
+}//end class


### PR DESCRIPTION
# Description
There are three CLI arguments related to the reporting:
* `--report=[comma separated list]`
* `--report-file=[path to file]`
* `--report-<type>=[path to file]`

The `--report-file...` option is ignored when in CBF mode. Whether that is the correct behaviour or not, is outside the scope of the current bug fix.

In the `Config::processLongArgument()` method, the `--report-file` option is handled _before_ the `--report-<type>` option to ensure that `--report-file` is handled correctly, as the handling of the `--report-<type>` argument is based on seeing the prefix `--report-`, which overlaps with `--report-file`.

However, this logic was broken in CBF mode, as in that case, the `--report-file` CLI arg would still fall through to the `--report-<type>` handling, which would break the setting of the `$reports`.

Fixed now.

Includes tests specifically for this issue.

_This is a logic bug only and had no impact on end-users, as the `Runner::runPHPCBF()` method includes a hard-coded overrule of the `reportFile` and `report` settings._

## Suggested changelog entry
_N/A_

