### PR TITLE
4.0 | Composer: temporarily limit the supported PHPUnit 11 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-xmlwriter": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3"
+        "phpunit/phpunit": "^8.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28"
     },
     "bin": [
         "bin/phpcbf",


### PR DESCRIPTION
# Description
There is a problem with the latest PHPUnit 11 releases, which cause the test runs to hang and time out in CI after six hours.

Limiting the builds to use a PHPUnit 11 version below the problematic ones should unblock contributing for now.

The timing is a bit unfortunate, what with the PHP 8.5 deprecations being merged and the latest PHPUnit versions containing related fixes, but it will be a while still before PHP 8.5 is released, so I'm not too concerned about that and I expect a new PHPUnit release fixing the "hanging" well before that time.

Related upstream issue: sebastianbergmann/phpunit#6304

## Suggested changelog entry
_N/A_