### PR TITLE
GH Actions: apply work-around for testing against PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php == '8.5' && '8.4' || matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
@@ -228,6 +228,14 @@ jobs:
         with:
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Install PHP again (PHP 8.5)"
+        if: ${{ matrix.php == '8.5' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          coverage: none
 
       - name: 'PHPCS: set the path to PHP'
         run: php "bin/phpcs" --config-set php_path php


### PR DESCRIPTION
# Description
Currently every single `composer install` on PHP 8.5 fails due to a deprecation notice coming from a Composer dependency during the reading of the `composer.json` file.

While it is expected that this will be fixed soonish (fix is already available in the dependency, we're just waiting for a new release of both the dependency as well as of Composer), I rather not have the red crosses on every single PR while working on getting PHPCS 4.0 released.

So, this commit adds a temporary work-around which should allow the tests to run against PHP 8.5 again. This should also allow us to monitor if any of the other deprecation PRs which have gone into PHP 8.5 cause issues for PHPCS.

Once a new version of Composer has been released, we should be able to revert this commit.


## Suggested changelog entry
_N/A_
