### PR TITLE
Modernize: use class constants for constant arrays [4]

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -16,6 +16,16 @@ class ObjectOperatorIndentSniff implements Sniff
 {
 
     /**
+     * Tokens to listen for.
+     *
+     * @var array<int|string>
+     */
+    private const TARGET_TOKENS = [
+        T_OBJECT_OPERATOR,
+        T_NULLSAFE_OBJECT_OPERATOR,
+    ];
+
+    /**
      * The number of spaces code should be indented.
      *
      * @var integer
@@ -29,16 +39,6 @@ class ObjectOperatorIndentSniff implements Sniff
      */
     public $multilevel = false;
 
-    /**
-     * Tokens to listen for.
-     *
-     * @var array
-     */
-    private $targets = [
-        T_OBJECT_OPERATOR,
-        T_NULLSAFE_OBJECT_OPERATOR,
-    ];
-
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -47,7 +47,7 @@ class ObjectOperatorIndentSniff implements Sniff
      */
     public function register()
     {
-        return $this->targets;
+        return self::TARGET_TOKENS;
 
     }//end register()
 
@@ -67,14 +67,14 @@ class ObjectOperatorIndentSniff implements Sniff
 
         // Make sure this is the first object operator in a chain of them.
         $start = $phpcsFile->findStartOfStatement($stackPtr);
-        $prev  = $phpcsFile->findPrevious($this->targets, ($stackPtr - 1), $start);
+        $prev  = $phpcsFile->findPrevious(self::TARGET_TOKENS, ($stackPtr - 1), $start);
         if ($prev !== false) {
             return;
         }
 
         // Make sure this is a chained call.
         $end  = $phpcsFile->findEndOfStatement($stackPtr);
-        $next = $phpcsFile->findNext($this->targets, ($stackPtr + 1), $end);
+        $next = $phpcsFile->findNext(self::TARGET_TOKENS, ($stackPtr + 1), $end);
         if ($next === false) {
             // Not a chained call.
             return;
@@ -189,7 +189,7 @@ class ObjectOperatorIndentSniff implements Sniff
             }//end if
 
             $next = $phpcsFile->findNext(
-                $this->targets,
+                self::TARGET_TOKENS,
                 ($next + 1),
                 $end
             );

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -16,6 +16,30 @@ use PHP_CodeSniffer\Util\Tokens;
 class SideEffectsSniff implements Sniff
 {
 
+    /**
+     * Tokens which represent symbols in the context of this sniff.
+     *
+     * @var array<int|string, int|string>
+     */
+    private const SYMBOL_TOKENS = [
+        T_CLASS     => T_CLASS,
+        T_INTERFACE => T_INTERFACE,
+        T_TRAIT     => T_TRAIT,
+        T_ENUM      => T_ENUM,
+        T_FUNCTION  => T_FUNCTION,
+    ];
+
+    /**
+     * Condition tokens within which symbols may be defined.
+     *
+     * @var array<int|string, int|string>
+     */
+    private const CONDITION_TOKENS = [
+        T_IF     => T_IF,
+        T_ELSE   => T_ELSE,
+        T_ELSEIF => T_ELSEIF,
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,20 +102,6 @@ class SideEffectsSniff implements Sniff
      */
     private function searchForConflict($phpcsFile, $start, $end, $tokens)
     {
-        $symbols = [
-            T_CLASS     => T_CLASS,
-            T_INTERFACE => T_INTERFACE,
-            T_TRAIT     => T_TRAIT,
-            T_ENUM      => T_ENUM,
-            T_FUNCTION  => T_FUNCTION,
-        ];
-
-        $conditions = [
-            T_IF     => T_IF,
-            T_ELSE   => T_ELSE,
-            T_ELSEIF => T_ELSEIF,
-        ];
-
         $checkAnnotations = $phpcsFile->config->annotations;
 
         $firstSymbol = null;
@@ -192,7 +202,7 @@ class SideEffectsSniff implements Sniff
             }
 
             // Detect and skip over symbols.
-            if (isset($symbols[$tokens[$i]['code']]) === true
+            if (isset(self::SYMBOL_TOKENS[$tokens[$i]['code']]) === true
                 && isset($tokens[$i]['scope_closer']) === true
             ) {
                 if ($firstSymbol === null) {
@@ -251,7 +261,7 @@ class SideEffectsSniff implements Sniff
             // Conditional statements are allowed in symbol files as long as the
             // contents is only a symbol definition. So don't count these as effects
             // in this case.
-            if (isset($conditions[$tokens[$i]['code']]) === true) {
+            if (isset(self::CONDITION_TOKENS[$tokens[$i]['code']]) === true) {
                 if (isset($tokens[$i]['scope_opener']) === false) {
                     // Probably an "else if", so just ignore.
                     continue;

--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -16,6 +16,16 @@ class BooleanOperatorPlacementSniff implements Sniff
 {
 
     /**
+     * Boolean operator tokens.
+     *
+     * @var array<int|string>
+     */
+    private const BOOLEAN_OPERATORS = [
+        T_BOOLEAN_AND,
+        T_BOOLEAN_OR,
+    ];
+
+    /**
      * Used to restrict the placement of the boolean operator.
      *
      * Allowed value are "first" or "last".
@@ -70,11 +80,6 @@ class BooleanOperatorPlacementSniff implements Sniff
             return;
         }
 
-        $find = [
-            T_BOOLEAN_AND,
-            T_BOOLEAN_OR,
-        ];
-
         if ($this->allowOnly === 'first' || $this->allowOnly === 'last') {
             $position = $this->allowOnly;
         } else {
@@ -86,7 +91,7 @@ class BooleanOperatorPlacementSniff implements Sniff
         $operators = [];
 
         do {
-            $operator = $phpcsFile->findNext($find, ($operator + 1), $parenCloser);
+            $operator = $phpcsFile->findNext(self::BOOLEAN_OPERATORS, ($operator + 1), $parenCloser);
             if ($operator === false) {
                 break;
             }

--- a/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class NullableTypeDeclarationSniff implements Sniff
 {
@@ -18,21 +19,17 @@ class NullableTypeDeclarationSniff implements Sniff
     /**
      * An array of valid tokens after `T_NULLABLE` occurrences.
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
-    private $validTokens = [
-        T_STRING               => true,
-        T_NAME_QUALIFIED       => true,
-        T_NAME_FULLY_QUALIFIED => true,
-        T_NAME_RELATIVE        => true,
-        T_CALLABLE             => true,
-        T_SELF                 => true,
-        T_PARENT               => true,
-        T_STATIC               => true,
-        T_NULL                 => true,
-        T_FALSE                => true,
-        T_TRUE                 => true,
-    ];
+    private const VALID_TOKENS = (Tokens::NAME_TOKENS + [
+        T_CALLABLE => T_CALLABLE,
+        T_SELF     => T_SELF,
+        T_PARENT   => T_PARENT,
+        T_STATIC   => T_STATIC,
+        T_NULL     => T_NULL,
+        T_FALSE    => T_FALSE,
+        T_TRUE     => T_TRUE,
+    ]);
 
 
     /**
@@ -66,7 +63,7 @@ class NullableTypeDeclarationSniff implements Sniff
 
         $tokens           = $phpcsFile->getTokens();
         $nextNonEmptyCode = $tokens[$nextNonEmptyPtr]['code'];
-        $validTokenFound  = isset($this->validTokens[$nextNonEmptyCode]);
+        $validTokenFound  = isset(self::VALID_TOKENS[$nextNonEmptyCode]);
 
         if ($validTokenFound === true && $nextNonEmptyPtr === ($stackPtr + 1)) {
             // Valid structure.

--- a/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
+++ b/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
@@ -16,6 +16,17 @@ use PHP_CodeSniffer\Util\Tokens;
 class ConstantVisibilitySniff implements Sniff
 {
 
+    /**
+     * Visibility tokens which are valid for class constants.
+     *
+     * @var array<int, int>
+     */
+    private const VALID_VISIBILITY = [
+        T_PRIVATE   => T_PRIVATE,
+        T_PUBLIC    => T_PUBLIC,
+        T_PROTECTED => T_PROTECTED,
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -50,14 +61,8 @@ class ConstantVisibilitySniff implements Sniff
         $ignore   = Tokens::EMPTY_TOKENS;
         $ignore[] = T_FINAL;
 
-        $validVisibility = [
-            T_PRIVATE   => T_PRIVATE,
-            T_PUBLIC    => T_PUBLIC,
-            T_PROTECTED => T_PROTECTED,
-        ];
-
         $prev = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
-        if (isset($validVisibility[$tokens[$prev]['code']]) === true) {
+        if (isset(self::VALID_VISIBILITY[$tokens[$prev]['code']]) === true) {
             return;
         }
 

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -17,6 +17,17 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 {
 
     /**
+     * Modifier keywords which can be used in class declarations.
+     *
+     * @var array<int|string, int|string>
+     */
+    private const CLASS_MODIFIERS = [
+        T_ABSTRACT => T_ABSTRACT,
+        T_FINAL    => T_FINAL,
+        T_READONLY => T_READONLY,
+    ];
+
+    /**
      * The number of spaces code should be indented.
      *
      * @var integer
@@ -65,16 +76,10 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         $stackPtrType = strtolower($tokens[$stackPtr]['content']);
 
         // Check alignment of the keyword and braces.
-        $classModifiers = [
-            T_ABSTRACT => T_ABSTRACT,
-            T_FINAL    => T_FINAL,
-            T_READONLY => T_READONLY,
-        ];
-
         $prevNonSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
-        if (isset($classModifiers[$tokens[$prevNonEmpty]['code']]) === true) {
+        if (isset(self::CLASS_MODIFIERS[$tokens[$prevNonEmpty]['code']]) === true) {
             $spaces    = 0;
             $errorCode = 'SpaceBeforeKeyword';
             if ($tokens[$prevNonEmpty]['line'] !== $tokens[$stackPtr]['line']) {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -17,6 +17,20 @@ class SwitchDeclarationSniff implements Sniff
 {
 
     /**
+     * Tokens which can terminate a "case".
+     *
+     * @var array<int|string, int|string>
+     */
+    private const CASE_TERMINATING_TOKENS = [
+        T_RETURN   => T_RETURN,
+        T_BREAK    => T_BREAK,
+        T_CONTINUE => T_CONTINUE,
+        T_THROW    => T_THROW,
+        T_EXIT     => T_EXIT,
+        T_GOTO     => T_GOTO,
+    ];
+
+    /**
      * The number of spaces code should be indented.
      *
      * @var integer
@@ -382,17 +396,8 @@ class SwitchDeclarationSniff implements Sniff
         } else if ($tokens[$lastToken]['code'] === T_SEMICOLON) {
             // We found the last statement of the CASE. Now we want to
             // check whether it is a terminating one.
-            $terminators = [
-                T_RETURN   => T_RETURN,
-                T_BREAK    => T_BREAK,
-                T_CONTINUE => T_CONTINUE,
-                T_THROW    => T_THROW,
-                T_EXIT     => T_EXIT,
-                T_GOTO     => T_GOTO,
-            ];
-
             $terminator = $phpcsFile->findStartOfStatement(($lastToken - 1));
-            if (isset($terminators[$tokens[$terminator]['code']]) === true) {
+            if (isset(self::CASE_TERMINATING_TOKENS[$tokens[$terminator]['code']]) === true) {
                 return $terminator;
             }
         }//end if


### PR DESCRIPTION
# Description

_This PR is part of a series._

These commits change a number of either `private` properties or inline variables to `private` class constants.

This wasn't previously possible as support for constant arrays was only added in PHP 5.6.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change