### PR TITLE
Change the exit codes

### DIFF
--- a/.github/workflows/test-requirements-check.yml
+++ b/.github/workflows/test-requirements-check.yml
@@ -142,7 +142,14 @@ jobs:
       - name: Run the test
         id: check
         continue-on-error: true
-        run: php "bin/${{ matrix.cmd }}" --version
+        shell: bash
+        run: |
+          set +e
+          php "bin/${{ matrix.cmd }}" --version
+          exitcode="$?"
+          echo "EXITCODE=$exitcode" >> "$GITHUB_OUTPUT"
+          echo "Exitcode is: $exitcode"
+          exit "$exitcode"
 
       - name: Check the result of a successful test against expectation
         if: ${{ steps.check.outcome == 'success' && matrix.expect == 'fail' }}
@@ -150,6 +157,14 @@ jobs:
 
       - name: Check the result of a failed test against expectation
         if: ${{ steps.check.outcome != 'success' && matrix.expect == 'success' }}
+        run: exit 1
+
+      - name: Verify the exit code is 0 when requirements are met
+        if: ${{ matrix.expect == 'success' && steps.check.outputs.EXITCODE != 0 }}
+        run: exit 1
+
+      - name: Verify the exit code is 64 when requirements are not met
+        if: ${{ matrix.expect == 'fail' && steps.check.outputs.EXITCODE != 64 }}
         run: exit 1
 
   build-phars:
@@ -199,7 +214,14 @@ jobs:
       - name: Run the test
         id: check
         continue-on-error: true
-        run: php ${{ matrix.cmd }}.phar --version
+        shell: bash
+        run: |
+          set +e
+          php ${{ matrix.cmd }}.phar --version
+          exitcode="$?"
+          echo "EXITCODE=$exitcode" >> "$GITHUB_OUTPUT"
+          echo "Exitcode is: $exitcode"
+          exit "$exitcode"
 
       - name: Check the result of a successful test against expectation
         if: ${{ steps.check.outcome == 'success' && matrix.expect == 'fail' }}
@@ -207,4 +229,12 @@ jobs:
 
       - name: Check the result of a failed test against expectation
         if: ${{ steps.check.outcome != 'success' && matrix.expect == 'success' }}
+        run: exit 1
+
+      - name: Verify the exit code is 0 when requirements are met
+        if: ${{ matrix.expect == 'success' && steps.check.outputs.EXITCODE != 0 }}
+        run: exit 1
+
+      - name: Verify the exit code is 64 when requirements are not met
+        if: ${{ matrix.expect == 'fail' && steps.check.outputs.EXITCODE != 64 }}
         run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ composer.lock
 phpstan.neon
 /node_modules/
 /tests/Standards/sniffStnd.xml
