### PR TITLE
Refactor IsCamelCapsTest to use data providers and add more tests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -43,6 +43,7 @@
         "mins",
         "nekudotayim",
         "nowdoc",
+        "numeronym",
         "paamayim",
         "pcre",
         "php's",

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -330,7 +330,7 @@ class Common
     /**
      * Returns true if the specified string is in the camel caps format.
      *
-     * @param string  $string      The string the verify.
+     * @param string  $string      The string to verify.
      * @param boolean $classFormat If true, check to see if the string is in the
      *                             class format. Class format strings must start
      *                             with a capital letter and contain no

--- a/tests/Core/Util/Common/IsCamelCapsTest.php
+++ b/tests/Core/Util/Common/IsCamelCapsTest.php
@@ -24,101 +24,302 @@ final class IsCamelCapsTest extends TestCase
     /**
      * Test valid public function/method names.
      *
+     * @param string $name   The tested name.
+     * @param bool   $strict Value of the $strict flag.
+     *
+     * @dataProvider dataValidNotClassFormatPublic
+     *
      * @return void
      */
-    public function testValidNotClassFormatPublic()
+    public function testValidNotClassFormatPublic($name, $strict)
     {
-        $this->assertTrue(Common::isCamelCaps('thisIsCamelCaps', false, true, true));
-        $this->assertTrue(Common::isCamelCaps('thisISCamelCaps', false, true, false));
+        $this->assertTrue(Common::isCamelCaps($name, false, true, $strict));
 
     }//end testValidNotClassFormatPublic()
 
 
     /**
+     * Data provider.
+     *
+     * @see testValidNotClassFormatPublic()
+     *
+     * @return array<string, array<string, string|bool>>
+     */
+    public static function dataValidNotClassFormatPublic()
+    {
+        return [
+            'lower camelCase string in strict mode'               => [
+                'name'   => 'thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with acronym in relaxed mode' => [
+                'name'   => 'thisISCamelCaps',
+                'strict' => false,
+            ],
+        ];
+
+    }//end dataValidNotClassFormatPublic()
+
+
+    /**
      * Test invalid public function/method names.
+     *
+     * @param string $name The tested name.
+     *
+     * @dataProvider dataInvalidNotClassFormatPublic
      *
      * @return void
      */
-    public function testInvalidNotClassFormatPublic()
+    public function testInvalidNotClassFormatPublic($name)
     {
-        $this->assertFalse(Common::isCamelCaps('_thisIsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('thisISCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('ThisIsCamelCaps', false, true, true));
-
-        $this->assertFalse(Common::isCamelCaps('3thisIsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('*thisIsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('-thisIsCamelCaps', false, true, true));
-
-        $this->assertFalse(Common::isCamelCaps('this*IsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('this-IsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('this_IsCamelCaps', false, true, true));
-        $this->assertFalse(Common::isCamelCaps('this_is_camel_caps', false, true, true));
+        $this->assertFalse(Common::isCamelCaps($name, false, true, true));
 
     }//end testInvalidNotClassFormatPublic()
 
 
     /**
+     * Data provider.
+     *
+     * @see testInvalidNotClassFormatPublic()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataInvalidNotClassFormatPublic()
+    {
+        return [
+            'string with initial underscore (invalid when $public is true)'      => [
+                'name' => '_thisIsCamelCaps',
+            ],
+            'lower camelCase string with acronym (invalid when $strict is true)' => [
+                'name' => 'thisISCamelCaps',
+            ],
+            'PascalCase string'                                                  => [
+                'name' => 'ThisIsCamelCaps',
+            ],
+            'lower camelCase string with initial digit'                          => [
+                'name' => '3thisIsCamelCaps',
+            ],
+            'lower camelCase string with initial [^a-zA-z_] character: *'        => [
+                'name' => '*thisIsCamelCaps',
+            ],
+            'lower camelCase string with initial [^a-zA-z_] character: -'        => [
+                'name' => '-thisIsCamelCaps',
+            ],
+            'lower camelCase string with medial [^a-zA-z_] character: *'         => [
+                'name' => 'this*IsCamelCaps',
+            ],
+            'lower camelCase string with medial [^a-zA-z_] character: -'         => [
+                'name' => 'this-IsCamelCaps',
+            ],
+            'lower camelCase string with single medial underscore'               => [
+                'name' => 'this_IsCamelCaps',
+            ],
+            'snake_case string'                                                  => [
+                'name' => 'this_is_camel_caps',
+            ],
+        ];
+
+    }//end dataInvalidNotClassFormatPublic()
+
+
+    /**
      * Test valid private method names.
+     *
+     * @param string $name   The tested name.
+     * @param bool   $strict Value of the $strict flag.
+     *
+     * @dataProvider dataValidNotClassFormatPrivate
      *
      * @return void
      */
-    public function testValidNotClassFormatPrivate()
+    public function testValidNotClassFormatPrivate($name, $strict)
     {
-        $this->assertTrue(Common::isCamelCaps('_thisIsCamelCaps', false, false, true));
-        $this->assertTrue(Common::isCamelCaps('_thisISCamelCaps', false, false, false));
-        $this->assertTrue(Common::isCamelCaps('_i18N', false, false, true));
-        $this->assertTrue(Common::isCamelCaps('_i18n', false, false, true));
+        $this->assertTrue(Common::isCamelCaps($name, false, false, $strict));
 
     }//end testValidNotClassFormatPrivate()
 
 
     /**
+     * Data provider.
+     *
+     * @see testValidNotClassFormatPrivate()
+     *
+     * @return array<string, array<string, string|bool>>
+     */
+    public static function dataValidNotClassFormatPrivate()
+    {
+        return [
+            'lower camelCase string with initial underscore'             => [
+                'name'   => '_thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with acronym and initial underscore' => [
+                'name'   => '_thisISCamelCaps',
+                'strict' => false,
+            ],
+            '_i18N'                                                      => [
+                'name'   => '_i18N',
+                'strict' => true,
+            ],
+            '_i18n'                                                      => [
+                'name'   => '_i18n',
+                'strict' => true,
+            ],
+        ];
+
+    }//end dataValidNotClassFormatPrivate()
+
+
+    /**
      * Test invalid private method names.
+     *
+     * @param string $name   The tested name.
+     * @param bool   $strict Value of the $strict flag.
+     *
+     * @dataProvider dataInvalidNotClassFormatPrivate
      *
      * @return void
      */
-    public function testInvalidNotClassFormatPrivate()
+    public function testInvalidNotClassFormatPrivate($name, $strict)
     {
-        $this->assertFalse(Common::isCamelCaps('thisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('_thisISCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('_ThisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('__thisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('__thisISCamelCaps', false, false, false));
-
-        $this->assertFalse(Common::isCamelCaps('3thisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('*thisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('-thisIsCamelCaps', false, false, true));
-        $this->assertFalse(Common::isCamelCaps('_this_is_camel_caps', false, false, true));
+        $this->assertFalse(Common::isCamelCaps($name, false, false, $strict));
 
     }//end testInvalidNotClassFormatPrivate()
 
 
     /**
+     * Data provider.
+     *
+     * @see testInvalidNotClassFormatPrivate()
+     *
+     * @return array<string, array<string, string|bool>>
+     */
+    public static function dataInvalidNotClassFormatPrivate()
+    {
+        return [
+            'lower camelCase string without initial underscore'                                   => [
+                'name'   => 'thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with initial underscore, but with an acronym, in strict mode' => [
+                'name'   => '_thisISCamelCaps',
+                'strict' => true,
+            ],
+            'PascalCase string with initial underscore'                                           => [
+                'name'   => '_ThisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with two initial underscores'                                 => [
+                'name'   => '__thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with two initial underscores and acronym in relaxed mode'     => [
+                'name'   => '__thisISCamelCaps',
+                'strict' => false,
+            ],
+            'lower camelCase string with initial digit'                                           => [
+                'name'   => '3thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with initial [^a-zA-Z_] character: *'                         => [
+                'name'   => '*thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with initial [^a-zA-Z_] character: -'                         => [
+                'name'   => '-thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'snake_case string with initial underscore'                                           => [
+                'name'   => '_this_is_camel_caps',
+                'strict' => true,
+            ],
+        ];
+
+    }//end dataInvalidNotClassFormatPrivate()
+
+
+    /**
      * Test valid class names.
+     *
+     * @param string $name   The tested name.
+     * @param bool   $strict Value of the $strict flag.
+     *
+     * @dataProvider dataValidClassFormatPublic
      *
      * @return void
      */
-    public function testValidClassFormatPublic()
+    public function testValidClassFormatPublic($name, $strict)
     {
-        $this->assertTrue(Common::isCamelCaps('ThisIsCamelCaps', true, true, true));
-        $this->assertTrue(Common::isCamelCaps('ThisISCamelCaps', true, true, false));
-        $this->assertTrue(Common::isCamelCaps('This3IsCamelCaps', true, true, false));
+        $this->assertTrue(Common::isCamelCaps($name, true, true, $strict));
 
     }//end testValidClassFormatPublic()
 
 
     /**
+     * Data provider.
+     *
+     * @see testValidClassFormatPublic()
+     *
+     * @return array<string, array<string, string|bool>>
+     */
+    public static function dataValidClassFormatPublic()
+    {
+        return [
+            'PascalCase string'                          => [
+                'name'   => 'ThisIsCamelCaps',
+                'strict' => true,
+            ],
+            'PascalCase string with acronym'             => [
+                'name'   => 'ThisISCamelCaps',
+                'strict' => false,
+            ],
+            'PascalCase string with digit between words' => [
+                'name'   => 'This3IsCamelCaps',
+                'strict' => false,
+            ],
+        ];
+
+    }//end dataValidClassFormatPublic()
+
+
+    /**
      * Test invalid class names.
+     *
+     * @param string $name The tested name.
+     *
+     * @dataProvider dataInvalidClassFormat
      *
      * @return void
      */
-    public function testInvalidClassFormat()
+    public function testInvalidClassFormat($name)
     {
-        $this->assertFalse(Common::isCamelCaps('thisIsCamelCaps', true));
-        $this->assertFalse(Common::isCamelCaps('This-IsCamelCaps', true));
-        $this->assertFalse(Common::isCamelCaps('This_Is_Camel_Caps', true));
+        $this->assertFalse(Common::isCamelCaps($name, true));
 
     }//end testInvalidClassFormat()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidClassFormat()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataInvalidClassFormat()
+    {
+        return [
+            'lower camelCase string'                             => [
+                'name' => 'thisIsCamelCaps',
+            ],
+            'PascalCase string with medial illegal character: -' => [
+                'name' => 'This-IsCamelCaps',
+            ],
+            'capitalised snake case'                             => [
+                'name' => 'This_Is_Camel_Caps',
+            ],
+        ];
+
+    }//end dataInvalidClassFormat()
 
 
     /**
@@ -127,14 +328,41 @@ final class IsCamelCapsTest extends TestCase
      * Note that the private flag is ignored if the class format
      * flag is set, so these names are all invalid.
      *
+     * @param string $name   The tested name.
+     * @param bool   $public Value of the $public flag.
+     *
+     * @dataProvider dataInvalidClassFormatPrivate
+     *
      * @return void
      */
-    public function testInvalidClassFormatPrivate()
+    public function testInvalidClassFormatPrivate($name, $public)
     {
-        $this->assertFalse(Common::isCamelCaps('_ThisIsCamelCaps', true, true));
-        $this->assertFalse(Common::isCamelCaps('_ThisIsCamelCaps', true, false));
+        $this->assertFalse(Common::isCamelCaps($name, true, $public));
 
     }//end testInvalidClassFormatPrivate()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidClassFormatPrivate()
+     *
+     * @return array<string, array<string, string|bool>>
+     */
+    public static function dataInvalidClassFormatPrivate()
+    {
+        return [
+            'PascalCase string with initial underscore (public)'  => [
+                'name'   => '_ThisIsCamelCaps',
+                'public' => true,
+            ],
+            'PascalCase string with initial underscore (private)' => [
+                'name'   => '_ThisIsCamelCaps',
+                'public' => false,
+            ],
+        ];
+
+    }//end dataInvalidClassFormatPrivate()
 
 
 }//end class

--- a/tests/Core/Util/Common/IsCamelCapsTest.php
+++ b/tests/Core/Util/Common/IsCamelCapsTest.php
@@ -379,33 +379,33 @@ final class IsCamelCapsTest extends TestCase
 
 
     /**
-     * Test invalid class names with the private flag set.
+     * Test invalid class names with the public flag set.
      *
-     * Note that the private flag is ignored if the class format
+     * Note that the public flag is ignored if the class format
      * flag is set, so these names are all invalid.
      *
      * @param string $name   The tested name.
      * @param bool   $public Value of the $public flag.
      *
-     * @dataProvider dataInvalidClassFormatPrivate
+     * @dataProvider dataInvalidClassFormatWithPublicFlag
      *
      * @return void
      */
-    public function testInvalidClassFormatPrivate($name, $public)
+    public function testInvalidClassFormatWithPublicFlag($name, $public)
     {
         $this->assertFalse(Common::isCamelCaps($name, true, $public));
 
-    }//end testInvalidClassFormatPrivate()
+    }//end testInvalidClassFormatWithPublicFlag()
 
 
     /**
      * Data provider.
      *
-     * @see testInvalidClassFormatPrivate()
+     * @see testInvalidClassFormatWithPublicFlag()
      *
      * @return array<string, array<string, string|bool>>
      */
-    public static function dataInvalidClassFormatPrivate()
+    public static function dataInvalidClassFormatWithPublicFlag()
     {
         return [
             'PascalCase string with initial underscore (public)'  => [
@@ -426,7 +426,7 @@ final class IsCamelCapsTest extends TestCase
             ],
         ];
 
-    }//end dataInvalidClassFormatPrivate()
+    }//end dataInvalidClassFormatWithPublicFlag()
 
 
     /**

--- a/tests/Core/Util/Common/IsCamelCapsTest.php
+++ b/tests/Core/Util/Common/IsCamelCapsTest.php
@@ -56,6 +56,10 @@ final class IsCamelCapsTest extends TestCase
                 'name'   => 'thisISCamelCaps',
                 'strict' => false,
             ],
+            'lower camelCase string with initial acronym'         => [
+                'name'   => 'ISThisCamelCaps',
+                'strict' => false,
+            ],
         ];
 
     }//end dataValidNotClassFormatPublic()
@@ -87,35 +91,48 @@ final class IsCamelCapsTest extends TestCase
     public static function dataInvalidNotClassFormatPublic()
     {
         return [
-            'string with initial underscore (invalid when $public is true)'      => [
+            'string with initial underscore (invalid when $public is true)'              => [
                 'name' => '_thisIsCamelCaps',
             ],
-            'lower camelCase string with acronym (invalid when $strict is true)' => [
+            'lower camelCase string with acronym (invalid when $strict is true)'         => [
                 'name' => 'thisISCamelCaps',
             ],
-            'PascalCase string'                                                  => [
+            'lower camelCase string with initial acronym (invalid when $strict is true)' => [
+                'name' => 'ISThisCamelCaps',
+            ],
+            'PascalCase string'                                                          => [
                 'name' => 'ThisIsCamelCaps',
             ],
-            'lower camelCase string with initial digit'                          => [
+            'lower camelCase string with initial digit'                                  => [
                 'name' => '3thisIsCamelCaps',
             ],
-            'lower camelCase string with initial [^a-zA-z_] character: *'        => [
+            'lower camelCase string with initial illegal character: *'                   => [
                 'name' => '*thisIsCamelCaps',
             ],
-            'lower camelCase string with initial [^a-zA-z_] character: -'        => [
+            'lower camelCase string with initial illegal character: -'                   => [
                 'name' => '-thisIsCamelCaps',
             ],
-            'lower camelCase string with medial [^a-zA-z_] character: *'         => [
+            'lower camelCase string with initial illegal character: é'                   => [
+                'name' => 'éCamelCaps',
+            ],
+            'lower camelCase string with medial illegal character: *'                    => [
                 'name' => 'this*IsCamelCaps',
             ],
-            'lower camelCase string with medial [^a-zA-z_] character: -'         => [
+            'lower camelCase string with medial illegal character: -'                    => [
                 'name' => 'this-IsCamelCaps',
             ],
-            'lower camelCase string with single medial underscore'               => [
+            'lower camelCase string with medial illegal character: é'                    => [
+                // No camels were harmed in the cspell:disable-next-line.
+                'name' => 'thisIsCamélCaps',
+            ],
+            'lower camelCase string with single medial underscore'                       => [
                 'name' => 'this_IsCamelCaps',
             ],
-            'snake_case string'                                                  => [
+            'snake_case string'                                                          => [
                 'name' => 'this_is_camel_caps',
+            ],
+            'empty string'                                                               => [
+                'name' => '',
             ],
         ];
 
@@ -149,19 +166,23 @@ final class IsCamelCapsTest extends TestCase
     public static function dataValidNotClassFormatPrivate()
     {
         return [
-            'lower camelCase string with initial underscore'             => [
+            'lower camelCase string with initial underscore'                        => [
                 'name'   => '_thisIsCamelCaps',
                 'strict' => true,
             ],
-            'lower camelCase string with acronym and initial underscore' => [
+            'lower camelCase string with acronym and initial underscore'            => [
                 'name'   => '_thisISCamelCaps',
                 'strict' => false,
             ],
-            '_i18N'                                                      => [
+            'lower camelCase string with acronym after initial underscore'          => [
+                'name'   => '_ISThisCamelCaps',
+                'strict' => false,
+            ],
+            'numeronym with initial underscore and capital after digit'             => [
                 'name'   => '_i18N',
                 'strict' => true,
             ],
-            '_i18n'                                                      => [
+            'numeronym with initial underscore and lowercase character after digit' => [
                 'name'   => '_i18n',
                 'strict' => true,
             ],
@@ -221,16 +242,28 @@ final class IsCamelCapsTest extends TestCase
                 'name'   => '3thisIsCamelCaps',
                 'strict' => true,
             ],
-            'lower camelCase string with initial [^a-zA-Z_] character: *'                         => [
+            'lower camelCase string with initial illegal character: *'                            => [
                 'name'   => '*thisIsCamelCaps',
                 'strict' => true,
             ],
-            'lower camelCase string with initial [^a-zA-Z_] character: -'                         => [
+            'lower camelCase string with initial illegal character: -'                            => [
                 'name'   => '-thisIsCamelCaps',
+                'strict' => true,
+            ],
+            'lower camelCase string with initial illegal character: é'                            => [
+                'name'   => 'éCamelCaps',
                 'strict' => true,
             ],
             'snake_case string with initial underscore'                                           => [
                 'name'   => '_this_is_camel_caps',
+                'strict' => true,
+            ],
+            'single underscore'                                                                   => [
+                'name'   => '_',
+                'strict' => true,
+            ],
+            'empty string'                                                                        => [
+                'name'   => '',
                 'strict' => true,
             ],
         ];
@@ -277,6 +310,26 @@ final class IsCamelCapsTest extends TestCase
                 'name'   => 'This3IsCamelCaps',
                 'strict' => false,
             ],
+            'PascalCase string with digit inside word'   => [
+                'name'   => 'Th1sIsCamelCaps',
+                'strict' => false,
+            ],
+            'Single capital (strict)'                    => [
+                'name'   => 'A',
+                'strict' => true,
+            ],
+            'Single capital with digit (strict)'         => [
+                'name'   => 'A1',
+                'strict' => true,
+            ],
+            'Single capital (relaxed)'                   => [
+                'name'   => 'A',
+                'strict' => false,
+            ],
+            'Single capital with digit (relaxed)'        => [
+                'name'   => 'A1',
+                'strict' => false,
+            ],
         ];
 
     }//end dataValidClassFormatPublic()
@@ -316,6 +369,9 @@ final class IsCamelCapsTest extends TestCase
             ],
             'capitalised snake case'                             => [
                 'name' => 'This_Is_Camel_Caps',
+            ],
+            'empty string'                                       => [
+                'name' => '',
             ],
         ];
 
@@ -360,9 +416,97 @@ final class IsCamelCapsTest extends TestCase
                 'name'   => '_ThisIsCamelCaps',
                 'public' => false,
             ],
+            'empty string (public)'                               => [
+                'name'   => '',
+                'public' => true,
+            ],
+            'empty string (private)'                              => [
+                'name'   => '',
+                'public' => false,
+            ],
         ];
 
     }//end dataInvalidClassFormatPrivate()
+
+
+    /**
+     * Test valid strings with default arguments.
+     *
+     * @param string $name The tested name.
+     *
+     * @dataProvider dataValidDefaultArguments
+     *
+     * @return void
+     */
+    public function testValidDefaultArguments($name)
+    {
+        $this->assertTrue(Common::isCamelCaps($name));
+
+    }//end testValidDefaultArguments()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testValidDefaultArguments()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataValidDefaultArguments()
+    {
+        return [
+            'lower camelCase string'                   => [
+                'name' => 'thisIsCamelCaps',
+            ],
+            'lower camelCase string with medial digit' => [
+                'name' => 'this3IsCamelCaps',
+            ],
+        ];
+
+    }//end dataValidDefaultArguments()
+
+
+    /**
+     * Test invalid strings with default arguments.
+     *
+     * @param string $name The tested name.
+     *
+     * @dataProvider dataInvalidDefaultArguments
+     *
+     * @return void
+     */
+    public function testInvalidDefaultArguments($name)
+    {
+        $this->assertFalse(Common::isCamelCaps($name));
+
+    }//end testInvalidDefaultArguments()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidDefaultArguments()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataInvalidDefaultArguments()
+    {
+        return [
+            'PascalCase string'                              => [
+                'name' => 'ThisIsCamelCaps',
+            ],
+            'PascalCase string with acronym'                 => [
+                'name' => 'ThisISCamelCaps',
+            ],
+            'lower camelCase string with initial underscore' => [
+                'name' => '_thisIsCamelCaps',
+            ],
+            'lower camelCase string with acronym'            => [
+                'name' => 'thisISCamelCaps',
+            ],
+        ];
+
+    }//end dataInvalidDefaultArguments()
 
 
 }//end class


### PR DESCRIPTION
# Description
I've refactored the existing tests to use data providers and added more tests to document the existing behaviour. See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/846

## Suggested changelog entry
n/a

## Related issues/external references

Fixes #846

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
