### PR TITLE
GH Actions/verify release: auto-trigger Wiki update on new release

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -40,6 +40,25 @@ jobs:
           repository: PHPCSStandards/schema.phpcodesniffer.com
           event-type: phpcs-release
 
+  #######################################################
+  # Trigger an update of the documentation in the Wiki. #
+  #######################################################
+  trigger-wiki-update:
+    runs-on: ubuntu-latest
+
+    # Only run this workflow in the context of this repo.
+    if: github.repository_owner == 'PHPCSStandards'
+
+    name: "Trigger update of wiki"
+
+    steps:
+      - name: Trigger wiki update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WORKFLOW_DISPATCH_DOCS_PAT }}
+          repository: PHPCSStandards/PHP_CodeSniffer-documentation
+          event-type: phpcs-release
+
   ##################################################################################
   # Verify the release is available in all the right places and works as expected. #
   ##################################################################################


### PR DESCRIPTION
# Description
As of now, the Wiki is publicly editable via PRs to the [PHPCSStandards/PHP_CodeSniffer-documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) repository.

The editable version of the Wiki includes some automation, like automatically updating various output examples displayed in the Wiki.

The resulting output may change between PHPCS versions, so this commit adds a job to the "verify release" workflow to automatically trigger a rebuild of the Wiki for each new PHPCS release.

## Suggested changelog entry
Other:
The Wiki documentation is now publicly editable via PRs to the [PHPCSStandards/PHP_CodeSniffer-documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) repository. Contributions welcome ;-)