+/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/*.fixed
+/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/phpcs.cache

--- a/requirements.php
+++ b/requirements.php
@@ -29,7 +29,8 @@ namespace PHP_CodeSniffer;
  */
 function checkRequirements()
 {
-    $exitCode = 3;
+    // IMPORTANT: Must stay in sync with the value of the `PHP_CodeSniffer\Util\ExitCode::REQUIREMENTS_NOT_MET` constant!
+    $exitCode = 64;
 
     // Check the PHP version.
     if (PHP_VERSION_ID < 70200) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -17,6 +17,7 @@ use Phar;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\ExitCode;
 use PHP_CodeSniffer\Util\Help;
 use PHP_CodeSniffer\Util\Standards;
 
@@ -678,10 +679,10 @@ class Config
         case 'h':
         case '?':
             $this->printUsage();
-            throw new DeepExitException('', 0);
+            throw new DeepExitException('', ExitCode::OKAY);
         case 'i' :
             $output = Standards::prepareInstalledStandardsForDisplay().PHP_EOL;
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException($output, ExitCode::OKAY);
         case 'v' :
             if ($this->quiet === true) {
                 // Ignore when quiet mode is enabled.
@@ -747,7 +748,7 @@ class Config
             if ($changed === false && ini_get($ini[0]) !== $ini[1]) {
                 $error  = sprintf('ERROR: Ini option "%s" cannot be changed at runtime.', $ini[0]).PHP_EOL;
                 $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
             break;
         case 'n' :
@@ -789,11 +790,11 @@ class Config
         switch ($arg) {
         case 'help':
             $this->printUsage();
-            throw new DeepExitException('', 0);
+            throw new DeepExitException('', ExitCode::OKAY);
         case 'version':
             $output  = 'PHP_CodeSniffer version '.self::VERSION.' ('.self::STABILITY.') ';
             $output .= 'by Squiz and PHPCSStandards'.PHP_EOL;
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException($output, ExitCode::OKAY);
         case 'colors':
             if (isset($this->overriddenDefaults['colors']) === true) {
                 break;
@@ -840,7 +841,7 @@ class Config
             ) {
                 $error  = 'ERROR: Setting a config option requires a name and value'.PHP_EOL.PHP_EOL;
                 $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             $key     = $this->cliArgs[($pos + 1)];
@@ -850,7 +851,7 @@ class Config
             try {
                 $this->setConfigData($key, $value);
             } catch (Exception $e) {
-                throw new DeepExitException($e->getMessage().PHP_EOL, 3);
+                throw new DeepExitException($e->getMessage().PHP_EOL, ExitCode::PROCESS_ERROR);
             }
 
             $output = 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
@@ -860,12 +861,12 @@ class Config
             } else {
                 $output .= "Config value \"$key\" updated successfully; old value was \"$current\"".PHP_EOL;
             }
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException($output, ExitCode::OKAY);
         case 'config-delete':
             if (isset($this->cliArgs[($pos + 1)]) === false) {
                 $error  = 'ERROR: Deleting a config option requires the name of the option'.PHP_EOL.PHP_EOL;
                 $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             $output = 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
@@ -878,24 +879,24 @@ class Config
                 try {
                     $this->setConfigData($key, null);
                 } catch (Exception $e) {
-                    throw new DeepExitException($e->getMessage().PHP_EOL, 3);
+                    throw new DeepExitException($e->getMessage().PHP_EOL, ExitCode::PROCESS_ERROR);
                 }
 
                 $output .= "Config value \"$key\" removed successfully; old value was \"$current\"".PHP_EOL;
             }
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException($output, ExitCode::OKAY);
         case 'config-show':
             $data    = self::getAllConfigData();
             $output  = 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
             $output .= $this->prepareConfigDataForDisplay($data);
-            throw new DeepExitException($output, 0);
+            throw new DeepExitException($output, ExitCode::OKAY);
         case 'runtime-set':
             if (isset($this->cliArgs[($pos + 1)]) === false
                 || isset($this->cliArgs[($pos + 2)]) === false
             ) {
                 $error  = 'ERROR: Setting a runtime config option requires a name and value'.PHP_EOL.PHP_EOL;
                 $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             $key   = $this->cliArgs[($pos + 1)];
@@ -946,7 +947,7 @@ class Config
                     if (is_dir($dir) === false) {
                         $error  = 'ERROR: The specified cache file path "'.$this->cacheFile.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
+                        throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                     }
 
                     if ($dir === '.') {
@@ -972,7 +973,7 @@ class Config
                 if (is_dir($this->cacheFile) === true) {
                     $error  = 'ERROR: The specified cache file path "'.$this->cacheFile.'" is a directory'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
             } else if (substr($arg, 0, 10) === 'bootstrap=') {
                 $files     = explode(',', substr($arg, 10));
@@ -982,7 +983,7 @@ class Config
                     if ($path === false) {
                         $error  = 'ERROR: The specified bootstrap file "'.$file.'" does not exist'.PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
+                        throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                     }
 
                     $bootstrap[] = $path;
@@ -996,7 +997,7 @@ class Config
                 if ($path === false) {
                     $error  = 'ERROR: The specified file list "'.$fileList.'" does not exist'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
 
                 $files = file($path);
@@ -1038,7 +1039,7 @@ class Config
                     if (is_dir($dir) === false) {
                         $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
+                        throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                     }
 
                     $this->reportFile = $dir.'/'.basename($this->reportFile);
@@ -1049,7 +1050,7 @@ class Config
                 if (is_dir($this->reportFile) === true) {
                     $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" is a directory'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
             } else if (substr($arg, 0, 13) === 'report-width=') {
                 if (isset($this->overriddenDefaults['reportWidth']) === true) {
@@ -1080,7 +1081,7 @@ class Config
                 if (is_dir($this->basepath) === false) {
                     $error  = 'ERROR: The specified basepath "'.$this->basepath.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                     $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
             } else if ((substr($arg, 0, 7) === 'report=' || substr($arg, 0, 7) === 'report-')) {
                 $reports = [];
@@ -1101,7 +1102,7 @@ class Config
                             if (is_dir($dir) === false) {
                                 $error  = 'ERROR: The specified '.$report.' report file path "'.$output.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
                                 $error .= $this->printShortUsage(true);
-                                throw new DeepExitException($error, 3);
+                                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                             }
 
                             $output = $dir.'/'.basename($output);
@@ -1109,7 +1110,7 @@ class Config
                             if (is_dir($output) === true) {
                                 $error  = 'ERROR: The specified '.$report.' report file path "'.$output.'" is a directory'.PHP_EOL.PHP_EOL;
                                 $error .= $this->printShortUsage(true);
-                                throw new DeepExitException($error, 3);
+                                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                             }
                         }//end if
                     }//end if
@@ -1167,7 +1168,7 @@ class Config
                                 $error .= 'PHP_CodeSniffer >= 4.0 only supports scanning PHP files.'.PHP_EOL;
                                 $error .= 'Received: '.substr($arg, 11).PHP_EOL.PHP_EOL;
                                 $error .= $this->printShortUsage(true);
-                                throw new DeepExitException($error, 3);
+                                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                             }
                         }
 
@@ -1258,7 +1259,7 @@ class Config
                         $validOptions
                     );
                     $error       .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
 
                 $this->generator = $this->validGenerators[$lowerCaseGeneratorName];
@@ -1384,7 +1385,7 @@ class Config
 
             $error .= PHP_EOL;
             $error .= $this->printShortUsage(true);
-            throw new DeepExitException(ltrim($error), 3);
+            throw new DeepExitException(ltrim($error), ExitCode::PROCESS_ERROR);
         }
 
         return $sniffs;
@@ -1413,7 +1414,7 @@ class Config
 
             $error  = "ERROR: option \"$arg\" not known".PHP_EOL.PHP_EOL;
             $error .= $this->printShortUsage(true);
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         $this->processFilePath($arg);
@@ -1444,7 +1445,7 @@ class Config
 
             $error  = 'ERROR: The file "'.$path.'" does not exist.'.PHP_EOL.PHP_EOL;
             $error .= $this->printShortUsage(true);
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         } else {
             // Can't modify the files array directly because it's not a real
             // class member, so need to use this little get/modify/set trick.
@@ -1652,7 +1653,7 @@ class Config
                 && is_writable($configFile) === false
             ) {
                 $error = 'ERROR: Config file '.$configFile.' is not writable'.PHP_EOL.PHP_EOL;
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
         }//end if
 
@@ -1673,7 +1674,7 @@ class Config
 
             if (file_put_contents($configFile, $output) === false) {
                 $error = 'ERROR: Config file '.$configFile.' could not be written'.PHP_EOL.PHP_EOL;
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             self::$configDataFile = $configFile;
@@ -1731,7 +1732,7 @@ class Config
 
         if (Common::isReadable($configFile) === false) {
             $error = 'ERROR: Config file '.$configFile.' is not readable'.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         include $configFile;

--- a/src/Exceptions/DeepExitException.php
+++ b/src/Exceptions/DeepExitException.php
@@ -5,8 +5,13 @@
  * Allows the runner to return an exit code instead of putting exit codes elsewhere
  * in the source code.
  *
+ * Exit codes passed to this exception (as the `$code` parameter) MUST be one of the
+ * predefined exit code constants per the `PHP_CodeSniffer\Util\ExitCode` class; or a bitmask sum of those.
+ *
  * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/src/Files/DummyFile.php
+++ b/src/Files/DummyFile.php
@@ -62,19 +62,23 @@ class DummyFile extends File
     /**
      * Set the error, warning, and fixable counts for the file.
      *
-     * @param int $errorCount   The number of errors found.
-     * @param int $warningCount The number of warnings found.
-     * @param int $fixableCount The number of fixable errors found.
-     * @param int $fixedCount   The number of errors that were fixed.
+     * @param int $errorCount          The number of errors found.
+     * @param int $warningCount        The number of warnings found.
+     * @param int $fixableErrorCount   The number of fixable errors found.
+     * @param int $fixableWarningCount The number of fixable warning found.
+     * @param int $fixedErrorCount     The number of errors that were fixed.
+     * @param int $fixedWarningCount   The number of warning that were fixed.
      *
      * @return void
      */
-    public function setErrorCounts($errorCount, $warningCount, $fixableCount, $fixedCount)
+    public function setErrorCounts($errorCount, $warningCount, $fixableErrorCount, $fixableWarningCount, $fixedErrorCount, $fixedWarningCount)
     {
-        $this->errorCount   = $errorCount;
-        $this->warningCount = $warningCount;
-        $this->fixableCount = $fixableCount;
-        $this->fixedCount   = $fixedCount;
+        $this->errorCount          = $errorCount;
+        $this->warningCount        = $warningCount;
+        $this->fixableErrorCount   = $fixableErrorCount;
+        $this->fixableWarningCount = $fixableWarningCount;
+        $this->fixedErrorCount     = $fixedErrorCount;
+        $this->fixedWarningCount   = $fixedWarningCount;
 
     }//end setErrorCounts()
 

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\ExitCode;
 use RecursiveArrayIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -157,7 +158,7 @@ class FileList implements Iterator, Countable
                 $filename = realpath($filterType);
                 if ($filename === false) {
                     $error = "ERROR: Custom filter \"$filterType\" not found".PHP_EOL;
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
 
                 $filterClass = Autoload::loadFile($filename);

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -106,9 +106,10 @@ class LocalFile extends File
                 $this->replayErrors($cache['errors'], $cache['warnings']);
                 $this->configCache['cache'] = true;
             } else {
-                $this->errorCount   = $cache['errorCount'];
-                $this->warningCount = $cache['warningCount'];
-                $this->fixableCount = $cache['fixableCount'];
+                $this->errorCount          = $cache['errorCount'];
+                $this->warningCount        = $cache['warningCount'];
+                $this->fixableErrorCount   = $cache['fixableErrorCount'];
+                $this->fixableWarningCount = $cache['fixableWarningCount'];
             }
 
             if (PHP_CODESNIFFER_VERBOSITY > 0
@@ -129,14 +130,15 @@ class LocalFile extends File
         parent::process();
 
         $cache = [
-            'hash'         => $hash,
-            'errors'       => $this->errors,
-            'warnings'     => $this->warnings,
-            'metrics'      => $this->metrics,
-            'errorCount'   => $this->errorCount,
-            'warningCount' => $this->warningCount,
-            'fixableCount' => $this->fixableCount,
-            'numTokens'    => $this->numTokens,
+            'hash'                => $hash,
+            'errors'              => $this->errors,
+            'warnings'            => $this->warnings,
+            'metrics'             => $this->metrics,
+            'errorCount'          => $this->errorCount,
+            'warningCount'        => $this->warningCount,
+            'fixableErrorCount'   => $this->fixableErrorCount,
+            'fixableWarningCount' => $this->fixableWarningCount,
+            'numTokens'           => $this->numTokens,
         ];
 
         Cache::set($this->path, $cache);
@@ -166,11 +168,12 @@ class LocalFile extends File
      */
     private function replayErrors($errors, $warnings)
     {
-        $this->errors       = [];
-        $this->warnings     = [];
-        $this->errorCount   = 0;
-        $this->warningCount = 0;
-        $this->fixableCount = 0;
+        $this->errors            = [];
+        $this->warnings          = [];
+        $this->errorCount        = 0;
+        $this->warningCount      = 0;
+        $this->fixableErrorCount = 0;
+        $this->fixableWarningCount = 0;
 
         $this->replayingErrors = true;
 

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -102,7 +102,12 @@ class Fixer
     private $inConflict = false;
 
     /**
-     * The number of fixes that have been performed.
+     * The actual number of fixes that have been performed.
+     *
+     * I.e. how many fixes were applied. This may be higher than the originally found
+     * issues if the fixer from one sniff causes other sniffs to come into play in follow-up loops.
+     * Example: if a brace is moved to a new line, the `ScopeIndent` sniff may need to ensure
+     * the brace is indented correctly in the next loop.
      *
      * @var integer
      */
@@ -336,7 +341,7 @@ class Fixer
 
 
     /**
-     * Get a count of fixes that have been performed on the file.
+     * Get a count of the actual number of fixes that have been performed on the file.
      *
      * This value is reset every time a new file is started, or an existing
      * file is restarted.

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -16,6 +16,12 @@ use PHP_CodeSniffer\Reports\Report;
 use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\ExitCode;
 
+/**
+ * Manages reporting of errors and warnings.
+ *
+ * @property-read int $totalFixable Total number of errors/warnings that can be fixed.
+ * @property-read int $totalFixed   Total number of errors/warnings that were fixed.
+ */
 class Reporter
 {
 
@@ -48,18 +54,32 @@ class Reporter
     public $totalWarnings = 0;
 
     /**
-     * Total number of errors/warnings that can be fixed.
+     * Total number of errors that can be fixed.
      *
      * @var integer
      */
-    public $totalFixable = 0;
+    public $totalFixableErrors = 0;
 
     /**
-     * Total number of errors/warnings that were fixed.
+     * Total number of warnings that can be fixed.
      *
      * @var integer
      */
-    public $totalFixed = 0;
+    public $totalFixableWarnings = 0;
+
+    /**
+     * Total number of errors that were fixed.
+     *
+     * @var integer
+     */
+    public $totalFixedErrors = 0;
+
+    /**
+     * Total number of warnings that were fixed.
+     *
+     * @var integer
+     */
+    public $totalFixedWarnings = 0;
 
     /**
      * A cache of report objects.
@@ -161,6 +181,81 @@ class Reporter
 
 
     /**
+     * Check whether a (virtual) property is set.
+     *
+     * @param string $name Property name.
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return ($name === 'totalFixable' || $name === 'totalFixed');
+
+    }//end __isset()
+
+
+    /**
+     * Get the value of an inaccessible property.
+     *
+     * The properties supported via this method are both deprecated since PHP_CodeSniffer 4.0.
+     * - For $totalFixable, use `($reporter->totalFixableErrors + $reporter->totalFixableWarnings)` instead.
+     * - For $totalFixed, use `($reporter->totalFixedErrors + $reporter->totalFixedWarnings)` instead.
+     *
+     * @param string $name The name of the property.
+     *
+     * @return int
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the setting name is invalid.
+     */
+    public function __get($name)
+    {
+        if ($name === 'totalFixable') {
+            return ($this->totalFixableErrors + $this->totalFixableWarnings);
+        }
+
+        if ($name === 'totalFixed') {
+            return ($this->totalFixedErrors + $this->totalFixedWarnings);
+        }
+
+        throw new RuntimeException("ERROR: access requested to unknown property \"Reporter::\${$name}\"");
+
+    }//end __get()
+
+
+    /**
+     * Setting a dynamic/virtual property on this class is not allowed.
+     *
+     * @param string $name  Property name.
+     * @param mixed  $value Property value.
+     *
+     * @return bool
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
+     */
+    public function __set($name, $value)
+    {
+        throw new RuntimeException("ERROR: setting property \"Reporter::\${$name}\" is not allowed");
+
+    }//end __set()
+
+
+    /**
+     * Unsetting a dynamic/virtual property on this class is not allowed.
+     *
+     * @param string $name Property name.
+     *
+     * @return bool
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
+     */
+    public function __unset($name)
+    {
+        throw new RuntimeException("ERROR: unsetting property \"Reporter::\${$name}\" is not allowed");
+
+    }//end __unset()
+
+
+    /**
      * Generates and prints final versions of all reports.
      *
      * Returns TRUE if any of the reports output content to the screen
@@ -220,7 +315,7 @@ class Reporter
             $this->totalFiles,
             $this->totalErrors,
             $this->totalWarnings,
-            $this->totalFixable,
+            ($this->totalFixableErrors + $this->totalFixableWarnings),
             $this->config->showSources,
             $this->config->reportWidth,
             $this->config->interactive,
@@ -307,12 +402,10 @@ class Reporter
 
             // When PHPCBF is running, we need to use the fixable error values
             // after the report has run and fixed what it can.
-            if (PHP_CODESNIFFER_CBF === true) {
-                $this->totalFixable += $phpcsFile->getFixableCount();
-                $this->totalFixed   += $phpcsFile->getFixedCount();
-            } else {
-                $this->totalFixable += $reportData['fixable'];
-            }
+            $this->totalFixableErrors   += $phpcsFile->getFixableErrorCount();
+            $this->totalFixableWarnings += $phpcsFile->getFixableWarningCount();
+            $this->totalFixedErrors     += $phpcsFile->getFixedErrorCount();
+            $this->totalFixedWarnings   += $phpcsFile->getFixedWarningCount();
         }
 
     }//end cacheFileReport()

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Reports\Report;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\ExitCode;
 
 class Reporter
 {
@@ -103,7 +104,7 @@ class Reporter
                 $filename = realpath($type);
                 if ($filename === false) {
                     $error = "ERROR: Custom report \"$type\" not found".PHP_EOL;
-                    throw new DeepExitException($error, 3);
+                    throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
 
                 $reportClassName = Autoload::loadFile($filename);
@@ -132,7 +133,7 @@ class Reporter
 
             if ($reportClassName === '') {
                 $error = "ERROR: Class file for report \"$type\" not found".PHP_EOL;
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             $reportClass = new $reportClassName();

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -15,6 +15,7 @@ namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\ExitCode;
 use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
@@ -60,7 +61,7 @@ class Cbf implements Report
             // even if nothing was fixed. Exit here because we
             // can't process any more than 1 file in this setup.
             $fixedContent = $phpcsFile->fixer->getContents();
-            throw new DeepExitException($fixedContent, 1);
+            throw new DeepExitException($fixedContent, ExitCode::OKAY);
         }
 
         if ($errors === 0) {

--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -11,6 +11,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Util\ExitCode;
 
 class Gitblame extends VersionControl
 {
@@ -74,7 +75,7 @@ class Gitblame extends VersionControl
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         $rawContent = stream_get_contents($handle);

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -11,6 +11,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Util\ExitCode;
 
 class Hgblame extends VersionControl
 {
@@ -86,14 +87,14 @@ class Hgblame extends VersionControl
             chdir($location);
         } else {
             $error = 'ERROR: Could not locate .hg directory '.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         $command = 'hg blame -u -d -v "'.$filename.'" 2>&1';
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         $rawContent = stream_get_contents($handle);

--- a/src/Reports/Svnblame.php
+++ b/src/Reports/Svnblame.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Reports;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Util\ExitCode;
 
 class Svnblame extends VersionControl
 {
@@ -57,7 +58,7 @@ class Svnblame extends VersionControl
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         $rawContent = stream_get_contents($handle);

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -118,7 +118,7 @@ class Runner
                 $this->config->cache = false;
             }
 
-            $numErrors = $this->run();
+            $this->run();
 
             // Print all the reports for this run.
             $this->reporter->printReports();
@@ -140,16 +140,7 @@ class Runner
             return $exitCode;
         }//end try
 
-        if ($numErrors === 0) {
-            // No errors found.
-            return 0;
-        } else if ($this->reporter->totalFixable === 0) {
-            // Errors found, but none of them can be fixed by PHPCBF.
-            return 1;
-        } else {
-            // Errors found, and some can be fixed by PHPCBF.
-            return 2;
-        }
+        return ExitCode::calculate($this->reporter);
 
     }//end runPHPCS()
 
@@ -235,24 +226,7 @@ class Runner
             return $exitCode;
         }//end try
 
-        if ($this->reporter->totalFixed === 0) {
-            // Nothing was fixed by PHPCBF.
-            if ($this->reporter->totalFixable === 0) {
-                // Nothing found that could be fixed.
-                return 0;
-            } else {
-                // Something failed to fix.
-                return 2;
-            }
-        }
-
-        if ($this->reporter->totalFixable === 0) {
-            // PHPCBF fixed all fixable errors.
-            return 1;
-        }
-
-        // PHPCBF fixed some fixable errors, but others failed to fix.
-        return 2;
+        return ExitCode::calculate($this->reporter);
 
     }//end runPHPCBF()
 
@@ -319,7 +293,8 @@ class Runner
     /**
      * Performs the run.
      *
-     * @return int The number of errors and warnings found.
+     * @return void
+     *
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
@@ -453,11 +428,13 @@ class Runner
 
                     // Reset the reporter to make sure only figures from this
                     // file batch are recorded.
-                    $this->reporter->totalFiles    = 0;
-                    $this->reporter->totalErrors   = 0;
-                    $this->reporter->totalWarnings = 0;
-                    $this->reporter->totalFixable  = 0;
-                    $this->reporter->totalFixed    = 0;
+                    $this->reporter->totalFiles           = 0;
+                    $this->reporter->totalErrors          = 0;
+                    $this->reporter->totalWarnings        = 0;
+                    $this->reporter->totalFixableErrors   = 0;
+                    $this->reporter->totalFixableWarnings = 0;
+                    $this->reporter->totalFixedErrors     = 0;
+                    $this->reporter->totalFixedWarnings   = 0;
 
                     // Process the files.
                     $pathsProcessed = [];
@@ -492,11 +469,13 @@ class Runner
                     // Write information about the run to the filesystem
                     // so it can be picked up by the main process.
                     $childOutput = [
-                        'totalFiles'    => $this->reporter->totalFiles,
-                        'totalErrors'   => $this->reporter->totalErrors,
-                        'totalWarnings' => $this->reporter->totalWarnings,
-                        'totalFixable'  => $this->reporter->totalFixable,
-                        'totalFixed'    => $this->reporter->totalFixed,
+                        'totalFiles'           => $this->reporter->totalFiles,
+                        'totalErrors'          => $this->reporter->totalErrors,
+                        'totalWarnings'        => $this->reporter->totalWarnings,
+                        'totalFixableErrors'   => $this->reporter->totalFixableErrors,
+                        'totalFixableWarnings' => $this->reporter->totalFixableWarnings,
+                        'totalFixedErrors'     => $this->reporter->totalFixedErrors,
+                        'totalFixedWarnings'   => $this->reporter->totalFixedWarnings,
                     ];
 
                     $output  = '<'.'?php'."\n".' $childOutput = ';
@@ -538,26 +517,6 @@ class Runner
         if ($this->config->cache === true) {
             Cache::save();
         }
-
-        $ignoreWarnings = Config::getConfigData('ignore_warnings_on_exit');
-        $ignoreErrors   = Config::getConfigData('ignore_errors_on_exit');
-
-        $return = ($this->reporter->totalErrors + $this->reporter->totalWarnings);
-        if ($ignoreErrors !== null) {
-            $ignoreErrors = (bool) $ignoreErrors;
-            if ($ignoreErrors === true) {
-                $return -= $this->reporter->totalErrors;
-            }
-        }
-
-        if ($ignoreWarnings !== null) {
-            $ignoreWarnings = (bool) $ignoreWarnings;
-            if ($ignoreWarnings === true) {
-                $return -= $this->reporter->totalWarnings;
-            }
-        }
-
-        return $return;
 
     }//end run()
 
@@ -616,8 +575,9 @@ class Runner
                 StatusWriter::write('DONE in '.Timing::getHumanReadableDuration(Timing::getDurationSince($startTime)), 0, 0);
 
                 if (PHP_CODESNIFFER_CBF === true) {
-                    $errors = $file->getFixableCount();
-                    StatusWriter::write(" ($errors fixable violations)");
+                    $errors   = $file->getFixableErrorCount();
+                    $warnings = $file->getFixableWarningCount();
+                    StatusWriter::write(" ($errors fixable errors, $warnings fixable warnings)");
                 } else {
                     $errors   = $file->getErrorCount();
                     $warnings = $file->getWarningCount();
@@ -758,17 +718,19 @@ class Runner
             if (isset($childOutput) === false) {
                 // The child process died, so the run has failed.
                 $file = new DummyFile('', $this->ruleset, $this->config);
-                $file->setErrorCounts(1, 0, 0, 0);
+                $file->setErrorCounts(1, 0, 0, 0, 0, 0);
                 $this->printProgress($file, $totalBatches, $numProcessed);
                 $success = false;
                 continue;
             }
 
-            $this->reporter->totalFiles    += $childOutput['totalFiles'];
-            $this->reporter->totalErrors   += $childOutput['totalErrors'];
-            $this->reporter->totalWarnings += $childOutput['totalWarnings'];
-            $this->reporter->totalFixable  += $childOutput['totalFixable'];
-            $this->reporter->totalFixed    += $childOutput['totalFixed'];
+            $this->reporter->totalFiles           += $childOutput['totalFiles'];
+            $this->reporter->totalErrors          += $childOutput['totalErrors'];
+            $this->reporter->totalWarnings        += $childOutput['totalWarnings'];
+            $this->reporter->totalFixableErrors   += $childOutput['totalFixableErrors'];
+            $this->reporter->totalFixableWarnings += $childOutput['totalFixableWarnings'];
+            $this->reporter->totalFixedErrors     += $childOutput['totalFixedErrors'];
+            $this->reporter->totalFixedWarnings   += $childOutput['totalFixedWarnings'];
 
             if (isset($debugOutput) === true) {
                 echo $debugOutput;
@@ -785,8 +747,10 @@ class Runner
             $file->setErrorCounts(
                 $childOutput['totalErrors'],
                 $childOutput['totalWarnings'],
-                $childOutput['totalFixable'],
-                $childOutput['totalFixed']
+                $childOutput['totalFixableErrors'],
+                $childOutput['totalFixableWarnings'],
+                $childOutput['totalFixedErrors'],
+                $childOutput['totalFixedWarnings']
             );
             $this->printProgress($file, $totalBatches, $numProcessed);
         }//end while

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -21,6 +21,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Files\FileList;
 use PHP_CodeSniffer\Util\Cache;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\ExitCode;
 use PHP_CodeSniffer\Util\Standards;
 use PHP_CodeSniffer\Util\Timing;
 use PHP_CodeSniffer\Util\Tokens;
@@ -278,7 +279,7 @@ class Runner
                 // out by letting them know which standards are installed.
                 $error  = 'ERROR: the "'.$standard.'" coding standard is not installed.'.PHP_EOL.PHP_EOL;
                 $error .= Standards::prepareInstalledStandardsForDisplay().PHP_EOL;
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
         }
 
@@ -309,7 +310,7 @@ class Runner
         } catch (RuntimeException $e) {
             $error  = rtrim($e->getMessage(), "\r\n").PHP_EOL.PHP_EOL;
             $error .= $this->config->printShortUsage(true);
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
     }//end init()
@@ -348,7 +349,7 @@ class Runner
             if (empty($this->config->files) === true) {
                 $error  = 'ERROR: You must supply at least one file or directory to process.'.PHP_EOL.PHP_EOL;
                 $error .= $this->config->printShortUsage(true);
-                throw new DeepExitException($error, 3);
+                throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
 
             if (PHP_CODESNIFFER_VERBOSITY > 0) {
@@ -380,7 +381,7 @@ class Runner
         if ($numFiles === 0) {
             $error  = 'ERROR: No files were checked.'.PHP_EOL;
             $error .= 'All specified files were excluded or did not match filtering rules.'.PHP_EOL.PHP_EOL;
-            throw new DeepExitException($error, 3);
+            throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
         }
 
         // Turn all sniff errors into exceptions.
@@ -694,7 +695,8 @@ class Runner
                 case 's':
                     break(2);
                 case 'q':
-                    throw new DeepExitException('', 0);
+                    // User request to "quit": exit code should be 0.
+                    throw new DeepExitException('', ExitCode::OKAY);
                 default:
                     // Repopulate the sniffs because some of them save their state
                     // and only clear it when the file changes, but we are rechecking

--- a/src/Util/ExitCode.php
+++ b/src/Util/ExitCode.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Exit codes.
+ *
+ * Note: The "missing" exit codes 8 and 32 are reserved for future use.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is intended for internal use only and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @internal
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Util;
+
+final class ExitCode
+{
+
+    /**
+     * Exit code to indicate no issues were found in the code under scan; or a non-scan request succeeded.
+     *
+     * @var int
+     */
+    public const OKAY = 0;
+
+    /**
+     * Exit code to indicate auto-fixable issues were found.
+     *
+     * @var int
+     */
+    public const FIXABLE = 1;
+
+    /**
+     * Exit code to indicate issues were found, which are not auto-fixable.
+     *
+     * @var int
+     */
+    public const NON_FIXABLE = 2;
+
+    /**
+     * [CBF only] Exit code to indicate a file failed to fix.
+     *
+     * Typically, this is caused by a fixer conflict between sniffs.
+     *
+     * @var int
+     */
+    public const FAILED_TO_FIX = 4;
+
+    /**
+     * Exit code to indicate PHP_CodeSniffer ran into a problem while processing the request.
+     *
+     * Examples of when this code should be used:
+     * - Invalid CLI flag used.
+     * - Blocking errors in the ruleset file(s).
+     * - A dependency required to generate a report not being available, like git for the gitblame report.
+     *
+     * @var int
+     */
+    public const PROCESS_ERROR = 16;
+
+    /**
+     * Exit code to indicate the requirements to run PHP_CodeSniffer are not met.
+     *
+     * This exit code is here purely for documentation purposes.
+     * This exit code should only be used in the requirements check (`requirements.php` file), but that
+     * file can't use the constant as it would block _this_ file from using modern PHP.
+     *
+     * {@internal The code in the requirements.php file and below should always stay in sync!}
+     *
+     * @var int
+     */
+    public const REQUIREMENTS_NOT_MET = 64;
+
+
+}//end class

--- a/src/Util/ExitCode.php
+++ b/src/Util/ExitCode.php
@@ -17,6 +17,9 @@
 
 namespace PHP_CodeSniffer\Util;
 
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Reporter;
+
 final class ExitCode
 {
 
@@ -74,6 +77,69 @@ final class ExitCode
      * @var int
      */
     public const REQUIREMENTS_NOT_MET = 64;
+
+
+    /**
+     * Calculate the exit code based on the results of the run as recorded in the Reporter object.
+     *
+     * @param \PHP_CodeSniffer\Reporter $reporter Reporter object for the run.
+     *
+     * @return int
+     */
+    public static function calculate(Reporter $reporter)
+    {
+        // First figure out what the relevant numbers are on which we need to base the exit code.
+        $ignoreNonAutofixable  = (bool) (Config::getConfigData('ignore_non_auto_fixable_on_exit') ?? false);
+        $totalRelevantErrors   = $reporter->totalErrors;
+        $totalRelevantWarnings = $reporter->totalWarnings;
+
+        if ($ignoreNonAutofixable === true) {
+            $totalRelevantErrors   = $reporter->totalFixableErrors;
+            $totalRelevantWarnings = $reporter->totalFixableWarnings;
+        }
+
+        $ignoreErrors   = (bool) (Config::getConfigData('ignore_errors_on_exit') ?? false);
+        $ignoreWarnings = (bool) (Config::getConfigData('ignore_warnings_on_exit') ?? false);
+
+        $totalRelevantIssues        = 0;
+        $totalRelevantFixableIssues = 0;
+        $totalRelevantFixedIssues   = 0;
+
+        if ($ignoreErrors === false) {
+            $totalRelevantIssues        += $totalRelevantErrors;
+            $totalRelevantFixableIssues += $reporter->totalFixableErrors;
+            $totalRelevantFixedIssues   += $reporter->totalFixedErrors;
+        }
+
+        if ($ignoreWarnings === false) {
+            $totalRelevantIssues        += $totalRelevantWarnings;
+            $totalRelevantFixableIssues += $reporter->totalFixableWarnings;
+            $totalRelevantFixedIssues   += $reporter->totalFixedWarnings;
+        }
+
+        // Next figure out what the exit code should be.
+        $exitCode = self::OKAY;
+
+        if (PHP_CODESNIFFER_CBF === true
+            && ($reporter->totalFixableErrors + $reporter->totalFixableWarnings) > 0
+        ) {
+            // Something failed to fix.
+            $exitCode |= self::FAILED_TO_FIX;
+        }
+
+        // Are there issues which PHPCBF could fix ?
+        if ($totalRelevantFixableIssues > 0) {
+            $exitCode |= self::FIXABLE;
+        }
+
+        // Are there issues which PHPCBF cannot fix ?
+        if (($totalRelevantIssues - $totalRelevantFixableIssues - $totalRelevantFixedIssues) > 0) {
+            $exitCode |= self::NON_FIXABLE;
+        }
+
+        return $exitCode;
+
+    }//end calculate()
 
 
 }//end class

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -573,7 +573,7 @@ final class Help
 
             'config-explain' => [
                 'text' => 'Default values for a selection of options can be stored in a user-specific CodeSniffer.conf configuration file.'."\n"
-                    .'This applies to the following options: "default_standard", "report_format", "tab_width", "encoding", "severity", "error_severity", "warning_severity", "show_warnings", "report_width", "show_progress", "quiet", "colors", "cache", "parallel", "installed_paths", "php_version", "ignore_errors_on_exit", "ignore_warnings_on_exit".',
+                    .'This applies to the following options: "default_standard", "report_format", "tab_width", "encoding", "severity", "error_severity", "warning_severity", "show_warnings", "report_width", "show_progress", "quiet", "colors", "cache", "parallel", "installed_paths", "php_version", "ignore_errors_on_exit", "ignore_warnings_on_exit", "ignore_non_auto_fixable_on_exit".',
             ],
             'config-show'    => [
                 'argument'    => '--config-show',

--- a/tests/Core/Reporter/MagicMethodsTest.php
+++ b/tests/Core/Reporter/MagicMethodsTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Tests to safeguard that removed properties from the Reporter class are still accessible.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Reporter;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Reporter;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests to safeguard that a few removed properties from the Reporter class are still accessible for reading, but not writing.
+ *
+ * @covers \PHP_CodeSniffer\Reporter::__get
+ * @covers \PHP_CodeSniffer\Reporter::__set
+ * @covers \PHP_CodeSniffer\Reporter::__isset
+ * @covers \PHP_CodeSniffer\Reporter::__unset
+ */
+final class MagicMethodsTest extends TestCase
+{
+
+
+    /**
+     * Verify the magic __isset() method returns `false` for everything but the explicitly supported properties.
+     *
+     * @return void
+     */
+    public function testMagicIssetReturnsFalseForUnknownProperty()
+    {
+        $reporter = new Reporter(new ConfigDouble());
+
+        $this->assertFalse(isset($reporter->unknown));
+
+    }//end testMagicIssetReturnsFalseForUnknownProperty()
+
+
+    /**
+     * Verify the magic __get() method rejects requests for anything but the explicitly supported properties.
+     *
+     * @return void
+     */
+    public function testMagicGetThrowsExceptionForUnsupportedProperty()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ERROR: access requested to unknown property "Reporter::$invalid"');
+
+        (new Reporter(new ConfigDouble()))->invalid;
+
+    }//end testMagicGetThrowsExceptionForUnsupportedProperty()
+
+
+    /**
+     * Test the magic __get() method handles supported properties.
+     *
+     * @param string $propertyName  The name of the property to request.
+     * @param int    $set           Value to set for the properties comprising the virtual ones.
+     * @param int    $expectedValue The expected value for the property.
+     *
+     * @dataProvider dataMagicGetReturnsValueForSupportedProperty
+     *
+     * @return void
+     */
+    public function testMagicGetReturnsValueForSupportedProperty($propertyName, $set, $expectedValue)
+    {
+        $reporter = new Reporter(new ConfigDouble());
+
+        if ($set !== 0) {
+            $reporter->totalFixableErrors   = $set;
+            $reporter->totalFixableWarnings = $set;
+            $reporter->totalFixedErrors     = $set;
+            $reporter->totalFixedWarnings   = $set;
+        }
+
+        $this->assertTrue(isset($reporter->$propertyName));
+        $this->assertSame($expectedValue, $reporter->$propertyName);
+
+    }//end testMagicGetReturnsValueForSupportedProperty()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string|int>>
+     */
+    public static function dataMagicGetReturnsValueForSupportedProperty()
+    {
+        return [
+            'Property: totalFixable - 0' => [
+                'propertyName'  => 'totalFixable',
+                'set'           => 0,
+                'expectedValue' => 0,
+            ],
+            'Property: totalFixed - 0'   => [
+                'propertyName'  => 'totalFixed',
+                'set'           => 0,
+                'expectedValue' => 0,
+            ],
+            'Property: totalFixable - 2' => [
+                'propertyName'  => 'totalFixable',
+                'set'           => 1,
+                'expectedValue' => 2,
+            ],
+            'Property: totalFixed - 4'   => [
+                'propertyName'  => 'totalFixed',
+                'set'           => 2,
+                'expectedValue' => 4,
+            ],
+        ];
+
+    }//end dataMagicGetReturnsValueForSupportedProperty()
+
+
+    /**
+     * Verify the magic __set() method rejects everything.
+     *
+     * @return void
+     */
+    public function testMagicSetThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ERROR: setting property "Reporter::$totalFixable" is not allowed');
+
+        $reporter = new Reporter(new ConfigDouble());
+        $reporter->totalFixable = 10;
+
+    }//end testMagicSetThrowsException()
+
+
+    /**
+     * Verify the magic __unset() method rejects everything.
+     *
+     * @return void
+     */
+    public function testMagicUnsetThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ERROR: unsetting property "Reporter::$totalFixed" is not allowed');
+
+        $reporter = new Reporter(new ConfigDouble());
+        unset($reporter->totalFixed);
+
+    }//end testMagicUnsetThrowsException()
+
+
+}//end class

--- a/tests/Core/Util/ExitCode/ExitCodeTest.php
+++ b/tests/Core/Util/ExitCode/ExitCodeTest.php
@@ -1,0 +1,673 @@
+<?php
+/**
+ * Integration tests for the exit codes generation.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Util\ExitCode;
+
+use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\Core\Runner\AbstractRunnerTestCase;
+use PHP_CodeSniffer\Tests\Core\StatusWriterTestHelper;
+
+/**
+ * Integration tests for the exit codes generation.
+ *
+ * @covers \PHP_CodeSniffer\Util\ExitCode
+ */
+final class ExitCodeTest extends AbstractRunnerTestCase
+{
+    // Using the Helper to catch output send to STDERR. For this test, we don't care about the output.
+    use StatusWriterTestHelper;
+
+    /**
+     * Location where the "files to scan" can be found for these tests.
+     *
+     * @var string
+     */
+    private const SOURCE_DIR = __DIR__.'/Fixtures/ExitCodeTest/';
+
+    /**
+     * Path to a file to use for the caching tests.
+     *
+     * @var string
+     */
+    private const CACHE_FILE = __DIR__.'/Fixtures/ExitCodeTest/phpcs.cache';
+
+
+    /**
+     * Prepare a clean test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        // Redirect the StatusWriter output from STDERR to memory.
+        $this->redirectStatusWriterOutputToStream();
+
+        // Reset static properties on the Config class.
+        AbstractRunnerTestCase::setUp();
+
+    }//end setUp()
+
+
+    /**
+     * Clean up after the test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        // Reset all static properties on the StatusWriter class.
+        $this->resetStatusWriterProperties();
+
+        // Reset $_SERVER['argv'] between tests.
+        AbstractRunnerTestCase::tearDown();
+
+        // Delete the cache file between tests to prevent a cache from an earlier test run influencing the results of the tests.
+        @unlink(self::CACHE_FILE);
+
+    }//end tearDown()
+
+
+    /**
+     * Clean up after the tests.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        $globPattern = self::SOURCE_DIR.'/*.inc.fixed';
+        $globPattern = str_replace('/', DIRECTORY_SEPARATOR, $globPattern);
+
+        $fixedFiles = glob($globPattern, GLOB_NOESCAPE);
+
+        if (is_array($fixedFiles) === true) {
+            foreach ($fixedFiles as $file) {
+                @unlink($file);
+            }
+        }
+
+        AbstractRunnerTestCase::tearDownAfterClass();
+
+    }//end tearDownAfterClass()
+
+
+    /**
+     * Verify generated exit codes (PHPCS).
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @dataProvider dataPhpcs
+     *
+     * @return void
+     */
+    public function testPhpcsNoParallel($extraArgs, $expected)
+    {
+        $extraArgs[] = self::SOURCE_DIR.'mix-errors-warnings.inc';
+
+        $this->runPhpcsAndCheckExitCode($extraArgs, $expected);
+
+    }//end testPhpcsNoParallel()
+
+
+    /**
+     * Verify generated exit codes (PHPCS) when using parallel processing.
+     *
+     * Note: there tests are skipped on Windows as the PCNTL extension needed for parallel processing
+     * isn't available on Windows.
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @dataProvider dataPhpcs
+     * @requires     OS ^(?!WIN).*
+     *
+     * @return void
+     */
+    public function testPhpcsParallel($extraArgs, $expected)
+    {
+        // Deliberately using `parallel=3` to scan 5 files to make sure that the results
+        // from multiple batches get recorded and added correctly.
+        $extraArgs[] = self::SOURCE_DIR;
+        $extraArgs[] = '--parallel=3';
+
+        $this->runPhpcsAndCheckExitCode($extraArgs, $expected);
+
+    }//end testPhpcsParallel()
+
+
+    /**
+     * Verify generated exit codes (PHPCS) when caching of results is used.
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @dataProvider dataPhpcs
+     *
+     * @return void
+     */
+    public function testPhpcsWithCache($extraArgs, $expected)
+    {
+        $extraArgs[] = self::SOURCE_DIR.'mix-errors-warnings.inc';
+        $extraArgs[] = '--cache='.self::CACHE_FILE;
+
+        // Make sure we start without a cache.
+        if (method_exists($this, 'assertFileDoesNotExist') === true) {
+            $this->assertFileDoesNotExist(self::CACHE_FILE);
+        } else {
+            // PHPUnit < 9.1.0.
+            $this->assertFileNotExists(self::CACHE_FILE);
+        }
+
+        // First run with these arguments to create the cache.
+        $this->runPhpcsAndCheckExitCode($extraArgs, $expected);
+
+        // Check that the cache file was created.
+        $this->assertFileExists(self::CACHE_FILE);
+
+        // Second run to verify the exit code is the same when the results are taking from the cache.
+        $this->runPhpcsAndCheckExitCode($extraArgs, $expected);
+
+    }//end testPhpcsWithCache()
+
+
+    /**
+     * Test Helper: run PHPCS and verify the generated exit code.
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @return void
+     */
+    private function runPhpcsAndCheckExitCode($extraArgs, $expected)
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+        $this->setServerArgs('phpcs', $extraArgs);
+
+        // Catch & discard the screen output. That's not what we're interested in for this test.
+        ob_start();
+        $runner = new Runner();
+        $actual = $runner->runPHPCS();
+        ob_end_clean();
+
+        $this->assertSame($expected, $actual);
+
+    }//end runPhpcsAndCheckExitCode()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|array<string>>>
+     */
+    public static function dataPhpcs()
+    {
+        return [
+            'No issues'                                                                      => [
+                'extraArgs' => ['--sniffs=TestStandard.ExitCodes.NoIssues'],
+                'expected'  => 0,
+            ],
+            'Only auto-fixable issues'                                                       => [
+                'extraArgs' => ['--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.FixableWarning'],
+                'expected'  => 1,
+            ],
+            'Only non-fixable issues'                                                        => [
+                'extraArgs' => ['--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.Warning'],
+                'expected'  => 2,
+            ],
+            'Both auto-fixable + non-fixable issues'                                         => [
+                'extraArgs' => [],
+                'expected'  => 3,
+            ],
+
+            // In both the below cases, we still have both fixable and non-fixable issues, so exit code = 3.
+            'Only errors'                                                                    => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.FixableWarning,TestStandard.ExitCodes.Warning'],
+                'expected'  => 3,
+            ],
+            'Only warnings'                                                                  => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Error'],
+                'expected'  => 3,
+            ],
+
+            // In both the below cases, we still have 1 fixable and 1 non-fixable issue which we need to take into account, so exit code = 3.
+            'Mix of errors and warnings, ignoring warnings for exit code'                    => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 3,
+            ],
+            'Mix of errors and warnings, ignoring errors for exit code'                      => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 3,
+            ],
+
+            'Mix of errors and warnings, ignoring non-auto-fixable for exit code'            => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+            'Mix of errors and warnings, ignoring errors + non-auto-fixable for exit code'   => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+            'Mix of errors and warnings, ignoring warnings + non-auto-fixable for exit code' => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+            'Mix of errors and warnings, ignoring errors + warnings for exit code'           => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Mix of errors and warnings, explicitly ignoring nothing for exit code'          => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '0',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '0',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '0',
+                ],
+                'expected'  => 3,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring errors for exit code'           => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+            'Non-fixable error and fixable warning, ignoring errors for exit code'           => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring warnings for exit code'         => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+            'Non-fixable error and fixable warning, ignoring warnings for exit code'         => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring non-auto-fixable for exit code' => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+            'Non-fixable error and fixable warning, ignoring non-auto-fixable for exit code' => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 1,
+            ],
+        ];
+
+    }//end dataPhpcs()
+
+
+    /**
+     * Verify generated exit codes (PHPCBF).
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @dataProvider dataPhpcbf
+     * @group        CBF
+     *
+     * @return void
+     */
+    public function testPhpcbfNoParallel($extraArgs, $expected)
+    {
+        $extraArgs[] = self::SOURCE_DIR.'mix-errors-warnings.inc';
+
+        $this->runPhpcbfAndCheckExitCode($extraArgs, $expected);
+
+    }//end testPhpcbfNoParallel()
+
+
+    /**
+     * Verify generated exit codes (PHPCBF) when using parallel processing.
+     *
+     * Note: there tests are skipped on Windows as the PCNTL extension needed for parallel processing
+     * isn't available on Windows.
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @dataProvider dataPhpcbf
+     * @group        CBF
+     * @requires     OS ^(?!WIN).*
+     *
+     * @return void
+     */
+    public function testPhpcbfParallel($extraArgs, $expected)
+    {
+        // Deliberately using `parallel=3` to scan 5 files to make sure that the results
+        // from multiple batches get recorded and added correctly.
+        $extraArgs[] = self::SOURCE_DIR;
+        $extraArgs[] = '--parallel=3';
+
+        $this->runPhpcbfAndCheckExitCode($extraArgs, $expected);
+
+    }//end testPhpcbfParallel()
+
+
+    /**
+     * Test Helper: run PHPCBF and verify the generated exit code.
+     *
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     * @param int           $expected  The expected exit code.
+     *
+     * @return void
+     */
+    private function runPhpcbfAndCheckExitCode($extraArgs, $expected)
+    {
+        if (PHP_CODESNIFFER_CBF === false) {
+            $this->markTestSkipped('This test needs CBF mode to run');
+        }
+
+        $this->setServerArgs('phpcbf', $extraArgs);
+
+        // Catch & discard the screen output. That's not what we're interested in for this test.
+        ob_start();
+        $runner = new Runner();
+        $actual = $runner->runPHPCBF();
+        ob_end_clean();
+
+        $this->assertSame($expected, $actual);
+
+    }//end runPhpcbfAndCheckExitCode()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|array<string>>>
+     */
+    public static function dataPhpcbf()
+    {
+        return [
+            'No issues'                                                                                      => [
+                'extraArgs' => ['--sniffs=TestStandard.ExitCodes.NoIssues'],
+                'expected'  => 0,
+            ],
+            'Fixed all auto-fixable issues, no issues left'                                                  => [
+                'extraArgs' => ['--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.FixableWarning'],
+                'expected'  => 0,
+            ],
+            'Fixed all auto-fixable issues, has non-autofixable issues left'                                 => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.FailToFix'],
+                'expected'  => 2,
+            ],
+            'Fixed all auto-fixable issues, has non-autofixable issues left, ignoring those for exit code'   => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Failed to fix, only fixable issues remaining'                                                   => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.Warning'],
+                'expected'  => 5,
+            ],
+            'Failed to fix, both fixable + non-fixable issues remaining'                                     => [
+                'extraArgs' => [],
+                'expected'  => 7,
+            ],
+            'Failed to fix, both fixable + non-fixable issues remaining, ignoring non-fixable for exit code' => [
+                'extraArgs' => [
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 5,
+            ],
+
+            // In both the below cases, we still have 1 non-fixable issue which we need to take into account, so exit code = 2.
+            'Only errors'                                                                                    => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.FailToFix,TestStandard.ExitCodes.FixableWarning,TestStandard.ExitCodes.Warning'],
+                'expected'  => 2,
+            ],
+            'Only warnings'                                                                                  => [
+                'extraArgs' => ['--exclude=TestStandard.ExitCodes.FailToFix,TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Error'],
+                'expected'  => 2,
+            ],
+
+            // In both the below cases, we still have 1 non-fixable issue which we need to take into account, so exit code = 2.
+            'Mix of errors and warnings, ignoring warnings for exit code'                                    => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+            'Mix of errors and warnings, ignoring errors for exit code'                                      => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+
+            'Mix of errors and warnings, ignoring non-auto-fixable for exit code'                            => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Mix of errors and warnings, ignoring errors + non-auto-fixable for exit code'                   => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Mix of errors and warnings, ignoring warnings + non-auto-fixable for exit code'                 => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Mix of errors and warnings, ignoring errors + warnings for exit code'                           => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Mix of errors and warnings, explicitly ignoring nothing for exit code'                          => [
+                'extraArgs' => [
+                    '--exclude=TestStandard.ExitCodes.FailToFix',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '0',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '0',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '0',
+                ],
+                'expected'  => 2,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring errors for exit code'                           => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+            'Non-fixable error and fixable warning, ignoring errors for exit code'                           => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_errors_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring warnings for exit code'                         => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Non-fixable error and fixable warning, ignoring warnings for exit code'                         => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_warnings_on_exit',
+                    '1',
+                ],
+                'expected'  => 2,
+            ],
+
+            'Fixable error and non-fixable warning, ignoring non-auto-fixable for exit code'                 => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.FixableError,TestStandard.ExitCodes.Warning',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+            'Non-fixable error and fixable warning, ignoring non-auto-fixable for exit code'                 => [
+                'extraArgs' => [
+                    '--sniffs=TestStandard.ExitCodes.Error,TestStandard.ExitCodes.FixableWarning',
+                    '--runtime-set',
+                    'ignore_non_auto_fixable_on_exit',
+                    '1',
+                ],
+                'expected'  => 0,
+            ],
+        ];
+
+    }//end dataPhpcbf()
+
+
+    /**
+     * Helper method to prepare the CLI arguments for a test.
+     *
+     * @param string        $cmd       The command. Either 'phpcs' or 'phpcbf'.
+     * @param array<string> $extraArgs Any extra arguments to pass on the command line.
+     *
+     * @return void
+     */
+    private function setServerArgs($cmd, $extraArgs)
+    {
+        $standard = __DIR__.'/ExitCodeTest.xml';
+
+        $_SERVER['argv'] = [
+            $cmd,
+            "--standard=$standard",
+            '--report-width=80',
+            '--suffix=.fixed',
+        ];
+
+        foreach ($extraArgs as $arg) {
+            $_SERVER['argv'][] = $arg;
+        }
+
+    }//end setServerArgs()
+
+
+}//end class

