### PR TITLE
Squiz/MemberVarScope: update for properties with asymmetric visibility

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -33,9 +33,15 @@ class MemberVarScopeSniff extends AbstractVariableSniff
             return;
         }
 
-        $error = 'Scope modifier not specified for member variable "%s"';
-        $data  = [$tokens[$stackPtr]['content']];
-        $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
+        if ($properties['set_scope'] === false) {
+            $error = 'Scope modifier not specified for member variable "%s"';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
+        } else {
+            $error = 'Read scope modifier not specified for member variable "%s"';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addError($error, $stackPtr, 'AsymReadMissing', $data);
+        }
 
     }//end processMemberVar()
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -74,3 +74,14 @@ interface Base {
 class PHP84FinalProperties {
     final int $final;
 }
+
+class AsymVisibility {
+    // The read scope is public, but not specified. Error should use different error code.
+    public(set) $asymPublic  = 'hello';
+    protected(set) $asymProtected  = 'hello';
+    private(set) $asymPrivate  = 'hello';
+
+    public public(set) $asymPublicPublic  = 'hello';
+    protected(set) public $asymPublicProtected  = 'hello';
+    protected private(set) $asymProtectedPrivate  = 'hello';
+}

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -40,6 +40,9 @@ final class MemberVarScopeUnitTest extends AbstractSniffUnitTest
             66 => 2,
             67 => 1,
             75 => 1,
+            80 => 1,
+            81 => 1,
+            82 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

Do still flag when the "get" (read) scope is not specified, but do so with a different error code to allow for rulesets to ignore that error.

Includes tests.



## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Squiz.Scope.MemberVarScope



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734


