### PR TITLE
Help: improve information about requesting reports

### DIFF
--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -487,8 +487,9 @@ final class Help
 
         $options['Reporting Options'] = [
             'report'             => [
-                'argument'    => '--report=<report>',
-                'description' => 'Print either the "full", "xml", "checkstyle", "csv", "json", "junit", "emacs", "source", "summary", "diff", "svnblame", "gitblame", "hgblame", "notifysend" or "performance" report or specify the path to a custom report class. By default, the "full" report is displayed.',
+                'argument'    => '--report=<report(s)>',
+                'description' => 'A comma-separated list of reports to print. Available reports: "full", "xml", "checkstyle", "csv", "json", "junit", "emacs", "source", "summary", "diff", "svnblame", "gitblame", "hgblame", "notifysend" or "performance".'."\n"
+                    .'Or specify the path to a custom report class. By default, the "full" report is displayed.',
             ],
             'report-file'        => [
                 'argument'    => '--report-file=<reportFile>',


### PR DESCRIPTION
# Description
The help info did not mention that multiple reports can be requested in one go. Fixed now.


## Suggested changelog entry
Improved the help information about "reports".

## Todo

- [ ] Update wiki with the new phrasing.
