### PR TITLE
Config: remove code related to the now unsupported PEAR installation

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1704,11 +1704,6 @@ class Config
             $configFile = dirname($path).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
         } else {
             $configFile = dirname(__DIR__).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
-            if (is_file($configFile) === false
-                && strpos('@data_dir@', '@data_dir') === false
-            ) {
-                $configFile = '@data_dir@/PHP_CodeSniffer/CodeSniffer.conf';
-            }
         }
 
         if (is_file($configFile) === false) {


### PR DESCRIPTION
# Description

PR #4 dropped support for installing PHPCS via PEAR. This commit removes code related to a PEAR placeholder called `@data_dir@` as it is not necessary anymore.

The original version of this code was added in https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/980c835c2a4ec35de43e5b67ad88dbdb7dd50860#diff-36ecedca179eab0b3cd245e872a96ab26fa08e567437e167f4eda1779c15c89R1370-R1372. Two methods were added that use the `@data_dir@` placeholder in that commit: `setConfigData()` and `getAllConfigData()`. A subsequent commit changed `setConfigData()` to only use the PEAR path for the config file if the `@data_dir@` placeholder was replaced with something else: https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/7bb73831f5d8bbb269e626bc28f8cb5d47c9b191. A later commit did the same for `getAllConfigData()` together with other unrelated changes: https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/9392185cf09dde201a36fc97cdef84049fc17ece.

It seems that the PEAR file package.xml was responsible for replacing `@data_dir@` with an actual path: https://github
.com/PHPCSStandards/PHP_CodeSniffer/blob/6d22f38f6c846512d321f3d5ac15c8805c694084/package.xml#L293-L295.

PR #4 removed the `@data_dir@` related code from `setConfigData()`, but not from `getAllConfigData()`.

> If we want to play it safe (if there are any doubts), the PR should be pulled to 4.x. Otherwise it can go into 3.x.

Regarding this question asked in the issue, from all that I can see, it is safe to remove this code in 3.x. The removed if condition only evaluates to `true` and thus changes the value of the `$configFile` variable if the `@data_dir@` placeholder is modified in the code, which should not happen under supported circumstances. That being said, I'm happy to change the base branch of this PR to `4.x` if you prefer.


## Suggested changelog entry
_N/A_


## Related issues/external references

Fixes #1101 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
