### PR TITLE
PHP 8.5 | Tests: prevent deprecation notice for Reflection*::setAccessible()

### DIFF
--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -185,7 +185,8 @@ final class ConfigDouble extends Config
     private function getStaticConfigProperty($name)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
+
         return $property->getValue();
 
     }//end getStaticConfigProperty()
@@ -202,9 +203,9 @@ final class ConfigDouble extends Config
     private function setStaticConfigProperty($name, $value)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, $value);
-        $property->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
     }//end setStaticConfigProperty()
 

--- a/tests/Core/Config/AbstractRealConfigTestCase.php
+++ b/tests/Core/Config/AbstractRealConfigTestCase.php
@@ -82,9 +82,9 @@ abstract class AbstractRealConfigTestCase extends TestCase
     protected static function setStaticConfigProperty($name, $value)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, $value);
-        $property->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
     }//end setStaticConfigProperty()
 

--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -228,7 +228,7 @@ final class GitModifiedTest extends AbstractFilterTestCase
         $filter = new GitModified($fakeDI, '/', self::$config, self::$ruleset);
 
         $reflMethod = new ReflectionMethod($filter, 'exec');
-        $reflMethod->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke($filter, $cmd);
 
         $this->assertSame($expected, $result);

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -228,7 +228,7 @@ final class GitStagedTest extends AbstractFilterTestCase
         $filter = new GitStaged($fakeDI, '/', self::$config, self::$ruleset);
 
         $reflMethod = new ReflectionMethod($filter, 'exec');
-        $reflMethod->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke($filter, $cmd);
 
         $this->assertSame($expected, $result);

--- a/tests/Core/Ruleset/DisplayCachedMessagesTest.php
+++ b/tests/Core/Ruleset/DisplayCachedMessagesTest.php
@@ -280,14 +280,14 @@ final class DisplayCachedMessagesTest extends AbstractRulesetTestCase
     private function mockCachedMessages(Ruleset $ruleset, $messages)
     {
         $reflProperty = new ReflectionProperty($ruleset, 'msgCache');
-        $reflProperty->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $reflProperty->setAccessible(true);
 
         $msgCache = $reflProperty->getValue($ruleset);
         foreach ($messages as $msg => $type) {
             $msgCache->add($msg, $type);
         }
 
-        $reflProperty->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $reflProperty->setAccessible(false);
 
     }//end mockCachedMessages()
 
@@ -302,9 +302,9 @@ final class DisplayCachedMessagesTest extends AbstractRulesetTestCase
     private function invokeDisplayCachedMessages(Ruleset $ruleset)
     {
         $reflMethod = new ReflectionMethod($ruleset, 'displayCachedMessages');
-        $reflMethod->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $reflMethod->invoke($ruleset);
-        $reflMethod->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
 
     }//end invokeDisplayCachedMessages()
 

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.php
@@ -172,9 +172,9 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
     public function testRegistersWhenADeprecatedSniffIsLoaded()
     {
         $property = new ReflectionProperty(self::$ruleset, 'deprecatedSniffs');
-        $property->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $actualValue = $property->getValue(self::$ruleset);
-        $property->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
         // Only verify there is one deprecated sniff registered.
         // There are other tests which test the deprecated sniff handling in more detail.

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -137,9 +137,9 @@ abstract class AbstractTokenizerTestCase extends TestCase
     public static function clearResolvedTokensCache()
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Tokenizers\PHP', 'resolveTokenCache');
-        $property->setAccessible(true);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, []);
-        $property->setAccessible(false);
+        (PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
     }//end clearResolvedTokensCache()
 


### PR DESCRIPTION
# Description

Since PHP 8.1, calling the `Reflection*::setAccessible()` methods is no longer necessary as reflected properties/methods/etc will always be accessible. However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the `Reflection*::setAccessible()` methods is now formally deprecated and will yield a deprecation notice, which will fail test runs. As of PHP 9.0, the `setAccessible()` method(s) will be removed.

With the latter in mind, this commit prevents the deprecation notice by making the calls to `setAccessible()` conditional.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

## Suggested changelog entry
_N/A_: test only change