### PR TITLE
Modernize: Util\Help: use constant array in class constant

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1512,7 +1512,7 @@ class Config
      */
     public function printPHPCSUsage()
     {
-        $longOptions   = explode(',', Help::DEFAULT_LONG_OPTIONS);
+        $longOptions   = Help::DEFAULT_LONG_OPTIONS;
         $longOptions[] = 'cache';
         $longOptions[] = 'no-cache';
         $longOptions[] = 'report';
@@ -1538,7 +1538,7 @@ class Config
      */
     public function printPHPCBFUsage()
     {
-        $longOptions   = explode(',', Help::DEFAULT_LONG_OPTIONS);
+        $longOptions   = Help::DEFAULT_LONG_OPTIONS;
         $longOptions[] = 'suffix';
         $shortOptions  = Help::DEFAULT_SHORT_OPTIONS;
 

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -34,11 +34,36 @@ final class Help
     /**
      * Long options which are available for both the `phpcs` as well as the `phpcbf` command.
      *
-     * {@internal This should be a constant array, but those aren't supported until PHP 5.6.}
-     *
-     * @var string Comma-separated list of the option names.
+     * @var array<string> List of the option names.
      */
-    public const DEFAULT_LONG_OPTIONS = 'basepath,bootstrap,colors,encoding,error-severity,exclude,extensions,file,file-list,filter,ignore,ignore-annotations,no-colors,parallel,php-ini,report-width,runtime-set,severity,sniffs,standard,stdin-path,tab-width,version,vv,vvv,warning-severity';
+    public const DEFAULT_LONG_OPTIONS = [
+        'basepath',
+        'bootstrap',
+        'colors',
+        'encoding',
+        'error-severity',
+        'exclude',
+        'extensions',
+        'file',
+        'file-list',
+        'filter',
+        'ignore',
+        'ignore-annotations',
+        'no-colors',
+        'parallel',
+        'php-ini',
+        'report-width',
+        'runtime-set',
+        'severity',
+        'sniffs',
+        'standard',
+        'stdin-path',
+        'tab-width',
+        'version',
+        'vv',
+        'vvv',
+        'warning-severity',
+    ];
 
     /**
      * Minimum screen width.

--- a/tests/Core/Util/Help/HelpTest.php
+++ b/tests/Core/Util/Help/HelpTest.php
@@ -190,7 +190,7 @@ final class HelpTest extends TestCase
      */
     public static function dataOptionFiltering()
     {
-        $allLongOptions   = explode(',', Help::DEFAULT_LONG_OPTIONS);
+        $allLongOptions   = Help::DEFAULT_LONG_OPTIONS;
         $allLongOptions[] = 'cache';
         $allLongOptions[] = 'no-cache';
         $allLongOptions[] = 'report';
@@ -248,7 +248,7 @@ final class HelpTest extends TestCase
                 ],
             ],
             'Default options only'                            => [
-                'longOptions'  => explode(',', Help::DEFAULT_LONG_OPTIONS),
+                'longOptions'  => Help::DEFAULT_LONG_OPTIONS,
                 'shortOptions' => Help::DEFAULT_SHORT_OPTIONS,
                 'expected'     => [
                     'Scan targets'           => 8,


### PR DESCRIPTION
# Description
This changes the format/type of a `public` constant, but as the class is `final` and marked as `@internal`, i.e. not in the public API, this should not be regarded as a BC-break.


## Suggested changelog entry
_N/A_ There should be no functional impact of this change
