### PR TITLE
4.0 | Composer: update the version constraints for PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-xmlwriter": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28"
+        "phpunit/phpunit": "^8.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
     },
     "bin": [
         "bin/phpcbf",


### PR DESCRIPTION
# Description
PHPUnit has released a new version which fixes the process hanging, which was previously worked around via PR #1181.

This commit updates the Composer version constraints to still allow a range of PHPUnit 11 version, while preventing the problematic versions from being installed.

Related upstream issue: sebastianbergmann/phpunit#6304


## Suggested changelog entry
_N/A_