### PR TITLE
TimingTest: remove flaky assertions

### DIFF
--- a/tests/Core/Util/Timing/TimingTest.php
+++ b/tests/Core/Util/Timing/TimingTest.php
@@ -52,8 +52,6 @@ final class TimingTest extends TestCase
         $duration = Timing::getDuration();
 
         $this->assertTrue(is_float($duration));
-        $this->assertGreaterThan(1, $duration);
-        $this->assertLessThan(15, $duration);
 
     }//end testGetDurationWithStartReturnsMilliseconds()
 


### PR DESCRIPTION
# Description
This should probably get a better test to ensure that the method actually returns microseconds, but time is difficult to test, which makes these assertions flaky and that's even worse.

For now, let's remove the flaky assertions.

## Suggested changelog entry
_N/A_
