### PR TITLE
PHP 8.5 | Tokenizer/PHP: properly fix "Using null as an array offset" deprecation

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2255,6 +2255,9 @@ class PHP extends Tokenizer
                 for ($i = ($stackPtr - 1); $i >= 0; $i--) {
                     if (is_array($tokens[$i]) === true) {
                         $tokenType = $tokens[$i][0];
+                    } else if ($tokens[$i] === null) {
+                        // Ignore skipped tokens.
+                        continue;
                     } else {
                         $tokenType = $tokens[$i];
                     }

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2271,7 +2271,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($prevNonEmpty === null
-                        && @isset(Tokens::$emptyTokens[$tokenType]) === false
+                        && isset(Tokens::$emptyTokens[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
                         if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
@@ -2290,8 +2290,8 @@ class PHP extends Tokenizer
 
                     if ($tokenType === T_FUNCTION
                         || $tokenType === T_FN
-                        || @isset(Tokens::$methodPrefixes[$tokenType]) === true
-                        || @isset(Tokens::$scopeModifiers[$tokenType]) === true
+                        || isset(Tokens::$methodPrefixes[$tokenType]) === true
+                        || isset(Tokens::$scopeModifiers[$tokenType]) === true
                         || $tokenType === T_VAR
                         || $tokenType === T_READONLY
                     ) {
@@ -2314,7 +2314,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    if (@isset(Tokens::$emptyTokens[$tokenType]) === false) {
+                    if (isset(Tokens::$emptyTokens[$tokenType]) === false) {
                         $lastSeenNonEmpty = $tokenType;
                     }
                 }//end for

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2244,6 +2244,24 @@ class PHP extends Tokenizer
                     break;
                 }//end for
 
+                // Handle live coding/parse errors elegantly.
+                // If the "?" is the last non-empty token in the file, we cannot draw a definitive conclusion,
+                // so tokenize as T_INLINE_THEN.
+                if ($i === $numTokens) {
+                    if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                        echo "\t\t* token $stackPtr at end of file changed from ? to T_INLINE_THEN".PHP_EOL;
+                    }
+
+                    $newToken['code'] = T_INLINE_THEN;
+                    $newToken['type'] = 'T_INLINE_THEN';
+
+                    $insideInlineIf[] = $stackPtr;
+
+                    $finalTokens[$newStackPtr] = $newToken;
+                    $newStackPtr++;
+                    continue;
+                }
+
                 /*
                  * This can still be a nullable type or a ternary.
                  * Do additional checking.
@@ -2253,11 +2271,13 @@ class PHP extends Tokenizer
                 $lastSeenNonEmpty = null;
 
                 for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+                    if (isset($tokens[$i]) === false) {
+                        // Ignore skipped tokens (related to PHP 8+ slash/hash comment vs new line retokenization).
+                        continue;
+                    }
+
                     if (is_array($tokens[$i]) === true) {
                         $tokenType = $tokens[$i][0];
-                    } else if ($tokens[$i] === null) {
-                        // Ignore skipped tokens.
-                        continue;
                     } else {
                         $tokenType = $tokens[$i];
                     }

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenParseErrorTest.inc
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenParseErrorTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+// This should be the only test in the file.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1216
+
+/* testLiveCoding */
+$ternary = true
+    # This must be a slash or hash comment and the next line must **NOT** have any indentation for the PHP 8.5 deprecation notice to occur.
+? //comment.

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenParseErrorTest.php
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenParseErrorTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests the retokenization of ? to T_NULLABLE or T_INLINE_THEN.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+/**
+ * Tests the retokenization of ? to T_NULLABLE or T_INLINE_THEN.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class NullableVsInlineThenParseErrorTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Verify that a "?" as the last functional token in a file (live coding) is tokenized as `T_INLINE_THEN`
+     * as it cannot yet be determined what the token would be once the code is finalized.
+     *
+     * @return void
+     */
+    public function testInlineThenAtEndOfFile()
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken('/* testLiveCoding */', [T_NULLABLE, T_INLINE_THEN]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_INLINE_THEN, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_INLINE_THEN (code)');
+        $this->assertSame('T_INLINE_THEN', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_INLINE_THEN (type)');
+
+    }//end testInlineThenAtEndOfFile()
+
+
+}//end class

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
@@ -22,7 +22,11 @@ $closure = function (
     /* testClosureParamTypeNullableInt */
     ?Int $a,
     /* testClosureParamTypeNullableCallable */
-    ?    Callable $b
+    ?    Callable $b,
+    /* testClosureParamTypeNullableStringWithAttributeAndSlashComment */
+    #[AttributeForParam]
+    // This must be a slash or hash comment and the next line must **NOT** have any indentation for the PHP 8.5 deprecation notice (issue PHPCSStandards/PHP_CodeSniffer#1216) to occur.
+?string $c
 /* testClosureReturnTypeNullableInt */
 ) :?INT{};
 

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
@@ -50,16 +50,17 @@ final class NullableVsInlineThenTest extends AbstractTokenizerTestCase
     public static function dataNullable()
     {
         return [
-            'property declaration, readonly, no visibility'  => ['/* testNullableReadonlyOnly */'],
-            'property declaration, private set'              => ['/* testNullablePrivateSet */'],
-            'property declaration, public and protected set' => ['/* testNullablePublicProtectedSet */'],
-            'property declaration, final, no visibility'     => ['/* testNullableFinalOnly */'],
-            'property declaration, abstract, no visibility'  => ['/* testNullableAbstractOnly */'],
+            'property declaration, readonly, no visibility'                 => ['/* testNullableReadonlyOnly */'],
+            'property declaration, private set'                             => ['/* testNullablePrivateSet */'],
+            'property declaration, public and protected set'                => ['/* testNullablePublicProtectedSet */'],
+            'property declaration, final, no visibility'                    => ['/* testNullableFinalOnly */'],
+            'property declaration, abstract, no visibility'                 => ['/* testNullableAbstractOnly */'],
 
-            'closure param type, nullable int'               => ['/* testClosureParamTypeNullableInt */'],
-            'closure param type, nullable callable'          => ['/* testClosureParamTypeNullableCallable */'],
-            'closure return type, nullable int'              => ['/* testClosureReturnTypeNullableInt */'],
-            'function return type, nullable callable'        => ['/* testFunctionReturnTypeNullableCallable */'],
+            'closure param type, nullable int'                              => ['/* testClosureParamTypeNullableInt */'],
+            'closure param type, nullable callable'                         => ['/* testClosureParamTypeNullableCallable */'],
+            'closure param type, nullable string with comment, issue #1216' => ['/* testClosureParamTypeNullableStringWithAttributeAndSlashComment */'],
+            'closure return type, nullable int'                             => ['/* testClosureReturnTypeNullableInt */'],
+            'function return type, nullable callable'                       => ['/* testFunctionReturnTypeNullableCallable */'],
         ];
 
     }//end dataNullable()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Fixes #1215 / #1216

## Suggested changelog entry
Ignore skipped tokens in tokenizer.

## Related issues/external references

Fixes #1215 / #1216


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes. (N/A)
- [x] I have verified that the code complies with the projects coding standards.
- [x] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
