### PR TITLE
Squiz/FunctionComment: bug fix - classnames with underscores truncate the return type

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -76,7 +76,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $phpcsFile->addError($error, $return, 'MissingReturnType');
             } else {
                 // Support both a return type and a description.
-                preg_match('`^((?:\|?(?:array\([^\)]*\)|[\\\\a-z0-9\[\]]+))*)( .*)?`i', $content, $returnParts);
+                preg_match('`^((?:\|?(?:array\([^\)]*\)|[\\\\a-z0-9_\[\]]+))*)( .*)?`i', $content, $returnParts);
                 if (isset($returnParts[1]) === false) {
                     return;
                 }

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1167,3 +1167,30 @@ public function setTranslator($a): void
 {
     $this->translator = $translator;
 }
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return int|WP_Error
+ */
+function doNotTruncateClassNamesContainingUnderscoresAtEndOfType() {
+    return 0;
+}
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return WP_Error|int
+ */
+function doNotTruncateClassNamesContainingUnderscoresAtStartOfType() {
+    return 0;
+}
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return int|WP_Error|false
+ */
+function doNotTruncateClassNamesContainingUnderscoresInTheMiddelOfType() {
+    return 0;
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1167,3 +1167,30 @@ public function setTranslator($a): void
 {
     $this->translator = $translator;
 }
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return integer|WP_Error
+ */
+function doNotTruncateClassNamesContainingUnderscoresAtEndOfType() {
+    return 0;
+}
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return WP_Error|integer
+ */
+function doNotTruncateClassNamesContainingUnderscoresAtStartOfType() {
+    return 0;
+}
+
+/**
+ * Issue PHPCSStandards/PHP_CodeSniffer#1197.
+ *
+ * @return integer|WP_Error|false
+ */
+function doNotTruncateClassNamesContainingUnderscoresInTheMiddelOfType() {
+    return 0;
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -141,6 +141,9 @@ final class FunctionCommentUnitTest extends AbstractSniffUnitTest
             1144 => 1,
             1145 => 1,
             1151 => 1,
+            1174 => 1,
+            1183 => 1,
+            1192 => 1,
         ];
 
         // Scalar type hints only work from PHP 7 onwards.


### PR DESCRIPTION
# Description
If a return type included a class name containing an underscore, the type would be truncated at the underscore and would not take anything after it into account.

Bug introduced in PHPCS 2.8.1 via PR squizlabs/PHP_CodeSniffer#1310 and for some reason never reported... :flushed:

Fixed now.

Includes tests.

Fixes #1197


## Suggested changelog entry
Fixed: Squiz.Commenting.FunctionComment: if the return type contained a class name with underscores, the return type would be truncated leading to incorrect results.


