### PR TITLE
GH Actions: auto-trigger update of schema website

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -21,6 +21,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ###############################################################
+  # Trigger an update of the schema.phpcodesniffer.com website. #
+  ###############################################################
+  trigger-schema-site-update:
+    runs-on: ubuntu-latest
+
+    # Only run this workflow in the context of this repo.
+    if: github.repository_owner == 'PHPCSStandards'
+
+    name: "Trigger update of schema website"
+
+    steps:
+      - name: Trigger schema website update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WORKFLOW_DISPATCH_PAT }}
+          repository: PHPCSStandards/schema.phpcodesniffer.com
+          event-type: phpcs-release
+
   ##################################################################################
   # Verify the release is available in all the right places and works as expected. #
   ##################################################################################
@@ -129,9 +148,9 @@ jobs:
         if: ${{ steps.asset_version.outputs.VERSION != steps.version.outputs.TAG }}
         run: exit 1
 
-  # #########################################
-  # Verify install via PHIVE.
-  # #########################################
+  #############################
+  # Verify install via PHIVE. #
+  #############################
   verify-phive:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description
Adds a workflow job to send out a GH API request whenever a new release is tagged. The API request will trigger a workflow in the https://github.com/PHPCSStandards/schema.phpcodesniffer.com repository, which will update the schema.phpcodesniffer.com website.

As this is a cross-repo request, the standard GH secret is not sufficient. A Personal Access Token has been created on the PHPCSStandards organisation to facilitate workflow dispatches. This PAT has been added to the repo actions secrets, so it can be safely used in this workflow.

The PAT token is a fine-grained one and needs the following permissions for this dispatch to succeed:
- contents: read & write
- metadata: read only (automatically selected when selecting the contents permission)

Note: The Personal Access Token needs to be renewed once a year.

## Suggested changelog entry
Other:
The latest PHP_CodeSniffer XSD file is now available via the following permalink: schema.phpcodesniffer.com/phpcs.xsd
Older XSD files can be referenced via permalinks based on their minor: schema.phpcodesniffer.com/#.#/phpcs.xsd


## Related issues/external references

Fixes #1094 (together with the newly set up https://github.com/PHPCSStandards/schema.phpcodesniffer.com repo
