### PR TITLE
PHP 8.5 | Update tests involving the `disable_classes` ini setting

### DIFF
--- a/tests/Core/Config/IniSetTest.php
+++ b/tests/Core/Config/IniSetTest.php
@@ -300,10 +300,10 @@ final class IniSetTest extends TestCase
         return [
             // Using Core directives available PHP cross-version to prevent the tests failing
             // on an unavailable directive or due to an extension not being available.
-            'php.ini only option: disable_classes'     => [
-                'option'           => 'disable_classes',
-                'newValue'         => 'DateTime,DOMComment',
-                'alternativeValue' => 'DOMComment,DateTime',
+            'php.ini only option: expose_php'          => [
+                'option'           => 'expose_php',
+                'newValue'         => '0',
+                'alternativeValue' => '1',
             ],
             'INI_PERDIR option: short_open_tag (bool)' => [
                 'option'           => 'short_open_tag',

--- a/tests/Core/Ruleset/IniSetFailIniOnlyTest.xml
+++ b/tests/Core/Ruleset/IniSetFailIniOnlyTest.xml
@@ -2,7 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="IniSetTest" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Ruleset to test ini values which can not be changed at runtime will be reported as such when set from the ruleset.</description>
 
-    <ini name="disable_classes" value="DateTime,DOMComment"/>
+    <ini name="expose_php" value="0"/>
 
     <!-- Prevent a "no sniff were registered" error. -->
     <rule ref="Generic.PHP.BacktickOperator"/>

--- a/tests/Core/Ruleset/ProcessRulesetIniSetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetIniSetTest.php
@@ -116,10 +116,10 @@ final class ProcessRulesetIniSetTest extends TestCase
         return [
             // Using Core directives available PHP cross-version to prevent the tests failing
             // on an unavailable directive or due to an extension not being available.
-            'php.ini only option: disable_classes'  => [
+            'php.ini only option: expose_php'       => [
                 'standard' => __DIR__.'/IniSetFailIniOnlyTest.xml',
-                'option'   => 'disable_classes',
-                'expected' => 'DateTime,DOMComment',
+                'option'   => 'expose_php',
+                'expected' => '0',
             ],
             'INI_PERDIR option: short_open_tag'     => [
                 'standard' => __DIR__.'/IniSetFailIniPerDirTest.xml',


### PR DESCRIPTION
# Description
A number of tests verify the behaviour of PHPCS when a user tries to change a "php.ini only" ini setting, which should result in an error being displayed.

Unfortunately, the ini setting which was being used for these tests will be removed as of PHP 8.5, so this commit switches out the `disable_classes` ini setting for the `expose_php` ini setting to still be able to verify the behaviour.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_5#remove_disable_classes_ini_setting
* https://www.php.net/manual/en/ini.core.php


## Suggested changelog entry
_N/A - test only change_

