### PR TITLE
4.0 | GH Actions: add automated check for usage of `Tokens::$...` properties

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,3 +172,21 @@ jobs:
         uses: ludeeus/action-shellcheck@2.0.0
         with:
           format: gcc
+
+  find-token-properties:
+    # The properties in the Tokens class have been deprecated.
+    # The code in this repository should always use the constants instead.
+    name: 'Find use of Tokens properties'
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Find uses
+        id: findprops
+        shell: cmd
+        run: |
+          findstr /S /N /C:"Tokens::$" *.php
+          IF %ERRORLEVEL% NEQ 1 (Echo Please use the Tokens constants instead of the properties &Exit /b 1)
+          IF %ERRORLEVEL% EQU 1 (Echo All good &Exit /b 0)


### PR DESCRIPTION
# Description
In the 4.x branch, only the `Tokens::...` constants should be used. The use of the properties from the `Tokens` class is deprecated.

This workflow job is intended to catch any accidental/force-of-habit usages of the `Tokens` properties.


## Suggested changelog entry
_N/A_
