### PR TITLE
PHP 8.4 | PSR2/PropertyDeclaration: add support for abstract properties 

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -44,6 +44,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         $find[] = T_VAR;
         $find[] = T_READONLY;
         $find[] = T_FINAL;
+        $find[] = T_ABSTRACT;
         $find[] = T_SEMICOLON;
         $find[] = T_OPEN_CURLY_BRACKET;
 
@@ -189,6 +190,31 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
 
                     $phpcsFile->fixer->replaceToken($finalPtr, '');
                     $phpcsFile->fixer->addContentBefore($scopePtr, $tokens[$finalPtr]['content'].' ');
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+        }//end if
+
+        if ($hasVisibilityModifier === true && $propertyInfo['is_abstract'] === true) {
+            $scopePtr    = $firstVisibilityModifier;
+            $abstractPtr = $phpcsFile->findPrevious(T_ABSTRACT, ($stackPtr - 1));
+            if ($abstractPtr > $scopePtr) {
+                $error = 'The abstract declaration must come before the visibility declaration';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'AbstractAfterVisibility');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    for ($i = ($abstractPtr + 1); $abstractPtr < $stackPtr; $i++) {
+                        if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->replaceToken($abstractPtr, '');
+                    $phpcsFile->fixer->addContentBefore($scopePtr, $tokens[$abstractPtr]['content'].' ');
 
                     $phpcsFile->fixer->endChangeset();
                 }

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
@@ -126,3 +126,11 @@ class AsymmetricVisibility {
     final static protected(set) bool $wrongOrder12;
     static public(set) final bool $wrongOrder13;
 }
+
+abstract class AbstractProperties {
+    abstract public int $foo { get; }
+    abstract protected (D|N)|false  $foo { set; }
+    abstract array $foo { get; }
+    public ABSTRACT ?int $wrongOrder1 { set; }
+    protected abstract ?string $wrongOrder2 { get; }
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -123,3 +123,11 @@ class AsymmetricVisibility {
     final protected(set) static bool $wrongOrder12;
     final public(set) static bool $wrongOrder13;
 }
+
+abstract class AbstractProperties {
+    abstract public int $foo { get; }
+    abstract protected (D|N)|false $foo { set; }
+    abstract array $foo { get; }
+    ABSTRACT public ?int $wrongOrder1 { set; }
+    abstract protected ?string $wrongOrder2 { get; }
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -76,6 +76,10 @@ final class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             125 => 1,
             126 => 1,
             127 => 2,
+            132 => 1,
+            133 => 1,
+            134 => 1,
+            135 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
⚠️ Depends on PR #1184 ⚠️ 

---

# Description

Includes handling the modifier order when `abstract` is used. This introduces a new `AbstractAfterVisibility` error code.

Includes tests.

Note: the modifier keyword order checks could probably do with some optimization, but that can be handled later.


## Suggested changelog entry
Added support for PHP 8.4 abstract properties to the following sniffs:
- PSR2.Classes.PropertyDeclaration

- The PSR2.Classes.PropertyDeclaration will now check that the `abstract` modifier keyword is placed before a visibility keyword. 
    - Errors will be reported via a new `AbstractAfterVisibility` error code.


## Related issues/external references

Related to #734