### PR TITLE
Phpcs 4.0/feature/modernize use class constants for constant arrays 3

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -24,21 +24,14 @@ class UnusedFunctionParameterSniff implements Sniff
 {
 
     /**
-     * The list of class type hints which will be ignored.
-     *
-     * @var array
-     */
-    public $ignoreTypeHints = [];
-
-    /**
      * A list of all PHP magic methods with fixed method signatures.
      *
      * Note: `__construct()` and `__invoke()` are excluded on purpose
      * as their method signature is not fixed.
      *
-     * @var array
+     * @var array<string, true>
      */
-    private $magicMethods = [
+    private const MAGIC_METHODS = [
         '__destruct'    => true,
         '__call'        => true,
         '__callstatic'  => true,
@@ -55,6 +48,13 @@ class UnusedFunctionParameterSniff implements Sniff
         '__clone'       => true,
         '__debuginfo'   => true,
     ];
+
+    /**
+     * The list of class type hints which will be ignored.
+     *
+     * @var array
+     */
+    public $ignoreTypeHints = [];
 
 
     /**
@@ -101,7 +101,7 @@ class UnusedFunctionParameterSniff implements Sniff
                 // Check for magic methods and ignore these as the method signature cannot be changed.
                 $methodName   = $phpcsFile->getDeclarationName($stackPtr);
                 $methodNameLc = strtolower($methodName);
-                if (isset($this->magicMethods[$methodNameLc]) === true) {
+                if (isset(self::MAGIC_METHODS[$methodNameLc]) === true) {
                     return;
                 }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -33,7 +33,7 @@ class UselessOverridingMethodSniff implements Sniff
      *
      * @var array<int|string, bool> Keys are the token constants, value is irrelevant.
      */
-    private $validOOScopes = [
+    private const VALID_OO_SCOPES = [
         T_CLASS      => true,
         T_ANON_CLASS => true,
         T_TRAIT      => true,
@@ -74,8 +74,8 @@ class UselessOverridingMethodSniff implements Sniff
         $conditions    = $token['conditions'];
         $lastCondition = end($conditions);
 
-        // Skip functions that are not a method part of a class, anon class or trait.
-        if (isset($this->validOOScopes[$lastCondition]) === false) {
+        // Skip functions that are not a method, i.e. part of a class, anon class or trait.
+        if (isset(self::VALID_OO_SCOPES[$lastCondition]) === false) {
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -21,6 +21,27 @@ class CyclomaticComplexitySniff implements Sniff
 {
 
     /**
+     * Predicate nodes for PHP.
+     *
+     * @var array<int|string, true>
+     */
+    private const PREDICATE_NODES = [
+        T_CASE                     => true,
+        T_DEFAULT                  => true,
+        T_CATCH                    => true,
+        T_IF                       => true,
+        T_FOR                      => true,
+        T_FOREACH                  => true,
+        T_WHILE                    => true,
+        T_ELSEIF                   => true,
+        T_INLINE_THEN              => true,
+        T_COALESCE                 => true,
+        T_COALESCE_EQUAL           => true,
+        T_MATCH_ARROW              => true,
+        T_NULLSAFE_OBJECT_OPERATOR => true,
+    ];
+
+    /**
      * A complexity higher than this value will throw a warning.
      *
      * @var integer
@@ -69,28 +90,11 @@ class CyclomaticComplexitySniff implements Sniff
         $start = $tokens[$stackPtr]['scope_opener'];
         $end   = $tokens[$stackPtr]['scope_closer'];
 
-        // Predicate nodes for PHP.
-        $find = [
-            T_CASE                     => true,
-            T_DEFAULT                  => true,
-            T_CATCH                    => true,
-            T_IF                       => true,
-            T_FOR                      => true,
-            T_FOREACH                  => true,
-            T_WHILE                    => true,
-            T_ELSEIF                   => true,
-            T_INLINE_THEN              => true,
-            T_COALESCE                 => true,
-            T_COALESCE_EQUAL           => true,
-            T_MATCH_ARROW              => true,
-            T_NULLSAFE_OBJECT_OPERATOR => true,
-        ];
-
         $complexity = 1;
 
         // Iterate from start to end and count predicate nodes.
         for ($i = ($start + 1); $i < $end; $i++) {
-            if (isset($find[$tokens[$i]['code']]) === true) {
+            if (isset(self::PREDICATE_NODES[$tokens[$i]['code']]) === true) {
                 $complexity++;
             }
         }

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -19,9 +19,9 @@ class LowerCaseConstantSniff implements Sniff
     /**
      * The tokens this sniff is targetting.
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
-    private $targets = [
+    private const TARGET_TOKENS = [
         T_TRUE  => T_TRUE,
         T_FALSE => T_FALSE,
         T_NULL  => T_NULL,
@@ -32,23 +32,19 @@ class LowerCaseConstantSniff implements Sniff
      *
      * @var array<int|string, int|string>
      */
-    private $propertyTypeTokens = [
+    private const PROPERTY_TYPE_TOKENS = (Tokens::NAME_TOKENS + [
         T_CALLABLE               => T_CALLABLE,
         T_SELF                   => T_SELF,
         T_PARENT                 => T_PARENT,
         T_FALSE                  => T_FALSE,
         T_TRUE                   => T_TRUE,
         T_NULL                   => T_NULL,
-        T_STRING                 => T_STRING,
-        T_NAME_QUALIFIED         => T_NAME_QUALIFIED,
-        T_NAME_FULLY_QUALIFIED   => T_NAME_FULLY_QUALIFIED,
-        T_NAME_RELATIVE          => T_NAME_RELATIVE,
         T_TYPE_UNION             => T_TYPE_UNION,
         T_TYPE_INTERSECTION      => T_TYPE_INTERSECTION,
         T_TYPE_OPEN_PARENTHESIS  => T_TYPE_OPEN_PARENTHESIS,
         T_TYPE_CLOSE_PARENTHESIS => T_TYPE_CLOSE_PARENTHESIS,
         T_NULLABLE               => T_NULLABLE,
-    ];
+    ]);
 
 
     /**
@@ -58,7 +54,7 @@ class LowerCaseConstantSniff implements Sniff
      */
     public function register()
     {
-        $targets = $this->targets;
+        $targets = self::TARGET_TOKENS;
 
         // Register scope modifiers to filter out property type declarations.
         $targets  += Tokens::SCOPE_MODIFIERS;
@@ -130,7 +126,7 @@ class LowerCaseConstantSniff implements Sniff
             || $tokens[$stackPtr]['code'] === T_FINAL
             || $tokens[$stackPtr]['code'] === T_ABSTRACT
         ) {
-            $skipOver = (Tokens::EMPTY_TOKENS + $this->propertyTypeTokens);
+            $skipOver = (Tokens::EMPTY_TOKENS + self::PROPERTY_TYPE_TOKENS);
             $skipTo   = $phpcsFile->findNext($skipOver, ($stackPtr + 1), null, true);
             if ($skipTo !== false) {
                 return $skipTo;
@@ -161,7 +157,7 @@ class LowerCaseConstantSniff implements Sniff
             }
 
             // Do a quick check if any of the targets exist in the declaration.
-            $found = $phpcsFile->findNext($this->targets, $tokens[$stackPtr]['parenthesis_opener'], $end);
+            $found = $phpcsFile->findNext(self::TARGET_TOKENS, $tokens[$stackPtr]['parenthesis_opener'], $end);
             if ($found === false) {
                 // Skip forward, no need to examine these tokens again.
                 return $end;
@@ -180,7 +176,7 @@ class LowerCaseConstantSniff implements Sniff
                 }
 
                 for ($i = $param['default_token']; $i < $paramEnd; $i++) {
-                    if (isset($this->targets[$tokens[$i]['code']]) === true) {
+                    if (isset(self::TARGET_TOKENS[$tokens[$i]['code']]) === true) {
                         $this->processConstant($phpcsFile, $i);
                     }
                 }

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -20,9 +20,9 @@ class LowerCaseTypeSniff implements Sniff
     /**
      * Native types supported by PHP.
      *
-     * @var array
+     * @var array<string, true>
      */
-    private $phpTypes = [
+    private const PHP_TYPES = [
         'self'     => true,
         'parent'   => true,
         'array'    => true,
@@ -146,7 +146,7 @@ class LowerCaseTypeSniff implements Sniff
                             );
                         } else {
                             $type = $tokens[$startOfType]['content'];
-                            if (isset($this->phpTypes[strtolower($type)]) === true) {
+                            if (isset(self::PHP_TYPES[strtolower($type)]) === true) {
                                 $this->processType($phpcsFile, $startOfType, $type, $error, $errorCode);
                             }
                         }
@@ -182,7 +182,7 @@ class LowerCaseTypeSniff implements Sniff
                             $error,
                             $errorCode
                         );
-                    } else if (isset($this->phpTypes[strtolower($type)]) === true) {
+                    } else if (isset(self::PHP_TYPES[strtolower($type)]) === true) {
                         $this->processType($phpcsFile, $props['type_token'], $type, $error, $errorCode);
                     }
                 }
@@ -213,7 +213,7 @@ class LowerCaseTypeSniff implements Sniff
                     $error,
                     $errorCode
                 );
-            } else if (isset($this->phpTypes[strtolower($returnType)]) === true) {
+            } else if (isset(self::PHP_TYPES[strtolower($returnType)]) === true) {
                 $this->processType($phpcsFile, $props['return_type_token'], $returnType, $error, $errorCode);
             }
         }
@@ -244,7 +244,7 @@ class LowerCaseTypeSniff implements Sniff
                         $error,
                         $errorCode
                     );
-                } else if (isset($this->phpTypes[strtolower($typeHint)]) === true) {
+                } else if (isset(self::PHP_TYPES[strtolower($typeHint)]) === true) {
                     $this->processType($phpcsFile, $param['type_hint_token'], $typeHint, $error, $errorCode);
                 }
             }
@@ -285,7 +285,7 @@ class LowerCaseTypeSniff implements Sniff
             ) {
                 if ($typeTokenCount === 1
                     && $type !== ''
-                    && isset($this->phpTypes[strtolower($type)]) === true
+                    && isset(self::PHP_TYPES[strtolower($type)]) === true
                 ) {
                     $this->processType($phpcsFile, $typeStart, $type, $error, $errorCode);
                 }
@@ -309,7 +309,7 @@ class LowerCaseTypeSniff implements Sniff
         // Handle type at end of type string.
         if ($typeTokenCount === 1
             && $type !== ''
-            && isset($this->phpTypes[strtolower($type)]) === true
+            && isset(self::PHP_TYPES[strtolower($type)]) === true
         ) {
             $this->processType($phpcsFile, $typeStart, $type, $error, $errorCode);
         }

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
@@ -20,7 +20,7 @@ class UnnecessaryHeredocSniff implements Sniff
      *
      * @var array<string>
      */
-    private $escapeChars = [
+    private const ESCAPE_CHARS = [
         // Octal sequences.
         '\0',
         '\1',
@@ -111,7 +111,7 @@ class UnnecessaryHeredocSniff implements Sniff
         $phpcsFile->recordMetric($stackPtr, 'Heredoc contains interpolation or expression', 'no');
 
         // Check for escape sequences which aren't supported in nowdocs.
-        foreach ($this->escapeChars as $testChar) {
+        foreach (self::ESCAPE_CHARS as $testChar) {
             if (strpos($body, $testChar) !== false) {
                 return;
             }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -20,6 +20,24 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
 {
 
     /**
+     * Tokens which when they precede an open parenthesis indicate
+     * that this is a type of structure this sniff should ignore.
+     *
+     * @var array<int|string, int|string>
+     */
+    private const IGNORE_TOKENS = (Tokens::FUNCTION_NAME_TOKENS + [
+        T_VARIABLE             => T_VARIABLE,
+        T_CLOSE_PARENTHESIS    => T_CLOSE_PARENTHESIS,
+        T_CLOSE_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
+        T_CLOSE_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
+        T_CLOSE_SHORT_ARRAY    => T_CLOSE_SHORT_ARRAY,
+        T_THROW                => T_THROW,
+        T_YIELD                => T_YIELD,
+        T_YIELD_FROM           => T_YIELD_FROM,
+        T_CLONE                => T_CLONE,
+    ]);
+
+    /**
      * The number of spaces desired on the inside of the parentheses.
      *
      * @var integer
@@ -33,14 +51,6 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
      */
     public $ignoreNewlines = false;
 
-    /**
-     * Tokens which when they precede an open parenthesis indicate
-     * that this is a type of structure this sniff should ignore.
-     *
-     * @var array
-     */
-    private $ignoreTokens = [];
-
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -49,19 +59,6 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
      */
     public function register()
     {
-        $this->ignoreTokens = Tokens::FUNCTION_NAME_TOKENS;
-
-        $this->ignoreTokens[T_VARIABLE]            = T_VARIABLE;
-        $this->ignoreTokens[T_CLOSE_PARENTHESIS]   = T_CLOSE_PARENTHESIS;
-        $this->ignoreTokens[T_CLOSE_CURLY_BRACKET] = T_CLOSE_CURLY_BRACKET;
-        $this->ignoreTokens[T_CLOSE_SQUARE_BRACKET] = T_CLOSE_SQUARE_BRACKET;
-        $this->ignoreTokens[T_CLOSE_SHORT_ARRAY]    = T_CLOSE_SHORT_ARRAY;
-
-        $this->ignoreTokens[T_THROW]      = T_THROW;
-        $this->ignoreTokens[T_YIELD]      = T_YIELD;
-        $this->ignoreTokens[T_YIELD_FROM] = T_YIELD_FROM;
-        $this->ignoreTokens[T_CLONE]      = T_CLONE;
-
         return [
             T_OPEN_PARENTHESIS,
             T_CLOSE_PARENTHESIS,
@@ -101,7 +98,7 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
 
         $preOpener = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($opener - 1), null, true);
         if ($preOpener !== false
-            && isset($this->ignoreTokens[$tokens[$preOpener]['code']]) === true
+            && isset(self::IGNORE_TOKENS[$tokens[$preOpener]['code']]) === true
             && ($tokens[$preOpener]['code'] !== T_CLOSE_CURLY_BRACKET
             || isset($tokens[$preOpener]['scope_condition']) === false )
         ) {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -16,6 +16,20 @@ class DisallowSpaceIndentSniff implements Sniff
 {
 
     /**
+     * Tokens which can include indentation.
+     *
+     * @var array<int|string, true>
+     */
+    private const TOKENS_CONTAINING_INDENT = [
+        T_WHITESPACE             => true,
+        T_INLINE_HTML            => true,
+        T_DOC_COMMENT_WHITESPACE => true,
+        T_COMMENT                => true,
+        T_END_HEREDOC            => true,
+        T_END_NOWDOC             => true,
+    ];
+
+    /**
      * The --tab-width CLI value that is being used.
      *
      * @var integer
@@ -62,20 +76,11 @@ class DisallowSpaceIndentSniff implements Sniff
             }
         }
 
-        $checkTokens = [
-            T_WHITESPACE             => true,
-            T_INLINE_HTML            => true,
-            T_DOC_COMMENT_WHITESPACE => true,
-            T_COMMENT                => true,
-            T_END_HEREDOC            => true,
-            T_END_NOWDOC             => true,
-        ];
-
         $eolLen = strlen($phpcsFile->eolChar);
 
         $tokens = $phpcsFile->getTokens();
         for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
-            if ($tokens[$i]['column'] !== 1 || isset($checkTokens[$tokens[$i]['code']]) === false) {
+            if ($tokens[$i]['column'] !== 1 || isset(self::TOKENS_CONTAINING_INDENT[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -16,6 +16,22 @@ class DisallowTabIndentSniff implements Sniff
 {
 
     /**
+     * Tokens which can include indentation.
+     *
+     * @var array<int|string, true>
+     */
+    private const TOKENS_CONTAINING_INDENT = [
+        T_WHITESPACE             => true,
+        T_INLINE_HTML            => true,
+        T_DOC_COMMENT_WHITESPACE => true,
+        T_DOC_COMMENT_STRING     => true,
+        T_COMMENT                => true,
+        T_END_HEREDOC            => true,
+        T_END_NOWDOC             => true,
+        T_YIELD_FROM             => true,
+    ];
+
+    /**
      * The --tab-width CLI value that is being used.
      *
      * @var integer
@@ -58,20 +74,10 @@ class DisallowTabIndentSniff implements Sniff
             }
         }
 
-        $tokens      = $phpcsFile->getTokens();
-        $checkTokens = [
-            T_WHITESPACE             => true,
-            T_INLINE_HTML            => true,
-            T_DOC_COMMENT_WHITESPACE => true,
-            T_DOC_COMMENT_STRING     => true,
-            T_COMMENT                => true,
-            T_END_HEREDOC            => true,
-            T_END_NOWDOC             => true,
-            T_YIELD_FROM             => true,
-        ];
+        $tokens = $phpcsFile->getTokens();
 
         for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
-            if (isset($checkTokens[$tokens[$i]['code']]) === false) {
+            if (isset(self::TOKENS_CONTAINING_INDENT[$tokens[$i]['code']]) === false) {
                 continue;
             }
 


### PR DESCRIPTION
# Description

_This PR is part of a series._

These commits change a number of either `private` properties or inline variables to `private` class constants.

This wasn't previously possible as support for constant arrays was only added in PHP 5.6.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change