### PR TITLE
Filter/Filter: remove outdated code that is no longer needed

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -247,13 +247,6 @@ class Filter extends RecursiveFilterIterator
         }
 
         foreach ($ignorePatterns as $pattern => $type) {
-            // Maintains backwards compatibility in case the ignore pattern does
-            // not have a relative/absolute value.
-            if (is_int($pattern) === true) {
-                $pattern = $type;
-                $type    = 'absolute';
-            }
-
             $replacements = [
                 '\\,' => ',',
                 '*'   => '.*',


### PR DESCRIPTION
# Description

This PR removes an if condition to maintain backwards compatibility that is no longer needed. It was added via https://github.com/squizlabs/PHP_CodeSniffer/commit/4982619b53bf7cea6255bc1dac57b89096c046f4 to preserve backwards compatibility back in a time when it was possible to programmatically set ignore patterns using `CodeSniffer::setIgnorePatterns()` (see https://pear.php.net/bugs/bug.php?id=19859). This method was removed a long time ago via https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/f61025c5617a493b655a5f572a3e13749b3a51f8#diff-c36ecedca179eab0b3cd245e872a96ab26fa08e567437e167f4eda1779c15c89L431-L435, and since then, there is no way for users to set the ignore pattern array with numeric indices.

## Suggested changelog entry

_N/A_

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.