### PR TITLE
PHP 8.4 | Various sniffs: add tests with abstract properties

### DIFF
--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -18,3 +18,7 @@ $anon = new ReadOnly class() {};
 class FinalProperties {
     FINAL int $prop = 1;
 }
+
+ABSTRACT class AbstractProperties {
+    Abstract int $prop {set;}
+}

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -18,3 +18,7 @@ $anon = new readonly class() {};
 class FinalProperties {
     final int $prop = 1;
 }
+
+abstract class AbstractProperties {
+    abstract int $prop {set;}
+}

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -42,6 +42,8 @@ final class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             14 => 1,
             16 => 1,
             19 => 1,
+            22 => 1,
+            23 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -331,3 +331,10 @@ class AsymVisibility {
      */
     private(set) int $prop = 1;
 }
+
+abstract class AbstractProperties {
+    /**
+     * Comment should be ignored.
+     */
+    abstract int $prop {get;}
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -333,3 +333,10 @@ class AsymVisibility {
      */
     private(set) int $prop = 1;
 }
+
+abstract class AbstractProperties {
+    /**
+     * Comment should be ignored.
+     */
+    abstract int $prop {get;}
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -131,3 +131,16 @@ class AsymVisibility {
      */
     private(set) int $prop = 1;
 }
+
+/**
+  *  Some info about the class here.
+    */
+abstract class AbstractClassWithAbstractProp
+{
+    /**
+   *Some info about the property here.
+    *
+     *  @var int
+      */
+    abstract $property {get;}
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -131,3 +131,16 @@ class AsymVisibility {
      */
     private(set) int $prop = 1;
 }
+
+/**
+ *  Some info about the class here.
+ */
+abstract class AbstractClassWithAbstractProp
+{
+    /**
+     * Some info about the property here.
+     *
+     * @var int
+     */
+    abstract $property {get;}
+}

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -68,6 +68,13 @@ final class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
             $errors[121] = 1;
             $errors[125] = 1;
             $errors[126] = 1;
+
+            $errors[136] = 1;
+            $errors[137] = 1;
+            $errors[141] = 2;
+            $errors[142] = 1;
+            $errors[143] = 1;
+            $errors[144] = 1;
         }//end if
 
         return $errors;

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -85,3 +85,7 @@ class AsymVisibility {
     protected(set) public $asymPublicProtected  = 'hello';
     protected private(set) $asymProtectedPrivate  = 'hello';
 }
+
+abstract class PHP84AbstractProperties {
+    abstract string $abstract {get;}
+}

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -43,6 +43,7 @@ final class MemberVarScopeUnitTest extends AbstractSniffUnitTest
             80 => 1,
             81 => 1,
             82 => 1,
+            90 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc
@@ -202,3 +202,8 @@ class AsymVisibility {
     protected(set) public $asymPublicProtected  = 'hello';
     protected private(set) $asymProtectedPrivate  = 'hello';
 }
+
+abstract class AbstractProperties {
+    abstract public ?MyType $spacing_correct {get;}
+    protected   abstract   $spacing_incorrect { set; }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.1.inc.fixed
@@ -195,3 +195,8 @@ class AsymVisibility {
     protected(set) public $asymPublicProtected  = 'hello';
     protected private(set) $asymProtectedPrivate  = 'hello';
 }
+
+abstract class AbstractProperties {
+    abstract public ?MyType $spacing_correct {get;}
+    protected abstract $spacing_incorrect { set; }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -73,6 +73,7 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
                 197 => 1,
                 198 => 3,
                 199 => 2,
+                208 => 2,
             ];
 
         case 'ScopeKeywordSpacingUnitTest.3.inc':


### PR DESCRIPTION

# Description
### PHP 8.4 | Squiz/DocCommentAlignment: add tests with abstract property

### PHP 8.4 | Squiz/BlockComment: add test with abstract property

### PHP 8.4 | Squiz/LowercaseClassKeywords: add test with abstract property

### PHP 8.4 | Squiz/MemberVarScope: add test with abstract property

### PHP 8.4 | Squiz/ScopeKeywordSpacing: add tests with abstract properties


## Suggested changelog entry
_N/A_ (test only change)


## Related issues/external references

Related to #734