--- a/tests/Core/Util/ExitCode/ExitCodeTest.xml
+++ b/tests/Core/Util/ExitCode/ExitCodeTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ExitCodeTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <config name="installed_paths" value="./tests/Core/Util/ExitCode/Fixtures/TestStandard/"/>
+
+    <rule ref="TestStandard"/>
+
+</ruleset>

--- a/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/mix-errors-warnings.inc
+++ b/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/mix-errors-warnings.inc
@@ -1,0 +1,6 @@
+<?PHP
+
+// Comment.
+echo 'hello'  ;
+
+$var = 10;

--- a/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-errors.inc
+++ b/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-errors.inc
@@ -1,0 +1,5 @@
+<?PHP
+
+echo 'hello';
+
+$var = 10;

--- a/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-fixable-errors.inc
+++ b/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-fixable-errors.inc
@@ -1,0 +1,3 @@
+<?PHP
+
+echo 'hello';

--- a/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-fixable-warnings.inc
+++ b/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-fixable-warnings.inc
@@ -1,0 +1,3 @@
+<?php
+
+print 'hello'  ;

--- a/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-warnings.inc
+++ b/tests/Core/Util/ExitCode/Fixtures/ExitCodeTest/only-warnings.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Comment.
+print 'hello'  ;

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/ErrorSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/ErrorSniff.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ErrorSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_VARIABLE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] === '$var') {
+            $phpcsFile->addError('Variables should have descriptive names. Found: $var', $stackPtr, 'VarFound');
+        }
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FailToFixSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FailToFixSniff.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FailToFixSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_ECHO];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
+            || $tokens[($stackPtr + 1)]['length'] > 60
+        ) {
+            return;
+        }
+
+        $error = 'There should be 60 spaces after an ECHO keyword';
+        $fix   = $phpcsFile->addFixableError($error, ($stackPtr + 1), 'ShortSpace');
+        if ($fix === true) {
+            // The fixer deliberately only adds one space in each loop to ensure it runs out of loops before the file complies.
+            $phpcsFile->fixer->addContent($stackPtr, ' ');
+        }
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FixableErrorSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FixableErrorSniff.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FixableErrorSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_OPEN_TAG];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens     = $phpcsFile->getTokens();
+        $contents   = $tokens[$stackPtr]['content'];
+        $contentsLC = strtolower($contents);
+        if ($contentsLC !== $contents) {
+            $fix = $phpcsFile->addFixableError('Use lowercase open tag', $stackPtr, 'Found');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $contentsLC);
+            }
+        }
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FixableWarningSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/FixableWarningSniff.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FixableWarningSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_SEMICOLON];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[($stackPtr - 1)]['code'] === T_WHITESPACE) {
+            $fix = $phpcsFile->addFixableWarning('There should be no whitespace before a semicolon', ($stackPtr - 1), 'Found');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+            }
+        }
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/NoIssuesSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/NoIssuesSniff.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class NoIssuesSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_ECHO];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do nothing.
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/WarningSniff.php
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/Sniffs/ExitCodes/WarningSniff.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Util\ExitCode\ExitCodeTest
+ */
+
+namespace TestStandard\Sniffs\ExitCodes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class WarningSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_COMMENT];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $phpcsFile->addWarning('Commments are not allowed', $stackPtr, 'Found');
+    }
+}

