### PR TITLE
PHP 8.4 | Squiz/MemberVarSpacing: add support for abstract properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -58,6 +58,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         $validPrefixes[] = T_FINAL;
         $validPrefixes[] = T_VAR;
         $validPrefixes[] = T_READONLY;
+        $validPrefixes[] = T_ABSTRACT;
 
         $startOfStatement = $phpcsFile->findNext($validPrefixes, ($endOfPreviousStatement + 1), $stackPtr, false, null, true);
         if ($startOfStatement === false) {

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc
@@ -459,3 +459,16 @@ class AsymVisibility {
 
     private(set) private bool $asymPrivate;
 }
+
+abstract class PHP84AbstractProperties {
+    abstract int $abstractA {get;}
+
+    /**
+     * Docblock
+     */
+    public abstract string $publicAbstract { set; }
+    #[AnAttribute]
+    abstract bool $abstractB {get;}
+
+    abstract protected bool $abstractProtected { set; }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.1.inc.fixed
@@ -446,3 +446,18 @@ class AsymVisibility {
 
     private(set) private bool $asymPrivate;
 }
+
+abstract class PHP84AbstractProperties {
+
+    abstract int $abstractA {get;}
+
+    /**
+     * Docblock
+     */
+    public abstract string $publicAbstract { set; }
+
+    #[AnAttribute]
+    abstract bool $abstractB {get;}
+
+    abstract protected bool $abstractProtected { set; }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -91,6 +91,8 @@ final class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
                 456 => 1,
                 457 => 1,
                 460 => 1,
+                464 => 1,
+                471 => 1,
             ];
 
         default:


### PR DESCRIPTION
# Description
If a property uses the `abstract` modifier keyword, the spacing between properties would not be determined, leading to false negatives.

Fixed now.

Includes tests.


## Suggested changelog entry
Added support for PHP 8.4 abstract properties to the following sniffs:
- Squiz.WhiteSpace.MemberVarSpacing


## Related issues/external references

Related to #734