### PR TITLE
Squiz/MemberVarSpacing: update for properties with asymmetric visibility

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -53,7 +53,9 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $endOfPreviousStatement = $phpcsFile->findPrevious($stopPoints, ($stackPtr - 1), null, false, null, true);
 
-        $validPrefixes   = Tokens::$methodPrefixes;
+        $validPrefixes   = Tokens::$scopeModifiers;
+        $validPrefixes[] = T_STATIC;
+        $validPrefixes[] = T_FINAL;
         $validPrefixes[] = T_VAR;
         $validPrefixes[] = T_READONLY;
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
@@ -444,3 +444,18 @@ class MultilineCommentShouldNotBeSplitUp {
      */
     public $prop;
 }
+
+class AsymVisibility {
+    protected private(set) int $asymProtectedPrivate;
+
+    /**
+     * Docblock
+     */
+    protected(set) final string $asymProtected;
+    #[AnAttribute]
+
+    public(set) string|bool $asymPublic;
+
+
+    private(set) private bool $asymPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
@@ -431,3 +431,18 @@ class MultilineCommentShouldNotBeSplitUp {
      */
     public $prop;
 }
+
+class AsymVisibility {
+
+    protected private(set) int $asymProtectedPrivate;
+
+    /**
+     * Docblock
+     */
+    protected(set) final string $asymProtected;
+
+    #[AnAttribute]
+    public(set) string|bool $asymPublic;
+
+    private(set) private bool $asymPrivate;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -87,6 +87,10 @@ final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
                 427 => 1,
                 437 => 1,
                 445 => 1,
+                449 => 1,
+                456 => 1,
+                457 => 1,
+                460 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description

Allow for the sniff to calculate the "lines before" correctly when asym visibility is used

Includes tests.



## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Squiz.WhiteSpace.MemberVarSpacing



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734