--- a/tests/Core/Util/ExitCode/Fixtures/TestStandard/ruleset.xml
+++ b/tests/Core/Util/ExitCode/Fixtures/TestStandard/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="TestStandard" namespace="TestStandard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+
+</ruleset>


### PR DESCRIPTION
# Description
### Introduce new ExitCode class 

This class contains class constants for the new exit codes, so code referencing the constants becomes more self-documenting.

Closes squizlabs/PHP_CodeSniffer#3696

### Requirements check: use new exit code 

Includes safeguarding the exit code via the `test-requirements-check.yml` workflow.

### Use new exit codes for DeepExitExceptions 

Includes updating the documentation of the `DeepExitException` class.

### Change exit codes for scan runs 

This commit implements the change in the exit codes for scan runs, both `phpcs` as well as `phpcbf`, as previously outlined and extensively discussed in #184.

It also introduces a new `ignore_non_auto_fixable_on_exit` config flag to influence the exit code.

To allow for determining whether there are fixable and/or non-fixable issues left at the end of a run, while also supporting the previously already supported `ignore_errors_on_exit` and `ignore_warnings_on_exit` config flags, this required more extensive changes than originally anticipated.

Originally, the `File` class and the `Reporter` class tracked (single file/all files) totals for:
* Errors found
* Warnings found
* Fixable violations found (errors and warnings combined)
* Violations fixed (errors and warnings combined)

