### PR TITLE
Filters/Filter: expand test coverage for the Filter::accept() method

### DIFF
--- a/tests/Core/Filters/Filter/AcceptTest.xml
+++ b/tests/Core/Filters/Filter/AcceptTest.xml
@@ -2,10 +2,14 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AcceptTest" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Ruleset to test the filtering based on exclude patterns.</description>
 
-    <!-- Directory pattern. -->
+    <!-- Directory patterns. -->
     <exclude-pattern>*/something/*</exclude-pattern>
+    <exclude-pattern>*/src/Generators/*</exclude-pattern>
     <!-- File pattern. -->
     <exclude-pattern>*/Other/Main\.php$</exclude-pattern>
+
+    <!-- Relative directory pattern. -->
+    <exclude-pattern type="relative">/AnotherDir/*</exclude-pattern>
 
     <rule ref="Generic">
         <exclude name="Generic.Debug"/>


### PR DESCRIPTION
# Description

This PR expands the `Filter::accept()` tests to cover cases that were not covered before:
  - Run the tests on Windows as there is dedicated code when the directory separator is "\\".
  - Real directories trigger code that relies on is_dir() returning `true`.
  - Sets Config::$local to `true` and ensure in this case directories are not accepted.
  - Files without an extension, with an invalid one or starting with a dot are ignored.
  - Duplicated files are ignored.
  - Relative exclude patterns are handled correctly.

## Suggested changelog entry
_N/A_

## Additional notes

There is still one uncovered `if` block in a protected method called by `Filter::accept()`:

https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/d14042488843aa11c6b7273fdc1689c7d1d65be7/src/Filters/Filter.php#L250-L255

As far as I can check, there is no need to maintain this backwards compatibility code anymore, and it can be removed. It was added via https://github.com/squizlabs/PHP_CodeSniffer/commit/4982619b53bf7cea6255bc1dac57b89096c046f4 to preserve backwards compatibility back in a time when it was possible to programmatically set ignore patterns using `CodeSniffer::setIgnorePatterns()` (see https://pear.php.net/bugs/bug.php?id=19859). This method was removed a long time ago via https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/f61025c5617a493b655a5f572a3e13749b3a51f8#diff-c36ecedca179eab0b3cd245e872a96ab26fa08e567437e167f4eda1779c15c89L431-L435, and since then, I don't think there is a way for users to set the ignore pattern array with numeric indices. Happy to open a separate issue to discuss this if you think that is a good idea.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
