### PR TITLE
Add option to allow heredoc after function open bracket

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -54,6 +54,13 @@ class FunctionCallSignatureSniff implements Sniff
      */
     public $requiredSpacesBeforeClose = 0;
 
+    /**
+     * Allows Heredoc and Nowdoc to start after the opening bracket.
+     *
+     * @var boolean
+     */
+    public $allowHereDocAfterOpenBracket = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -402,7 +409,15 @@ class FunctionCallSignatureSniff implements Sniff
             }
         }//end if
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($openBracket + 1), null, true);
+        $nextTokens = Tokens::$emptyTokens;
+        if ($this->allowHereDocAfterOpenBracket === true) {
+            $nextTokens += [
+                T_START_HEREDOC,
+                T_START_NOWDOC,
+            ];
+        }
+
+        $next = $phpcsFile->findNext($nextTokens, ($openBracket + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
             $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ContentAfterOpenBracket');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
This may be a naive opinion, but I feel like such code shouldn't fail `PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket`:

```php
throw new \Exception(<<<ERR
    Here be my long error message,
    which includes a description of what happened.
    There's also some example code of what to do instead.
    ERR,
    ErrorCodes::INVALID_WHATEVER
);
```

I can't see other clean way to write a Heredoc/Nowdoc onto a multiline function without spending a whole extra line _just_ with the opening marker.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Add `allowHereDocAfterOpenBracket` option to `PSR2.Methods.FunctionCallSignature`


## Related issues/external references

I didn't open one as the change was quite small and self-descriptive :man_shrugging: 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
    > I didn't find a way to write a test for a specific property?
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] ~I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.~
    > It doesn't look there's any docs to update?

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
