### PR TITLE
4.0 | Modernize: use `::class` resolution

### DIFF
--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -17,6 +17,7 @@ use Iterator;
 use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Filters\Filter;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\ExitCode;
@@ -156,7 +157,7 @@ class FileList implements Iterator, Countable
         $filterType = $this->config->filter;
 
         if ($filterType === null) {
-            $filterClass = '\PHP_CodeSniffer\Filters\Filter';
+            $filterClass = Filter::class;
         } else {
             if (strpos($filterType, '.') !== false) {
                 // This is a path to a custom filter class.

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -151,7 +151,7 @@ class Filter extends RecursiveFilterIterator
     #[ReturnTypeWillChange]
     public function getChildren()
     {
-        $filterClass = get_called_class();
+        $filterClass = static::class;
         $children    = new $filterClass(
             new RecursiveDirectoryIterator($this->current(), (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)),
             $this->basedir,

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -404,7 +404,7 @@ class Fixer
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-            if ($bt[1]['class'] === __CLASS__) {
+            if ($bt[1]['class'] === self::class) {
                 $sniff = 'Fixer';
             } else {
                 $sniff = $this->getSniffCodeForDebug($bt[1]['class']);
@@ -478,7 +478,7 @@ class Fixer
         if (empty($this->changeset) === false) {
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 $bt = debug_backtrace();
-                if ($bt[1]['class'] === 'PHP_CodeSniffer\Fixer') {
+                if ($bt[1]['class'] === self::class) {
                     $sniff = $bt[2]['class'];
                     $line  = $bt[1]['line'];
                 } else {
@@ -531,7 +531,7 @@ class Fixer
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-            if ($bt[1]['class'] === 'PHP_CodeSniffer\Fixer') {
+            if ($bt[1]['class'] === self::class) {
                 $sniff = $bt[2]['class'];
                 $line  = $bt[1]['line'];
             } else {
@@ -636,7 +636,7 @@ class Fixer
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-            if ($bt[1]['class'] === 'PHP_CodeSniffer\Fixer') {
+            if ($bt[1]['class'] === self::class) {
                 $sniff = $bt[2]['class'];
                 $line  = $bt[1]['line'];
             } else {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -14,6 +14,7 @@ namespace PHP_CodeSniffer;
 use InvalidArgumentException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
+use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\MessageCollector;
 use PHP_CodeSniffer\Util\Standards;
@@ -1470,7 +1471,7 @@ class Ruleset
                 continue;
             }
 
-            if ($reflection->implementsInterface('PHP_CodeSniffer\\Sniffs\\Sniff') === false) {
+            if ($reflection->implementsInterface(Sniff::class) === false) {
                 $message  = 'All sniffs must implement the PHP_CodeSniffer\\Sniffs\\Sniff interface.'.PHP_EOL;
                 $message .= "Interface not implemented for sniff $className.".PHP_EOL;
                 $message .= 'Contact the sniff author to fix the sniff.';
@@ -1486,7 +1487,7 @@ class Ruleset
                     && empty($value) === false
                     && in_array('PHP', $value, true) === false
                 ) {
-                    if ($reflection->implementsInterface('PHP_CodeSniffer\\Sniffs\\DeprecatedSniff') === true) {
+                    if ($reflection->implementsInterface(DeprecatedSniff::class) === true) {
                         // Silently ignore the sniff if the sniff is marked as deprecated.
                         continue;
                     }

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -232,7 +232,7 @@ class FileCommentSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (get_class($this) === 'PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff') {
+        if (static::class === 'PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff') {
             $docBlock = 'file';
         } else {
             $docBlock = 'class';

--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -182,7 +182,7 @@ final class ConfigDouble extends Config
      */
     private function getStaticConfigProperty($name)
     {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property = new ReflectionProperty(Config::class, $name);
         (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults') {
@@ -204,7 +204,7 @@ final class ConfigDouble extends Config
      */
     private function setStaticConfigProperty($name, $value)
     {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property = new ReflectionProperty(Config::class, $name);
         (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults') {

--- a/tests/Core/AbstractMethodTestCase.php
+++ b/tests/Core/AbstractMethodTestCase.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Tests\Core;
 
 use Exception;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
@@ -54,7 +55,7 @@ abstract class AbstractMethodTestCase extends TestCase
         $ruleset = new Ruleset($config);
 
         // Default to a file with the same name as the test class. Extension is property based.
-        $relativeCN     = str_replace(__NAMESPACE__, '', get_called_class());
+        $relativeCN     = str_replace(__NAMESPACE__, '', static::class);
         $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
         $pathToTestFile = realpath(__DIR__).$relativePath.'.inc';
 
@@ -235,7 +236,7 @@ abstract class AbstractMethodTestCase extends TestCase
      */
     public function expectRunTimeException($message)
     {
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
 
     }//end expectRunTimeException()

--- a/tests/Core/Config/AbstractRealConfigTestCase.php
+++ b/tests/Core/Config/AbstractRealConfigTestCase.php
@@ -10,6 +10,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Config;
 
+use PHP_CodeSniffer\Config;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -73,7 +74,7 @@ abstract class AbstractRealConfigTestCase extends TestCase
      */
     protected static function setStaticConfigProperty($name, $value)
     {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property = new ReflectionProperty(Config::class, $name);
         (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, $value);
         (PHP_VERSION_ID < 80100) && $property->setAccessible(false);

--- a/tests/Core/Config/ExtensionsArgTest.php
+++ b/tests/Core/Config/ExtensionsArgTest.php
@@ -8,6 +8,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Config;
 
+use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
@@ -134,7 +135,7 @@ final class ExtensionsArgTest extends TestCase
         $message .= 'PHP_CodeSniffer >= 4.0 only supports scanning PHP files.'.PHP_EOL;
         $message .= 'Received: '.$passedValue.PHP_EOL.PHP_EOL;
 
-        $this->expectException('PHP_CodeSniffer\Exceptions\DeepExitException');
+        $this->expectException(DeepExitException::class);
         $this->expectExceptionMessage($message);
 
         new ConfigDouble(["--extensions={$passedValue}"]);

--- a/tests/Core/Config/GeneratorArgTest.php
+++ b/tests/Core/Config/GeneratorArgTest.php
@@ -8,6 +8,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Config;
 
+use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
@@ -123,10 +124,9 @@ final class GeneratorArgTest extends TestCase
      */
     public function testInvalidGenerator($generatorName)
     {
-        $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
-        $message   = 'ERROR: "'.$generatorName.'" is not a valid generator. The following generators are supported: Text, HTML and Markdown.';
+        $message = 'ERROR: "'.$generatorName.'" is not a valid generator. The following generators are supported: Text, HTML and Markdown.';
 
-        $this->expectException($exception);
+        $this->expectException(DeepExitException::class);
         $this->expectExceptionMessage($message);
 
         new ConfigDouble(["--generator={$generatorName}"]);

--- a/tests/Core/Config/SniffsExcludeArgsTest.php
+++ b/tests/Core/Config/SniffsExcludeArgsTest.php
@@ -8,6 +8,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Config;
 
+use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 
@@ -39,12 +40,11 @@ final class SniffsExcludeArgsTest extends TestCase
             $cmd = 'phpcbf';
         }
 
-        $exception = 'PHP_CodeSniffer\Exceptions\DeepExitException';
-        $message   = 'ERROR: The --'.$argument.' option only supports sniff codes.'.PHP_EOL;
-        $message  .= 'Sniff codes are in the form "Standard.Category.Sniff".'.PHP_EOL;
-        $message  .= PHP_EOL;
-        $message  .= 'The following problems were detected:'.PHP_EOL;
-        $message  .= '* '.implode(PHP_EOL.'* ', $errors).PHP_EOL;
+        $message  = 'ERROR: The --'.$argument.' option only supports sniff codes.'.PHP_EOL;
+        $message .= 'Sniff codes are in the form "Standard.Category.Sniff".'.PHP_EOL;
+        $message .= PHP_EOL;
+        $message .= 'The following problems were detected:'.PHP_EOL;
+        $message .= '* '.implode(PHP_EOL.'* ', $errors).PHP_EOL;
 
         if ($suggestion !== null) {
             $message .= PHP_EOL;
@@ -55,7 +55,7 @@ final class SniffsExcludeArgsTest extends TestCase
         $message .= "Run \"{$cmd} --help\" for usage information".PHP_EOL;
         $message .= PHP_EOL;
 
-        $this->expectException($exception);
+        $this->expectException(DeepExitException::class);
         $this->expectExceptionMessage($message);
 
         new ConfigDouble(["--$argument=$value"]);

--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -40,7 +40,7 @@ final class GitModifiedTest extends AbstractFilterTestCase
             self::$config,
             self::$ruleset,
         ];
-        $mockObj         = $this->getMockedClass('PHP_CodeSniffer\Filters\GitModified', $constructorArgs, ['exec']);
+        $mockObj         = $this->getMockedClass(GitModified::class, $constructorArgs, ['exec']);
 
         $mockObj->expects($this->once())
             ->method('exec')
@@ -71,7 +71,7 @@ final class GitModifiedTest extends AbstractFilterTestCase
             self::$config,
             self::$ruleset,
         ];
-        $mockObj         = $this->getMockedClass('PHP_CodeSniffer\Filters\GitModified', $constructorArgs, ['exec']);
+        $mockObj         = $this->getMockedClass(GitModified::class, $constructorArgs, ['exec']);
 
         $mockObj->expects($this->once())
             ->method('exec')

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -40,7 +40,7 @@ final class GitStagedTest extends AbstractFilterTestCase
             self::$config,
             self::$ruleset,
         ];
-        $mockObj         = $this->getMockedClass('PHP_CodeSniffer\Filters\GitStaged', $constructorArgs, ['exec']);
+        $mockObj         = $this->getMockedClass(GitStaged::class, $constructorArgs, ['exec']);
 
         $mockObj->expects($this->once())
             ->method('exec')
@@ -71,7 +71,7 @@ final class GitStagedTest extends AbstractFilterTestCase
             self::$config,
             self::$ruleset,
         ];
-        $mockObj         = $this->getMockedClass('PHP_CodeSniffer\Filters\GitStaged', $constructorArgs, ['exec']);
+        $mockObj         = $this->getMockedClass(GitStaged::class, $constructorArgs, ['exec']);
 
         $mockObj->expects($this->once())
             ->method('exec')

--- a/tests/Core/Ruleset/AbstractRulesetTestCase.php
+++ b/tests/Core/Ruleset/AbstractRulesetTestCase.php
@@ -9,17 +9,11 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Ruleset;
 
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractRulesetTestCase extends TestCase
 {
-
-    /**
-     * The fully qualified name of the PHPCS runtime exception class.
-     *
-     * @var string
-     */
-    private const RUNTIME_EXCEPTION = 'PHP_CodeSniffer\Exceptions\RuntimeException';
 
 
     /**
@@ -75,7 +69,7 @@ abstract class AbstractRulesetTestCase extends TestCase
      */
     protected function expectRuntimeExceptionMessage($message)
     {
-        $this->expectException(self::RUNTIME_EXCEPTION);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
 
     }//end expectRuntimeExceptionMessage()
@@ -92,11 +86,11 @@ abstract class AbstractRulesetTestCase extends TestCase
     protected function expectRuntimeExceptionRegex($regex)
     {
         if (method_exists($this, 'expectExceptionMessageMatches') === true) {
-            $this->expectException(self::RUNTIME_EXCEPTION);
+            $this->expectException(RuntimeException::class);
             $this->expectExceptionMessageMatches($regex);
         } else {
             // PHPUnit < 8.4.0.
-            $this->expectException(self::RUNTIME_EXCEPTION);
+            $this->expectException(RuntimeException::class);
             $this->expectExceptionMessageRegExp($regex);
         }
 

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\AbstractMethodTestCase;
+use PHP_CodeSniffer\Tokenizers\PHP;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -59,7 +60,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
             $ruleset = new Ruleset($config);
 
             // Default to a file with the same name as the test class. Extension is property based.
-            $relativeCN     = str_replace(__NAMESPACE__, '', get_called_class());
+            $relativeCN     = str_replace(__NAMESPACE__, '', static::class);
             $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
             $pathToTestFile = realpath(__DIR__).$relativePath.'.inc';
 
@@ -120,7 +121,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
      */
     public static function clearResolvedTokensCache()
     {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Tokenizers\PHP', 'resolveTokenCache');
+        $property = new ReflectionProperty(PHP::class, 'resolveTokenCache');
         (PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, []);
         (PHP_VERSION_ID < 80100) && $property->setAccessible(false);

--- a/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenTestCase.php
+++ b/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenTestCase.php
@@ -37,7 +37,7 @@ abstract class ReplaceTabsInTokenTestCase extends AbstractTokenizerTestCase
      */
     public static function setUpBeforeClass(): void
     {
-        $relativeCN         = str_replace(__NAMESPACE__.'\\', '', get_called_class());
+        $relativeCN         = str_replace(__NAMESPACE__.'\\', '', static::class);
         self::$caseFileName = __DIR__.DIRECTORY_SEPARATOR.$relativeCN.'.inc';
 
         $baseFileName = realpath(__DIR__.'/ReplaceTabsInTokenTest.inc');

--- a/tests/Core/Util/Common/GetSniffCodeTest.php
+++ b/tests/Core/Util/Common/GetSniffCodeTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Util\Common;
 
+use InvalidArgumentException;
 use PHP_CodeSniffer\Util\Common;
 use PHPUnit\Framework\TestCase;
 
@@ -32,10 +33,9 @@ final class GetSniffCodeTest extends TestCase
      */
     public function testGetSniffCodeThrowsExceptionOnInvalidInput($input)
     {
-        $exception = 'InvalidArgumentException';
-        $message   = 'The $sniffClass parameter must be a non-empty string';
+        $message = 'The $sniffClass parameter must be a non-empty string';
 
-        $this->expectException($exception);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
 
         Common::getSniffCode($input);
@@ -72,10 +72,9 @@ final class GetSniffCodeTest extends TestCase
      */
     public function testGetSniffCodeThrowsExceptionOnInputWhichIsNotASniffTestClass($input)
     {
-        $exception = 'InvalidArgumentException';
-        $message   = 'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received:';
+        $message = 'The $sniffClass parameter was not passed a fully qualified sniff(test) class name. Received:';
 
-        $this->expectException($exception);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
 
         Common::getSniffCode($input);

--- a/tests/Core/Util/Help/HelpTest.php
+++ b/tests/Core/Util/Help/HelpTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Util\Help;
 
+use InvalidArgumentException;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Util\Help;
 use PHPUnit\Framework\TestCase;
@@ -139,10 +140,9 @@ final class HelpTest extends TestCase
      */
     public function testConstructorInvalidArgumentException()
     {
-        $exception = 'InvalidArgumentException';
-        $message   = 'The $shortOptions parameter must be a string';
+        $message = 'The $shortOptions parameter must be a string';
 
-        $this->expectException($exception);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
 
         new Help(new ConfigDouble(), [], []);

--- a/tests/Core/Util/MessageCollector/MessageCollectorTest.php
+++ b/tests/Core/Util/MessageCollector/MessageCollectorTest.php
@@ -8,6 +8,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Util\MessageCollector;
 
+use InvalidArgumentException;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Tests\Core\AbstractWriterTestCase;
 use PHP_CodeSniffer\Util\MessageCollector;
 
@@ -31,10 +33,9 @@ final class MessageCollectorTest extends AbstractWriterTestCase
      */
     public function testAddingNonStringMessageResultsInException($message)
     {
-        $exception    = 'InvalidArgumentException';
         $exceptionMsg = 'The $message should be of type string. Received: ';
 
-        $this->expectException($exception);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMsg);
 
         $msgCollector = new MessageCollector();
@@ -73,10 +74,9 @@ final class MessageCollectorTest extends AbstractWriterTestCase
      */
     public function testAddingMessageWithUnsupportedMessageTypeResultsInException($type)
     {
-        $exception    = 'InvalidArgumentException';
         $exceptionMsg = 'The message $type should be one of the predefined MessageCollector constants. Received: ';
 
-        $this->expectException($exception);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMsg);
 
         $msgCollector = new MessageCollector();
@@ -300,9 +300,7 @@ final class MessageCollectorTest extends AbstractWriterTestCase
      */
     public function testDisplayingBlockingErrors($messages, $expected)
     {
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-
-        $this->expectException($exception);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($expected);
 
         $msgCollector = new MessageCollector();

--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -150,7 +150,7 @@ TEMPLATE;
             $this->markTestSkipped();
         }
 
-        $sniffCode      = Common::getSniffCode(get_class($this));
+        $sniffCode      = Common::getSniffCode(static::class);
         $sniffCodeParts = explode('.', $sniffCode);
         $standardName   = $sniffCodeParts[0];
 


### PR DESCRIPTION
# Description
... which is a PHP 5.5+ syntax and can now be used what with support for PHP < 7.2 having been dropped.

Note: I have not applied this change to test expectations in data providers.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change

