### PR TITLE
Modernize: use class constant for constant array [6]

### DIFF
--- a/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
@@ -20,7 +20,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
      *
      * @var array<int|string>
      */
-    protected $find = [
+    private const TARGET_TOKENS = [
         T_NULLSAFE_OBJECT_OPERATOR,
         T_OBJECT_OPERATOR,
         T_INLINE_THEN,
@@ -38,7 +38,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $operator = $this->getTargetToken('/* testObjectOperator */', $this->find);
+        $operator = $this->getTargetToken('/* testObjectOperator */', self::TARGET_TOKENS);
         $this->assertSame(T_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is object operator');
         $this->assertSame('T_OBJECT_OPERATOR', $tokens[$operator]['type'], 'Failed asserting type is object operator');
 
@@ -59,7 +59,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $operator = $this->getTargetToken($testMarker, $this->find);
+        $operator = $this->getTargetToken($testMarker, self::TARGET_TOKENS);
         $this->assertSame(T_NULLSAFE_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is nullsafe object operator');
         $this->assertSame('T_NULLSAFE_OBJECT_OPERATOR', $tokens[$operator]['type'], 'Failed asserting type is nullsafe object operator');
 
@@ -99,7 +99,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $operator = $this->getTargetToken($testMarker, $this->find);
+        $operator = $this->getTargetToken($testMarker, self::TARGET_TOKENS);
         $this->assertSame(T_INLINE_THEN, $tokens[$operator]['code'], 'Failed asserting code is inline then');
         $this->assertSame('T_INLINE_THEN', $tokens[$operator]['type'], 'Failed asserting type is inline then');
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -20,7 +20,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      *
      * @var array<int>
      */
-    protected $conditionStopTokens = [
+    private const CONDITION_STOP_TOKENS = [
         T_BREAK,
         T_CONTINUE,
         T_EXIT,
@@ -272,7 +272,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
         if (($opener + 1) !== $closer) {
             $end = $closer;
             if (isset($conditionStopMarker) === true) {
-                $end = ( $this->getTargetToken($conditionStopMarker, $this->conditionStopTokens) + 1);
+                $end = ( $this->getTargetToken($conditionStopMarker, self::CONDITION_STOP_TOKENS) + 1);
             }
 
             for ($i = ($opener + 1); $i < $end; $i++) {


### PR DESCRIPTION
# Description

_This PR is part of a series._

These commits change a number of either `private` properties or inline variables to `private` class constants.

This wasn't previously possible as support for constant arrays was only added in PHP 5.6.

## Suggested changelog entry
_N/A_ There should be no functional impact of this change