### PR TITLE
Modernize: use class constant for constant array [1]

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -123,6 +123,18 @@ class Config
     ];
 
     /**
+     * A list of valid generators.
+     *
+     * @var array<string, string> Keys are the lowercase version of the generator name, while values
+     *                            are the name of the associated PHP generator class.
+     */
+    private const VALID_GENERATORS = [
+        'text'     => 'Text',
+        'html'     => 'HTML',
+        'markdown' => 'Markdown',
+    ];
+
+    /**
      * An array of settings that PHPCS and PHPCBF accept.
      *
      * This array is not meant to be accessed directly. Instead, use the settings
@@ -190,21 +202,6 @@ class Config
      * @var string[]
      */
     private $cliArgs = [];
-
-    /**
-     * A list of valid generators.
-     *
-     * {@internal Once support for PHP < 5.6 is dropped, this property should be refactored into a
-     * class constant.}
-     *
-     * @var array<string, string> Keys are the lowercase version of the generator name, while values
-     *                            are the associated PHP generator class.
-     */
-    private $validGenerators = [
-        'text'     => 'Text',
-        'html'     => 'HTML',
-        'markdown' => 'Markdown',
-    ];
 
     /**
      * Command line values that the user has supplied directly.
@@ -1250,8 +1247,8 @@ class Config
                 $generatorName          = substr($arg, 10);
                 $lowerCaseGeneratorName = strtolower($generatorName);
 
-                if (isset($this->validGenerators[$lowerCaseGeneratorName]) === false) {
-                    $validOptions = implode(', ', $this->validGenerators);
+                if (isset(self::VALID_GENERATORS[$lowerCaseGeneratorName]) === false) {
+                    $validOptions = implode(', ', self::VALID_GENERATORS);
                     $validOptions = substr_replace($validOptions, ' and', strrpos($validOptions, ','), 1);
                     $error        = sprintf(
                         'ERROR: "%s" is not a valid generator. The following generators are supported: %s.'.PHP_EOL.PHP_EOL,
@@ -1262,7 +1259,7 @@ class Config
                     throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                 }
 
-                $this->generator = $this->validGenerators[$lowerCaseGeneratorName];
+                $this->generator = self::VALID_GENERATORS[$lowerCaseGeneratorName];
                 $this->overriddenDefaults['generator'] = true;
             } else if (substr($arg, 0, 9) === 'encoding=') {
                 if (isset($this->overriddenDefaults['encoding']) === true) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -135,6 +135,18 @@ class Config
     ];
 
     /**
+     * The default configuration file names supported by PHPCS.
+     *
+     * @var array<string> The supported file names in order of precedence (highest first).
+     */
+    private const CONFIG_FILENAMES = [
+        '.phpcs.xml',
+        'phpcs.xml',
+        '.phpcs.xml.dist',
+        'phpcs.xml.dist',
+    ];
+
+    /**
      * An array of settings that PHPCS and PHPCBF accept.
      *
      * This array is not meant to be accessed directly. Instead, use the settings
@@ -426,15 +438,8 @@ class Config
             // Look for a default ruleset in the current directory or higher.
             $currentDir = getcwd();
 
-            $defaultFiles = [
-                '.phpcs.xml',
-                'phpcs.xml',
-                '.phpcs.xml.dist',
-                'phpcs.xml.dist',
-            ];
-
             do {
-                foreach ($defaultFiles as $defaultFilename) {
+                foreach (self::CONFIG_FILENAMES as $defaultFilename) {
                     $default = $currentDir.DIRECTORY_SEPARATOR.$defaultFilename;
                     if (is_file($default) === true) {
                         $this->standards = [$default];

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -19,6 +19,29 @@ abstract class Tokenizer
 {
 
     /**
+     * List of tokens which may contain tab characters.
+     *
+     * @var array<int|string, true>
+     */
+    private const TOKENS_WITH_TABS = [
+        T_WHITESPACE               => true,
+        T_COMMENT                  => true,
+        T_DOC_COMMENT              => true,
+        T_DOC_COMMENT_WHITESPACE   => true,
+        T_DOC_COMMENT_STRING       => true,
+        T_CONSTANT_ENCAPSED_STRING => true,
+        T_DOUBLE_QUOTED_STRING     => true,
+        T_START_HEREDOC            => true,
+        T_START_NOWDOC             => true,
+        T_HEREDOC                  => true,
+        T_NOWDOC                   => true,
+        T_END_HEREDOC              => true,
+        T_END_NOWDOC               => true,
+        T_INLINE_HTML              => true,
+        T_YIELD_FROM               => true,
+    ];
+
+    /**
      * The config data for the run.
      *
      * @var \PHP_CodeSniffer\Config
@@ -188,24 +211,6 @@ abstract class Tokenizer
         $encoding         = $this->config->encoding;
         $tabWidth         = $this->config->tabWidth;
 
-        $tokensWithTabs = [
-            T_WHITESPACE               => true,
-            T_COMMENT                  => true,
-            T_DOC_COMMENT              => true,
-            T_DOC_COMMENT_WHITESPACE   => true,
-            T_DOC_COMMENT_STRING       => true,
-            T_CONSTANT_ENCAPSED_STRING => true,
-            T_DOUBLE_QUOTED_STRING     => true,
-            T_START_HEREDOC            => true,
-            T_START_NOWDOC             => true,
-            T_HEREDOC                  => true,
-            T_NOWDOC                   => true,
-            T_END_HEREDOC              => true,
-            T_END_NOWDOC               => true,
-            T_INLINE_HTML              => true,
-            T_YIELD_FROM               => true,
-        ];
-
         $this->numTokens = count($this->tokens);
         for ($i = 0; $i < $this->numTokens; $i++) {
             $this->tokens[$i]['line']   = $lineNumber;
@@ -216,7 +221,7 @@ abstract class Tokenizer
                 $length      = $this->knownLengths[$this->tokens[$i]['code']];
                 $currColumn += $length;
             } else if ($tabWidth === 0
-                || isset($tokensWithTabs[$this->tokens[$i]['code']]) === false
+                || isset(self::TOKENS_WITH_TABS[$this->tokens[$i]['code']]) === false
                 || strpos($this->tokens[$i]['content'], "\t") === false
             ) {
                 // There are no tabs in this content, or we aren't replacing them.


### PR DESCRIPTION
# Description

_This PR is part of a series._

These commits change a number of either `private` properties or inline variables to `private` class constants.

This wasn't previously possible as support for constant arrays was only added in PHP 5.6.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change