### PR TITLE
GH Actions: improve "don't run on forks" condition

### DIFF
--- a/.github/workflows/happy-new-year.yml
+++ b/.github/workflows/happy-new-year.yml
@@ -28,7 +28,7 @@ jobs:
   update-year-in-test:
     runs-on: ubuntu-latest
     # Don't run the cron job on forks.
-    if: ${{ github.event_name != 'schedule' || github.repository == 'PHPCSStandards/PHP_CodeSniffer' }}
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     name: "Happy New Year"
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     steps:
       - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     steps:
       - name: Checkout code
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     env:
       XMLLINT_INDENT: '    '
@@ -131,7 +131,7 @@ jobs:
   yamllint:
     name: 'Lint Yaml'
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
     with:
@@ -140,13 +140,13 @@ jobs:
   markdownlint:
     name: 'Lint Markdown'
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
 
   remark:
     name: 'QA Markdown'
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'PHPCSStandards')
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main


### PR DESCRIPTION
# Description
Remove the condition containing a hard-coded repository name in favour of a more generic condition which should safeguard that the cron job doesn't run on forks just the same.


## Suggested changelog entry
_N/A_