### PR TITLE
Squiz/FunctionDeclarationArgumentSpacing: fix typo in `SpacingAfterVis[i]bility` error code

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -320,7 +320,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                         $spacesAfter,
                     ];
 
-                    $fix = $phpcsFile->addFixableError($error, $visibilityToken, 'SpacingAfterVisbility', $data);
+                    $fix = $phpcsFile->addFixableError($error, $visibilityToken, 'SpacingAfterVisibility', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->beginChangeset();
                         $phpcsFile->fixer->addContent($visibilityToken, ' ');


### PR DESCRIPTION
# Description
Follow up on #792, related to #1135

The `SpacingAfterVis[i]bility` error code was introduced in v 3.12.0 (March this year) for constructor property promotion. The `SpacingAfterSetVis[i]bility` error code was introduced in v 3.13.1 (this month) for constructor property promotion with asym visibility.

Both contained the same typo.

PR #1135 fixes the asym error code and will be included in PHPCS 3.13.2.

This commit now fixes the non-asym error code and will be included in PHPCS 4.0.0.

## Suggested changelog entry
Changed: Squiz.Functions.FunctionDeclarationArgumentSpacing: the `SpacingAfterVisbility` error code to `SpacingAfterVisibility`


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


