### PR TITLE
Runner: fix progress bar when running in parallel

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -791,7 +791,7 @@ class Runner
             $errors   = $file->getErrorCount();
             $warnings = $file->getWarningCount();
             $fixable  = $file->getFixableCount();
-            $fixed    = $file->getFixedCount();
+            $fixed    = ($file->getFixedErrorCount() + $file->getFixedWarningCount());
 
             if (PHP_CODESNIFFER_CBF === true) {
                 // Files with fixed errors or warnings are F (green).

--- a/tests/EndToEnd/phpcbf_test.sh
+++ b/tests/EndToEnd/phpcbf_test.sh
@@ -26,6 +26,13 @@ function test_phpcbf_returns_error_on_issues() {
   assert_contains "A TOTAL OF 1 ERROR WERE FIXED IN 1 FILE" "$OUTPUT"
 }
 
+function test_phpcbf_progressbar_shows_fixes_with_parallel_on() {
+  OUTPUT="$( { bin/phpcbf --no-colors --parallel=10 --no-cache --suffix=.fixed --standard=tests/EndToEnd/Fixtures/endtoend.xml.dist tests/EndToEnd/Fixtures/ClassWithStyleError.inc; } 2>&1 )"
+  assert_successful_code
+
+  assert_contains "F 1 / 1 (100%)" "$OUTPUT"
+}
+
 function test_phpcbf_bug_1112() {
   # See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1112
   if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
# Description

@rodrigoprimo and me came across this while debugging something completely different.

Turns out the split between fixable/fixed error vs warnings, which was necessary in 4.0 to allow for the exit code change, was breaking the progress bar display when parallel processing was enabled.

Basically, parallel processing "mocks" the accumulated fixable/fixed error and warning counts via a `DummyFile` before calling `Runner::printProgress()`. Then the `Runner::printProgress()` method calls the `File::getFixed()` method, however, that method doesn't look at the "split" fixed counts, but at the accumulated total fixes, but as this is a mocked `DummyFile`, that number will always be `0`.

IIRC, updating the `File::getFixed()` method to calculate the number based on the split fixed errors and warnings was breaking other things, which is why it was left as-is.

The down-side of that, as we now discovered, is that the progress bar when running in parallel would always just show a `.` and not the `F` when files were fixed.

Either way, this should be fixed now.

Includes a test via the new bashunit end-to-end testsuite.

## Suggested changelog entry
Fixed: progress bar wasn't showing files as fixed when running `phpcbf` in parallel mode.