Additionally, the total for "fixed" could be higher than the "fixable" count as it totals the fixes applied in all loops, including fixes for issues _created by fixers_ and not in the original scan, which made the "fixed" total unusable for the new exit code determination.

To allow for correctly determining the new exit codes, the "fixable" total had to be split up into "fixable errors" and "fixable warnings", both in the `File` class, as well as in the `Reporter` class.
Secondly, the "fixed" total also had to be split up, as well as being based on the _effective_ number of fixes made instead of the _actual_ number of fixes made.

These changes also affect the way scan results are cached, as the cache now also needs to store the split up numbers (for "fixable") and how parallel processing accumulates the totals of the child processes.

And as the logic for the exit code determination for the new exit codes is largely the same for both `phpcs` as well as `phpcbf`, a new `ExitCode::calculate()` method has been introduced to transparently handle this for both.

Notable API changes:
* The signature of the `DummyFile::setErrorCounts()` method has changed:
    ```diff
    -public function setErrorCounts($errorCount, $warningCount, $fixableCount, $fixedCount)
    +public function setErrorCounts($errorCount, $warningCount, $fixableErrorCount, $fixableWarningCount, $fixedErrorCount, $fixedWarningCount)
    ```
* The `Reporter::$totalFixable` and `Reporter::$totalFixed` properties are now deprecated. They will still be supported as readonly properties for the 4.x branch (via magic methods), but support will be removed in PHPCS 5.0.
* The return value of the `private` `Runner::run()` method has changed from `int` to `void` as the return value was no longer used.

