### PR TITLE
Revert "GH Actions: apply work-around for testing against PHP 8.5"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php == '8.5' && '8.4' || matrix.php }}
+          php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
@@ -228,14 +228,6 @@ jobs:
         with:
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: "Install PHP again (PHP 8.5)"
-        if: ${{ matrix.php == '8.5' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
-          coverage: none
 
       - name: 'PHPCS: set the path to PHP'
         run: php "bin/phpcs" --config-set php_path php


### PR DESCRIPTION
# Description
This reverts commit ac0d22ea3d5891b99f94ad59dc391fb2275313e4 / PR #1191 as it should no longer be needed now Composer 2.8.11 has been released.


## Suggested changelog entry
_N/A_


## Related issues/external references

Ref: https://github.com/composer/composer/releases/tag/2.8.11