### PR TITLE
TimingTest: remove flaky assertions

### DIFF
--- a/tests/Core/Util/Timing/TimingTest.php
+++ b/tests/Core/Util/Timing/TimingTest.php
@@ -70,8 +70,6 @@ final class TimingTest extends TestCase
         $duration = Timing::getDurationSince($startTime);
 
         $this->assertIsFloat($duration);
-        $this->assertGreaterThan(1, $duration);
-        $this->assertLessThan(15, $duration);
 
     }//end testGetDurationSinceReturnsMilliseconds()
 


### PR DESCRIPTION
# Description

Follow up on and similar to #1096, but now for a new test which was added in the 4.x branch.

As per the previous commit:
> This should probably get a better test to ensure that the method actually returns microseconds, but time is difficult to test, which makes these assertions flaky and that's even worse.
>
> For now, let's remove the flaky assertions.


## Suggested changelog entry
_N/A_
