### PR TITLE
PHP 8.5 | Fix runtime "Using null as an array offset" deprecations

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1876,6 +1876,10 @@ class File
             throw new RuntimeException('$stackPtr must be of type T_VARIABLE');
         }
 
+        if (empty($this->tokens[$stackPtr]['conditions']) === true) {
+            throw new RuntimeException('$stackPtr is not a class member var');
+        }
+
         $conditions = array_keys($this->tokens[$stackPtr]['conditions']);
         $ptr        = array_pop($conditions);
         if (isset($this->tokens[$ptr]) === false

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2268,7 +2268,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($prevNonEmpty === null
-                        && isset(Tokens::$emptyTokens[$tokenType]) === false
+                        && @isset(Tokens::$emptyTokens[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
                         if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
@@ -2287,8 +2287,8 @@ class PHP extends Tokenizer
 
                     if ($tokenType === T_FUNCTION
                         || $tokenType === T_FN
-                        || isset(Tokens::$methodPrefixes[$tokenType]) === true
-                        || isset(Tokens::$scopeModifiers[$tokenType]) === true
+                        || @isset(Tokens::$methodPrefixes[$tokenType]) === true
+                        || @isset(Tokens::$scopeModifiers[$tokenType]) === true
                         || $tokenType === T_VAR
                         || $tokenType === T_READONLY
                     ) {
@@ -2311,7 +2311,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (isset(Tokens::$emptyTokens[$tokenType]) === false) {
+                    if (@isset(Tokens::$emptyTokens[$tokenType]) === false) {
                         $lastSeenNonEmpty = $tokenType;
                     }
                 }//end for

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1468,16 +1468,18 @@ class PHP extends Tokenizer
                 $newToken['type']    = 'T_ATTRIBUTE';
                 $newToken['content'] = '#[';
                 $finalTokens[$newStackPtr] = $newToken;
+                $newStackPtr++;
 
-                $tokens[$bracketCloser]    = [];
-                $tokens[$bracketCloser][0] = T_ATTRIBUTE_END;
-                $tokens[$bracketCloser][1] = ']';
+                if ($bracketCloser !== null) {
+                    $tokens[$bracketCloser]    = [];
+                    $tokens[$bracketCloser][0] = T_ATTRIBUTE_END;
+                    $tokens[$bracketCloser][1] = ']';
 
-                if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    echo "\t\t* token $bracketCloser changed from T_CLOSE_SQUARE_BRACKET to T_ATTRIBUTE_END".PHP_EOL;
+                    if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                        echo "\t\t* token $bracketCloser changed from T_CLOSE_SQUARE_BRACKET to T_ATTRIBUTE_END".PHP_EOL;
+                    }
                 }
 
-                $newStackPtr++;
                 continue;
             }//end if
 


### PR DESCRIPTION
# Description

### PHP 8.5 | File::getMemberProperties(): fix "Using null as an array offset" deprecation

If a variable in the global scope is passed to `File::getMemberProperties()`, the token may not have any "conditions".
This would result in `array_keys()` returning an empty array, which will cause `array_pop()` to return `null`, leading to the deprecation notice.

Fixed now via some extra defensive coding.

This change is already covered via the existing tests.

### PHP 8.5 | Tokenizer/PHP: fix "Using null as an array offset" deprecation 

If an attribute is unclosed (missing the closing `]` bracket), the `PHP::findCloser()` returns `null`, which will lead to the PHP 8.5 deprecation notice.
This can only occur during live coding or when a file has a parse error, but PHPCS should handle that situation gracefully.

Fixed now.

This change is already covered via the existing tests.

### PHP 8.5 | Tokenizer/PHP: temporarily silence "Using null as an array offset" deprecation

When running the `NullsafeObjectOperatorTest`, the "Using null as an array offset" deprecation gets triggered in the tokenizer layer handling re-tokenization to `T_NULLABLE` and/or `T_INLINE_THEN`.

This should only be possible if the below code at the top of the loop would result in `$tokenType` being `null`, which shouldn't be possible....
https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/f1c9394f1724ed45ca42029da330ff5c702af2a9/src/Tokenizers/PHP.php#L2254-L2258

With this conundrum in mind, I'm electing to (temporarily) silence the deprecation notice for now until there is more time to investigate in more depth.

## Suggested changelog entry
Fixed: PHP 8.5 runtime "Using null as an array offset" deprecations


## Related issues/external references

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

