### PR TITLE
fix: array declaration sniff

### DIFF
--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -15,7 +15,15 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class ArrayDeclarationSniff implements Sniff
 {
+    /**
+     * Controls how to align the double arrow in multi-line arrays:
+     * - true: align the double arrow to the longest index
+     * - false: align the double arrow to length of the index
+     *
+     * @var bool
+     */
     public bool $alignDoubleArrowToLongestIndex = true;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -825,7 +833,7 @@ class ArrayDeclarationSniff implements Sniff
 
             $arrowStart = ($tokens[$indexPointer]['column'] + $index['index_length'] + 1);
 
-            if ($this->alignDoubleArrowToLongestIndex) {
+            if ($this->alignDoubleArrowToLongestIndex === true) {
                 $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
             }
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class ArrayDeclarationSniff implements Sniff
 {
-    public bool $alignDoubleArrowToLongestElement = true;
+    public bool $alignDoubleArrowToLongestIndex = true;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -825,7 +825,7 @@ class ArrayDeclarationSniff implements Sniff
 
             $arrowStart = ($tokens[$indexPointer]['column'] + $index['index_length'] + 1);
 
-            if ($this->alignDoubleArrowToLongestElement) {
+            if ($this->alignDoubleArrowToLongestIndex) {
                 $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
             }
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -15,12 +15,13 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class ArrayDeclarationSniff implements Sniff
 {
+
     /**
      * Controls how to align the double arrow in multi-line arrays:
      * - true: align the double arrow to the longest index
      * - false: align the double arrow to length of the index
      *
-     * @var bool
+     * @var boolean
      */
     public bool $alignDoubleArrowToLongestIndex = true;
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class ArrayDeclarationSniff implements Sniff
 {
-
+    public bool $alignDoubleArrowToLongestElement = true;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -823,7 +823,12 @@ class ArrayDeclarationSniff implements Sniff
                 }
             }//end if
 
-            $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
+            $arrowStart = ($tokens[$indexPointer]['column'] + $index['index_length'] + 1);
+
+            if ($this->alignDoubleArrowToLongestElement) {
+                $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
+            }
+
             if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
                 $expected       = ($arrowStart - ($index['index_length'] + $tokens[$indexPointer]['column']));
                 $found          = ($tokens[$index['arrow']]['column'] - ($index['index_length'] + $tokens[$indexPointer]['column']));
@@ -847,11 +852,9 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($index['arrow'] - 1), str_repeat(' ', $expected));
                     }
                 }
-
-                continue;
             }//end if
 
-            $valueStart = ($arrowStart + 3);
+            $valueStart = ($tokens[$index['arrow']]['column'] + 3);
             if ($tokens[$valuePointer]['column'] !== $valueStart) {
                 $expected = ($valueStart - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));
                 $found    = ($tokens[$valuePointer]['column'] - ($tokens[$index['arrow']]['length'] + $tokens[$index['arrow']]['column']));


### PR DESCRIPTION
# Description
This adds two changes to array declaration sniff:
- Removes continue when `DoubleArrowNotAligned` is triggered - currently with continue it simply doesn't fix array values as expected - it keeps whitespaces for it in case double arrow is not aligned as expected
- Adds `alignDoubleArrowToLongestIndex` property to `ArrayDeclarationSniff`, with true value by defualt, when changed to false phpcs will align double arrow to length of index of element

Basically for example now when running phpcs for such array:

```php
$array = [
  'asdasdasdsadsadsadassad'     =>        $this->greenhouseGas->id,
  'xyz'     =>      
            $this->xyz->asd,
  123     =>
    $this->xyz->asd,
  456     =>        $this->xyz->asd,
];
```

With `alignDoubleArrowToLongestIndex` value as `true` will produce output:

```php
$array = [
  'asdasdasdsadsadsadassad' => $this->greenhouseGas->id,
  'xyz'                     => $this->xyz->asd,
  123                       => $this->xyz->asd,
  456                       => $this->xyz->asd,
];
```

With `alignDoubleArrowToLongestIndex` value as `false` will produce output:

```php
$array = [
  'asdasdasdsadsadsadassad' => $this->greenhouseGas->id,
  'xyz' => $this->xyz->asd,
  123 => $this->xyz->asd,
  456 => $this->xyz->asd,
];
```

## Suggested changelog entry
- Add property `alignDoubleArrowToLongestIndex` to `Squiz.Arrays.ArrayDeclaration` to allow double arrow alignment without keeping double arrow on same position of all elements
- Fixes `Squiz.Arrays.ArrayDeclaration.ValueNotAligned` not being reported when `Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned` was reported for same array element

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.