### PR TITLE
Declare dependency on bcmath extension

### DIFF
--- a/tests/Core/Ruleset/ProcessRulesetShouldProcessElementTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetShouldProcessElementTest.php
@@ -215,6 +215,8 @@ final class ProcessRulesetShouldProcessElementTest extends TestCase
      * Verify that in CS mode, phpcs-only <ini> directives are respected and phpcbf-only <ini>
      * directives are ignored.
      *
+     * @requires extension bcmath
+     *
      * @return void
      */
     public function testShouldProcessIniCsonly()
@@ -234,7 +236,8 @@ final class ProcessRulesetShouldProcessElementTest extends TestCase
      * Verify that in CBF mode, phpcbf-only <ini> directives are respected and phpcs-only <ini>
      * directives are ignored.
      *
-     * @group CBF
+     * @group    CBF
+     * @requires extension bcmath
      *
      * @return void
      */


### PR DESCRIPTION
# Description
While running the test suite for this repository within a limited environment, several tests were failing without the `bcmath` PHP extension. This change skips these tests when the `bcmath` extension is not loaded. Elsewhere, we use this same syntax to skip tests which depend on the `bcmath` extension.

## Suggested changelog entry
*None required*

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.