### PR TITLE
Generic/LowerCaseKeyword: add support for asym visibility keywords

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -33,6 +33,9 @@ class LowerCaseKeywordSniff implements Sniff
             T_MATCH_DEFAULT => T_MATCH_DEFAULT,
             T_PARENT        => T_PARENT,
             T_SELF          => T_SELF,
+            T_PUBLIC_SET    => T_PUBLIC_SET,
+            T_PROTECTED_SET => T_PROTECTED_SET,
+            T_PRIVATE_SET   => T_PRIVATE_SET,
         ];
 
         return $targets;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -60,5 +60,17 @@ $c = function() {
     FROM fun();
 }
 
+class AsymmetricVisibility {
+    public(set) int $correctPublicSet;
+    protected(set) int $correctProtectedSet;
+    private(set) int $correctPrivateSet;
+
+    PubliC(SeT) int $wrongCasePublic;
+    PROTECTED(set) array $wrongCaseProtected;
+    protected(sEt) int $wrongCaseProtectedSet;
+    Private(set) int $wrongCasePrivate;
+    private(SET) readonly ?string $wrongCasePrivateSet;
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -60,5 +60,17 @@ $c = function() {
     from fun();
 }
 
+class AsymmetricVisibility {
+    public(set) int $correctPublicSet;
+    protected(set) int $correctProtectedSet;
+    private(set) int $correctPrivateSet;
+
+    public(set) int $wrongCasePublic;
+    protected(set) array $wrongCaseProtected;
+    protected(set) int $wrongCaseProtectedSet;
+    private(set) int $wrongCasePrivate;
+    private(set) readonly ?string $wrongCasePrivateSet;
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -55,6 +55,11 @@ final class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             57 => 2,
             58 => 1,
             60 => 1,
+            68 => 1,
+            69 => 1,
+            70 => 1,
+            71 => 1,
+            72 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Generic.PHP.LowerCaseKeyword



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734

