### PR TITLE
PSR12/FileHeader: minor consistency fix

### DIFF
--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -52,7 +52,7 @@ class FileHeaderSniff implements Sniff
             $headerLines = $this->getHeaderLines($phpcsFile, $openTag);
             if (empty($headerLines) === true && $openTag === $stackPtr) {
                 // No content in the file.
-                return;
+                return $phpcsFile->numTokens;
             }
 
             $possibleHeaders[$openTag] = $headerLines;


### PR DESCRIPTION


# Description
Ensure that the method always returns `int`.


## Suggested changelog entry
_N/A_