### PR TITLE
GH Actions: actually run tests against Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,11 @@ jobs:
           # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
           - php: '5.4'
             os: 'windows-latest'
+          # By default, the memory limit should be disabled with setup_php, but we're still running
+          # into memory limit issues when the full test suite is run on PHP 5.6 in Windows.
+          # As support for PHP < 7.2 will be dropped in PHPCS 4.0 anyhow, let's just skip the build.
+          - php: '5.6'
+            os: 'windows-latest'
 
         include:
           # Skip test runs on builds which are also run in the coverage job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ strategy.job-index }}-${{ github.ref }}
       cancel-in-progress: true
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
 
     strategy:


### PR DESCRIPTION
# Description
This was already correctly done for the `quicktest` and the `coverage` jobs, but apparently, changing the `runs-on` was missed for the `test` job.

Oops.

Fixed now.

## Suggested changelog entry
_N/A_