### PR TITLE
Squiz/ScopeKeywordSpacing: update for properties with asymmetric visibility

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -24,8 +24,9 @@ class ScopeKeywordSpacingSniff implements Sniff
      */
     public function register()
     {
-        $register   = Tokens::$methodPrefixes;
-        $register[] = T_READONLY;
+        $register  = Tokens::$methodPrefixes;
+        $register += Tokens::$scopeModifiers;
+        $register[T_READONLY] = T_READONLY;
         return $register;
 
     }//end register()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -192,3 +192,13 @@ class FinalProperties {
     final readonly public ?MyType $spacing_correct;
     protected   final   $spacing_incorrect = 'foo';
 }
+
+class AsymVisibility {
+    public(set)      string $asymPublic  = 'hello';
+    public  protected(set)   final  $asymProtected  = 'hello';
+    private(set)     public   string|false $asymPrivate  = 'hello';
+
+    public public(set) $asymPublicPublic  = 'hello';
+    protected(set) public $asymPublicProtected  = 'hello';
+    protected private(set) $asymProtectedPrivate  = 'hello';
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -185,3 +185,13 @@ class FinalProperties {
     final readonly public ?MyType $spacing_correct;
     protected final $spacing_incorrect = 'foo';
 }
+
+class AsymVisibility {
+    public(set) string $asymPublic  = 'hello';
+    public protected(set) final $asymProtected  = 'hello';
+    private(set) public string|false $asymPrivate  = 'hello';
+
+    public public(set) $asymPublicPublic  = 'hello';
+    protected(set) public $asymPublicProtected  = 'hello';
+    protected private(set) $asymProtectedPrivate  = 'hello';
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -70,6 +70,9 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
                 187 => 1,
                 188 => 1,
                 193 => 2,
+                197 => 1,
+                198 => 3,
+                199 => 2,
             ];
 
         case 'ScopeKeywordSpacingUnitTest.3.inc':


### PR DESCRIPTION

# Description
:warning: This PR depends on PR #1116.

---

Prevent false negatives for the "incorrect space after keyword" error.

Includes tests.



## Suggested changelog entry
- Added support for PHP 8.4 asymmetric visibility modifiers to the following sniffs:
    - Squiz.WhiteSpace.ScopeKeywordSpacing



## Related issues/external references

Follow up on #851 
Follow up on #1116

Related to #734