Includes mentioning the new `ignore_non_auto_fixable_on_exit` config flag in the CLI help text.

Includes extensive integration tests for the exit code calculations and the changes made in support of the new exit codes.
Includes git-ignoring temporary files which will be created during the test run in case the test run would bork out before the tear down methods are run.

Includes tests for the new magic methods in the `Reporter` class to safeguard that the deprecated properties are still accessible, but not writeable.

Includes improving the documentation for `Fixer::$numFixes`/`Fixer::getFixCount()` to mention that these numbers are _actual_ number fixes, not _effective_ number of fixes.

Fixes #184
Fixes squizlabs/PHP_CodeSniffer#2898

### Use the new exit codes when scanning code from STDIN


## Suggested changelog entry
Changed:
* Both `phpcs` as well as  `phpcbf` will now exit with exit code `0` if no issues were found/remain after fixing.
    - Non auto-fixable issues can be ignored for the exit code determination by setting the new `ignore_non_auto_fixable_on_exit` config flag to `1`.
    - For full details on the new exit codes, please refer to the [Wiki "Advanced Usage" page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage).
* The signature of the `DummyFile::setErrorCounts()` method has changed and now expect the following parameters: `($errorCount, $warningCount, $fixableErrorCount, $fixableWarningCount, $fixedErrorCount, $fixedWarningCount`.

Deprecated:
* The `Reporter::$totalFixable` and `Reporter::$totalFixed` properties are now deprecated. They will still be supported as readonly properties for the 4.x branch, but support will be removed in PHPCS 5.0.
