### PR TITLE
AbstractMethodTestCase/AbstractTokenizerTestCase: use LocalFile instead of DummyFile

### DIFF
--- a/tests/Core/AbstractMethodTestCase.php
+++ b/tests/Core/AbstractMethodTestCase.php
@@ -10,8 +10,8 @@
 namespace PHP_CodeSniffer\Tests\Core;
 
 use Exception;
-use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
@@ -58,11 +58,7 @@ abstract class AbstractMethodTestCase extends TestCase
         $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
         $pathToTestFile = realpath(__DIR__).$relativePath.'.inc';
 
-        // Make sure the file gets parsed correctly based on the file type.
-        $contents  = 'phpcs_input_file: '.$pathToTestFile.PHP_EOL;
-        $contents .= file_get_contents($pathToTestFile);
-
-        self::$phpcsFile = new DummyFile($contents, $ruleset, $config);
+        self::$phpcsFile = new LocalFile($pathToTestFile, $ruleset, $config);
         self::$phpcsFile->parse();
 
     }//end setUpBeforeClass()

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -12,7 +12,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizers;
 
-use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
@@ -63,11 +63,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
             $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
             $pathToTestFile = realpath(__DIR__).$relativePath.'.inc';
 
-            // Make sure the file gets parsed correctly based on the file type.
-            $contents  = 'phpcs_input_file: '.$pathToTestFile.PHP_EOL;
-            $contents .= file_get_contents($pathToTestFile);
-
-            $this->phpcsFile = new DummyFile($contents, $ruleset, $config);
+            $this->phpcsFile = new LocalFile($pathToTestFile, $ruleset, $config);
             $this->phpcsFile->parse();
         }//end if
 


### PR DESCRIPTION
# Description
Should work just the same and just as well.

Historical context: looks like the use of `DummyFile` is a left over from a time long, long ago, when the "test case code" was included in the same file as the unit test class. This was changed in 2016 for PHPCS 2.x via PR squizlabs/PHP_CodeSniffer#1193, but then the merge up into PHPCS 3.x (which introduced `DummyFile`) did not change the object instantiation.


## Suggested changelog entry
_N/A_