### PR TITLE
Tokenizer/PHP/NullableVsInlineThenTest: add more test cases

### DIFF
--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
@@ -18,8 +18,58 @@ abstract class Nullable
     abstract ?string $prop5 { get; }
 }
 
+$closure = function (
+    /* testClosureParamTypeNullableInt */
+    ?Int $a,
+    /* testClosureParamTypeNullableCallable */
+    ?    Callable $b
+/* testClosureReturnTypeNullableInt */
+) :?INT{};
+
+/* testFunctionReturnTypeNullableCallable */
+function testCallableReturn() : ? callable {}
+
 class InlineThen
 {
     /* testInlineThenInPropertyDefaultValue */
     public int $prop = self::SOMECONT ? PHP_CONST ? OTHER_CONST;
 }
+
+/* testInlineThenWithArrayDeclaration */
+$ternary = true ? array() : null;
+
+/* testInlineThenWithUnqualifiedNameAndNothingElse */
+$ternary = true ? CONSTANT_NAME : null;
+
+/* testInlineThenWithUnqualifiedNameAndParens */
+$ternary = true ? callMe() : null;
+
+/* testInlineThenWithUnqualifiedNameAndDoubleColon */
+$ternary = true ? ClassName::callMe() : null;
+
+/* testInlineThenWithFullyQualifiedNameAndNothingElse */
+$ternary = true ? \CONSTANT_NAME : null;
+
+/* testInlineThenWithFullyQualifiedNameAndParens */
+$ternary = true ? \Fully\callMe() : null;
+
+/* testInlineThenWithFullyQualifiedNameAndDoubleColon */
+$ternary = true ? \Fully\ClassName::callMe() : null;
+
+/* testInlineThenWithPartiallyQualifiedNameAndNothingElse */
+$ternary = true ? Partially\CONSTANT_NAME : null;
+
+/* testInlineThenWithPartiallyQualifiedNameAndParens */
+$ternary = true ? Partially\callMe() : null;
+
+/* testInlineThenWithPartiallyQualifiedNameAndDoubleColon */
+$ternary = true ? Partially\ClassName::callMe() : null;
+
+/* testInlineThenWithNamespaceRelativeNameAndNothingElse */
+$ternary = true ? Partially\CONSTANT_NAME : null;
+
+/* testInlineThenWithNamespaceRelativeNameAndParens */
+$ternary = true ? Partially\callMe() : null;
+
+/* testInlineThenWithNamespaceRelativeNameAndDoubleColon */
+$ternary = true ? Partially\ClassName::callMe() : null;

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
@@ -55,6 +55,11 @@ final class NullableVsInlineThenTest extends AbstractTokenizerTestCase
             'property declaration, public and protected set' => ['/* testNullablePublicProtectedSet */'],
             'property declaration, final, no visibility'     => ['/* testNullableFinalOnly */'],
             'property declaration, abstract, no visibility'  => ['/* testNullableAbstractOnly */'],
+
+            'closure param type, nullable int'               => ['/* testClosureParamTypeNullableInt */'],
+            'closure param type, nullable callable'          => ['/* testClosureParamTypeNullableCallable */'],
+            'closure return type, nullable int'              => ['/* testClosureReturnTypeNullableInt */'],
+            'function return type, nullable callable'        => ['/* testFunctionReturnTypeNullableCallable */'],
         ];
 
     }//end dataNullable()
@@ -91,7 +96,25 @@ final class NullableVsInlineThenTest extends AbstractTokenizerTestCase
     public static function dataInlineThen()
     {
         return [
-            'ternary in property default value' => ['/* testInlineThenInPropertyDefaultValue */'],
+            'ternary in property default value'                            => ['/* testInlineThenInPropertyDefaultValue */'],
+
+            'ternary ? followed by array declaration'                      => ['/* testInlineThenWithArrayDeclaration */'],
+
+            'ternary ? followed by unqualified constant'                   => ['/* testInlineThenWithUnqualifiedNameAndNothingElse */'],
+            'ternary ? followed by unqualified function call'              => ['/* testInlineThenWithUnqualifiedNameAndParens */'],
+            'ternary ? followed by unqualified static method call'         => ['/* testInlineThenWithUnqualifiedNameAndDoubleColon */'],
+
+            'ternary ? followed by fully qualified constant'               => ['/* testInlineThenWithFullyQualifiedNameAndNothingElse */'],
+            'ternary ? followed by fully qualified function call'          => ['/* testInlineThenWithFullyQualifiedNameAndParens */'],
+            'ternary ? followed by fully qualified static method call'     => ['/* testInlineThenWithFullyQualifiedNameAndDoubleColon */'],
+
+            'ternary ? followed by partially qualified constant'           => ['/* testInlineThenWithPartiallyQualifiedNameAndNothingElse */'],
+            'ternary ? followed by partially qualified function call'      => ['/* testInlineThenWithPartiallyQualifiedNameAndParens */'],
+            'ternary ? followed by partially qualified static method call' => ['/* testInlineThenWithPartiallyQualifiedNameAndDoubleColon */'],
+
+            'ternary ? followed by namespace relative constant'            => ['/* testInlineThenWithNamespaceRelativeNameAndNothingElse */'],
+            'ternary ? followed by namespace relative function call'       => ['/* testInlineThenWithNamespaceRelativeNameAndParens */'],
+            'ternary ? followed by namespace relative static method call'  => ['/* testInlineThenWithNamespaceRelativeNameAndDoubleColon */'],
         ];
 
     }//end dataInlineThen()


### PR DESCRIPTION
# Description
These tests will on PHPCS 4.x cause a "Using null as an array offset" deprecation notice on PHP 8.5.


## Suggested changelog entry
_N/A_


## Related issues/external references

Loosely related to #1215 and #1216, but yet another instance of this.