### PR TITLE
Squiz/FunctionDeclarationArgumentSpacing: handle asym modifiers for constructor property promotion

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -340,6 +340,40 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                 }//end if
             }//end if
 
+            if (isset($param['set_visibility_token']) === true && $param['set_visibility_token'] !== false) {
+                $visibilityToken      = $param['set_visibility_token'];
+                $afterVisibilityToken = $phpcsFile->findNext(T_WHITESPACE, ($visibilityToken + 1), $param['token'], true);
+
+                $spacesAfter = 0;
+                if ($afterVisibilityToken !== false
+                    && $tokens[$visibilityToken]['line'] !== $tokens[$afterVisibilityToken]['line']
+                ) {
+                    $spacesAfter = 'newline';
+                } else if ($tokens[($visibilityToken + 1)]['code'] === T_WHITESPACE) {
+                    $spacesAfter = $tokens[($visibilityToken + 1)]['length'];
+                }
+
+                if ($spacesAfter !== 1) {
+                    $error = 'Expected 1 space after set-visibility modifier "%s"; %s found';
+                    $data  = [
+                        $tokens[$visibilityToken]['content'],
+                        $spacesAfter,
+                    ];
+
+                    $fix = $phpcsFile->addFixableError($error, $visibilityToken, 'SpacingAfterSetVisbility', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+                        $phpcsFile->fixer->addContent($visibilityToken, ' ');
+
+                        for ($i = ($visibilityToken + 1); $tokens[$i]['code'] === T_WHITESPACE; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }//end if
+            }//end if
+
             if (isset($param['readonly_token']) === true) {
                 $readonlyToken      = $param['readonly_token'];
                 $afterReadonlyToken = $phpcsFile->findNext(T_WHITESPACE, ($readonlyToken + 1), $param['token'], true);

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc
@@ -210,3 +210,18 @@ class PropertyPromotionSpacingAfterModifier {
         string $tooMuchSpaceNewLines,
     ) {}
 }
+
+class AsymVisibilityPropertyPromotionSpacingAfterComma {
+    public function __construct(private(set) string|int $propA, protected(set) bool $correctSpace,  public(set) MyClass $tooMuchSpace,public(set) string $noSpace) {}
+}
+
+class AsymVisibilityPropertyPromotionSpacingAfterModifier {
+    public function __construct(
+        private(set)$noSpace,
+        public(set)    MyClass $tooMuchSpace,
+        protected(set)   public   string $tooMuchSpaceX2,
+        private
+        public(set)
+        string $tooMuchSpaceNewLines,
+    ) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.1.inc.fixed
@@ -184,3 +184,16 @@ class PropertyPromotionSpacingAfterModifier {
         readonly public string $tooMuchSpaceNewLines,
     ) {}
 }
+
+class AsymVisibilityPropertyPromotionSpacingAfterComma {
+    public function __construct(private(set) string|int $propA, protected(set) bool $correctSpace, public(set) MyClass $tooMuchSpace, public(set) string $noSpace) {}
+}
+
+class AsymVisibilityPropertyPromotionSpacingAfterModifier {
+    public function __construct(
+        private(set) $noSpace,
+        public(set) MyClass $tooMuchSpace,
+        protected(set) public string $tooMuchSpaceX2,
+        private public(set) string $tooMuchSpaceNewLines,
+    ) {}
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -95,6 +95,12 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnit
                 207 => 2,
                 208 => 1,
                 209 => 1,
+                215 => 2,
+                220 => 1,
+                221 => 1,
+                222 => 2,
+                223 => 1,
+                224 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

This commit adds handling of the spacing after asymmetric visibility modifiers used for constructor property promotion to this sniff.

The spacing requirements are aligned with the spacing expectations of the `Squiz.WhiteSpace.ScopeKeywordSpacing` sniff, so the sniffs should not conflict with each other.

Additionally, the new check has a dedicated error code, which means that - if there would be a conflict anywhere - the asym visibility spacing check within this sniff can easily be turned off.

Includes tests.


## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Squiz.Functions.FunctionDeclarationArgumentSpacing



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734

