### PR TITLE
PHP 8.4 | Squiz/VariableComment: add support for abstract properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -36,6 +36,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_STATIC                 => T_STATIC,
             T_READONLY               => T_READONLY,
             T_FINAL                  => T_FINAL,
+            T_ABSTRACT               => T_ABSTRACT,
             T_WHITESPACE             => T_WHITESPACE,
             T_STRING                 => T_STRING,
             T_NS_SEPARATOR           => T_NS_SEPARATOR,

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -486,3 +486,10 @@ class AsymVisibility {
      */
     private(set) protected int $hasDocblockC;
 }
+
+abstract class PHP84AbstractProperties {
+    /**
+     * @var Type
+     */
+    abstract Type $hasDocblock {get;}
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -486,3 +486,10 @@ class AsymVisibility {
      */
     private(set) protected int $hasDocblockC;
 }
+
+abstract class PHP84AbstractProperties {
+    /**
+     * @var Type
+     */
+    abstract Type $hasDocblock {get;}
+}


### PR DESCRIPTION
# Description
If a property uses the `abstract` modifier keyword, the property docblock (providing there is one) would never be found, leading to false positives.

Fixed now.

Includes tests.

## Suggested changelog entry
Added support for PHP 8.4 abstract properties to the following sniffs:
- Squiz.Commenting.VariableComment


## Related issues/external references

Related to #734
