### PR TITLE
Modernize: use class constant for constant array [5]

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -15,6 +15,18 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class FileCommentSniff implements Sniff
 {
 
+    /**
+     * Required tags in correct order.
+     *
+     * @var array<string, true>
+     */
+    private const REQUIRED_TAGS = [
+        '@package'    => true,
+        '@subpackage' => true,
+        '@author'     => true,
+        '@copyright'  => true,
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -123,18 +135,10 @@ class FileCommentSniff implements Sniff
             $phpcsFile->addError($error, $commentEnd, 'SpacingAfterComment');
         }
 
-        // Required tags in correct order.
-        $required = [
-            '@package'    => true,
-            '@subpackage' => true,
-            '@author'     => true,
-            '@copyright'  => true,
-        ];
-
         $foundTags = [];
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             $name       = $tokens[$tag]['content'];
-            $isRequired = isset($required[$name]);
+            $isRequired = isset(self::REQUIRED_TAGS[$name]);
 
             if ($isRequired === true && in_array($name, $foundTags, true) === true) {
                 $error = 'Only one %s tag is allowed in a file comment';
@@ -185,7 +189,7 @@ class FileCommentSniff implements Sniff
 
         // Check if the tags are in the correct position.
         $pos = 0;
-        foreach ($required as $tag => $true) {
+        foreach (self::REQUIRED_TAGS as $tag => $true) {
             if (in_array($tag, $foundTags, true) === false) {
                 $error = 'Missing %s tag in file comment';
                 $data  = [$tag];

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -16,6 +16,17 @@ use PHP_CodeSniffer\Util\Tokens;
 class InlineCommentSniff implements Sniff
 {
 
+    /**
+     * Characters which are accepted to end a sentence.
+     *
+     * @var array<string, string>
+     */
+    private const VALID_SENTENCE_END_CHARS = [
+        'full-stops'        => '.',
+        'exclamation marks' => '!',
+        'or question marks' => '?',
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -227,17 +238,11 @@ class InlineCommentSniff implements Sniff
         // Only check the end of comment character if the start of the comment
         // is a letter, indicating that the comment is just standard text.
         if (preg_match('/^\p{L}/u', $commentText) === 1) {
-            $commentCloser   = $commentText[(strlen($commentText) - 1)];
-            $acceptedClosers = [
-                'full-stops'        => '.',
-                'exclamation marks' => '!',
-                'or question marks' => '?',
-            ];
-
-            if (in_array($commentCloser, $acceptedClosers, true) === false) {
+            $commentCloser = $commentText[(strlen($commentText) - 1)];
+            if (in_array($commentCloser, self::VALID_SENTENCE_END_CHARS, true) === false) {
                 $error = 'Inline comments must end in %s';
                 $ender = '';
-                foreach ($acceptedClosers as $closerName => $symbol) {
+                foreach (self::VALID_SENTENCE_END_CHARS as $closerName => $symbol) {
                     $ender .= ' '.$closerName.',';
                 }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -16,19 +16,19 @@ class LongConditionClosingCommentSniff implements Sniff
 {
 
     /**
-     * The openers that we are interested in.
+     * The condition openers that we are interested in.
      *
-     * @var array<int|string>
+     * @var array<int|string, int|string>
      */
-    private static $openers = [
-        T_SWITCH,
-        T_IF,
-        T_FOR,
-        T_FOREACH,
-        T_WHILE,
-        T_TRY,
-        T_CASE,
-        T_MATCH,
+    private const CONDITION_OPENERS = [
+        T_SWITCH  => T_SWITCH,
+        T_IF      => T_IF,
+        T_FOR     => T_FOR,
+        T_FOREACH => T_FOREACH,
+        T_WHILE   => T_WHILE,
+        T_TRY     => T_TRY,
+        T_CASE    => T_CASE,
+        T_MATCH   => T_MATCH,
     ];
 
     /**
@@ -84,7 +84,7 @@ class LongConditionClosingCommentSniff implements Sniff
         $endBrace       = $tokens[$stackPtr];
 
         // We are only interested in some code blocks.
-        if (in_array($startCondition['code'], self::$openers, true) === false) {
+        if (isset(self::CONDITION_OPENERS[$startCondition['code']]) === false) {
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -21,9 +21,9 @@ class PostStatementCommentSniff implements Sniff
      * If post statement comments are found within the condition
      * parenthesis of these structures, leave them alone.
      *
-     * @var array
+     * @var array<int|string, true>
      */
-    private $controlStructureExceptions = [
+    private const CONTROL_STRUCTURE_EXCEPTIONS = [
         T_IF      => true,
         T_ELSEIF  => true,
         T_SWITCH  => true,
@@ -92,7 +92,7 @@ class PostStatementCommentSniff implements Sniff
             $nestedParens = $tokens[$stackPtr]['nested_parenthesis'];
             foreach ($nestedParens as $open => $close) {
                 if (isset($tokens[$open]['parenthesis_owner']) === true
-                    && isset($this->controlStructureExceptions[$tokens[$tokens[$open]['parenthesis_owner']]['code']]) === true
+                    && isset(self::CONTROL_STRUCTURE_EXCEPTIONS[$tokens[$tokens[$open]['parenthesis_owner']]['code']]) === true
                 ) {
                     return;
                 }

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -19,9 +19,9 @@ class ComparisonOperatorUsageSniff implements Sniff
     /**
      * A list of valid comparison operators.
      *
-     * @var array
+     * @var array<int|string, true>
      */
-    private static $validOps = [
+    private const VALID_OPERATIONS = [
         T_IS_IDENTICAL        => true,
         T_IS_NOT_IDENTICAL    => true,
         T_LESS_THAN           => true,
@@ -36,7 +36,7 @@ class ComparisonOperatorUsageSniff implements Sniff
      *
      * @var array<int|string, string>
      */
-    private static $invalidOps = [
+    private const INVALID_OPERATIONS = [
         T_IS_EQUAL     => '===',
         T_IS_NOT_EQUAL => '!==',
         T_BOOLEAN_NOT  => '=== FALSE',
@@ -149,15 +149,15 @@ class ComparisonOperatorUsageSniff implements Sniff
 
         for ($i = $start; $i <= $end; $i++) {
             $type = $tokens[$i]['code'];
-            if (isset(self::$invalidOps[$type]) === true) {
+            if (isset(self::INVALID_OPERATIONS[$type]) === true) {
                 $error = 'Operator %s prohibited; use %s instead';
                 $data  = [
                     $tokens[$i]['content'],
-                    self::$invalidOps[$type],
+                    self::INVALID_OPERATIONS[$type],
                 ];
                 $phpcsFile->addError($error, $i, 'NotAllowed', $data);
                 $foundOps++;
-            } else if (isset(self::$validOps[$type]) === true) {
+            } else if (isset(self::VALID_OPERATIONS[$type]) === true) {
                 $foundOps++;
             }
 

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -25,9 +25,9 @@ class NonExecutableCodeSniff implements Sniff
      * `throw` can be used as an expression since PHP 8.0.
      * {@link https://wiki.php.net/rfc/throw_expression}
      *
-     * @var array
+     * @var array<int, int>
      */
-    private $expressionTokens = [
+    private const EXPRESSION_TOKENS = [
         T_EXIT  => T_EXIT,
         T_THROW => T_THROW,
     ];
@@ -68,7 +68,7 @@ class NonExecutableCodeSniff implements Sniff
         $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         // Tokens which can be used in inline expressions need special handling.
-        if (isset($this->expressionTokens[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(self::EXPRESSION_TOKENS[$tokens[$stackPtr]['code']]) === true) {
             // If this token is preceded by a logical operator, it only relates to one line
             // and should be ignored. For example: fopen() or die().
             // Note: There is one exception: throw expressions can not be used with xor.

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -15,6 +15,32 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DoubleQuoteUsageSniff implements Sniff
 {
 
+    /**
+     * Escape chars which are supported in double quoted strings, but not in single quoted strings.
+     *
+     * @var array<string>
+     */
+    private const ESCAPE_CHARS = [
+        '\0',
+        '\1',
+        '\2',
+        '\3',
+        '\4',
+        '\5',
+        '\6',
+        '\7',
+        '\n',
+        '\r',
+        '\f',
+        '\t',
+        '\v',
+        '\x',
+        '\b',
+        '\e',
+        '\u',
+        '\'',
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -91,28 +117,7 @@ class DoubleQuoteUsageSniff implements Sniff
             return $skipTo;
         }//end if
 
-        $allowedChars = [
-            '\0',
-            '\1',
-            '\2',
-            '\3',
-            '\4',
-            '\5',
-            '\6',
-            '\7',
-            '\n',
-            '\r',
-            '\f',
-            '\t',
-            '\v',
-            '\x',
-            '\b',
-            '\e',
-            '\u',
-            '\'',
-        ];
-
-        foreach ($allowedChars as $testChar) {
+        foreach (self::ESCAPE_CHARS as $testChar) {
             if (strpos($workingString, $testChar) !== false) {
                 return $skipTo;
             }


### PR DESCRIPTION
# Description

_This PR is part of a series._

These commits change a number of either `private` properties or inline variables to `private` class constants.

This wasn't previously possible as support for constant arrays was only added in PHP 5.6.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change