### PR TITLE
CS: normalize code style rules [2]

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -256,7 +256,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
          *
          * @return void
          */
-        public static function addSearchPath(string $path, string $nsPrefix='')
+        public static function addSearchPath(string $path, string $nsPrefix = '')
         {
             self::$searchPaths[$path] = rtrim(trim((string) $nsPrefix), '\\');
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,7 +53,11 @@
         <exclude name="Squiz.Commenting.VariableComment.LinkTagNotAllowed"/>
     </rule>
     <rule ref="Squiz.Formatting.OperatorBracket"/>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
     <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>

--- a/src/Config.php
+++ b/src/Config.php
@@ -415,7 +415,7 @@ class Config
      *
      * @return void
      */
-    public function __construct(array $cliArgs=[], bool $dieOnUnknownArg=true)
+    public function __construct(array $cliArgs = [], bool $dieOnUnknownArg = true)
     {
         if (defined('PHP_CODESNIFFER_IN_TESTS') === true) {
             // Let everything through during testing so that we can
@@ -1490,7 +1490,7 @@ class Config
      *
      * @return string|void
      */
-    public function printShortUsage(bool $returnOutput=false)
+    public function printShortUsage(bool $returnOutput = false)
     {
         if (PHP_CODESNIFFER_CBF === true) {
             $usage = 'Run "phpcbf --help" for usage information';
@@ -1633,7 +1633,7 @@ class Config
      * @see    getConfigData()
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException If the config file can not be written.
      */
-    public function setConfigData(string $key, ?string $value, bool $temp=false)
+    public function setConfigData(string $key, ?string $value, bool $temp = false)
     {
         if (isset($this->overriddenDefaults['runtime-set']) === true
             && isset($this->overriddenDefaults['runtime-set'][$key]) === true

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -674,9 +674,9 @@ class File
         string $error,
         ?int $stackPtr,
         string $code,
-        array $data=[],
-        int $severity=0,
-        bool $fixable=false
+        array $data = [],
+        int $severity = 0,
+        bool $fixable = false
     ) {
         if ($stackPtr === null) {
             $line   = 1;
@@ -708,9 +708,9 @@ class File
         string $warning,
         ?int $stackPtr,
         string $code,
-        array $data=[],
-        int $severity=0,
-        bool $fixable=false
+        array $data = [],
+        int $severity = 0,
+        bool $fixable = false
     ) {
         if ($stackPtr === null) {
             $line   = 1;
@@ -741,8 +741,8 @@ class File
         string $error,
         int $line,
         string $code,
-        array $data=[],
-        int $severity=0
+        array $data = [],
+        int $severity = 0
     ) {
         return $this->addMessage(true, $error, $line, 1, $code, $data, $severity, false);
 
@@ -765,8 +765,8 @@ class File
         string $warning,
         int $line,
         string $code,
-        array $data=[],
-        int $severity=0
+        array $data = [],
+        int $severity = 0
     ) {
         return $this->addMessage(false, $warning, $line, 1, $code, $data, $severity, false);
 
@@ -791,8 +791,8 @@ class File
         string $error,
         int $stackPtr,
         string $code,
-        array $data=[],
-        int $severity=0
+        array $data = [],
+        int $severity = 0
     ) {
         $recorded = $this->addError($error, $stackPtr, $code, $data, $severity, true);
         if ($recorded === true && $this->fixer->enabled === true) {
@@ -822,8 +822,8 @@ class File
         string $warning,
         int $stackPtr,
         string $code,
-        array $data=[],
-        int $severity=0
+        array $data = [],
+        int $severity = 0
     ) {
         $recorded = $this->addWarning($warning, $stackPtr, $code, $data, $severity, true);
         if ($recorded === true && $this->fixer->enabled === true) {
@@ -2264,7 +2264,7 @@ class File
      * @return string The token contents.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position does not exist.
      */
-    public function getTokensAsString($start, $length, bool $origContent=false)
+    public function getTokensAsString($start, $length, bool $origContent = false)
     {
         if (is_int($start) === false || isset($this->tokens[$start]) === false) {
             throw new RuntimeException('The $start position for getTokensAsString() must exist in the token stack');
@@ -2324,10 +2324,10 @@ class File
     public function findPrevious(
         $types,
         int $start,
-        ?int $end=null,
-        bool $exclude=false,
-        ?string $value=null,
-        bool $local=false
+        ?int $end = null,
+        bool $exclude = false,
+        ?string $value = null,
+        bool $local = false
     ) {
         $types = (array) $types;
 
@@ -2405,10 +2405,10 @@ class File
     public function findNext(
         $types,
         int $start,
-        ?int $end=null,
-        bool $exclude=false,
-        ?string $value=null,
-        bool $local=false
+        ?int $end = null,
+        bool $exclude = false,
+        ?string $value = null,
+        bool $local = false
     ) {
         $types = (array) $types;
 
@@ -2451,7 +2451,7 @@ class File
      *
      * @return int
      */
-    public function findStartOfStatement(int $start, $ignore=null)
+    public function findStartOfStatement(int $start, $ignore = null)
     {
         $startTokens = Tokens::BLOCK_OPENERS;
         $startTokens[T_OPEN_SHORT_ARRAY]   = true;
@@ -2642,7 +2642,7 @@ class File
      *
      * @return int
      */
-    public function findEndOfStatement(int $start, $ignore=null)
+    public function findEndOfStatement(int $start, $ignore = null)
     {
         $endTokens = [
             T_COLON                => true,
@@ -2769,7 +2769,7 @@ class File
      *                   FALSE when no matching token could be found between the start of
      *                   the line and the start token.
      */
-    public function findFirstOnLine($types, int $start, bool $exclude=false, ?string $value=null)
+    public function findFirstOnLine($types, int $start, bool $exclude = false, ?string $value = null)
     {
         if (is_array($types) === false) {
             $types = [$types];
@@ -2860,7 +2860,7 @@ class File
      *
      * @return int|false
      */
-    public function getCondition(int $stackPtr, $type, bool $first=true)
+    public function getCondition(int $stackPtr, $type, bool $first = true)
     {
         // Check for the existence of the token.
         if (isset($this->tokens[$stackPtr]) === false) {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -117,7 +117,7 @@ class FileList implements Iterator, Countable
      *
      * @return void
      */
-    public function addFile(string $path, ?File $file=null)
+    public function addFile(string $path, ?File $file = null)
     {
         // No filtering is done for STDIN when the filename
         // has not been specified.

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -235,7 +235,7 @@ class Fixer
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException When the diff command fails.
      */
-    public function generateDiff(?string $filePath=null, bool $colors=true)
+    public function generateDiff(?string $filePath = null, bool $colors = true)
     {
         if ($filePath === null) {
             $filePath = $this->currentFile->getFilename();
@@ -689,7 +689,7 @@ class Fixer
      *
      * @return bool If the change was accepted.
      */
-    public function substrToken(int $stackPtr, int $start, ?int $length=null)
+    public function substrToken(int $stackPtr, int $start, ?int $length = null)
     {
         $current = $this->getTokenContent($stackPtr);
 

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -42,7 +42,7 @@ class Cbf implements Report
      * @return bool
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $errors = $phpcsFile->getFixableCount();
         if ($errors !== 0) {
@@ -139,10 +139,10 @@ class Cbf implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $lines = explode(PHP_EOL, $cachedData);
         array_pop($lines);

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -32,7 +32,7 @@ class Checkstyle implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $out = new XMLWriter;
         $out->openMemory();
@@ -95,10 +95,10 @@ class Checkstyle implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
         echo '<checkstyle version="'.Config::VERSION.'">'.PHP_EOL;

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -34,7 +34,7 @@ class Code implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if ($report['errors'] === 0 && $report['warnings'] === 0) {
             // Nothing to print.
@@ -340,10 +340,10 @@ class Code implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         if ($cachedData === '') {
             return;

--- a/src/Reports/Csv.php
+++ b/src/Reports/Csv.php
@@ -30,7 +30,7 @@ class Csv implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if ($report['errors'] === 0 && $report['warnings'] === 0) {
             // Nothing to print.
@@ -78,10 +78,10 @@ class Csv implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo 'File,Line,Column,Type,Message,Source,Severity,Fixable'.PHP_EOL;
         echo $cachedData;

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -32,7 +32,7 @@ class Diff implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $errors = $phpcsFile->getFixableCount();
         if ($errors === 0) {
@@ -106,10 +106,10 @@ class Diff implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo $cachedData;
         if ($toScreen === true && $cachedData !== '') {

--- a/src/Reports/Emacs.php
+++ b/src/Reports/Emacs.php
@@ -30,7 +30,7 @@ class Emacs implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if ($report['errors'] === 0 && $report['warnings'] === 0) {
             // Nothing to print.
@@ -78,10 +78,10 @@ class Emacs implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo $cachedData;
 

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -30,7 +30,7 @@ class Full implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if ($report['errors'] === 0 && $report['warnings'] === 0) {
             // Nothing to print.
@@ -238,10 +238,10 @@ class Full implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         if ($cachedData === '') {
             return;

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -30,7 +30,7 @@ class Info implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $metrics = $phpcsFile->getMetrics();
         foreach ($metrics as $metric => $data) {
@@ -66,10 +66,10 @@ class Info implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $lines = explode(PHP_EOL, $cachedData);
         array_pop($lines);

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -31,7 +31,7 @@ class Json implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $filename = str_replace('\\', '\\\\', $report['filename']);
         $filename = str_replace('"', '\"', $filename);
@@ -92,10 +92,10 @@ class Json implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo '{"totals":{"errors":'.$totalErrors.',"warnings":'.$totalWarnings.',"fixable":'.$totalFixable.'},"files":{';
         echo rtrim($cachedData, ',');

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -33,7 +33,7 @@ class Junit implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $out = new XMLWriter;
         $out->openMemory();
@@ -106,10 +106,10 @@ class Junit implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         // Figure out the total number of tests.
         $tests   = 0;

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -96,7 +96,7 @@ class Notifysend implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         echo $report['filename'].PHP_EOL;
 
@@ -129,10 +129,10 @@ class Notifysend implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $checkedFiles = explode(PHP_EOL, trim($cachedData));
 

--- a/src/Reports/Performance.php
+++ b/src/Reports/Performance.php
@@ -32,7 +32,7 @@ class Performance implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $times = $phpcsFile->getListenerTimes();
         foreach ($times as $sniff => $time) {
@@ -66,10 +66,10 @@ class Performance implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $lines = explode(PHP_EOL, $cachedData);
         array_pop($lines);

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -52,7 +52,7 @@ interface Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80);
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80);
 
 
     /**
@@ -77,10 +77,10 @@ interface Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     );
 
 

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -30,7 +30,7 @@ class Source implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if ($report['errors'] === 0 && $report['warnings'] === 0) {
             // Nothing to print.
@@ -86,10 +86,10 @@ class Source implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $lines = explode(PHP_EOL, $cachedData);
         array_pop($lines);

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -30,7 +30,7 @@ class Summary implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         if (PHP_CODESNIFFER_VERBOSITY === 0
             && $report['errors'] === 0
@@ -68,10 +68,10 @@ class Summary implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $lines = explode(PHP_EOL, $cachedData);
         array_pop($lines);

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -38,7 +38,7 @@ abstract class VersionControl implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $blames = $this->getBlameContent($phpcsFile->getFilename());
 
@@ -153,10 +153,10 @@ abstract class VersionControl implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         $errorsShown = ($totalErrors + $totalWarnings);
         if ($errorsShown === 0) {

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -32,7 +32,7 @@ class Xml implements Report
      *
      * @return bool
      */
-    public function generateFileReport(array $report, File $phpcsFile, bool $showSources=false, int $width=80)
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
     {
         $out = new XMLWriter;
         $out->openMemory();
@@ -112,10 +112,10 @@ class Xml implements Report
         int $totalErrors,
         int $totalWarnings,
         int $totalFixable,
-        bool $showSources=false,
-        int $width=80,
-        bool $interactive=false,
-        bool $toScreen=true
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
     ) {
         echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
         echo '<phpcs version="'.Config::VERSION.'">'.PHP_EOL;

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -529,7 +529,7 @@ class Ruleset
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException - If the ruleset path is invalid.
      *                                                      - If a specified autoload file could not be found.
      */
-    public function processRuleset(string $rulesetPath, int $depth=0)
+    public function processRuleset(string $rulesetPath, int $depth = 0)
     {
         $rulesetPath = Common::realpath($rulesetPath);
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -896,7 +896,7 @@ class Ruleset
      *
      * @return array
      */
-    private function expandSniffDirectory(string $directory, int $depth=0)
+    private function expandSniffDirectory(string $directory, int $depth = 0)
     {
         $sniffs = [];
 
@@ -958,7 +958,7 @@ class Ruleset
      * @return array
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the reference is invalid.
      */
-    private function expandRulesetReference(string $ref, string $rulesetDir, int $depth=0)
+    private function expandRulesetReference(string $ref, string $rulesetDir, int $depth = 0)
     {
         // Naming an (external) standard "Internal" is not supported.
         if (strtolower($ref) === 'internal') {
@@ -1140,7 +1140,7 @@ class Ruleset
      * @return void
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If rule settings are invalid.
      */
-    private function processRule(SimpleXMLElement $rule, array $newSniffs, int $depth=0)
+    private function processRule(SimpleXMLElement $rule, array $newSniffs, int $depth = 0)
     {
         $ref  = (string) $rule['ref'];
         $todo = [$ref];
@@ -1738,7 +1738,7 @@ class Ruleset
      *
      * @return array
      */
-    public function getIgnorePatterns(?string $listener=null)
+    public function getIgnorePatterns(?string $listener = null)
     {
         if ($listener === null) {
             return $this->ignorePatterns;
@@ -1764,7 +1764,7 @@ class Ruleset
      *
      * @return array
      */
-    public function getIncludePatterns(?string $listener=null)
+    public function getIncludePatterns(?string $listener = null)
     {
         if ($listener === null) {
             return $this->includePatterns;

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -71,7 +71,7 @@ abstract class AbstractScopeSniff implements Sniff
     public function __construct(
         array $scopeTokens,
         array $tokens,
-        bool $listenOutside=false
+        bool $listenOutside = false
     ) {
         if (empty($scopeTokens) === true) {
             $error = 'The scope tokens list cannot be empty';

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -80,7 +80,7 @@ class MultipleStatementAlignmentSniff implements Sniff
      *
      * @return int
      */
-    public function checkAlignment(File $phpcsFile, int $stackPtr, ?int $end=null)
+    public function checkAlignment(File $phpcsFile, int $stackPtr, ?int $end = null)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -58,7 +58,7 @@ class DeprecatedFunctionsSniff extends ForbiddenFunctionsSniff
      *
      * @return void
      */
-    protected function addError(File $phpcsFile, int $stackPtr, string $functionName, ?string $pattern=null)
+    protected function addError(File $phpcsFile, int $stackPtr, string $functionName, ?string $pattern = null)
     {
         $data  = [$functionName];
         $error = 'Function %s() has been deprecated';

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -86,7 +86,7 @@ class DisallowAlternativePHPTagsSniff implements Sniff
      *
      * @return string
      */
-    protected function getSnippet(string $content, string $start='', int $length=40)
+    protected function getSnippet(string $content, string $start = '', int $length = 40)
     {
         $startPos = 0;
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -146,7 +146,7 @@ class DisallowShortOpenTagSniff implements Sniff
      *
      * @return string
      */
-    protected function getSnippet(string $content, string $start='', int $length=40)
+    protected function getSnippet(string $content, string $start = '', int $length = 40)
     {
         $startPos = 0;
 

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -210,7 +210,7 @@ class ForbiddenFunctionsSniff implements Sniff
      *
      * @return void
      */
-    protected function addError(File $phpcsFile, int $stackPtr, string $functionName, ?string $pattern=null)
+    protected function addError(File $phpcsFile, int $stackPtr, string $functionName, ?string $pattern = null)
     {
         $data  = [$functionName];
         $error = 'The use of function %s() is ';

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowLongArraySyntaxUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowLongArraySyntaxUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -45,7 +45,7 @@ final class DuplicateClassNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'DuplicateClassNameUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -45,7 +45,7 @@ final class AssignmentInConditionUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'AssignmentInConditionUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -66,7 +66,7 @@ final class EmptyPHPStatementUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'EmptyPHPStatementUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
@@ -45,7 +45,7 @@ final class ForLoopShouldBeWhileLoopUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ForLoopShouldBeWhileLoopUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -45,7 +45,7 @@ final class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ForLoopWithTestFunctionCallUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
@@ -45,7 +45,7 @@ final class JumbledIncrementerUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'JumbledIncrementerUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -45,7 +45,7 @@ final class UnconditionalIfStatementUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'UnconditionalIfStatementUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -45,7 +45,7 @@ final class UnnecessaryFinalModifierUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'UnnecessaryFinalModifierUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -45,7 +45,7 @@ final class UnusedFunctionParameterUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'UnusedFunctionParameterUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -45,7 +45,7 @@ final class UselessOverridingMethodUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'UselessOverridingMethodUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -46,7 +46,7 @@ final class DocCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DocCommentUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -30,7 +30,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'InlineControlStructureUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -30,7 +30,7 @@ final class ByteOrderMarkUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ByteOrderMarkUnitTest.1.inc':
@@ -55,7 +55,7 @@ final class ByteOrderMarkUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ByteOrderMarkUnitTest.3.inc':

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -30,7 +30,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'EndFileNewlineUnitTest.3.inc':
@@ -56,7 +56,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -30,7 +30,7 @@ final class EndFileNoNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'EndFileNoNewlineUnitTest.1.inc':
@@ -58,7 +58,7 @@ final class EndFileNoNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -43,7 +43,7 @@ final class ExecutableFileUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ExecutableFileUnitTest.2.inc':
@@ -66,7 +66,7 @@ final class ExecutableFileUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -30,7 +30,7 @@ final class InlineHTMLUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'InlineHTMLUnitTest.3.inc':
@@ -59,7 +59,7 @@ final class InlineHTMLUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -46,7 +46,7 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'LineLengthUnitTest.1.inc':
@@ -78,7 +78,7 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'LineLengthUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
@@ -51,7 +51,7 @@ final class LowercasedFilenameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'LowercasedFilenameUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -30,7 +30,7 @@ final class SpaceAfterCastUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'SpaceAfterCastUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -30,7 +30,7 @@ final class SpaceAfterNotUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'SpaceAfterNotUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionCallArgumentSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionCallArgumentSpacingUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -48,7 +48,7 @@ final class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffTe
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'OpeningFunctionBraceKernighanRitchieUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -30,7 +30,7 @@ final class CyclomaticComplexityUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'CyclomaticComplexityUnitTest.1.inc':
@@ -52,7 +52,7 @@ final class CyclomaticComplexityUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'CyclomaticComplexityUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
@@ -30,7 +30,7 @@ final class NestingLevelUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'NestingLevelUnitTest.1.inc':
@@ -52,7 +52,7 @@ final class NestingLevelUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'NestingLevelUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/AbstractClassNamePrefixUnitTest.php
@@ -29,7 +29,7 @@ final class AbstractClassNamePrefixUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'AbstractClassNamePrefixUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -30,7 +30,7 @@ final class CamelCapsFunctionNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'CamelCapsFunctionNameUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -30,7 +30,7 @@ final class ConstructorNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ConstructorNameUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
@@ -29,7 +29,7 @@ final class InterfaceNameSuffixUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'InterfaceNameSuffixUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/TraitNameSuffixUnitTest.php
@@ -29,7 +29,7 @@ final class TraitNameSuffixUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'TraitNameSuffixUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -30,7 +30,7 @@ final class UpperCaseConstantNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'UpperCaseConstantNameUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -30,7 +30,7 @@ final class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'CharacterBeforePHPOpeningTagUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -30,7 +30,7 @@ final class ClosingPHPTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClosingPHPTagUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowAlternativePHPTagsUnitTest.1.inc':
@@ -58,7 +58,7 @@ final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         if ($testFile === 'DisallowAlternativePHPTagsUnitTest.2.inc') {
             // Check if the Internal.NoCodeFound error can be expected on line 1.

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -54,7 +54,7 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowShortOpenTagUnitTest.1.inc':
@@ -88,7 +88,7 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowShortOpenTagUnitTest.3.inc':

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -30,7 +30,7 @@ final class LowerCaseConstantUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'LowerCaseConstantUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -30,7 +30,7 @@ final class LowerCaseTypeUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'LowerCaseTypeUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -30,7 +30,7 @@ final class RequireStrictTypesUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'RequireStrictTypesUnitTest.2.inc':
@@ -53,7 +53,7 @@ final class RequireStrictTypesUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'RequireStrictTypesUnitTest.11.inc':

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -34,7 +34,7 @@ final class SyntaxUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'SyntaxUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryHeredocUnitTest.php
@@ -45,7 +45,7 @@ final class UnnecessaryHeredocUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         $warnings = [
             100 => 1,

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -30,7 +30,7 @@ final class UnnecessaryStringConcatUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'UnnecessaryStringConcatUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -30,7 +30,7 @@ final class GitMergeConflictUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'GitMergeConflictUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ArbitraryParenthesesSpacingUnitTest.1.inc':
@@ -87,7 +87,7 @@ final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ArbitraryParenthesesSpacingUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -50,7 +50,7 @@ final class DisallowSpaceIndentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowSpaceIndentUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -46,7 +46,7 @@ final class DisallowTabIndentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowTabIndentUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class LanguageConstructSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'LanguageConstructSpacingUnitTest.1.inc':

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -53,7 +53,7 @@ final class ScopeIndentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         if ($testFile === 'ScopeIndentUnitTest.3.inc') {
             return [

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -30,7 +30,7 @@ final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'SpreadOperatorSpacingAfterUnitTest.1.inc':

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -371,7 +371,7 @@ class FunctionDeclarationSniff implements Sniff
      *
      * @return void
      */
-    public function processArgumentList(File $phpcsFile, int $stackPtr, int $indent, string $type='function')
+    public function processArgumentList(File $phpcsFile, int $stackPtr, int $indent, string $type = 'function')
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -50,7 +50,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassDeclarationUnitTest.1.inc':
@@ -87,7 +87,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return[];
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -30,7 +30,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassCommentUnitTest.1.inc':
@@ -80,7 +80,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassCommentUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -30,7 +30,7 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':
@@ -74,7 +74,7 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionCommentUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionDeclarationUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -30,7 +30,7 @@ final class ValidDefaultValueUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidDefaultValueUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -30,7 +30,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidFunctionNameUnitTest.1.inc':

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -30,7 +30,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidVariableNameUnitTest.1.inc':

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         if ($testFile === 'ClassDeclarationUnitTest.2.inc') {
             return [];

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -48,7 +48,7 @@ final class SideEffectsUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         return [];
 
@@ -65,7 +65,7 @@ final class SideEffectsUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'SideEffectsUnitTest.3.inc':

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -30,7 +30,7 @@ final class CamelCapsMethodNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'CamelCapsMethodNameUnitTest.1.inc':

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -30,7 +30,7 @@ final class DeclareStatementUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DeclareStatementUnitTest.1.inc':

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -30,7 +30,7 @@ final class FileHeaderUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FileHeaderUnitTest.2.inc':

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -30,7 +30,7 @@ final class OpenTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'OpenTagUnitTest.2.inc':

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'OperatorSpacingUnitTest.1.inc':

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -45,7 +45,7 @@ final class ConstantVisibilityUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ConstantVisibilityUnitTest.1.inc':

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class PropertyDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'PropertyDeclarationUnitTest.1.inc':
@@ -103,7 +103,7 @@ final class PropertyDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'PropertyDeclarationUnitTest.1.inc':

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -30,7 +30,7 @@ final class ClosingTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClosingTagUnitTest.1.inc':

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -30,7 +30,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'EndFileNewlineUnitTest.1.inc':
@@ -61,7 +61,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class MethodDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'MethodDeclarationUnitTest.1.inc':
@@ -69,7 +69,7 @@ final class MethodDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'MethodDeclarationUnitTest.1.inc':

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class UseDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'UseDeclarationUnitTest.2.inc':

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -653,7 +653,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      *
      * @return void
      */
-    protected function checkSpacingAfterParamType(File $phpcsFile, array $param, int $maxType, int $spacing=1)
+    protected function checkSpacingAfterParamType(File $phpcsFile, array $param, int $maxType, int $spacing = 1)
     {
         // Check number of spaces after the type.
         $spaces = ($maxType - strlen($param['type']) + $spacing);
@@ -712,7 +712,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      *
      * @return void
      */
-    protected function checkSpacingAfterParamName(File $phpcsFile, array $param, int $maxVar, int $spacing=1)
+    protected function checkSpacingAfterParamName(File $phpcsFile, array $param, int $maxVar, int $spacing = 1)
     {
         // Check number of spaces after the var name.
         $spaces = ($maxVar - strlen($param['var']) + $spacing);

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -175,7 +175,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
      *
      * @return void
      */
-    public function processBracket(File $phpcsFile, int $openBracket, array $tokens, string $type='function')
+    public function processBracket(File $phpcsFile, int $openBracket, array $tokens, string $type = 'function')
     {
         $errorPrefix = '';
         if ($type === 'use') {

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class ArrayDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ArrayDeclarationUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -71,7 +71,7 @@ final class ClassFileNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassFileNameUnitTest.inc':

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -30,7 +30,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassCommentUnitTest.1.inc':
@@ -65,7 +65,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ClassCommentUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -30,7 +30,7 @@ final class ClosingDeclarationCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClosingDeclarationCommentUnitTest.1.inc':
@@ -76,7 +76,7 @@ final class ClosingDeclarationCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -30,7 +30,7 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FileCommentUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionCommentUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionCommentUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -30,7 +30,7 @@ final class ControlSignatureUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
 
         switch ($testFile) {

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class ForLoopDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ForLoopDeclarationUnitTest.1.inc':
@@ -84,7 +84,7 @@ final class ForLoopDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         return [];
 

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
@@ -30,7 +30,7 @@ final class FileExtensionUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FileExtensionUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -30,7 +30,7 @@ final class OperatorBracketUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'OperatorBracketUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffTest
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionDeclarationArgumentSpacingUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionDeclarationUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -45,7 +45,7 @@ final class GlobalFunctionUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'GlobalFunctionUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -30,7 +30,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidFunctionNameUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -30,7 +30,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidVariableNameUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -30,7 +30,7 @@ final class DisallowMultipleAssignmentsUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'DisallowMultipleAssignmentsUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -30,7 +30,7 @@ final class EmbeddedPhpUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'EmbeddedPhpUnitTest.1.inc':
@@ -233,7 +233,7 @@ final class EmbeddedPhpUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         if ($testFile === 'EmbeddedPhpUnitTest.24.inc'
             && (bool) ini_get('short_open_tag') === false

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -30,7 +30,7 @@ final class HeredocUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'HeredocUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -45,7 +45,7 @@ final class NonExecutableCodeUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'NonExecutableCodeUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -30,7 +30,7 @@ final class MemberVarScopeUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'MemberVarScopeUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -30,7 +30,7 @@ final class MethodScopeUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'MethodScopeUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'FunctionSpacingUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class MemberVarSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'MemberVarSpacingUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'OperatorSpacingUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -30,7 +30,7 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ScopeKeywordSpacingUnitTest.1.inc':

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -30,7 +30,7 @@ final class SuperfluousWhitespaceUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'SuperfluousWhitespaceUnitTest.1.inc':

--- a/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
@@ -30,7 +30,7 @@ final class ClosingTagUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ClosingTagUnitTest.1.inc':

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -30,7 +30,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='')
+    public function getErrorList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidVariableNameUnitTest.1.inc':
@@ -90,7 +90,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
      *
      * @return array<int, int>
      */
-    public function getWarningList($testFile='')
+    public function getWarningList($testFile = '')
     {
         switch ($testFile) {
         case 'ValidVariableNameUnitTest.1.inc':

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -109,7 +109,7 @@ abstract class Tokenizer
      * @return void
      * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
-    public function __construct(string $content, ?Config $config, string $eolChar='\n')
+    public function __construct(string $content, ?Config $config, string $eolChar = '\n')
     {
         $this->eolChar = $eolChar;
 
@@ -140,7 +140,7 @@ abstract class Tokenizer
      *
      * @return boolean
      */
-    protected function isMinifiedContent(string $content, string $eolChar='\n')
+    protected function isMinifiedContent(string $content, string $eolChar = '\n')
     {
         // Minified files often have a very large number of characters per line
         // and cause issues when tokenizing.
@@ -501,7 +501,7 @@ abstract class Tokenizer
      *
      * @return void
      */
-    public function replaceTabsInToken(array &$token, string $prefix=' ', string $padding=' ', ?int $tabWidth=null)
+    public function replaceTabsInToken(array &$token, string $prefix = ' ', string $padding = ' ', ?int $tabWidth = null)
     {
         $checkEncoding = false;
         if (function_exists('iconv_strlen') === true) {
@@ -841,7 +841,7 @@ abstract class Tokenizer
      * @return int The position in the stack that closed the scope.
      * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the nesting level gets too deep.
      */
-    private function recurseScopeMap(int $stackPtr, int $depth=1, int &$ignore=0)
+    private function recurseScopeMap(int $stackPtr, int $depth = 1, int &$ignore = 0)
     {
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write("=> Begin scope map recursion at token $stackPtr with depth $depth", $depth);

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -307,7 +307,7 @@ class Cache
      *
      * @return mixed
      */
-    public static function get(?string $key=null)
+    public static function get(?string $key = null)
     {
         if ($key === null) {
             return self::$cache;

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -285,7 +285,7 @@ class Common
      *
      * @return string
      */
-    public static function prepareForOutput(string $content, array $exclude=[])
+    public static function prepareForOutput(string $content, array $exclude = [])
     {
         if (PHP_OS_FAMILY === 'Windows') {
             if (in_array("\r", $exclude, true) === false) {
@@ -358,9 +358,9 @@ class Common
      */
     public static function isCamelCaps(
         string $name,
-        bool $classFormat=false,
-        bool $visibilityPublic=true,
-        bool $strict=true
+        bool $classFormat = false,
+        bool $visibilityPublic = true,
+        bool $strict = true
     ) {
         // Check the first character first.
         if ($classFormat === false) {

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -137,7 +137,7 @@ final class Help
      * @param array<string>           $longOptions  The long options which should be shown.
      * @param string                  $shortOptions The short options which should be shown.
      */
-    public function __construct(Config $config, array $longOptions, string $shortOptions='')
+    public function __construct(Config $config, array $longOptions, string $shortOptions = '')
     {
         $this->config           = $config;
         $this->requestedOptions = array_merge($longOptions, str_split($shortOptions));

--- a/src/Util/MessageCollector.php
+++ b/src/Util/MessageCollector.php
@@ -96,7 +96,7 @@ final class MessageCollector
      * @throws \InvalidArgumentException If the message text is not a string.
      * @throws \InvalidArgumentException If the message type is not one of the accepted types.
      */
-    public function add($message, $type=self::NOTICE)
+    public function add($message, $type = self::NOTICE)
     {
         if (is_string($message) === false) {
             throw new InvalidArgumentException('The $message should be of type string. Received: '.gettype($message).'.');
@@ -146,7 +146,7 @@ final class MessageCollector
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException When there are blocking errors.
      */
-    public function display(string $order=self::ORDERBY_SEVERITY)
+    public function display(string $order = self::ORDERBY_SEVERITY)
     {
         if ($this->cache === []) {
             return;

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -77,8 +77,8 @@ class Standards
      * @see    getInstalledStandardPaths()
      */
     public static function getInstalledStandardDetails(
-        bool $includeGeneric=false,
-        string $standardsDir=''
+        bool $includeGeneric = false,
+        string $standardsDir = ''
     ) {
         $rulesets = [];
 
@@ -166,8 +166,8 @@ class Standards
      * @see    isInstalledStandard()
      */
     public static function getInstalledStandards(
-        bool $includeGeneric=false,
-        string $standardsDir=''
+        bool $includeGeneric = false,
+        string $standardsDir = ''
     ) {
         $installedStandards = [];
 

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -132,7 +132,7 @@ final class Timing
      *
      * @return void
      */
-    public static function printRunTime(bool $force=false)
+    public static function printRunTime(bool $force = false)
     {
         if ($force === false && self::$printed === true) {
             // A double call.

--- a/src/Util/Writers/StatusWriter.php
+++ b/src/Util/Writers/StatusWriter.php
@@ -60,7 +60,7 @@ final class StatusWriter
      *
      * @return void
      */
-    public static function write(string $message, int $indent=0, int $newlines=1)
+    public static function write(string $message, int $indent = 0, int $newlines = 1)
     {
         if (self::$paused === true) {
             return;
@@ -83,7 +83,7 @@ final class StatusWriter
      *
      * @return void
      */
-    public static function forceWrite(string $message, int $indent=0, int $newlines=1)
+    public static function forceWrite(string $message, int $indent = 0, int $newlines = 1)
     {
         if ($indent > 0) {
             $message = str_repeat("\t", $indent).$message;
@@ -106,7 +106,7 @@ final class StatusWriter
      *
      * @return void
      */
-    public static function writeNewline(int $nr=1)
+    public static function writeNewline(int $nr = 1)
     {
         self::write('', 0, $nr);
 
@@ -121,7 +121,7 @@ final class StatusWriter
      *
      * @return void
      */
-    public static function forceWriteNewline(int $nr=1)
+    public static function forceWriteNewline(int $nr = 1)
     {
         self::forceWrite('', 0, $nr);
 

--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -56,7 +56,7 @@ final class ConfigDouble extends Config
      *
      * @return void
      */
-    public function __construct(array $cliArgs=[], bool $skipSettingStandard=false, bool $skipSettingReportWidth=false)
+    public function __construct(array $cliArgs = [], bool $skipSettingStandard = false, bool $skipSettingReportWidth = false)
     {
         $this->skipSettingStandard = $skipSettingStandard;
 

--- a/tests/Core/AbstractMethodTestCase.php
+++ b/tests/Core/AbstractMethodTestCase.php
@@ -149,7 +149,7 @@ abstract class AbstractMethodTestCase extends TestCase
      *
      * @return int
      */
-    public function getTargetToken($commentString, $tokenType, $tokenContent=null)
+    public function getTargetToken($commentString, $tokenType, $tokenContent = null)
     {
         return self::getTargetTokenFromFile(self::$phpcsFile, $commentString, $tokenType, $tokenContent);
 
@@ -172,7 +172,7 @@ abstract class AbstractMethodTestCase extends TestCase
      * @throws \Exception When the test delimiter comment is not found.
      * @throws \Exception When the test target token is not found.
      */
-    public static function getTargetTokenFromFile(File $phpcsFile, $commentString, $tokenType, $tokenContent=null)
+    public static function getTargetTokenFromFile(File $phpcsFile, $commentString, $tokenType, $tokenContent = null)
     {
         $start   = ($phpcsFile->numTokens - 1);
         $comment = $phpcsFile->findPrevious(

--- a/tests/Core/Config/IniSetTest.php
+++ b/tests/Core/Config/IniSetTest.php
@@ -272,7 +272,7 @@ final class IniSetTest extends TestCase
      *
      * @return void
      */
-    public function testIniValueCannotBeUpdatedAtRuntime($option, $newValue, $alternativeValue='')
+    public function testIniValueCannotBeUpdatedAtRuntime($option, $newValue, $alternativeValue = '')
     {
         $this->expectException(DeepExitException::class);
         $this->expectExceptionMessage("ERROR: Ini option \"$option\" cannot be changed at runtime.");

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -36,7 +36,7 @@ final class ErrorSuppressionTest extends TestCase
      *
      * @return void
      */
-    public function testSuppressError($before, $after, $expectedErrors=0)
+    public function testSuppressError($before, $after, $expectedErrors = 0)
     {
         static $config, $ruleset;
 
@@ -150,7 +150,7 @@ final class ErrorSuppressionTest extends TestCase
      *
      * @return void
      */
-    public function testSuppressSomeErrors($before, $between, $expectedErrors=1)
+    public function testSuppressSomeErrors($before, $between, $expectedErrors = 1)
     {
         static $config, $ruleset;
 
@@ -232,7 +232,7 @@ EOD;
      *
      * @return void
      */
-    public function testSuppressWarning($before, $after, $expectedWarnings=0)
+    public function testSuppressWarning($before, $after, $expectedWarnings = 0)
     {
         static $config, $ruleset;
 
@@ -306,7 +306,7 @@ EOD;
      *
      * @return void
      */
-    public function testSuppressLine($before, $after='', $expectedErrors=1)
+    public function testSuppressLine($before, $after = '', $expectedErrors = 1)
     {
         static $config, $ruleset;
 
@@ -538,7 +538,7 @@ EOD;
      *
      * @return void
      */
-    public function testSuppressScope($before, $after, $expectedErrors=0)
+    public function testSuppressScope($before, $after, $expectedErrors = 0)
     {
         static $config, $ruleset;
 
@@ -624,7 +624,7 @@ EOD;
      *
      * @return void
      */
-    public function testSuppressFile($before, $after='', $expectedWarnings=0)
+    public function testSuppressFile($before, $after = '', $expectedWarnings = 0)
     {
         static $config, $ruleset;
 
@@ -718,7 +718,7 @@ EOD;
      *
      * @return void
      */
-    public function testDisableSelected($before, $expectedErrors=0, $expectedWarnings=0)
+    public function testDisableSelected($before, $expectedErrors = 0, $expectedWarnings = 0)
     {
         static $config, $ruleset;
 

--- a/tests/Core/Files/File/GetDeclarationNameTest.php
+++ b/tests/Core/Files/File/GetDeclarationNameTest.php
@@ -92,7 +92,7 @@ final class GetDeclarationNameTest extends AbstractMethodTestCase
      *
      * @return void
      */
-    public function testGetDeclarationName($testMarker, $expected, $targetType=null)
+    public function testGetDeclarationName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
             $targetType = [

--- a/tests/Core/Files/File/GetMethodParametersTest.php
+++ b/tests/Core/Files/File/GetMethodParametersTest.php
@@ -123,7 +123,7 @@ final class GetMethodParametersTest extends AbstractMethodTestCase
      *
      * @return void
      */
-    public function testNoParams($commentString, $targetTokenType=[T_FUNCTION, T_CLOSURE, T_FN])
+    public function testNoParams($commentString, $targetTokenType = [T_FUNCTION, T_CLOSURE, T_FN])
     {
         $target = $this->getTargetToken($commentString, $targetTokenType);
         $result = self::$phpcsFile->getMethodParameters($target);
@@ -3289,7 +3289,7 @@ final class GetMethodParametersTest extends AbstractMethodTestCase
      *
      * @return void
      */
-    private function getMethodParametersTestHelper($commentString, $expected, $targetType=[T_FUNCTION, T_CLOSURE, T_FN])
+    private function getMethodParametersTestHelper($commentString, $expected, $targetType = [T_FUNCTION, T_CLOSURE, T_FN])
     {
         $target = $this->getTargetToken($commentString, $targetType);
         $found  = self::$phpcsFile->getMethodParameters($target);

--- a/tests/Core/Files/FileList/AddFileTest.php
+++ b/tests/Core/Files/FileList/AddFileTest.php
@@ -50,7 +50,7 @@ final class AddFileTest extends AbstractFileListTestCase
      *
      * @return void
      */
-    public function testAddFile($fileName, $fileObject=null)
+    public function testAddFile($fileName, $fileObject = null)
     {
         $this->assertCount(0, $this->fileList);
 

--- a/tests/Core/Filters/AbstractFilterTestCase.php
+++ b/tests/Core/Filters/AbstractFilterTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractFilterTestCase extends TestCase
      *
      * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockedClass($className, array $constructorArgs=[], $methodsToMock=null)
+    protected function getMockedClass($className, array $constructorArgs = [], $methodsToMock = null)
     {
         $mockedObj = $this->getMockBuilder($className);
 

--- a/tests/Core/Ruleset/AbstractRulesetTestCase.php
+++ b/tests/Core/Ruleset/AbstractRulesetTestCase.php
@@ -25,7 +25,7 @@ abstract class AbstractRulesetTestCase extends TestCase
      *
      * @return void
      */
-    protected function assertXObjectHasProperty($propertyName, $object, $message='')
+    protected function assertXObjectHasProperty($propertyName, $object, $message = '')
     {
         if (method_exists($this, 'assertObjectHasProperty') === true) {
             $this->assertObjectHasProperty($propertyName, $object, $message);
@@ -47,7 +47,7 @@ abstract class AbstractRulesetTestCase extends TestCase
      *
      * @return void
      */
-    protected function assertXObjectNotHasProperty($propertyName, $object, $message='')
+    protected function assertXObjectNotHasProperty($propertyName, $object, $message = '')
     {
         if (method_exists($this, 'assertObjectNotHasProperty') === true) {
             $this->assertObjectNotHasProperty($propertyName, $object, $message);

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -78,7 +78,7 @@ final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
      *
      * @return void
      */
-    public function testDeprecatedSniffsListDoesNotShow($standard, $additionalArgs=[])
+    public function testDeprecatedSniffsListDoesNotShow($standard, $additionalArgs = [])
     {
         $args   = $additionalArgs;
         $args[] = '.';
@@ -134,7 +134,7 @@ final class ShowSniffDeprecationsTest extends AbstractRulesetTestCase
      *
      * @return void
      */
-    public function testDeprecatedSniffsListDoesNotShowNeedsCsMode($standard, $additionalArgs=[])
+    public function testDeprecatedSniffsListDoesNotShowNeedsCsMode($standard, $additionalArgs = [])
     {
         if (PHP_CODESNIFFER_CBF === true) {
             $this->markTestSkipped('This test needs CS mode to run');

--- a/tests/Core/Runner/PrintProgressDotsTest.php
+++ b/tests/Core/Runner/PrintProgressDotsTest.php
@@ -196,7 +196,7 @@ final class PrintProgressDotsTest extends TestCase
      *
      * @return void
      */
-    private function checkProgressDot($colors, $code, $sniffs, $expected, $enableFixer=false)
+    private function checkProgressDot($colors, $code, $sniffs, $expected, $enableFixer = false)
     {
         $this->expectNoStdoutOutput();
 

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -104,7 +104,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
      *
      * @return int
      */
-    protected function getTargetToken($commentString, $tokenType, $tokenContent=null)
+    protected function getTargetToken($commentString, $tokenType, $tokenContent = null)
     {
         return AbstractMethodTestCase::getTargetTokenFromFile($this->phpcsFile, $commentString, $tokenType, $tokenContent);
 

--- a/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
@@ -26,7 +26,7 @@ final class ArrayKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testArrayKeyword($testMarker, $testContent='array')
+    public function testArrayKeyword($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -84,7 +84,7 @@ final class ArrayKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testArrayType($testMarker, $testContent='array')
+    public function testArrayType($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -158,7 +158,7 @@ final class ArrayKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotArrayKeyword($testMarker, $testContent='array')
+    public function testNotArrayKeyword($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
@@ -139,7 +139,7 @@ final class BackfillEnumTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotEnums($testMarker, $testContent, $expectedType='T_STRING')
+    public function testNotEnums($testMarker, $testContent, $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_ENUM => T_ENUM];

--- a/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
@@ -838,7 +838,7 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotAnArrowFunction($testMarker, $testContent='fn', $expectedType='T_STRING')
+    public function testNotAnArrowFunction($testMarker, $testContent = 'fn', $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_FN => T_FN];
@@ -942,7 +942,7 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    private function backfillHelper($token, $skipScopeCloserCheck=false)
+    private function backfillHelper($token, $skipScopeCloserCheck = false)
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -994,7 +994,7 @@ final class BackfillFnTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    private function scopePositionTestHelper($token, $openerOffset, $closerOffset, $expectedCloserType='semicolon')
+    private function scopePositionTestHelper($token, $openerOffset, $closerOffset, $expectedCloserType = 'semicolon')
     {
         $tokens = $this->phpcsFile->getTokens();
         $expectedScopeOpener = ($token + $openerOffset);

--- a/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
@@ -30,7 +30,7 @@ final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testMatchExpression($testMarker, $openerOffset, $closerOffset, $testContent='match')
+    public function testMatchExpression($testMarker, $openerOffset, $closerOffset, $testContent = 'match')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -213,7 +213,7 @@ final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotAMatchStructure($testMarker, $testContent='match', $expectedType='T_STRING')
+    public function testNotAMatchStructure($testMarker, $testContent = 'match', $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_MATCH => T_MATCH];
@@ -484,7 +484,7 @@ final class BackfillMatchTokenTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    private function scopeTestHelper($token, $openerOffset, $closerOffset, $skipScopeCloserCheck=false)
+    private function scopeTestHelper($token, $openerOffset, $closerOffset, $skipScopeCloserCheck = false)
     {
         $tokens     = $this->phpcsFile->getTokens();
         $tokenArray = $tokens[$token];

--- a/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
@@ -28,7 +28,7 @@ final class BackfillReadonlyTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testReadonly($testMarker, $testContent='readonly')
+    public function testReadonly($testMarker, $testContent = 'readonly')
     {
         $tokens     = $this->phpcsFile->getTokens();
         $target     = $this->getTargetToken($testMarker, [T_READONLY, T_STRING], $testContent);
@@ -187,7 +187,7 @@ final class BackfillReadonlyTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotReadonly($testMarker, $testContent='readonly', $expectedType='T_STRING')
+    public function testNotReadonly($testMarker, $testContent = 'readonly', $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_READONLY => T_READONLY];

--- a/tests/Core/Tokenizers/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesTest.php
@@ -28,7 +28,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNormalParentheses($testMarker, $skipCheckInside=false)
+    public function testNormalParentheses($testMarker, $skipCheckInside = false)
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
@@ -31,7 +31,7 @@ final class DefaultKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testMatchDefault($testMarker, $testContent='default')
+    public function testMatchDefault($testMarker, $testContent = 'default')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -111,7 +111,7 @@ final class DefaultKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testSwitchDefault($testMarker, $testContent='default')
+    public function testSwitchDefault($testMarker, $testContent = 'default')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -169,7 +169,7 @@ final class DefaultKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotDefaultKeyword($testMarker, $testContent='DEFAULT', $expectedType='T_STRING')
+    public function testNotDefaultKeyword($testMarker, $testContent = 'DEFAULT', $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [

--- a/tests/Core/Tokenizers/PHP/ExitKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/ExitKeywordTest.php
@@ -123,7 +123,7 @@ final class ExitKeywordTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotExitKeyword($testMarker, $testContent, $expected='T_STRING')
+    public function testNotExitKeyword($testMarker, $testContent, $expected = 'T_STRING')
     {
         $tokens    = $this->phpcsFile->getTokens();
         $tokenCode = constant($expected);

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.php
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.php
@@ -189,7 +189,7 @@ final class GotoLabelTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotAGotoDeclaration($testMarker, $testContent, $expectedType='T_STRING')
+    public function testNotAGotoDeclaration($testMarker, $testContent, $expectedType = 'T_STRING')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [T_GOTO_LABEL => T_GOTO_LABEL];

--- a/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
@@ -95,7 +95,7 @@ final class NullsafeObjectOperatorTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testTernaryThen($testMarker, $testObjectOperator=false)
+    public function testTernaryThen($testMarker, $testObjectOperator = false)
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
@@ -26,7 +26,7 @@ final class CreateParenthesisNestingMapDNFTypesTest extends AbstractTokenizerTes
      *
      * @return void
      */
-    public function testNormalParentheses($testMarker, $owner=false)
+    public function testNormalParentheses($testMarker, $owner = false)
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/Tokenizer/CreatePositionMapYieldFromTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreatePositionMapYieldFromTest.php
@@ -32,7 +32,7 @@ final class CreatePositionMapYieldFromTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testYieldFromTabReplacement($testMarker, $expected, $content=null)
+    public function testYieldFromTabReplacement($testMarker, $expected, $content = null)
     {
         $tokens = $this->phpcsFile->getTokens();
         $target = $this->getTargetToken($testMarker, [T_YIELD_FROM], $content);

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
@@ -26,7 +26,7 @@ final class CreateTokenMapArrayParenthesesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testArrayKeyword($testMarker, $testContent='array')
+    public function testArrayKeyword($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -88,7 +88,7 @@ final class CreateTokenMapArrayParenthesesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testArrayType($testMarker, $testContent='array')
+    public function testArrayType($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -166,7 +166,7 @@ final class CreateTokenMapArrayParenthesesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNotArrayKeyword($testMarker, $testContent='array')
+    public function testNotArrayKeyword($testMarker, $testContent = 'array')
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesTest.php
@@ -79,7 +79,7 @@ final class CreateTokenMapClosureUseParenthesesTest extends AbstractTokenizerTes
      *
      * @return void
      */
-    public function testUseNotClosureNextOpenClose($testMarker, $expectedOwnerCode=null)
+    public function testUseNotClosureNextOpenClose($testMarker, $expectedOwnerCode = null)
     {
         $tokens = $this->phpcsFile->getTokens();
         $opener = $this->getTargetToken($testMarker, T_OPEN_PARENTHESIS);

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapCaseKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapCaseKeywordConditionsTest.php
@@ -76,7 +76,7 @@ final class RecurseScopeMapCaseKeywordConditionsTest extends AbstractTokenizerTe
      *
      * @return void
      */
-    public function testNotEnumCases($testMarker, $expectedTokens, $testCloserMarker=null)
+    public function testNotEnumCases($testMarker, $expectedTokens, $testCloserMarker = null)
     {
         $tokens     = $this->phpcsFile->getTokens();
         $caseIndex  = $this->getTargetToken($testMarker, [T_ENUM_CASE, T_CASE]);

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -44,7 +44,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      *
      * @return void
      */
-    public function testMatchDefault($testMarker, $testContent='default')
+    public function testMatchDefault($testMarker, $testContent = 'default')
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -154,7 +154,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      *
      * @return void
      */
-    public function testSwitchDefault($testMarker, $openerMarker, $closerMarker, $conditionStopMarker=null, $testContent='default', $sharedScopeCloser=false)
+    public function testSwitchDefault($testMarker, $openerMarker, $closerMarker, $conditionStopMarker = null, $testContent = 'default', $sharedScopeCloser = false)
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -356,7 +356,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
      *
      * @return void
      */
-    public function testNotDefaultKeyword($testMarker, $testContent='DEFAULT')
+    public function testNotDefaultKeyword($testMarker, $testContent = 'DEFAULT')
     {
         $targetTypes  = Tokens::NAME_TOKENS;
         $targetTypes += [

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapSwitchTokenScopeTest.php
@@ -32,7 +32,7 @@ final class RecurseScopeMapSwitchTokenScopeTest extends AbstractTokenizerTestCas
      *
      * @return void
      */
-    public function testSwitchScope($testMarker, $expectedTokens, $testOpenerMarker=null, $testCloserMarker=null)
+    public function testSwitchScope($testMarker, $expectedTokens, $testOpenerMarker = null, $testCloserMarker = null)
     {
         $tokens      = $this->phpcsFile->getTokens();
         $switchIndex = $this->getTargetToken($testMarker, [T_SWITCH]);

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
@@ -28,7 +28,7 @@ final class RecurseScopeMapWithNamespaceOperatorTest extends AbstractTokenizerTe
      *
      * @return void
      */
-    public function testScopeSetting($testMarker, $tokenTypes, $open=[T_OPEN_CURLY_BRACKET], $close=[T_CLOSE_CURLY_BRACKET])
+    public function testScopeSetting($testMarker, $tokenTypes, $open = [T_OPEN_CURLY_BRACKET], $close = [T_CLOSE_CURLY_BRACKET])
     {
         $tokens = $this->phpcsFile->getTokens();
 

--- a/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenTestCase.php
+++ b/tests/Core/Tokenizers/Tokenizer/ReplaceTabsInTokenTestCase.php
@@ -78,7 +78,7 @@ abstract class ReplaceTabsInTokenTestCase extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testNoReplacementsAreMadeWhenNoTabsAreFound($testMarker, $testTarget, $expected, $offset=0)
+    public function testNoReplacementsAreMadeWhenNoTabsAreFound($testMarker, $testTarget, $expected, $offset = 0)
     {
         $tokens  = $this->phpcsFile->getTokens();
         $target  = $this->getTargetToken($testMarker, $testTarget);
@@ -145,7 +145,7 @@ abstract class ReplaceTabsInTokenTestCase extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testTabReplacement($testMarker, $testTarget, $expected, $offset=0)
+    public function testTabReplacement($testMarker, $testTarget, $expected, $offset = 0)
     {
         $tokens  = $this->phpcsFile->getTokens();
         $target  = $this->getTargetToken($testMarker, $testTarget);

--- a/tests/Core/Util/Common/EscapeshellcmdTest.php
+++ b/tests/Core/Util/Common/EscapeshellcmdTest.php
@@ -34,7 +34,7 @@ final class EscapeshellcmdTest extends TestCase
      *
      * @return void
      */
-    public function testEscapeshellcmd($command, $expected, $expectedWin=null)
+    public function testEscapeshellcmd($command, $expected, $expectedWin = null)
     {
         if (PHP_OS_FAMILY === 'Windows' && empty($expectedWin) === false) {
             $expected = $expectedWin;

--- a/tests/Core/Util/Help/HelpTest.php
+++ b/tests/Core/Util/Help/HelpTest.php
@@ -723,7 +723,7 @@ final class HelpTest extends TestCase
      *
      * @return mixed
      */
-    private function invokeReflectionMethod(Help $help, $methodName, $params=null)
+    private function invokeReflectionMethod(Help $help, $methodName, $params = null)
     {
         $reflMethod = new ReflectionMethod($help, $methodName);
         (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);


### PR DESCRIPTION
# Description

* CS: always have spaces around equal sign in function declaration

## Suggested changelog entry
_N/A_


## Related issues/external references

Part of a series of PRs to address #155
