### PR TITLE
4.0 | Ruleset: minor tweak to property type handling for arrays

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -1646,23 +1646,27 @@ class Ruleset
             return;
         }
 
-        $value = $this->getRealPropertyValue($settings['value']);
+        $value = $settings['value'];
 
         // Handle properties set inline via phpcs:set.
         if (substr($name, -2) === '[]') {
             $values = [];
             if (is_string($value) === true) {
-                foreach (explode(',', $value) as $val) {
-                    list($k, $v) = explode('=>', $val.'=>');
-                    if ($v !== '') {
-                        $values[trim($k)] = $v;
-                    } else {
-                        $values[] = $k;
+                if (trim($value) !== '') {
+                    foreach (explode(',', $value) as $val) {
+                        list($k, $v) = explode('=>', $val.'=>');
+                        if ($v !== '') {
+                            $values[trim($k)] = $v;
+                        } else {
+                            $values[] = $k;
+                        }
                     }
                 }
             }
 
             $value = $this->getRealPropertyValue($values);
+        } else {
+            $value = $this->getRealPropertyValue($value);
         }
 
         if (isset($settings['extend']) === true

--- a/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
+++ b/tests/Core/Ruleset/Fixtures/PropertyTypeHandlingInline.inc
@@ -25,4 +25,8 @@
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithKeysAndValues[] string=>string,10=>10,float=>1.5,null=>null,true=>true,false=>false
 // phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsEmptyArray[]
 
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithJustValueTrue[] true
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithJustValueFalse[] false
+// phpcs:set TestStandard.SetProperty.PropertyTypeHandling expectsArrayWithJustValueNull[] null
+
 echo 'hello!';

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SetProperty/PropertyTypeHandlingSniff.php
@@ -240,6 +240,27 @@ final class PropertyTypeHandlingSniff implements Sniff
     ];
 
     /**
+     * Used to verify that - in particular inline - array properties with only a "special" value get handled correctly.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithJustValueTrue = [];
+
+    /**
+     * Used to verify that - in particular inline - array properties with only a "special" value get handled correctly.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithJustValueFalse = [];
+
+    /**
+     * Used to verify that - in particular inline - array properties with only a "special" value get handled correctly.
+     *
+     * @var array<mixed>
+     */
+    public $expectsArrayWithJustValueNull = [];
+
+    /**
      * Used to verify that if `extend` is used on a non-array property, the value still gets set, but not as an array.
      *
      * @var array<mixed>

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.php
@@ -174,6 +174,18 @@ final class PropertyTypeHandlingTest extends TestCase
                 'propertyName' => 'expectsEmptyArray',
                 'expected'     => [],
             ],
+            'Array with just the value "true"'               => [
+                'propertyName' => 'expectsArrayWithJustValueTrue',
+                'expected'     => [true],
+            ],
+            'Array with just the value "false"'              => [
+                'propertyName' => 'expectsArrayWithJustValueFalse',
+                'expected'     => [false],
+            ],
+            'Array with just the value "null"'               => [
+                'propertyName' => 'expectsArrayWithJustValueNull',
+                'expected'     => [null],
+            ],
         ];
 
     }//end dataTypeHandling()

--- a/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
+++ b/tests/Core/Ruleset/PropertyTypeHandlingTest.xml
@@ -108,6 +108,18 @@
                 <element value="true"/>
             </property>
 
+            <property name="expectsArrayWithJustValueTrue" type="array">
+                <element value="true"/>
+            </property>
+
+            <property name="expectsArrayWithJustValueFalse" type="array">
+                <element value="false"/>
+            </property>
+
+            <property name="expectsArrayWithJustValueNull" type="array">
+                <element value="null"/>
+            </property>
+
             <property name="expectsStringNotArray" extend="true" value="some value"/>
 
         </properties>


### PR DESCRIPTION
# Description

When array properties are set inline to one of the "special" values, i.e. `true`, `false` or `null`, this would not be handled correctly and always result in an empty array.

While it is highly debatable that this is something which will ever occur in real-life, as setting an array property like that would not give a sniff any usable information - basically the property should not have been an array property in that case -, it should still be handled correctly by the ruleset class.

Fixed now.

Includes additional tests.

Props to @rodrigoprimo for coming up with this scenario.

## Suggested changelog entry
_N/A_ This is basically already covered by the changelog entry for #1006