### PR TITLE
GH Actions/verify-release: fine tune update trigger conditions

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -27,8 +27,8 @@ jobs:
   trigger-schema-site-update:
     runs-on: ubuntu-latest
 
-    # Only run this workflow in the context of this repo.
-    if: github.repository_owner == 'PHPCSStandards'
+    # Only run this workflow in the context of this repo, don't run for changed workflow PR dry-runs.
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name != 'pull_request'
 
     name: "Trigger update of schema website"
 
@@ -46,8 +46,8 @@ jobs:
   trigger-wiki-update:
     runs-on: ubuntu-latest
 
-    # Only run this workflow in the context of this repo.
-    if: github.repository_owner == 'PHPCSStandards'
+    # Only run this workflow in the context of this repo, don't run for changed workflow PR dry-runs.
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name != 'pull_request'
 
     name: "Trigger update of wiki"
 


### PR DESCRIPTION
# Description
The `verify-release` workflow triggers two other workflows, however, this should only be done for actual releases, not when the workflow is run as a dry-run for PRs changing the workflow.


## Suggested changelog entry
_N/A_
