### PR TITLE
PEAR/ObjectOperatorIndent: improve end of statement detection when getting the next object operator

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -191,10 +191,7 @@ class ObjectOperatorIndentSniff implements Sniff
             $next = $phpcsFile->findNext(
                 $this->targets,
                 ($next + 1),
-                null,
-                false,
-                null,
-                true
+                $end
             );
         }//end while
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
@@ -140,3 +140,14 @@ $someObject
                     ->someOtherFunc(nameA: 23, nameB: 42)
 ->endSomething($value, name: $value)
 ->endEverything();
+
+// Issue https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1154
+$array = [
+    [
+        $item->one()->two(),
+    ],
+    $item->one()
+        ->two(),
+    $item->one()
+            ->two(),
+];

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
@@ -140,3 +140,14 @@ $someObject
     ->someOtherFunc(nameA: 23, nameB: 42)
     ->endSomething($value, name: $value)
     ->endEverything();
+
+// Issue https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1154
+$array = [
+    [
+        $item->one()->two(),
+    ],
+    $item->one()
+        ->two(),
+    $item->one()
+        ->two(),
+];

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -56,6 +56,7 @@ final class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
             140 => 1,
             141 => 1,
             142 => 1,
+            152 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
# Description

This PR fixes a bug where `PEAR.WhiteSpace.ObjectOperatorIndent` would generate a false positive when checking multiple chained object operators in a multidimensional array.

The problem is that the code was using the `$local` parameter of `findNext()` to limit the scope of the search when reassigning `$next` to the next object operator, and `$local` only considers a semicolon as the end of a statement.

Different chained calls are not necessarily separated by a semicolon (as shown in the test added in this commit). This means that the sniff currently considers the object operators on the second and third chained method calls as part of the first chained method call and checks their indentation using the indentation of the first element on the first chained call as its base.

To fix this problem, instead of relying on the `$local` parameter to find the end of the statement, the end of the statement as defined by `File::findEndOfStatement()` is now used.

See #1154 for more details on the problem.


## Suggested changelog entry
Fixed: false positive when `PEAR.WhiteSpaceObjectOperatorIndent` checks multiple chained method calls in a multidimensional array


## Related issues/external references

Fixes #1154
Fixes https://github.com/squizlabs/PHP_CodeSniffer/issues/3718


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
