### PR TITLE
PHP 8.4 | Generic/[Lower|Upper]CaseConstant: add support for abstract properties

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -78,6 +78,7 @@ class LowerCaseConstantSniff implements Sniff
         $targets[] = T_STATIC;
         $targets[] = T_READONLY;
         $targets[] = T_FINAL;
+        $targets[] = T_ABSTRACT;
 
         // Register function keywords to filter out param/return type declarations.
         $targets[] = T_FUNCTION;
@@ -139,6 +140,7 @@ class LowerCaseConstantSniff implements Sniff
             || $tokens[$stackPtr]['code'] === T_STATIC
             || $tokens[$stackPtr]['code'] === T_READONLY
             || $tokens[$stackPtr]['code'] === T_FINAL
+            || $tokens[$stackPtr]['code'] === T_ABSTRACT
         ) {
             $skipOver = (Tokens::$emptyTokens + $this->propertyTypeTokens);
             $skipTo   = $phpcsFile->findNext($skipOver, ($stackPtr + 1), null, true);

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc
@@ -172,3 +172,8 @@ class WithAsym {
 
     public protected(set) Type|NULL|bool $asym4 = TRUE;
 }
+
+abstract class SkipOverPHP84AbstractProperties {
+    abstract MyType|TRUE $propA {get;}
+    protected abstract NULL|MyClass $propB {set;}
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.1.inc.fixed
@@ -172,3 +172,8 @@ class WithAsym {
 
     public protected(set) Type|NULL|bool $asym4 = true;
 }
+
+abstract class SkipOverPHP84AbstractProperties {
+    abstract MyType|TRUE $propA {get;}
+    protected abstract NULL|MyClass $propB {set;}
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc
@@ -113,3 +113,8 @@ class WithAsym {
     protected(set) false|string|null $asym3 = null;
     public protected(set) Type|null|bool $asym4 = true;
 }
+
+abstract class SkipOverPHP84AbstractProperties {
+    abstract MyType|true $propA {get;}
+    protected abstract null|MyClass $propB {set;}
+}

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.inc.fixed
@@ -113,3 +113,8 @@ class WithAsym {
     protected(set) false|string|null $asym3 = NULL;
     public protected(set) Type|null|bool $asym4 = TRUE;
 }
+
+abstract class SkipOverPHP84AbstractProperties {
+    abstract MyType|true $propA {get;}
+    protected abstract null|MyClass $propB {set;}
+}


### PR DESCRIPTION
# Description
The `Generic.PHP.LowerCaseConstant` sniff is supposed to flag uppercase use of the `true`/`false`/null` constants and its sister-sniff `UpperCaseConstant` flags the lowercase variants. Both sniffs, however, are supposed to **_ignore_** the use of these keywords in type declarations - which may have their own rules.

This commit adds support for skipping over the types in PHP 8.4 `abstract` property declarations.

Includes tests.


## Suggested changelog entry
Added support for PHP 8.4 abstract properties to the following sniffs:
- Generic.PHP.LowerCaseConstant
- Generic.PHP.UpperCaseConstant


## Related issues/external references

Related to #734