### PR TITLE
Squiz/Commenting sniffs: update for properties with asymmetric visibility 

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -66,7 +66,7 @@ class BlockCommentSniff implements Sniff
             return;
         }
 
-        // If this is a function/class/interface doc block comment, skip it.
+        // If this is a function/class/interface/enum/property/const doc block comment, skip it.
         // We are only interested in inline doc block comments.
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
             $nextToken = $stackPtr;
@@ -80,16 +80,14 @@ class BlockCommentSniff implements Sniff
                 break;
             } while (true);
 
-            $ignore = [
+            $ignore  = Tokens::$scopeModifiers;
+            $ignore += [
                 T_CLASS     => true,
                 T_INTERFACE => true,
                 T_TRAIT     => true,
                 T_ENUM      => true,
                 T_FUNCTION  => true,
-                T_PUBLIC    => true,
-                T_PRIVATE   => true,
                 T_FINAL     => true,
-                T_PROTECTED => true,
                 T_STATIC    => true,
                 T_ABSTRACT  => true,
                 T_CONST     => true,

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -52,7 +52,7 @@ class DocCommentAlignmentSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // We are only interested in function/class/interface doc block comments.
+        // We are only interested in function/class/interface/enum/property/const doc block comments.
         $ignore = Tokens::$emptyTokens;
         if ($phpcsFile->tokenizerType === 'JS') {
             $ignore[] = T_EQUAL;
@@ -61,15 +61,14 @@ class DocCommentAlignmentSniff implements Sniff
         }
 
         $nextToken = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true);
-        $ignore    = [
+
+        $ignore  = Tokens::$scopeModifiers;
+        $ignore += [
             T_CLASS     => true,
             T_INTERFACE => true,
             T_ENUM      => true,
             T_ENUM_CASE => true,
             T_FUNCTION  => true,
-            T_PUBLIC    => true,
-            T_PRIVATE   => true,
-            T_PROTECTED => true,
             T_STATIC    => true,
             T_ABSTRACT  => true,
             T_FINAL     => true,

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -12,6 +12,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class VariableCommentSniff extends AbstractVariableSniff
 {
@@ -28,11 +29,9 @@ class VariableCommentSniff extends AbstractVariableSniff
      */
     public function processMemberVar(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-        $ignore = [
-            T_PUBLIC                 => T_PUBLIC,
-            T_PRIVATE                => T_PRIVATE,
-            T_PROTECTED              => T_PROTECTED,
+        $tokens  = $phpcsFile->getTokens();
+        $ignore  = Tokens::$scopeModifiers;
+        $ignore += [
             T_VAR                    => T_VAR,
             T_STATIC                 => T_STATIC,
             T_READONLY               => T_READONLY,

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -314,3 +314,20 @@ class FinalProperties {
      */
     final int $prop = 1;
 }
+
+class AsymVisibility {
+    /**
+     * Comment should be ignored.
+     */
+    public(set) int $prop = 1;
+
+    /**
+     * Comment should be ignored.
+     */
+    protected(set) int $prop = 1;
+
+    /**
+     * Comment should be ignored.
+     */
+    private(set) int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -316,3 +316,20 @@ class FinalProperties {
      */
     final int $prop = 1;
 }
+
+class AsymVisibility {
+    /**
+     * Comment should be ignored.
+     */
+    public(set) int $prop = 1;
+
+    /**
+     * Comment should be ignored.
+     */
+    protected(set) int $prop = 1;
+
+    /**
+     * Comment should be ignored.
+     */
+    private(set) int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -114,3 +114,20 @@ final class FinalClassWithFinalProp
       */
     final $property = 10;
 }
+
+class AsymVisibility {
+    /**
+    * Stars should be aligned.
+   */
+    public(set) int $prop = 1;
+
+    /**
+      * Stars should be aligned.
+       */
+    protected(set) int $prop = 1;
+
+    /**
+     * Stars should be aligned.
+     */
+    private(set) int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -114,3 +114,20 @@ final class FinalClassWithFinalProp
      */
     final $property = 10;
 }
+
+class AsymVisibility {
+    /**
+     * Stars should be aligned.
+     */
+    public(set) int $prop = 1;
+
+    /**
+     * Stars should be aligned.
+     */
+    protected(set) int $prop = 1;
+
+    /**
+     * Stars should be aligned.
+     */
+    private(set) int $prop = 1;
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -63,7 +63,12 @@ final class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
             $errors[112] = 1;
             $errors[113] = 1;
             $errors[114] = 1;
-        }
+
+            $errors[120] = 1;
+            $errors[121] = 1;
+            $errors[125] = 1;
+            $errors[126] = 1;
+        }//end if
 
         return $errors;
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -469,3 +469,20 @@ class PHP84FinalProperties {
      */
     final int $hasDocblock;
 }
+
+class AsymVisibility {
+    /**
+     * @var integer
+     */
+    public(set) int $hasDocblockA;
+
+    /**
+     * @var integer
+     */
+    public protected(set) int $hasDocblockB;
+
+    /**
+     * @var integer
+     */
+    private(set) protected int $hasDocblockC;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -469,3 +469,20 @@ class PHP84FinalProperties {
      */
     final int $hasDocblock;
 }
+
+class AsymVisibility {
+    /**
+     * @var integer
+     */
+    public(set) int $hasDocblockA;
+
+    /**
+     * @var integer
+     */
+    public protected(set) int $hasDocblockB;
+
+    /**
+     * @var integer
+     */
+    private(set) protected int $hasDocblockC;
+}


### PR DESCRIPTION
# Description

These commits all update commenting sniffs to allow them to correctly find a docblock when asym visbility is used.


### Squiz/BlockComment: update for properties with asymmetric visibility 

Prevent false positives for the "block comments must start with ..." error.

Includes tests.

### Squiz/DocCommentAlignment: update for properties with asymmetric visibility

Prevent false negatives for the "incorrect space before star" error.

Includes tests.

### Squiz/VariableComment: update for properties with asymmetric visibility 

Prevent false positives for the "no docblock found" error.

Includes tests.


## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Squiz.Commenting.BlockComment
    - Squiz.Commenting.DocCommentAlignment
    - Squiz.Commenting.VariableComment



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734

