### PR TITLE
Pull request template: add reminder to update wiki documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,7 @@ Fixes #
 - [ ] I have added tests to cover my changes.
 - [ ] I have verified that the code complies with the projects coding standards.
 - [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
+- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
 
 <!--
 ============================================================================================


### PR DESCRIPTION
# Description
Typically, the wiki needs to be updated when:
* A new `public` property is added to a sniff ([Customisable Sniff Properties page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties)).
* A new ruleset option is added ([Annotated Ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset)).
* Support for a new configuration option is added ([Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options)).
* A new report type is added ([Reporting](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Reporting)).

etc etc

## Suggested changelog entry
_N/A_