### PR TITLE
PEAR/ValidVariableName: update for properties with asymmetric visibility

### DIFF
--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -37,6 +37,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $memberName     = ltrim($tokens[$stackPtr]['content'], '$');
         $scope          = $memberProps['scope'];
         $scopeSpecified = $memberProps['scope_specified'];
+        if ($scopeSpecified === false && $memberProps['set_scope'] !== false) {
+            // Implicit `public` visibility for property with asymmetric visibility.
+            $scopeSpecified = true;
+        }
 
         if ($memberProps['scope'] === 'private') {
             $isPublic = false;

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -99,3 +99,17 @@ $util->setLogger(
         private $varName  = 'hello';
         private $_varName = 'hello';
 });
+
+class AsymVisibility {
+    // The read scope is public, but not specified. Enforce the naming conventions anyway.
+    private(set) $asymPublicImplied  = 'hello';
+    private(set) $_asymPublicImplied = 'hello';
+
+    // The read scope is private, so these properties should be handled as private properties.
+    private private(set) $asymPrivate  = 'hello';
+    private(set) private $_asymPrivate = 'hello';
+
+    // The read scope is public/protected, so these properties should be handled as public properties.
+    public private(set) $asymPublicPrivate  = 'hello';
+    private(set) protected $_asymPrivateProtected = 'hello';
+}

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -31,13 +31,16 @@ final class ValidVariableNameUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            12 => 1,
-            17 => 1,
-            22 => 1,
-            92 => 1,
-            93 => 1,
-            94 => 1,
-            99 => 1,
+            12  => 1,
+            17  => 1,
+            22  => 1,
+            92  => 1,
+            93  => 1,
+            94  => 1,
+            99  => 1,
+            106 => 1,
+            109 => 1,
+            114 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

The PEAR sniff does not enforce the naming conventions when no visibility is specified, but for asymmetric visibility, visibility **_is_** specified, even though the "read" visibility may be implied, so in my opinion, the sniff should enforce the naming conventions like normal.

Includes tests.


## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - PEAR.NamingConventions.ValidVariableName




## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734


