### PR TITLE
GH Actions/verify release: tweak the workflow

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -109,9 +109,11 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
-      # Note: the `.` is in the command to make it work for both PHPCS as well PHPCBF.
+      - name: Create a PHP file
+        run: echo '<?php echo "Hello, World!";' > hello.php
+
       - name: Verify the PHAR is nominally functional
-        run: php ${{ steps.source.outputs.FILE }} . -e --standard=PSR12
+        run: php ${{ steps.source.outputs.FILE }} -- -ps hello.php --standard=PSR2
 
       - name: Grab the version
         id: asset_version
@@ -186,9 +188,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_FORCE_TTY: true
 
-      # Note: the `.` is in the command to make it work for both PHPCS as well PHPCBF.
+      - name: Create a PHP file
+        run: echo '<?php echo "Hello, World!";' > hello.php
+
       - name: Verify the PHAR is nominally functional
-        run: php ./tools/${{ matrix.pharfile }} . -e --standard=PSR12
+        run: php ./tools/${{ matrix.pharfile }} -- -ps hello.php --standard=PSR2
 
       - name: Grab the version
         id: asset_version

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -148,24 +148,28 @@ jobs:
     name: "PHIVE: ${{ matrix.pharfile }}"
 
     steps:
-      - name: Retrieve latest release info
-        uses: octokit/request-action@v2.x
-        id: get_latest_release
-        with:
-          route: GET /repos/PHPCSStandards/PHP_CodeSniffer/releases/latest
+      # Phive does not support a stability flag yet, so it will always download the
+      # very latest release, even when this is a pre-release.
+      # I.e. to verify the downloaded version, we need to select the version number including pre-releases.
+      # Ref: https://github.com/phar-io/phive/issues/154
+      - name: Retrieve latest release info (including prereleases)
+        id: latest_release
+        run: |
+          latestRelease="$(gh release list --repo PHPCSStandards/PHP_CodeSniffer --limit 1 --json tagName --jq '.[0].tagName')"
+          echo "TAG=$latestRelease" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "DEBUG: Show API request failure status"
-        if: ${{ failure() }}
-        run: "echo No release found. Request failed with status ${{ steps.get_latest_release.outputs.status }}"
-
-      - name: Grab latest tag name from API response
-        id: version
-        run: |
-          echo "TAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> "$GITHUB_OUTPUT"
-
       - name: "DEBUG: Show tag name found in API response"
+        run: "echo ${{ steps.latest_release.outputs.TAG }}"
+
+      # Just get the version number, without alpha/beta/RC.
+      - name: Clean up the version number
+        id: version
+        # yamllint disable-line rule:line-length
+        run: echo "TAG=$(echo '${{ steps.latest_release.outputs.TAG }}' | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+(\.[0-9]+)+')" >> "$GITHUB_OUTPUT"
+
+      - name: "DEBUG: Show cleaned up tag name"
         run: "echo ${{ steps.version.outputs.TAG }}"
 
       - name: Setup PHP


### PR DESCRIPTION
# Description
### GH Actions/verify release: tweak the workflow [1] 

As of PHPCS 4.0.0, a new "No files were checked" error will be shown if `phpcs`/`phpcbf` runs a scan and no files end up being scanned.

Previously, to test that the downloaded PHAR file is nominally functional, the `php ${{ steps.source.outputs.FILE }} . -e --standard=PSR12` command was used.
For `phpcs`, this would "explain" the PSR12 standard, for `phpcbf`, this would spin up PHPCS and end up not scanning anything as there are no files in the working directory, but it did test that the PHAR file was functional.

This "trick" will no longer work with PHPCS 4.0.0 due to the new "No files were checked" error.
As I'd prefer for this check to do a simple scan, rather than exit out while reading the CLI arguments (like would happen with the `-h` or `-i` flags), I'm now implementing the suggestion made by @fredden in https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/758/files#diff-c871a3c5382d363c3ead11f0f87306fd5954b360eaa8a96fea8582bce1815827 and creating a simple PHP file to scan.

### GH Actions/verify release: tweak the workflow [2] 

PHIVE does not support a "stability" flag yet, which means that it will always grab the very latest release, even when this is an alpha/beta/RC pre-release.

As the GH API `releases/latest` route returns the latest _stable_ release, this causes the workflow to fail.
This was already previously identified as an area which needed attention in #758, and as we now have a pre-release as the latest release (`4.0.0beta1`), this now needs to be fixed.

Note: this still doesn't fix things completely, as in reality, the workflow should work based on the tag published if the workflow is triggered by a release to ensure that the "release assets" and "versioned web" jobs check the right release ("unversioned web" should still always check the latest stable release), but it is unclear where to grab that info from and as testing the info available when the workflow is triggered by a release requires doing a release, this is neigh impossible to test. I may need to create a dummy repo just to test.

For now, this at least fixes the Phive jobs.

## Suggested changelog entry
_N/A_