### PR TITLE
Skip tests when 'git' command is not available

### DIFF
--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Filters;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Filters\GitModified;
 use PHP_CodeSniffer\Tests\Core\Filters\AbstractFilterTestCase;
 use RecursiveArrayIterator;
@@ -217,6 +218,10 @@ final class GitModifiedTest extends AbstractFilterTestCase
     {
         if (is_dir(__DIR__.'/../../../.git') === false) {
             $this->markTestSkipped('Not a git repository');
+        }
+
+        if (Config::getExecutablePath('git') === null) {
+            $this->markTestSkipped('git command not available');
         }
 
         $fakeDI = new RecursiveArrayIterator(self::getFakeFileList());

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Filters;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Filters\GitStaged;
 use PHP_CodeSniffer\Tests\Core\Filters\AbstractFilterTestCase;
 use RecursiveArrayIterator;
@@ -217,6 +218,10 @@ final class GitStagedTest extends AbstractFilterTestCase
     {
         if (is_dir(__DIR__.'/../../../.git') === false) {
             $this->markTestSkipped('Not a git repository');
+        }
+
+        if (Config::getExecutablePath('git') === null) {
+            $this->markTestSkipped('git command not available');
         }
 
         $fakeDI = new RecursiveArrayIterator(self::getFakeFileList());


### PR DESCRIPTION
# Description
While running the test suite for this repository within a limited environment, several tests were failing without the `git` command-line tool available. This change skips these tests when the `git` command is not found.

To reproduce the "no `git` available" scenario, check out a copy of this repository, and run: `docker run --rm -it -w /work -v "$PWD:/work" php:8.4-cli-alpine vendor/bin/phpunit --no-coverage --testdox --filter=Git`

## Suggested changelog entry
*None required*

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.