### PR TITLE
CS: normalize code style rules [6]

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -92,7 +92,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                 } else {
                     self::$composerAutoloader = false;
                 }
-            }//end if
+            }
 
             $ds   = DIRECTORY_SEPARATOR;
             $path = false;
@@ -332,4 +332,4 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
     // it gets a chance to hear about every autoload request, and record
     // the file and class name for it.
     spl_autoload_register(__NAMESPACE__ . '\Autoload::load', true, true);
-}//end if
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,7 +44,6 @@
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
     <rule ref="Squiz.Commenting.InlineComment"/>
-    <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment">
         <exclude name="Squiz.Commenting.PostStatementComment.AnnotationFound"/>
     </rule>

--- a/scripts/BuildRequirementsCheckMatrix.php
+++ b/scripts/BuildRequirementsCheckMatrix.php
@@ -174,8 +174,8 @@ class BuildRequirementsCheckMatrix
                         ];
                     }
                 }
-            }//end foreach
-        }//end foreach
+            }
+        }
 
         return $builds;
     }

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -136,7 +136,7 @@ foreach ($scripts as $script) {
         }
 
         ++$fileCount;
-    }//end foreach
+    }
 
     // Add requirements check.
     $phar->addFromString('requirements.php', stripWhitespaceAndComments(realpath(__DIR__ . '/../requirements.php'), $config));
@@ -168,7 +168,7 @@ foreach ($scripts as $script) {
     $phar->setStub($stub);
 
     echo 'done' . PHP_EOL;
-}//end foreach
+}
 
 Timing::printRunTime();
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -344,7 +344,7 @@ class Config
         default :
             // No validation required.
             break;
-        }//end switch
+        }
 
         $this->settings[$name] = $value;
     }
@@ -444,7 +444,7 @@ class Config
                 $lastDir    = $currentDir;
                 $currentDir = dirname($currentDir);
             } while ($currentDir !== '.' && $currentDir !== $lastDir && Common::isReadable($currentDir) === true);
-        }//end if
+        }
 
         if (defined('STDIN') === false
             || PHP_OS_FAMILY === 'Windows'
@@ -478,7 +478,7 @@ class Config
                 $this->overriddenDefaults['stdin']        = true;
                 $this->overriddenDefaults['stdinContent'] = true;
             }
-        }//end if
+        }
 
         fclose($handle);
     }
@@ -529,8 +529,8 @@ class Config
                 }
             } else {
                 $this->processUnknownArgument($arg, $i);
-            }//end if
-        }//end for
+            }
+        }
     }
 
 
@@ -764,7 +764,7 @@ class Config
             } else {
                 $this->processUnknownArgument('-' . $arg, $pos);
             }
-        }//end switch
+        }
     }
 
 
@@ -958,7 +958,7 @@ class Config
                             $this->cacheFile = $dir . '/' . basename($this->cacheFile);
                         }
                     }
-                }//end if
+                }
 
                 $this->overriddenDefaults['cacheFile'] = true;
 
@@ -1035,7 +1035,7 @@ class Config
                     }
 
                     $this->reportFile = $dir . '/' . basename($this->reportFile);
-                }//end if
+                }
 
                 $this->overriddenDefaults['reportFile'] = true;
 
@@ -1106,8 +1106,8 @@ class Config
                                 $error .= $this->printShortUsage(true);
                                 throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
                             }
-                        }//end if
-                    }//end if
+                        }
+                    }
 
                     $reports[$report] = $output;
                 } else {
@@ -1120,7 +1120,7 @@ class Config
                     foreach ($reportNames as $report) {
                         $reports[$report] = null;
                     }
-                }//end if
+                }
 
                 // Remove the default value so the CLI value overrides it.
                 if (isset($this->overriddenDefaults['reports']) === false) {
@@ -1293,9 +1293,9 @@ class Config
                 } else {
                     $this->processUnknownArgument('--' . $arg, $pos);
                 }
-            }//end if
+            }
             break;
-        }//end switch
+        }
     }
 
 
@@ -1343,7 +1343,7 @@ class Config
                 $parts    = explode('.', $sniff, 4);
                 $sniffs[] = $parts[0] . '.' . $parts[1] . '.' . $parts[2];
             }
-        }//end foreach
+        }
 
         $sniffs = array_reduce(
             $sniffs,
@@ -1639,7 +1639,7 @@ class Config
                 $error = 'ERROR: Config file ' . $configFile . ' is not writable' . PHP_EOL . PHP_EOL;
                 throw new DeepExitException($error, ExitCode::PROCESS_ERROR);
             }
-        }//end if
+        }
 
         $phpCodeSnifferConfig = self::getAllConfigData();
 

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -409,8 +409,8 @@ class File
                             $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (PHP_CODESNIFFER_VERBOSITY > 2) {
                 $type    = $token['type'];
@@ -480,8 +480,8 @@ class File
                             $this->ignoredListeners[$class] = true;
                             continue;
                         }
-                    }//end if
-                }//end if
+                    }
+                }
 
                 $this->activeListener = $class;
 
@@ -513,8 +513,8 @@ class File
                 }
 
                 $this->activeListener = '';
-            }//end foreach
-        }//end foreach
+            }
+        }
 
         // If short open tags are off but the file being checked uses
         // short open tags, the whole content will be inline HTML
@@ -879,7 +879,7 @@ class File
                 $parts[0] . '.' . $parts[1],
                 $parts[0],
             ];
-        }//end if
+        }
 
         if (isset($this->tokenizer->ignoredLines[$line]) === true && $this->tokenizer->ignoredLines[$line]->isIgnored($sniffCode) === true) {
             return false;
@@ -1015,9 +1015,9 @@ class File
                     // This file path is being included.
                     $included = true;
                     break;
-                }//end foreach
-            }//end foreach
-        }//end if
+                }
+            }
+        }
 
         if ($included === false) {
             // There were include rules set, but this file
@@ -1652,8 +1652,8 @@ class File
                 $defaultStart = $this->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
                 $equalToken   = $i;
                 break;
-            }//end switch
-        }//end for
+            }
+        }
 
         return $vars;
     }
@@ -1749,8 +1749,8 @@ class File
             case T_STATIC:
                 $isStatic = true;
                 break;
-            }//end switch
-        }//end for
+            }
+        }
 
         $returnType         = '';
         $returnTypeToken    = false;
@@ -1810,7 +1810,7 @@ class File
                     $returnType        .= $this->tokens[$i]['content'];
                     $returnTypeEndToken = $i;
                 }
-            }//end for
+            }
 
             if ($this->tokens[$stackPtr]['code'] === T_FN) {
                 $bodyToken = T_FN_ARROW;
@@ -1820,7 +1820,7 @@ class File
 
             $end     = $this->findNext([$bodyToken, T_SEMICOLON], $this->tokens[$stackPtr]['parenthesis_closer']);
             $hasBody = $this->tokens[$end]['code'] === $bodyToken;
-        }//end if
+        }
 
         if ($returnType !== '' && $nullableReturnType === true) {
             $returnType = '?' . $returnType;
@@ -1975,8 +1975,8 @@ class File
             case T_ABSTRACT:
                 $isAbstract = true;
                 break;
-            }//end switch
-        }//end for
+            }
+        }
 
         $type         = '';
         $typeToken    = false;
@@ -2022,7 +2022,7 @@ class File
             if ($type !== '' && $nullableType === true) {
                 $type = '?' . $type;
             }
-        }//end if
+        }
 
         return [
             'scope'           => $scope,
@@ -2095,7 +2095,7 @@ class File
                 $isReadonly = true;
                 break;
             }
-        }//end for
+        }
 
         return [
             'is_abstract' => $isAbstract,
@@ -2180,9 +2180,9 @@ class File
                             return true;
                         }
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         // Pass by reference in function calls and assign by reference in arrays.
         if ($this->tokens[$tokenBefore]['code'] === T_OPEN_PARENTHESIS
@@ -2208,8 +2208,8 @@ class File
                 if ($this->tokens[$nextSignificantAfter]['code'] === T_VARIABLE) {
                     return true;
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         return false;
     }
@@ -2331,7 +2331,7 @@ class File
                     break;
                 }
             }
-        }//end for
+        }
 
         return false;
     }
@@ -2397,7 +2397,7 @@ class File
             if ($local === true && $this->tokens[$i]['code'] === T_SEMICOLON) {
                 break;
             }
-        }//end for
+        }
 
         return false;
     }
@@ -2492,7 +2492,7 @@ class File
                         $inNestedExpression = true;
                         break;
                     }
-                }//end for
+                }
 
                 if ($inNestedExpression === false) {
                     // $prevMatch will now either be the scope opener or a match arrow.
@@ -2523,9 +2523,9 @@ class File
                     }
 
                     return $next;
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         $lastNotEmpty = $start;
 
@@ -2582,12 +2582,12 @@ class File
                 if ($start !== false) {
                     $i = $start;
                 }
-            }//end if
+            }
 
             if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
-        }//end for
+        }
 
         return 0;
     }
@@ -2647,8 +2647,8 @@ class File
                         $start = $nextMatchArrow;
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         $lastNotEmpty = $start;
         for ($i = $start; $i < $this->numTokens; $i++) {
@@ -2696,12 +2696,12 @@ class File
                 if ($end !== false) {
                     $i = $end;
                 }
-            }//end if
+            }
 
             if (isset(Tokens::EMPTY_TOKENS[$this->tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
-        }//end for
+        }
 
         return ($this->numTokens - 1);
     }
@@ -2762,7 +2762,7 @@ class File
                     $foundToken = $i;
                 }
             }
-        }//end for
+        }
 
         return $foundToken;
     }

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -97,8 +97,8 @@ class FileList implements Iterator, Countable
                 }
             } else {
                 $this->addFile($path);
-            }//end if
-        }//end foreach
+            }
+        }
 
         reset($this->files);
         $this->numFiles = count($this->files);

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -119,7 +119,7 @@ class LocalFile extends File
             $this->numTokens = $cache['numTokens'];
             $this->fromCache = true;
             return;
-        }//end if
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::writeNewline();

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -252,7 +252,7 @@ class Filter extends RecursiveFilterIterator
                     $this->ignoreFilePatterns[$pattern] = $type;
                 }
             }
-        }//end if
+        }
 
         $relativePath = $path;
         if (strpos($path, $this->basedir) === 0) {
@@ -291,7 +291,7 @@ class Filter extends RecursiveFilterIterator
             if (preg_match($pattern, $testPath) === 1) {
                 return true;
             }
-        }//end foreach
+        }
 
         return false;
     }

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -203,7 +203,7 @@ class Fixer
             } elseif (PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::forceWrite("* fixed $this->numFixes violations, starting loop " . ($this->loops + 1) . ' *', 1);
             }
-        }//end while
+        }
 
         $this->enabled = false;
 
@@ -487,7 +487,7 @@ class Fixer
             }
 
             $this->changeset = [];
-        }//end if
+        }
     }
 
 
@@ -543,7 +543,7 @@ class Fixer
                 $oldContent .= $append;
                 $newContent .= $append;
             }
-        }//end if
+        }
 
         if ($this->inChangeset === true) {
             $this->changeset[$stackPtr] = $content;
@@ -585,12 +585,12 @@ class Fixer
                 }
 
                 return false;
-            }//end if
+            }
 
             $this->oldTokenValues[$stackPtr]['prev'] = $this->oldTokenValues[$stackPtr]['curr'];
             $this->oldTokenValues[$stackPtr]['curr'] = $content;
             $this->oldTokenValues[$stackPtr]['loop'] = $this->loops;
-        }//end if
+        }
 
         $this->fixedTokens[$stackPtr] = $this->tokens[$stackPtr];
         $this->tokens[$stackPtr]      = $content;
@@ -647,7 +647,7 @@ class Fixer
                 $oldContent .= $append;
                 $newContent .= $append;
             }
-        }//end if
+        }
 
         $this->tokens[$stackPtr] = $this->fixedTokens[$stackPtr];
         unset($this->fixedTokens[$stackPtr]);
@@ -803,7 +803,7 @@ class Fixer
             }
 
             $this->replaceToken($i, $newContent);
-        }//end for
+        }
 
         if ($useChangeset === true) {
             $this->endChangeset();

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -134,13 +134,13 @@ class Text extends Generator
         if ($firstTitleLines !== [] || $secondTitleLines !== []) {
             $titleRow  = $this->linesToTableRows($firstTitleLines, $secondTitleLines);
             $titleRow .= str_repeat('-', 100) . PHP_EOL;
-        }//end if
+        }
 
         $codeRow = '';
         if ($firstLines !== [] || $secondLines !== []) {
             $codeRow  = $this->linesToTableRows($firstLines, $secondLines);
             $codeRow .= str_repeat('-', 100) . PHP_EOL . PHP_EOL;
-        }//end if
+        }
 
         $output = '';
         if ($titleRow !== '' || $codeRow !== '') {
@@ -222,7 +222,7 @@ class Text extends Generator
             $rows .= '| ';
             $rows .= $column2Text . str_repeat(' ', max(0, (48 - strlen($column2Text))));
             $rows .= '|' . PHP_EOL;
-        }//end for
+        }
 
         return $rows;
     }

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -149,7 +149,7 @@ class Reporter
                         break;
                     }
                 }
-            }//end if
+            }
 
             if ($reportClassName === '') {
                 $error = "ERROR: Class file for report \"$type\" not found" . PHP_EOL;
@@ -175,7 +175,7 @@ class Reporter
             } else {
                 file_put_contents($output, '');
             }
-        }//end foreach
+        }
     }
 
 
@@ -385,8 +385,8 @@ class Reporter
                 file_put_contents($this->tmpFiles[$type], $generatedReport, (FILE_APPEND | LOCK_EX));
             } else {
                 file_put_contents($report['output'], $generatedReport, (FILE_APPEND | LOCK_EX));
-            }//end if
-        }//end foreach
+            }
+        }
 
         if ($errorsShown === true || PHP_CODESNIFFER_CBF === true) {
             $this->totalFiles++;
@@ -482,7 +482,7 @@ class Reporter
             }
 
             ksort($errors[$line]);
-        }//end foreach
+        }
 
         foreach ($phpcsFile->getWarnings() as $line => $lineWarnings) {
             foreach ($lineWarnings as $column => $colWarnings) {
@@ -509,10 +509,10 @@ class Reporter
                 } else {
                     $errors[$line][$column] = $newWarnings;
                 }
-            }//end foreach
+            }
 
             ksort($errors[$line]);
-        }//end foreach
+        }
 
         ksort($errors);
         $report['messages'] = $errors;

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -221,7 +221,7 @@ class Cbf implements Report
             }
 
             echo PHP_EOL;
-        }//end foreach
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         echo "\033[1mA TOTAL OF $totalFixed ERROR";

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -63,7 +63,7 @@ class Checkstyle implements Report
                     $out->endElement();
                 }
             }
-        }//end foreach
+        }
 
         $out->endElement();
         echo $out->flush();

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -70,7 +70,7 @@ class Code implements Report
             }
 
             $tokens = $phpcsFile->getTokens();
-        }//end if
+        }
 
         // Create an array that maps lines to the first token on the line.
         $lineTokens = [];
@@ -256,8 +256,8 @@ class Code implements Report
                             $snippet .= "\033[0m";
                         }
                     }
-                }//end for
-            }//end if
+                }
+            }
 
             echo str_repeat('-', $width) . PHP_EOL;
 
@@ -300,12 +300,12 @@ class Code implements Report
                     );
 
                     echo $errorMsg . PHP_EOL;
-                }//end foreach
-            }//end foreach
+                }
+            }
 
             echo str_repeat('-', $width) . PHP_EOL;
             echo rtrim($snippet) . PHP_EOL;
-        }//end foreach
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         if ($report['fixable'] > 0) {

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -56,7 +56,7 @@ class Diff implements Report
             }
 
             $phpcsFile->fixer->startFile($phpcsFile);
-        }//end if
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** START FILE FIXING ***', 1);

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -83,9 +83,9 @@ class Full implements Report
                     }
 
                     $maxErrorLength = max($maxErrorLength, ($length + 1));
-                }//end foreach
-            }//end foreach
-        }//end foreach
+                }
+            }
+        }
 
         $file       = $report['filename'];
         $fileLength = strlen($file);
@@ -172,7 +172,7 @@ class Full implements Report
                         } else {
                             $errorMsg .= ' ' . $sourceSuffix;
                         }
-                    }//end if
+                    }
 
                     // The padding that goes on the front of the line.
                     $padding = ($maxLineNumLength - strlen($line));
@@ -200,9 +200,9 @@ class Full implements Report
                     }
 
                     echo $errorMsg . PHP_EOL;
-                }//end foreach
-            }//end foreach
-        }//end foreach
+                }
+            }
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         if ($report['fixable'] > 0) {

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -154,10 +154,10 @@ class Info implements Report
                     'total',
                     number_format($totalCount)
                 );
-            }//end if
+            }
 
             echo PHP_EOL;
-        }//end foreach
+        }
 
         echo str_repeat('-', 70) . PHP_EOL;
     }

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -60,7 +60,7 @@ class Json implements Report
                     $messages .= json_encode($messagesObject) . ',';
                 }
             }
-        }//end foreach
+        }
 
         echo rtrim($messages, ',');
         echo ']},';

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -75,7 +75,7 @@ class Junit implements Report
                     }
                 }
             }
-        }//end if
+        }
 
         $out->endElement();
         echo $out->flush();

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -128,7 +128,7 @@ class Source implements Report
                     }
 
                     $parts[2] = $sniff;
-                }//end if
+                }
 
                 $maxLength = max($maxLength, strlen($sniff));
 
@@ -139,8 +139,8 @@ class Source implements Report
                 ];
             } else {
                 $sources[$source]['count'] += $count;
-            }//end if
-        }//end foreach
+            }
+        }
 
         if ($showSources === true) {
             $width = min($width, ($maxLength + 11));
@@ -239,10 +239,10 @@ class Source implements Report
                 } else {
                     echo $sniff . str_repeat(' ', ($width - 35 - strlen($sniff)));
                 }
-            }//end if
+            }
 
             echo $sourceData['count'] . PHP_EOL;
-        }//end foreach
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         echo "\033[1m" . 'A TOTAL OF ' . ($totalErrors + $totalWarnings) . ' SNIFF VIOLATION';
@@ -314,10 +314,10 @@ class Source implements Report
 
                     $lastWasUpper = true;
                 }
-            }//end if
+            }
 
             $friendlyName .= $name[$i];
-        }//end for
+        }
 
         $friendlyName    = trim($friendlyName);
         $friendlyName[0] = strtoupper($friendlyName[0]);

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -145,7 +145,7 @@ class Summary implements Report
             }
 
             echo PHP_EOL;
-        }//end foreach
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         echo "\033[1mA TOTAL OF $totalErrors ERROR";

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -84,7 +84,7 @@ abstract class VersionControl implements Report
             }
 
             unset($blames[($line - 1)]);
-        }//end foreach
+        }
 
         // Now go through and give the authors some credit for
         // all the lines that do not have errors.
@@ -108,7 +108,7 @@ abstract class VersionControl implements Report
             }
 
             $praiseCache[$author]['good']++;
-        }//end foreach
+        }
 
         foreach ($authorCache as $author => $errors) {
             echo "AUTHOR>>$author>>$errors" . PHP_EOL;
@@ -211,8 +211,8 @@ abstract class VersionControl implements Report
                 break;
             default:
                 break;
-            }//end switch
-        }//end foreach
+            }
+        }
 
         // Make sure the report width isn't too big.
         $maxLength = 0;
@@ -316,9 +316,9 @@ abstract class VersionControl implements Report
                     }
 
                     echo $line . PHP_EOL;
-                }//end foreach
-            }//end if
-        }//end foreach
+                }
+            }
+        }
 
         echo str_repeat('-', $width) . PHP_EOL;
         echo "\033[1m" . 'A TOTAL OF ' . $errorsShown . ' SNIFF VIOLATION';

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -69,7 +69,7 @@ class Xml implements Report
                     $out->endElement();
                 }
             }
-        }//end foreach
+        }
 
         $out->endElement();
 

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -230,7 +230,7 @@ class Ruleset
             }
 
             $sniffs = array_merge($sniffs, $this->processRuleset($standard));
-        }//end foreach
+        }
 
         // Ignore sniff restrictions if caching is on.
         if ($config->cache === true) {
@@ -326,7 +326,7 @@ class Ruleset
                 if ($currentStandard === null) {
                     break;
                 }
-            }//end if
+            }
 
             if (isset($this->deprecatedSniffs[$sniff]) === true) {
                 $sniff .= ' *';
@@ -334,7 +334,7 @@ class Ruleset
 
             $sniffsInStandard[] = $sniff;
             ++$lastCount;
-        }//end foreach
+        }
 
         if (count($this->deprecatedSniffs) > 0) {
             echo PHP_EOL . '* Sniffs marked with an asterisk are deprecated.' . PHP_EOL;
@@ -447,7 +447,7 @@ class Ruleset
             $message       .= '   ' . implode(PHP_EOL . '   ', explode(PHP_EOL, $wrapped));
 
             $messages[] = $message;
-        }//end foreach
+        }
 
         if (count($messages) === 0) {
             return;
@@ -585,7 +585,7 @@ class Ruleset
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::write("=> included autoloader $autoloadPath", ($depth + 1));
             }
-        }//end foreach
+        }
 
         // Process custom sniff config settings.
         // Processing rules:
@@ -615,7 +615,7 @@ class Ruleset
             if ($applied === true && PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::write('=> set config value ' . $name . ': ' . (string) $config['value'], ($depth + 1));
             }
-        }//end foreach
+        }
 
         // Process custom command line arguments.
         // Processing rules:
@@ -683,7 +683,7 @@ class Ruleset
                     // Remember which settings we've seen.
                     $cleanedValue .= $flag;
                     $this->cliSettingsApplied[$cliSettingName] = $depth;
-                }//end foreach
+                }
 
                 if ($cleanedValue === '') {
                     // No flags found which should be applied.
@@ -691,14 +691,14 @@ class Ruleset
                 }
 
                 $argString = '-' . $cleanedValue;
-            }//end if
+            }
 
             $cliArgs[] = $argString;
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::write("=> set command line value $argString", ($depth + 1));
             }
-        }//end foreach
+        }
 
         foreach ($ruleset->rule as $rule) {
             if (isset($rule['ref']) === false
@@ -744,8 +744,8 @@ class Ruleset
                             StatusWriter::write('Excluding sniff "' . $sniffCode . '" except for "' . $parts[3] . '"', ($depth + 2));
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($rule->exclude) === true) {
                 foreach ($rule->exclude as $exclude) {
@@ -780,11 +780,11 @@ class Ruleset
                             $this->expandRulesetReference((string) $exclude['name'], $rulesetDir, ($depth + 1))
                         );
                     }
-                }//end foreach
-            }//end if
+                }
+            }
 
             $this->processRule($rule, $newSniffs, $depth);
-        }//end foreach
+        }
 
         // Set custom php ini values as CLI args.
         foreach ($ruleset->{'ini'} as $arg) {
@@ -811,7 +811,7 @@ class Ruleset
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::write("=> set PHP ini value $name to $value", ($depth + 1));
             }
-        }//end foreach
+        }
 
         if (empty($this->config->files) === true) {
             // Process hard-coded file paths.
@@ -933,7 +933,7 @@ class Ruleset
             }
 
             $sniffs[] = $path;
-        }//end foreach
+        }
 
         return $sniffs;
     }
@@ -1080,8 +1080,8 @@ class Ruleset
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     StatusWriter::write('=> ' . Common::stripBasepath($ref, $this->config->basepath), ($depth + 2));
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if (is_dir($ref) === true) {
             if (is_file($ref . DIRECTORY_SEPARATOR . 'ruleset.xml') === true) {
@@ -1117,7 +1117,7 @@ class Ruleset
 
                 return $this->processRuleset($ref, ($depth + 2));
             }
-        }//end if
+        }
     }
 
 
@@ -1202,7 +1202,7 @@ class Ruleset
                         StatusWriter::write($statusMessage, ($depth + 2));
                     }
                 }
-            }//end if
+            }
 
             // Custom message.
             if (isset($rule->message) === true
@@ -1318,9 +1318,9 @@ class Ruleset
 
                             StatusWriter::write($statusMessage, ($depth + 2));
                         }
-                    }//end if
-                }//end foreach
-            }//end if
+                    }
+                }
+            }
 
             // Ignore patterns.
             foreach ($rule->{'exclude-pattern'} as $pattern) {
@@ -1345,7 +1345,7 @@ class Ruleset
 
                     StatusWriter::write($statusMessage . ': ' . (string) $pattern, ($depth + 2));
                 }
-            }//end foreach
+            }
 
             // Include patterns.
             foreach ($rule->{'include-pattern'} as $pattern) {
@@ -1370,8 +1370,8 @@ class Ruleset
 
                     StatusWriter::write($statusMessage . ': ' . (string) $pattern, ($depth + 2));
                 }
-            }//end foreach
-        }//end foreach
+            }
+        }
     }
 
 
@@ -1489,14 +1489,14 @@ class Ruleset
                     $this->msgCache->add($message, MessageCollector::ERROR);
                     continue;
                 }
-            }//end if
+            }
 
             $listeners[$className] = $className;
 
             if (PHP_CODESNIFFER_VERBOSITY > 2) {
                 StatusWriter::write("Registered $className");
             }
-        }//end foreach
+        }
 
         $this->sniffs = $listeners;
     }
@@ -1586,7 +1586,7 @@ class Ruleset
                     ];
                 }
             }
-        }//end foreach
+        }
     }
 
 
@@ -1707,7 +1707,7 @@ class Ruleset
             if ($valueLc === 'null') {
                 return null;
             }
-        }//end if
+        }
 
         return $value;
     }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -138,7 +138,7 @@ class Runner
             }
 
             return $exitCode;
-        }//end try
+        }
 
         return ExitCode::calculate($this->reporter);
     }
@@ -223,7 +223,7 @@ class Runner
             }
 
             return $exitCode;
-        }//end try
+        }
 
         return ExitCode::calculate($this->reporter);
     }
@@ -347,7 +347,7 @@ class Runner
                     StatusWriter::write("DONE ($size files in cache)");
                 }
             }
-        }//end if
+        }
 
         $numFiles = count($todo);
         if ($numFiles === 0) {
@@ -458,7 +458,7 @@ class Runner
 
                         $pathsProcessed[] = $path;
                         $todo->next();
-                    }//end for
+                    }
 
                     $debugOutput = ob_get_contents();
                     ob_end_clean();
@@ -493,14 +493,14 @@ class Runner
                     $output .= ";\n?" . '>';
                     file_put_contents($childOutFilename, $output);
                     exit();
-                }//end if
-            }//end for
+                }
+            }
 
             $success = $this->processChildProcs($childProcs);
             if ($success === false) {
                 throw new RuntimeException('One or more child processes failed to run');
             }
-        }//end if
+        }
 
         restore_error_handler();
 
@@ -621,7 +621,7 @@ class Runner
             }
 
             $file->addErrorOnLine($error, 1, 'Internal.Exception');
-        }//end try
+        }
 
         $this->reporter->cacheFileReport($file);
 
@@ -662,8 +662,8 @@ class Runner
                     $this->reporter->cacheFileReport($file);
                     break;
                 }
-            }//end while
-        }//end if
+            }
+        }
 
         // Clean up the file to save (a lot of) memory.
         $file->cleanUp();
@@ -748,7 +748,7 @@ class Runner
                 $childOutput['totalFixedWarnings']
             );
             $this->printProgress($file, $totalBatches, $numProcessed);
-        }//end while
+        }
 
         return $success;
     }
@@ -804,7 +804,7 @@ class Runner
                         $colorOpen  = "\033[32m";
                         $colorClose = "\033[0m";
                     }
-                }//end if
+                }
             } else {
                 // Files with errors are E (red).
                 // Files with fixable errors are E (green).
@@ -835,9 +835,9 @@ class Runner
 
                         $colorClose = "\033[0m";
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         StatusWriter::write($colorOpen . $progressDot . $colorClose, 0, 0);
 

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -99,7 +99,7 @@ abstract class AbstractPatternSniff implements Sniff
             }
 
             $this->parsedPatterns[$tokenType][] = $patternArray;
-        }//end foreach
+        }
 
         return array_unique(array_merge($listenTypes, $this->supplementaryTokens));
     }
@@ -308,7 +308,7 @@ abstract class AbstractPatternSniff implements Sniff
                         } else {
                             $stackPtr = ($prev - 1);
                         }
-                    }//end if
+                    }
                 } elseif ($pattern[$i]['type'] === 'skip') {
                     // Skip to next piece of relevant code.
                     if ($pattern[$i]['to'] === 'parenthesis_closer') {
@@ -388,7 +388,7 @@ abstract class AbstractPatternSniff implements Sniff
                     } else {
                         $found    = $tokens[$stackPtr]['content'] . $found;
                         $hasError = true;
-                    }//end if
+                    }
 
                     if ($hasError === false && $pattern[($i - 1)]['type'] !== 'newline') {
                         // Make sure they only have 1 newline.
@@ -397,9 +397,9 @@ abstract class AbstractPatternSniff implements Sniff
                             $hasError = true;
                         }
                     }
-                }//end if
-            }//end for
-        }//end if
+                }
+            }
+        }
 
         $stackPtr          = $origStackPtr;
         $lastAddedStackPtr = null;
@@ -456,7 +456,7 @@ abstract class AbstractPatternSniff implements Sniff
 
                             $lastAddedStackPtr = $stackPtr;
                             $stackPtr          = $next;
-                        }//end if
+                        }
 
                         if ($stackPtr !== $lastAddedStackPtr) {
                             $found .= $tokenContent;
@@ -466,7 +466,7 @@ abstract class AbstractPatternSniff implements Sniff
                             $found            .= $tokens[$stackPtr]['content'];
                             $lastAddedStackPtr = $stackPtr;
                         }
-                    }//end if
+                    }
 
                     if (isset($pattern[($i + 1)]) === true
                         && $pattern[($i + 1)]['type'] === 'skip'
@@ -522,7 +522,7 @@ abstract class AbstractPatternSniff implements Sniff
                             // our pattern. This means the pattern is not for us.
                             return false;
                         }
-                    }//end if
+                    }
 
                     // If we skipped past some whitespace tokens, then add them
                     // to the found string.
@@ -552,7 +552,7 @@ abstract class AbstractPatternSniff implements Sniff
                         if ($tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
                             $hasError = true;
                         }
-                    }//end if
+                    }
 
                     if ($next !== $lastAddedStackPtr) {
                         $found            .= $tokens[$next]['content'];
@@ -566,7 +566,7 @@ abstract class AbstractPatternSniff implements Sniff
                     } else {
                         $stackPtr = ($next + 1);
                     }
-                }//end if
+                }
             } elseif ($pattern[$i]['type'] === 'skip') {
                 if ($pattern[$i]['to'] === 'unknown') {
                     $next = $phpcsFile->findNext(
@@ -606,7 +606,7 @@ abstract class AbstractPatternSniff implements Sniff
 
                     // Skip to the closing token.
                     $stackPtr = ($tokens[$next][$pattern[$i]['to']] + 1);
-                }//end if
+                }
             } elseif ($pattern[$i]['type'] === 'string') {
                 if ($tokens[$stackPtr]['code'] !== T_STRING) {
                     $hasError = true;
@@ -659,7 +659,7 @@ abstract class AbstractPatternSniff implements Sniff
                             $next = ($newline + 1);
                         }
                     }
-                }//end if
+                }
 
                 if ($stackPtr !== $lastAddedStackPtr) {
                     $found .= $phpcsFile->getTokensAsString(
@@ -671,8 +671,8 @@ abstract class AbstractPatternSniff implements Sniff
                 }
 
                 $stackPtr = $next;
-            }//end if
-        }//end for
+            }
+        }
 
         if ($hasError === true) {
             $error = $this->prepareError($found, $patternCode);
@@ -789,7 +789,7 @@ abstract class AbstractPatternSniff implements Sniff
                 $lastToken      = ($i - $firstToken);
                 $firstToken     = ($i + 3);
                 $i += 2;
-            }//end if
+            }
 
             if ($specialPattern !== false || $isLastChar === true) {
                 // If we are at the end of the string, don't worry about a limit.
@@ -821,7 +821,7 @@ abstract class AbstractPatternSniff implements Sniff
                 if ($isLastChar === false && $i === ($length - 1)) {
                     $i--;
                 }
-            }//end if
+            }
 
             // Add the skip pattern *after* we have processed
             // all the tokens from the end of the last skip pattern
@@ -829,7 +829,7 @@ abstract class AbstractPatternSniff implements Sniff
             if ($specialPattern !== false) {
                 $patterns[] = $specialPattern;
             }
-        }//end for
+        }
 
         return $patterns;
     }
@@ -873,12 +873,12 @@ abstract class AbstractPatternSniff implements Sniff
             case ')':
                 $nestedParenthesis++;
                 break;
-            }//end switch
+            }
 
             if (isset($skip['to']) === true) {
                 break;
             }
-        }//end for
+        }
 
         if (isset($skip['to']) === false) {
             $skip['to'] = 'unknown';

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -138,7 +138,7 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
                     break;
                 }
             }
-        }//end if
+        }
 
         if ($inFunction === true) {
             return $this->processVariable($phpcsFile, $stackPtr);

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -97,7 +97,7 @@ class ArrayIndentSniff extends AbstractArraySniff
             }
 
             return;
-        }//end if
+        }
 
         $expectedIndent = ($startIndent + $this->indent);
 
@@ -144,7 +144,7 @@ class ArrayIndentSniff extends AbstractArraySniff
             } else {
                 $phpcsFile->fixer->replaceToken(($first - 1), $padding);
             }
-        }//end foreach
+        }
 
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($arrayEnd - 1), null, true);
         if ($tokens[$prev]['line'] === $tokens[$arrayEnd]['line']) {

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -99,15 +99,15 @@ class DuplicateClassNameSniff implements Sniff
                             'line' => $tokens[$stackPtr]['line'],
                         ];
                     }
-                }//end if
+                }
 
                 if (isset($tokens[$stackPtr]['scope_closer']) === true) {
                     $stackPtr = $tokens[$stackPtr]['scope_closer'];
                 }
-            }//end if
+            }
 
             $stackPtr = $phpcsFile->findNext($findTokens, ($stackPtr + 1));
-        }//end while
+        }
 
         return $phpcsFile->numTokens;
     }

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -113,7 +113,7 @@ class AssignmentInConditionSniff implements Sniff
 
             $opener = $token['parenthesis_opener'];
             $closer = $token['parenthesis_closer'];
-        }//end if
+        }
 
         $startPos = $opener;
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -130,7 +130,7 @@ class EmptyPHPStatementSniff implements Sniff
             }
 
             $phpcsFile->fixer->endChangeset();
-        }//end if
+        }
     }
 
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
@@ -92,6 +92,6 @@ class ForLoopWithTestFunctionCallSniff implements Sniff
                 $phpcsFile->addWarning($error, $stackPtr, 'NotAllowed');
                 break;
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -113,7 +113,7 @@ class UnusedFunctionParameterSniff implements Sniff
                     $errorCode .= 'InImplementedInterface';
                 }
             }
-        }//end if
+        }
 
         $params       = [];
         $methodParams = $phpcsFile->getMethodParameters($stackPtr);
@@ -189,8 +189,8 @@ class UnusedFunctionParameterSniff implements Sniff
                         // There is a return <token>.
                         return;
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             $foundContent = true;
 
@@ -240,8 +240,8 @@ class UnusedFunctionParameterSniff implements Sniff
                         unset($params[$varContent]);
                     }
                 }
-            }//end if
-        }//end for
+            }
+        }
 
         if ($foundContent === true && count($params) > 0) {
             $error = 'The method parameter %s is never used';
@@ -283,7 +283,7 @@ class UnusedFunctionParameterSniff implements Sniff
                         ];
                     }
                 }
-            }//end for
+            }
 
             if (count($errorInfo) > 0) {
                 $errorInfo = array_reverse($errorInfo);
@@ -296,6 +296,6 @@ class UnusedFunctionParameterSniff implements Sniff
                     $phpcsFile->addWarning($error, $info['position'], $info['errorcode'], $data);
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -149,7 +149,7 @@ class UselessOverridingMethodSniff implements Sniff
             if ($parenthesisCount === 0) {
                 break;
             }
-        }//end for
+        }
 
         $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
         if ($tokens[$next]['code'] !== T_SEMICOLON && $tokens[$next]['code'] !== T_CLOSE_TAG) {

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -175,8 +175,8 @@ class DocCommentSniff implements Sniff
                     $error = 'Doc comment long description must start with a capital letter';
                     $phpcsFile->addError($error, $long, 'LongNotCapital');
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if (empty($tokens[$commentStart]['comment_tags']) === true) {
             // No tags in the comment.
@@ -240,10 +240,10 @@ class DocCommentSniff implements Sniff
                 if ($paramGroupid === null) {
                     $paramGroupid = $groupid;
                 }
-            }//end if
+            }
 
             $tagGroups[$groupid][] = $tag;
-        }//end foreach
+        }
 
         foreach ($tagGroups as $groupid => $group) {
             $maxLength = 0;
@@ -296,7 +296,7 @@ class DocCommentSniff implements Sniff
                         $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }//end if
+            }
 
             // Now check paddings.
             foreach ($paddings as $tag => $padding) {
@@ -316,7 +316,7 @@ class DocCommentSniff implements Sniff
                     }
                 }
             }
-        }//end foreach
+        }
 
         // If there is a param group, it needs to be first.
         if ($paramGroupid !== null && $paramGroupid !== 0) {

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -113,8 +113,8 @@ class DisallowYodaConditionsSniff implements Sniff
                 && $this->isArrayStatic($phpcsFile, $beforeOpeningParenthesisIndex) === false
             ) {
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         $phpcsFile->addError(
             'Usage of Yoda conditions is not allowed; switch the expression order',

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -225,14 +225,14 @@ class InlineControlStructureSniff implements Sniff
                     if ($next !== false && $tokens[$next]['code'] === T_SEMICOLON) {
                         $end = $next;
                     }
-                }//end if
+                }
 
                 if ($tokens[$end]['code'] !== T_END_HEREDOC
                     && $tokens[$end]['code'] !== T_END_NOWDOC
                 ) {
                     break;
                 }
-            }//end if
+            }
 
             if (isset($tokens[$end]['parenthesis_closer']) === true) {
                 $end          = $tokens[$end]['parenthesis_closer'];
@@ -243,7 +243,7 @@ class InlineControlStructureSniff implements Sniff
             if ($tokens[$end]['code'] !== T_WHITESPACE) {
                 $lastNonEmpty = $end;
             }
-        }//end for
+        }
 
         if ($end === $phpcsFile->numTokens) {
             $end = $lastNonEmpty;
@@ -313,7 +313,7 @@ class InlineControlStructureSniff implements Sniff
             }
 
             $phpcsFile->fixer->addContent($endToken, $addedContent);
-        }//end if
+        }
 
         $phpcsFile->fixer->endChangeset();
     }

--- a/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -119,8 +119,8 @@ class LineEndingsSniff implements Sniff
                 if ($tokenContent !== $newContent) {
                     $phpcsFile->fixer->replaceToken($i, $newContent);
                 }
-            }//end for
-        }//end if
+            }
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -171,7 +171,7 @@ class LineLengthSniff implements Sniff
                     return;
                 }
             }
-        }//end if
+        }
 
         if ($this->absoluteLineLimit > 0
             && $lineLength > $this->absoluteLineLimit

--- a/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
@@ -96,6 +96,6 @@ class DisallowMultipleStatementsSniff implements Sniff
             }
         } else {
             $phpcsFile->recordMetric($stackPtr, 'Multiple statements on same line', 'no');
-        }//end if
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -194,14 +194,14 @@ class MultipleStatementAlignmentSniff implements Sniff
                             break;
                         }
                     }
-                }//end if
+                }
 
                 continue;
             } elseif ($assign !== $stackPtr && $tokens[$assign]['line'] === $lastLine) {
                 // Skip multiple assignments on the same line. We only need to
                 // try and align the first assignment.
                 continue;
-            }//end if
+            }
 
             if ($assign !== $stackPtr) {
                 if ($tokens[$assign]['level'] > $tokens[$stackPtr]['level']) {
@@ -238,7 +238,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                         }
                     }
                 }
-            }//end if
+            }
 
             $var = $phpcsFile->findPrevious(
                 Tokens::EMPTY_TOKENS,
@@ -277,7 +277,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                     }
 
                     $assignColumn = ($varEnd + $padding);
-                }//end if
+                }
 
                 if (($assignColumn + $assignLen) > ($assignments[$maxPadding]['assign_col'] + $assignments[$maxPadding]['assign_len'])) {
                     $newPadding = ($varEnd - $assignments[$maxPadding]['var_end'] + $assignLen - $assignments[$maxPadding]['assign_len'] + 1);
@@ -301,12 +301,12 @@ class MultipleStatementAlignmentSniff implements Sniff
                     }
                 } elseif ($padding > $assignments[$maxPadding]['expected']) {
                     $maxPadding = $assign;
-                }//end if
+                }
             } else {
                 $padding      = 1;
                 $assignColumn = ($varEnd + 1);
                 $maxPadding   = $assign;
-            }//end if
+            }
 
             $found = 0;
             if ($tokens[($var + 1)]['code'] === T_WHITESPACE) {
@@ -327,7 +327,7 @@ class MultipleStatementAlignmentSniff implements Sniff
 
             $lastLine   = $tokens[$assign]['line'];
             $prevAssign = $assign;
-        }//end for
+        }
 
         if (empty($assignments) === true) {
             return $stackPtr;
@@ -380,7 +380,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($assignment - 1), $newContent);
                 }
             }
-        }//end foreach
+        }
 
         if ($numAssignments > 1) {
             if ($errorGenerated === true) {

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -158,8 +158,8 @@ class FunctionCallArgumentSpacingSniff implements Sniff
 
                             $phpcsFile->fixer->endChangeset();
                         }
-                    }//end if
-                }//end if
+                    }
+                }
 
                 if ($tokens[($nextSeparator + 1)]['code'] !== T_WHITESPACE) {
                     // Ignore trailing comma's after last argument as that's outside the scope of this sniff.
@@ -185,8 +185,8 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                             }
                         }
                     }
-                }//end if
-            }//end if
-        }//end while
+                }
+            }
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -131,7 +131,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
+            }
 
             $phpcsFile->recordMetric($stackPtr, "$metricType opening brace placement", 'same line');
         } elseif ($lineDifference > 1) {
@@ -161,8 +161,8 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
 
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         $ignore   = Tokens::PHPCS_ANNOTATION_TOKENS;
         $ignore[] = T_WHITESPACE;
@@ -213,7 +213,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($openingBrace - 1), $indent);
                 }
             }
-        }//end if
+        }
 
         $phpcsFile->recordMetric($stackPtr, "$metricType opening brace placement", 'new line');
     }

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -111,10 +111,10 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
+            }
         } else {
             $phpcsFile->recordMetric($stackPtr, "$metricType opening brace placement", 'same line');
-        }//end if
+        }
 
         $ignore   = Tokens::PHPCS_ANNOTATION_TOKENS;
         $ignore[] = T_WHITESPACE;

--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -128,7 +128,7 @@ class ConstructorNameSniff extends AbstractScopeSniff
             }
 
             $startIndex = $nextNonEmpty;
-        }//end while
+        }
     }
 
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -80,7 +80,7 @@ class UpperCaseConstantNameSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         // Only interested in define statements now.
         if (strtolower(ltrim($tokens[$stackPtr]['content'], '\\')) !== 'define') {

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -131,7 +131,7 @@ class DisallowShortOpenTagSniff implements Sniff
                     return $i;
                 }
             }
-        }//end if
+        }
     }
 
 

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -191,7 +191,7 @@ class ForbiddenFunctionsSniff implements Sniff
             if (in_array($function, $this->forbiddenFunctionNames, true) === false) {
                 return;
             }
-        }//end if
+        }
 
         $this->addError($phpcsFile, $stackPtr, $function, $pattern);
     }

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -183,7 +183,7 @@ class LowerCaseConstantSniff implements Sniff
 
             // Skip over return type declarations.
             return $end;
-        }//end if
+        }
 
         // Handle everything else.
         $this->processConstant($phpcsFile, $stackPtr);

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -76,6 +76,6 @@ class LowerCaseKeywordSniff implements Sniff
             }
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PHP keyword case', 'lower');
-        }//end if
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -149,10 +149,10 @@ class LowerCaseTypeSniff implements Sniff
                                 $this->processType($phpcsFile, $startOfType, $type, $error, $errorCode);
                             }
                         }
-                    }//end if
+                    }
 
                     continue;
-                }//end if
+                }
 
                 if ($tokens[$i]['code'] !== T_VARIABLE) {
                     continue;
@@ -185,10 +185,10 @@ class LowerCaseTypeSniff implements Sniff
                         $this->processType($phpcsFile, $props['type_token'], $type, $error, $errorCode);
                     }
                 }
-            }//end for
+            }
 
             return;
-        }//end if
+        }
 
         /*
          * Check function return type.
@@ -247,7 +247,7 @@ class LowerCaseTypeSniff implements Sniff
                     $this->processType($phpcsFile, $param['type_hint_token'], $typeHint, $error, $errorCode);
                 }
             }
-        }//end foreach
+        }
     }
 
 
@@ -302,7 +302,7 @@ class LowerCaseTypeSniff implements Sniff
 
             ++$typeTokenCount;
             $type .= $tokens[$i]['content'];
-        }//end for
+        }
 
         // Handle type at end of type string.
         if ($typeTokenCount === 1

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -71,7 +71,7 @@ class RequireStrictTypesSniff implements Sniff
 
                 $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $tokens[$declare]['parenthesis_closer']);
             } while ($next !== false && $next < $tokens[$declare]['parenthesis_closer']);
-        }//end if
+        }
 
         if ($found === false) {
             $error = 'Missing required strict_types declaration';

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryHeredocSniff.php
@@ -105,7 +105,7 @@ class UnnecessaryHeredocSniff implements Sniff
                 $phpcsFile->recordMetric($stackPtr, 'Heredoc contains interpolation or expression', 'yes');
                 return;
             }
-        }//end foreach
+        }
 
         $phpcsFile->recordMetric($stackPtr, 'Heredoc contains interpolation or expression', 'no');
 

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -118,8 +118,8 @@ class GitMergeConflictSniff implements Sniff
                     }
                 }
                 break;
-            }//end switch
-        }//end for
+            }
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -106,7 +106,7 @@ class SubversionPropertiesSniff implements Sniff
                 ];
                 $phpcsFile->addError($error, $stackPtr, 'NoMatch', $data);
             }
-        }//end foreach
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;
@@ -175,11 +175,11 @@ class SubversionPropertiesSniff implements Sniff
                     fgetc($handle);
 
                     $properties[$key] = $value;
-                }//end while
+                }
 
                 fclose($handle);
-            }//end if
-        }//end foreach
+            }
+        }
 
         if ($foundPath === false) {
             return null;

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -170,9 +170,9 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
                     } else {
                         $phpcsFile->fixer->replaceToken(($stackPtr + 1), $expected);
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         if ($tokens[$stackPtr]['code'] === T_CLOSE_PARENTHESIS
             && isset($tokens[($stackPtr - 1)], $tokens[($stackPtr - 2)]) === true
@@ -224,8 +224,8 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
                     } else {
                         $phpcsFile->fixer->replaceToken(($stackPtr - 1), $expected);
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -130,7 +130,7 @@ class DisallowSpaceIndentSniff implements Sniff
 
                 // Don't record metrics for empty lines.
                 $recordMetrics = false;
-            }//end if
+            }
 
             $foundSpaces = substr_count($content, ' ');
             $foundTabs   = substr_count($content, "\t");
@@ -195,7 +195,7 @@ class DisallowSpaceIndentSniff implements Sniff
                 } elseif ($recordMetrics === true) {
                     $phpcsFile->recordMetric($i, 'Line indent', 'mixed');
                 }
-            }//end if
+            }
 
             $error     = 'Tabs must be used to indent lines; spaces are not allowed';
             $errorCode = 'SpacesUsed';
@@ -214,7 +214,7 @@ class DisallowSpaceIndentSniff implements Sniff
                 $padding .= str_repeat(' ', $expectedSpaces);
                 $phpcsFile->fixer->replaceToken($i, $padding . $nonWhitespace);
             }
-        }//end for
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -149,7 +149,7 @@ class DisallowTabIndentSniff implements Sniff
                             }
                         }
                     }
-                }//end if
+                }
             } else {
                 // Look for tabs so we can report and replace, but don't
                 // record any metrics about them because they aren't
@@ -158,7 +158,7 @@ class DisallowTabIndentSniff implements Sniff
                     $error     = 'Spaces must be used for alignment; tabs are not allowed';
                     $errorCode = 'NonIndentTabsUsed';
                 }
-            }//end if
+            }
 
             if ($foundTabs === 0) {
                 continue;
@@ -184,7 +184,7 @@ class DisallowTabIndentSniff implements Sniff
                     $phpcsFile->fixer->replaceToken($i, $newContent);
                 }
             }
-        }//end for
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -100,7 +100,7 @@ class IncrementDecrementSpacingSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         // Is this a post-increment/decrement ?
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
@@ -152,6 +152,6 @@ class IncrementDecrementSpacingSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -109,7 +109,7 @@ class LanguageConstructSpacingSniff implements Sniff
                 }
 
                 $yieldFromEnd = $i;
-            }//end if
+            }
 
             $error = 'Language constructs must be followed by a single space; expected 1 space between YIELD FROM found "%s"';
             $data  = [Common::prepareForOutput($found)];
@@ -130,10 +130,10 @@ class LanguageConstructSpacingSniff implements Sniff
 
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
+            }
 
             return ($yieldFromEnd + 1);
-        }//end if
+        }
 
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
             $content = $tokens[($stackPtr + 1)]['content'];
@@ -155,6 +155,6 @@ class LanguageConstructSpacingSniff implements Sniff
             if ($fix === true) {
                 $phpcsFile->fixer->addContent($stackPtr, ' ');
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -164,7 +164,7 @@ class ScopeIndentSniff implements Sniff
 
                 $this->ignoreIndentation[$token] = true;
             }
-        }//end if
+        }
 
         $this->exact     = (bool) $this->exact;
         $this->tabIndent = (bool) $this->tabIndent;
@@ -204,7 +204,7 @@ class ScopeIndentSniff implements Sniff
 
                     StatusWriter::write("* token $i on line $line set exact flag to $value *");
                 }
-            }//end if
+            }
 
             $checkToken  = null;
             $checkIndent = null;
@@ -409,7 +409,7 @@ class ScopeIndentSniff implements Sniff
                                 $type = $tokens[$first]['type'];
                                 StatusWriter::write("* amended first token is $first ($type) on line $line *", 1);
                             }
-                        }//end if
+                        }
 
                         if (isset($tokens[$first]['scope_closer']) === true
                             && $tokens[$first]['scope_closer'] === $first
@@ -438,7 +438,7 @@ class ScopeIndentSniff implements Sniff
                                     $type = $tokens[$first]['type'];
                                     StatusWriter::write("=> indent set to $currentIndent by token $first ($type)", 1);
                                 }
-                            }//end if
+                            }
                         } else {
                             // Don't force current indent to be divisible because there could be custom
                             // rules in place between parenthesis, such as with arrays.
@@ -453,12 +453,12 @@ class ScopeIndentSniff implements Sniff
                                 $type = $tokens[$first]['type'];
                                 StatusWriter::write("=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)", 1);
                             }
-                        }//end if
-                    }//end if
+                        }
+                    }
                 } elseif ($this->debug === true) {
                     StatusWriter::write(' * ignoring single-line definition *', 1);
-                }//end if
-            }//end if
+                }
+            }
 
             // Closing short array bracket should just be indented to at least
             // the same level as where it was opened (but can be more).
@@ -550,11 +550,11 @@ class ScopeIndentSniff implements Sniff
                             $type = $tokens[$first]['type'];
                             StatusWriter::write("=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)", 1);
                         }
-                    }//end if
+                    }
                 } elseif ($this->debug === true) {
                     StatusWriter::write(' * ignoring single-line definition *', 1);
-                }//end if
-            }//end if
+                }
+            }
 
             // Adjust lines within scopes while auto-fixing.
             if ($checkToken !== null
@@ -600,8 +600,8 @@ class ScopeIndentSniff implements Sniff
                         $type = $tokens[$checkToken]['type'];
                         StatusWriter::write('=> add adjustment of ' . $adjustments[$checkToken] . " for token $checkToken ($type) on line $line", 1);
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             // Scope closers reset the required indent to the same level as the opening condition.
             if (($checkToken !== null
@@ -675,8 +675,8 @@ class ScopeIndentSniff implements Sniff
                     } else {
                         $checkToken = null;
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if ($checkToken !== null
                 && isset(Tokens::SCOPE_OPENERS[$tokens[$checkToken]['code']]) === true
@@ -737,7 +737,7 @@ class ScopeIndentSniff implements Sniff
                         StatusWriter::write("=> checking indent of $checkIndent; main indent remains at $currentIndent", 1);
                     }
                 }
-            }//end if
+            }
 
             // Method prefix indentation has to be exact or else it will break
             // the rest of the function declaration, and potentially future ones.
@@ -772,8 +772,8 @@ class ScopeIndentSniff implements Sniff
 
                         $exact = true;
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             // Open PHP tags needs to be indented to exact column positions
             // so they don't cause problems with indent checks for the code
@@ -804,7 +804,7 @@ class ScopeIndentSniff implements Sniff
                         }
                     }
                 }
-            }//end if
+            }
 
             // Close tags needs to be indented to exact column positions.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_CLOSE_TAG) {
@@ -881,14 +881,14 @@ class ScopeIndentSniff implements Sniff
                             $expectedTabs,
                             $foundTabs,
                         ];
-                    }//end if
+                    }
                 } else {
                     $error .= '%s spaces, found %s';
                     $data   = [
                         $checkIndent,
                         $tokenIndent,
                     ];
-                }//end if
+                }
 
                 if ($this->debug === true) {
                     $line    = $tokens[$checkToken]['line'];
@@ -911,7 +911,7 @@ class ScopeIndentSniff implements Sniff
                         StatusWriter::write('=> add adjustment of ' . $adjustments[$checkToken] . " for token $checkToken ($type) on line $line", 1);
                     }
                 }
-            }//end if
+            }
 
             if ($checkToken !== null) {
                 $i = $checkToken;
@@ -957,7 +957,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             // Completely skip multi-line strings as the indent is a part of the
             // content itself.
@@ -1011,7 +1011,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             // Close tags reset the indent level, unless they are closing a tag
             // opened on the same line.
@@ -1046,7 +1046,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             // Anon classes and functions set the indent based on their own indent level.
             if ($tokens[$i]['code'] === T_CLOSURE || $tokens[$i]['code'] === T_ANON_CLASS) {
@@ -1113,7 +1113,7 @@ class ScopeIndentSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             // Scope openers increase the indent level.
             if (isset($tokens[$i]['scope_condition']) === true
@@ -1171,8 +1171,8 @@ class ScopeIndentSniff implements Sniff
                     }
 
                     continue;
-                }//end if
-            }//end if
+                }
+            }
 
             // Closing an anon class, closure, or match.
             // Each may be returned, which can confuse control structures that
@@ -1232,7 +1232,7 @@ class ScopeIndentSniff implements Sniff
 
                     $prev   = $condition;
                     $parens = 0;
-                }//end if
+                }
 
                 if ($prev === false) {
                     $prev = $phpcsFile->findPrevious([T_EQUAL, T_RETURN], ($tokens[$i]['scope_condition'] - 1), null, false, null, true);
@@ -1301,8 +1301,8 @@ class ScopeIndentSniff implements Sniff
                     $type = $tokens[$first]['type'];
                     StatusWriter::write("=> indent set to $currentIndent by token $first ($type)", 1);
                 }
-            }//end if
-        }//end for
+            }
+        }
 
         // Don't process the rest of the file.
         return $phpcsFile->numTokens;
@@ -1388,8 +1388,8 @@ class ScopeIndentSniff implements Sniff
                     $type   = $tokens[$x]['type'];
                     StatusWriter::write("=> Indent adjusted to $length for $type on line $line", 1);
                 }
-            }//end for
-        }//end if
+            }
+        }
 
         return true;
     }

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -52,7 +52,7 @@ final class DisallowLongArraySyntaxUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -89,6 +89,6 @@ final class DuplicateClassNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -87,6 +87,6 @@ final class AssignmentInConditionUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -101,6 +101,6 @@ final class EmptyPHPStatementUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -69,6 +69,6 @@ final class ForLoopWithTestFunctionCallUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -58,6 +58,6 @@ final class UnconditionalIfStatementUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -69,6 +69,6 @@ final class UnusedFunctionParameterUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -103,7 +103,7 @@ final class DocCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -86,7 +86,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -41,7 +41,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -43,7 +43,7 @@ final class EndFileNoNewlineUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -50,7 +50,7 @@ final class ExecutableFileUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -44,7 +44,7 @@ final class InlineHTMLUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -62,7 +62,7 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -105,6 +105,6 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -80,7 +80,7 @@ final class SpaceAfterCastUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -66,7 +66,7 @@ final class SpaceAfterNotUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -76,7 +76,7 @@ final class FunctionCallArgumentSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -93,7 +93,7 @@ final class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffTe
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -82,7 +82,7 @@ final class CamelCapsFunctionNameUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -50,7 +50,7 @@ final class ConstructorNameUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -53,7 +53,7 @@ final class UpperCaseConstantNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -38,7 +38,7 @@ final class CharacterBeforePHPOpeningTagUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -43,7 +43,7 @@ final class DisallowAlternativePHPTagsUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -72,7 +72,7 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -105,6 +105,6 @@ final class DisallowShortOpenTagUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -77,7 +77,7 @@ final class LowerCaseConstantUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -102,7 +102,7 @@ final class LowerCaseTypeUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -45,7 +45,7 @@ final class UnnecessaryStringConcatUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -116,7 +116,7 @@ final class GitMergeConflictUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -72,7 +72,7 @@ final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -97,6 +97,6 @@ final class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -116,7 +116,7 @@ final class DisallowSpaceIndentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -117,7 +117,7 @@ final class DisallowTabIndentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -79,7 +79,7 @@ final class LanguageConstructSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -49,7 +49,7 @@ final class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -95,8 +95,8 @@ class ClassDeclarationSniff implements Sniff
                 }
 
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         if ($tokens[($curlyBrace + 1)]['content'] !== $phpcsFile->eolChar) {
             $error = 'Opening %s brace must be on a line by itself';
@@ -140,6 +140,6 @@ class ClassDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -268,7 +268,7 @@ class FileCommentSniff implements Sniff
                 $phpcsFile->addError($error, $tag, 'Empty' . ucfirst(substr($name, 1)) . 'Tag', $data);
                 continue;
             }
-        }//end foreach
+        }
 
         // Check if the tags are in the correct position.
         $pos = 0;
@@ -310,7 +310,7 @@ class FileCommentSniff implements Sniff
             while (isset($foundTags[$pos]) === true && $foundTags[$pos] === $tag) {
                 $pos++;
             }
-        }//end foreach
+        }
     }
 
 
@@ -351,7 +351,7 @@ class FileCommentSniff implements Sniff
                 ];
                 $phpcsFile->addError($error, $tag, 'InvalidCategory', $data);
             }
-        }//end foreach
+        }
     }
 
 
@@ -402,8 +402,8 @@ class FileCommentSniff implements Sniff
                     $validName,
                 ];
                 $phpcsFile->addError($error, $tag, 'InvalidPackage', $data);
-            }//end if
-        }//end foreach
+            }
+        }
     }
 
 
@@ -446,7 +446,7 @@ class FileCommentSniff implements Sniff
                 $validName,
             ];
             $phpcsFile->addError($error, $tag, 'InvalidSubpackage', $data);
-        }//end foreach
+        }
     }
 
 
@@ -515,7 +515,7 @@ class FileCommentSniff implements Sniff
                 $error = '@copyright tag must contain a year and the name of the copyright holder';
                 $phpcsFile->addError($error, $tag, 'IncompleteCopyright');
             }
-        }//end foreach
+        }
     }
 
 

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -156,8 +156,8 @@ class FunctionCommentSniff implements Sniff
                 }
 
                 $i = $nextNonWhitespace;
-            }//end for
-        }//end if
+            }
+        }
 
         $commentStart = $tokens[$commentEnd]['comment_opener'];
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
@@ -221,7 +221,7 @@ class FunctionCommentSniff implements Sniff
 
             $error = 'Missing @return tag in function comment';
             $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
-        }//end if
+        }
     }
 
 
@@ -255,7 +255,7 @@ class FunctionCommentSniff implements Sniff
                 $error = 'Exception type missing for @throws tag in function comment';
                 $phpcsFile->addError($error, $tag, 'InvalidThrows');
             }
-        }//end foreach
+        }
     }
 
 
@@ -331,15 +331,15 @@ class FunctionCommentSniff implements Sniff
                     } else {
                         $error = 'Missing parameter comment';
                         $phpcsFile->addError($error, $tag, 'MissingParamComment');
-                    }//end if
+                    }
                 } else {
                     $error = 'Missing parameter name';
                     $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }//end if
+                }
             } else {
                 $error = 'Missing parameter type';
                 $phpcsFile->addError($error, $tag, 'MissingParamType');
-            }//end if
+            }
 
             $params[] = [
                 'tag'            => $tag,
@@ -351,7 +351,7 @@ class FunctionCommentSniff implements Sniff
                 'type_space'     => $typeSpace,
                 'var_space'      => $varSpace,
             ];
-        }//end foreach
+        }
 
         $realParams  = $phpcsFile->getMethodParameters($stackPtr);
         $foundParams = [];
@@ -409,9 +409,9 @@ class FunctionCommentSniff implements Sniff
                         for ($i = ($commentToken + 1); $i <= $param['comment_end']; $i++) {
                             $phpcsFile->fixer->replaceToken($i, '');
                         }
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
 
             // Make sure the param name is correct.
             if (isset($realParams[$pos]) === true) {
@@ -437,7 +437,7 @@ class FunctionCommentSniff implements Sniff
                 // We must have an extra parameter comment.
                 $error = 'Superfluous parameter comment';
                 $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
-            }//end if
+            }
 
             if ($param['comment'] === '') {
                 continue;
@@ -480,8 +480,8 @@ class FunctionCommentSniff implements Sniff
                     for ($i = ($commentToken + 1); $i <= $param['comment_end']; $i++) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             // Check the alignment of multi-line param comments.
             if ($param['tag'] !== $param['comment_end']) {
@@ -523,9 +523,9 @@ class FunctionCommentSniff implements Sniff
                             $phpcsFile->fixer->addContentBefore($commentToken, $padding);
                         }
                     }
-                }//end foreach
-            }//end if
-        }//end foreach
+                }
+            }
+        }
 
         $realNames = [];
         foreach ($realParams as $realParam) {

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -119,7 +119,7 @@ class MultiLineConditionSniff implements Sniff
                         }
                     }
                 }
-            }//end if
+            }
 
             if ($tokens[$i]['line'] !== $prevLine) {
                 if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
@@ -130,10 +130,10 @@ class MultiLineConditionSniff implements Sniff
                         // Closing brace needs to be indented to the same level
                         // as the statement.
                         $expectedIndent = $statementIndent;
-                    }//end if
+                    }
                 } else {
                     $expectedIndent = ($statementIndent + $this->indent);
-                }//end if
+                }
 
                 if ($tokens[$i]['code'] === T_COMMENT
                     || isset(Tokens::PHPCS_ANNOTATION_TOKENS[$tokens[$i]['code']]) === true
@@ -197,11 +197,11 @@ class MultiLineConditionSniff implements Sniff
                                 }
                             }
                         }
-                    }//end if
-                }//end if
+                    }
+                }
 
                 $prevLine = $tokens[$i]['line'];
-            }//end if
+            }
 
             if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true) {
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), null, true);
@@ -213,7 +213,7 @@ class MultiLineConditionSniff implements Sniff
                     continue;
                 }
             }
-        }//end for
+        }
 
         // From here on, we are checking the spacing of the opening and closing
         // braces. If this IF statement does not use braces, we end here.

--- a/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
+++ b/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
@@ -127,6 +127,6 @@ class IncludingFileSniff implements Sniff
                     $phpcsFile->fixer->replaceToken($stackPtr, 'require');
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -239,7 +239,7 @@ class FunctionCallSignatureSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         // Checking this: $value = my_function(...[*]).
         $spaceBeforeClose = 0;
@@ -303,9 +303,9 @@ class FunctionCallSignatureSniff implements Sniff
                     $phpcsFile->fixer->endChangeset();
                 } else {
                     $phpcsFile->fixer->replaceToken(($closer - 1), $padding);
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
     }
 
 
@@ -388,7 +388,7 @@ class FunctionCallSignatureSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($first - 1), $padding);
                 }
             }
-        }//end if
+        }
 
         $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
@@ -442,7 +442,7 @@ class FunctionCallSignatureSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
 
         $i = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
 
@@ -567,17 +567,17 @@ class FunctionCallSignatureSniff implements Sniff
                             }
 
                             $phpcsFile->fixer->endChangeset();
-                        }//end if
-                    }//end if
+                        }
+                    }
                 } else {
                     $nextCode = $i;
-                }//end if
+                }
 
                 if ($inArg === false) {
                     $argStart = $nextCode;
                     $argEnd   = $phpcsFile->findEndOfStatement($nextCode, [T_COLON]);
                 }
-            }//end if
+            }
 
             // If we are within an argument we should be ignoring commas
             // as these are not signalling the end of an argument.
@@ -609,11 +609,11 @@ class FunctionCallSignatureSniff implements Sniff
                             $phpcsFile->fixer->endChangeset();
                         }
                     }
-                }//end if
+                }
 
                 $argStart = $next;
                 $argEnd   = $phpcsFile->findEndOfStatement($next, [T_COLON]);
-            }//end if
-        }//end for
+            }
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -86,7 +86,7 @@ class FunctionDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         // Must be no space before the opening parenthesis. For closures, this is
         // enforced by the previous check because there is no content between the keywords
@@ -135,9 +135,9 @@ class FunctionDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         // Must be one space before and after USE keyword for closures.
         if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
@@ -184,8 +184,8 @@ class FunctionDeclarationSniff implements Sniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if ($this->isMultiLineDeclaration($phpcsFile, $stackPtr, $openBracket, $tokens) === true) {
             $this->processMultiLineDeclaration($phpcsFile, $stackPtr, $tokens);
@@ -327,11 +327,11 @@ class FunctionDeclarationSniff implements Sniff
                     }
 
                     $phpcsFile->fixer->endChangeset();
-                }//end if
+                }
 
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         $prev = $tokens[($opener - 1)];
         if ($prev['code'] !== T_WHITESPACE) {
@@ -431,8 +431,8 @@ class FunctionDeclarationSniff implements Sniff
                         $phpcsFile->fixer->addNewlineBefore($closeBracket);
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         // Each line between the parenthesis should be indented 4 spaces.
         $openBracket = $tokens[$stackPtr]['parenthesis_opener'];
@@ -490,7 +490,7 @@ class FunctionDeclarationSniff implements Sniff
                 }
 
                 $lastLine = $tokens[$i]['line'];
-            }//end if
+            }
 
             if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS
                 && isset($tokens[$i]['parenthesis_closer']) === true
@@ -523,6 +523,6 @@ class FunctionDeclarationSniff implements Sniff
                 $lastLine = $tokens[$i]['line'];
                 continue;
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -72,6 +72,6 @@ class ValidDefaultValueSniff implements Sniff
                 $phpcsFile->addError($error, $param['token'], 'NotAtEnd');
                 return;
             }
-        }//end foreach
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -89,6 +89,6 @@ class ValidClassNameSniff implements Sniff
                 $data[]  = $newName;
                 $phpcsFile->addError($error, $stackPtr, 'Invalid', $data);
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -168,7 +168,7 @@ class ObjectOperatorIndentSniff implements Sniff
                     }
 
                     $previousIndent = $expectedIndent;
-                }//end if
+                }
 
                 // It cant be the last thing on the line either.
                 $content = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);
@@ -185,13 +185,13 @@ class ObjectOperatorIndentSniff implements Sniff
                         $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }//end if
+            }
 
             $next = $phpcsFile->findNext(
                 self::TARGET_TOKENS,
                 ($next + 1),
                 $end
             );
-        }//end while
+        }
     }
 }

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -163,7 +163,7 @@ class ScopeClosingBraceSniff implements Sniff
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'Indent', $data);
             }
-        }//end if
+        }
 
         if ($fix === true) {
             $spaces = str_repeat(' ', $expectedIndent);

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -71,7 +71,7 @@ final class ClassDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -65,7 +65,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -90,6 +90,6 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -59,7 +59,7 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -86,6 +86,6 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -103,7 +103,7 @@ final class FunctionCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -117,7 +117,7 @@ final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -139,7 +139,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -50,7 +50,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -230,7 +230,7 @@ class SideEffectsSniff implements Sniff
 
                     continue;
                 }
-            }//end if
+            }
 
             // Special case for defined() as it can be used to see
             // if a constant (a symbol) should be defined or not and
@@ -254,7 +254,7 @@ class SideEffectsSniff implements Sniff
                         continue;
                     }
                 }
-            }//end if
+            }
 
             // Conditional statements are allowed in symbol files as long as the
             // contents is only a symbol definition. So don't count these as effects
@@ -290,7 +290,7 @@ class SideEffectsSniff implements Sniff
 
                 $i = $tokens[$i]['scope_closer'];
                 continue;
-            }//end if
+            }
 
             if ($firstEffect === null) {
                 $firstEffect = $i;
@@ -300,7 +300,7 @@ class SideEffectsSniff implements Sniff
                 // We have a conflict we have to report, so no point continuing.
                 break;
             }
-        }//end for
+        }
 
         return [
             'symbol' => $firstSymbol,

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -76,6 +76,6 @@ final class SideEffectsUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -49,7 +49,7 @@ final class CamelCapsMethodNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
@@ -129,7 +129,7 @@ class AnonClassDeclarationSniff extends ClassDeclarationSniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
     }
 
 
@@ -213,9 +213,9 @@ class AnonClassDeclarationSniff extends ClassDeclarationSniff
                     $phpcsFile->fixer->endChangeset();
                 } else {
                     $phpcsFile->fixer->replaceToken(($closeBracket - 1), '');
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
     }
 
 

--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -81,7 +81,7 @@ class ClassInstantiationSniff implements Sniff
 
             $classNameEnd = $i;
             break;
-        }//end for
+        }
 
         if ($classNameEnd === null) {
             return;

--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -200,7 +200,7 @@ class BooleanOperatorPlacementSniff implements Sniff
                         $phpcsFile->fixer->addContent($prev, ' ' . $tokens[$operator]['content']);
                         $phpcsFile->fixer->replaceToken($operator, '');
                     }
-                }//end if
+                }
             } else {
                 if ($tokens[$prev]['line'] === $tokens[$operator]['line']) {
                     if ($tokens[$next]['line'] === $tokens[$operator]['line']) {
@@ -221,9 +221,9 @@ class BooleanOperatorPlacementSniff implements Sniff
                         $phpcsFile->fixer->addContentBefore($next, $tokens[$operator]['content'] . ' ');
                         $phpcsFile->fixer->replaceToken($operator, '');
                     }
-                }//end if
-            }//end if
-        }//end foreach
+                }
+            }
+        }
 
         $phpcsFile->fixer->endChangeset();
     }

--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -160,7 +160,7 @@ class ControlStructureSpacingSniff implements Sniff
                     }
                 }
             }
-        }//end for
+        }
 
         // Check the closing parenthesis.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($parenCloser - 1), $parenOpener, true);
@@ -188,8 +188,8 @@ class ControlStructureSpacingSniff implements Sniff
 
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if ($tokens[$parenCloser]['line'] !== $tokens[$prev]['line']) {
             $requiredIndent = ($tokens[$first]['column'] - 1);

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -105,7 +105,7 @@ class DeclareStatementSniff implements Sniff
                     $equals = $phpcsFile->findNext(T_EQUAL, ($equals + 1));
                 }
             }
-        }//end if
+        }
 
         // There should be no space between equal sign and directive value.
         $value = $phpcsFile->findNext(T_WHITESPACE, ($equals + 1), null, true);
@@ -182,8 +182,8 @@ class DeclareStatementSniff implements Sniff
                 if ($tokens[$token]['type'] === 'T_OPEN_CURLY_BRACKET') {
                     $curlyBracket = $token;
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if ($curlyBracket !== false) {
             $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($curlyBracket - 1), null, true);
@@ -205,7 +205,7 @@ class DeclareStatementSniff implements Sniff
 
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
+            }
 
             $closeCurlyBracket = $tokens[$curlyBracket]['bracket_closer'];
 
@@ -222,7 +222,7 @@ class DeclareStatementSniff implements Sniff
                         $phpcsFile->fixer->addNewline($prevToken);
                     }
                 }
-            }//end if
+            }
 
             // Closing curly bracket must align with the declare keyword.
             if ($tokens[$stackPtr]['column'] !== $tokens[$closeCurlyBracket]['column']) {
@@ -253,6 +253,6 @@ class DeclareStatementSniff implements Sniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -109,7 +109,7 @@ class FileHeaderSniff implements Sniff
                     $phpcsFile->addError($error, $openTag, 'HeaderPosition');
                 }
             }
-        }//end if
+        }
 
         $this->processHeaderLines($phpcsFile, $possibleHeaders[$openTag]);
 
@@ -207,7 +207,7 @@ class FileHeaderSniff implements Sniff
                             'end'   => $end,
                         ];
                     }
-                }//end if
+                }
 
                 $next = $end;
                 break;
@@ -265,7 +265,7 @@ class FileHeaderSniff implements Sniff
 
                 // We found the start of the main code block.
                 break(2);
-            }//end switch
+            }
 
             $next = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);
         } while ($next !== false);
@@ -318,8 +318,8 @@ class FileHeaderSniff implements Sniff
 
                             $phpcsFile->fixer->endChangeset();
                         }
-                    }//end if
-                }//end if
+                    }
+                }
 
                 // Make sure we haven't seen this next block before.
                 if (isset($headerLines[($i + 1)]) === true
@@ -357,13 +357,13 @@ class FileHeaderSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($found[$line['type']]) === false) {
                 $found[$line['type']] = $line;
             }
-        }//end foreach
+        }
 
         /*
             Next, check that the order of the header blocks
@@ -419,7 +419,7 @@ class FileHeaderSniff implements Sniff
                     $blockOrder[$prevValidType],
                 ];
                 $phpcsFile->addError($error, $found[$type]['start'], 'IncorrectOrder', $data);
-            }//end if
-        }//end foreach
+            }
+        }
     }
 }

--- a/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
+++ b/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
@@ -76,6 +76,6 @@ class CompoundNamespaceDepthSniff implements Sniff
 
                 $depth = 1;
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -92,7 +92,7 @@ class UseDeclarationSniff implements Sniff
                     }
 
                     break;
-                }//end for
+                }
 
                 if ($tokens[$lastValidContent]['line'] !== ($tokens[$opener]['line'] + 1)) {
                     $error = 'The first trait import statement must be declared on the first non-comment line after the %s opening brace';
@@ -130,14 +130,14 @@ class UseDeclarationSniff implements Sniff
 
                                     $lastValidContent = $i;
                                 }
-                            }//end for
+                            }
 
                             $phpcsFile->fixer->endChangeset();
-                        }//end if
+                        }
                     } else {
                         $phpcsFile->addError($error, $useToken, 'UseAfterBrace', $data);
-                    }//end if
-                }//end if
+                    }
+                }
             } else {
                 // Make sure this use statement is not on the same line as the previous one.
                 $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($useToken - 1), null, true);
@@ -171,10 +171,10 @@ class UseDeclarationSniff implements Sniff
                             }
 
                             $phpcsFile->fixer->endChangeset();
-                        }//end if
-                    }//end if
-                }//end if
-            }//end if
+                        }
+                    }
+                }
+            }
 
             $error = 'Expected 1 space after USE in trait import statement; %s found';
             if ($tokens[($useToken + 1)]['code'] !== T_WHITESPACE) {
@@ -206,7 +206,7 @@ class UseDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($useToken + 1), ' ');
                     }
                 }
-            }//end if
+            }
 
             // Check the formatting of the statement.
             if (isset($tokens[$useToken]['scope_opener']) === true) {
@@ -251,7 +251,7 @@ class UseDeclarationSniff implements Sniff
 
                             $phpcsFile->fixer->endChangeset();
                         }
-                    }//end if
+                    }
                 } elseif ($tokens[$next]['code'] !== T_USE) {
                     // Comments are allowed on the same line as the use statement, so make sure
                     // we don't error for those.
@@ -286,7 +286,7 @@ class UseDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
+                }
             } else {
                 // Ensure use statements are grouped.
                 $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
@@ -294,8 +294,8 @@ class UseDeclarationSniff implements Sniff
                     $error = 'Imported traits must be grouped together';
                     $phpcsFile->addError($error, $useTokens[($usePos + 1)], 'NotGrouped');
                 }
-            }//end if
-        }//end foreach
+            }
+        }
 
         return $tokens[$ooToken]['scope_closer'];
     }
@@ -346,7 +346,7 @@ class UseDeclarationSniff implements Sniff
             } else {
                 $phpcsFile->addError($error, $opener, 'OpenBraceNewLine');
             }
-        }//end if
+        }
 
         $error = 'Expected 1 space before opening brace in trait import statement; %s found';
         if ($tokens[($opener - 1)]['code'] !== T_WHITESPACE) {
@@ -378,7 +378,7 @@ class UseDeclarationSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($opener - 1), ' ');
                 }
             }
-        }//end if
+        }
 
         $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($opener + 1), ($closer - 1), true);
         if ($next !== false && $tokens[$next]['line'] !== ($tokens[$opener]['line'] + 1)) {
@@ -403,7 +403,7 @@ class UseDeclarationSniff implements Sniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
 
         for ($i = ($stackPtr + 1); $i < $opener; $i++) {
             if ($tokens[$i]['code'] !== T_COMMA) {
@@ -449,8 +449,8 @@ class UseDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($i + 1), ' ');
                     }
                 }
-            }//end if
-        }//end for
+            }
+        }
 
         for ($i = ($opener + 1); $i < $closer; $i++) {
             if ($tokens[$i]['code'] === T_INSTEADOF) {
@@ -490,7 +490,7 @@ class UseDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
+                }
 
                 $error = 'Expected 1 space after INSTEADOF in trait import statement; %s found';
                 if ($tokens[($i + 1)]['code'] !== T_WHITESPACE) {
@@ -528,8 +528,8 @@ class UseDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if ($tokens[$i]['code'] === T_AS) {
                 $error = 'Expected 1 space before AS in trait import statement; %s found';
@@ -568,7 +568,7 @@ class UseDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
+                }
 
                 $error = 'Expected 1 space after AS in trait import statement; %s found';
                 if ($tokens[($i + 1)]['code'] !== T_WHITESPACE) {
@@ -606,8 +606,8 @@ class UseDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if ($tokens[$i]['code'] === T_SEMICOLON) {
                 if ($tokens[($i - 1)]['code'] === T_WHITESPACE) {
@@ -638,8 +638,8 @@ class UseDeclarationSniff implements Sniff
                         }
                     }
                 }
-            }//end if
-        }//end for
+            }
+        }
 
         $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closer - 1), ($opener + 1), true);
         if ($prev !== false && $tokens[$prev]['line'] !== ($tokens[$closer]['line'] - 1)) {
@@ -664,7 +664,7 @@ class UseDeclarationSniff implements Sniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 
 

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -61,7 +61,7 @@ final class DeclareStatementUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -64,7 +64,7 @@ final class FileHeaderUnitTest extends AbstractSniffTestCase
             return [4 => 2];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -37,7 +37,7 @@ final class OpenTagUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -58,7 +58,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -115,8 +115,8 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         // We'll need the indent of the class/interface declaration for later.
         $classIndent = 0;
@@ -174,7 +174,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                     }
                 }
             }
-        }//end if
+        }
 
         // Check after the class/interface name.
         if ($className !== null
@@ -244,7 +244,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         }
 
                         $phpcsFile->fixer->endChangeset();
-                    }//end if
+                    }
                 } else {
                     // Check the whitespace before. Whitespace after is checked
                     // later by looking at the whitespace before the first class name
@@ -258,9 +258,9 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                             $phpcsFile->fixer->replaceToken(($keyword - 1), ' ');
                         }
                     }
-                }//end if
-            }//end if
-        }//end foreach
+                }
+            }
+        }
 
         // Check each of the extends/implements class names. If the extends/implements
         // keyword is the last content on the line, it means we need to check for
@@ -393,7 +393,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                             }
                         }
                     }
-                }//end if
+                }
             } else {
                 if ($tokens[($className - 1)]['code'] === T_COMMA) {
                     $error = 'Expected 1 space before "%s"; 0 found';
@@ -430,9 +430,9 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                                 $phpcsFile->fixer->addContent($prev, ' ');
                             }
                         }
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
 
             if ($checkingImplements === true
                 && $tokens[($className + 1)]['code'] !== T_COMMA
@@ -457,8 +457,8 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                 $nextComma = $phpcsFile->findNext(T_COMMA, $className);
             } else {
                 $nextComma = ($className + 1);
-            }//end if
-        }//end foreach
+            }
+        }
     }
 
 
@@ -497,7 +497,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
 
         if ($tokens[$stackPtr]['code'] !== T_ANON_CLASS) {
             // Check the closing brace is on it's own line, but allow

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -119,8 +119,8 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         if ($propertyInfo['scope_specified'] === false && $propertyInfo['set_scope'] === false) {
             $error = 'Visibility must be declared on property "%s"';
@@ -176,7 +176,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
             }
 
             $firstVisibilityModifier = min($scopePtr, $setScopePtr);
-        }//end if
+        }
 
         if ($hasVisibilityModifier === true && $propertyInfo['is_final'] === true) {
             $scopePtr = $firstVisibilityModifier;
@@ -201,7 +201,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
 
         if ($hasVisibilityModifier === true && $propertyInfo['is_abstract'] === true) {
             $scopePtr    = $firstVisibilityModifier;
@@ -226,7 +226,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
 
         if ($hasVisibilityModifier === true && $propertyInfo['is_static'] === true) {
             $scopePtr  = $lastVisibilityModifier;
@@ -251,7 +251,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
 
         if ($hasVisibilityModifier === true && $propertyInfo['is_readonly'] === true) {
             $scopePtr    = $lastVisibilityModifier;
@@ -276,7 +276,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -105,7 +105,7 @@ class ControlStructureSpacingSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($parenCloser - 1), $parenOpener, true);
         if ($tokens[$prev]['line'] === $tokens[$parenCloser]['line']) {
@@ -132,6 +132,6 @@ class ControlStructureSpacingSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -153,8 +153,8 @@ class SwitchDeclarationSniff implements Sniff
 
                             $phpcsFile->fixer->endChangeset();
                         }
-                    }//end if
-                }//end if
+                    }
+                }
 
                 if ($tokens[$nextCloser]['scope_condition'] === $nextCase) {
                     // Only need to check some things once, even if the
@@ -181,8 +181,8 @@ class SwitchDeclarationSniff implements Sniff
                                 }
                             }
                         }
-                    }//end if
-                }//end if
+                    }
+                }
             } else {
                 $error = strtoupper($type) . ' statements must be defined using a colon';
                 if ($tokens[$opener]['code'] === T_SEMICOLON) {
@@ -194,7 +194,7 @@ class SwitchDeclarationSniff implements Sniff
                     // Probably a case/default statement with colon + curly braces.
                     $phpcsFile->addError($error, $nextCase, 'WrongOpener' . $type);
                 }
-            }//end if
+            }
 
             // We only want cases from here on in.
             if ($type !== 'case') {
@@ -219,7 +219,7 @@ class SwitchDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end while
+        }
     }
 
 
@@ -375,7 +375,7 @@ class SwitchDeclarationSniff implements Sniff
                         if ($hasTerminator === false) {
                             return false;
                         }
-                    }//end while
+                    }
 
                     // If we have not encountered a DEFAULT block by now, we cannot
                     // be sure that the whole statement terminates in every case.
@@ -386,7 +386,7 @@ class SwitchDeclarationSniff implements Sniff
                     return $hasTerminator;
                 } else {
                     return false;
-                }//end if
+                }
             } while ($currentCloser !== false && $tokens[$currentCloser]['code'] === T_CLOSE_CURLY_BRACKET);
 
             return true;
@@ -397,7 +397,7 @@ class SwitchDeclarationSniff implements Sniff
             if (isset(self::CASE_TERMINATING_TOKENS[$tokens[$terminator]['code']]) === true) {
                 return $terminator;
             }
-        }//end if
+        }
 
         return false;
     }

--- a/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
@@ -77,7 +77,7 @@ class ClosingTagSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'PHP closing tag at end of PHP-only file', 'yes');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PHP closing tag at end of PHP-only file', 'no');
-        }//end if
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -163,10 +163,10 @@ class UseDeclarationSniff implements Sniff
                         }
 
                         $phpcsFile->fixer->endChangeset();
-                    }//end if
-                }//end if
-            }//end if
-        }//end if
+                    }
+                }
+            }
+        }
 
         // Make sure this USE comes after the first namespace declaration.
         $prev = $phpcsFile->findPrevious(T_NAMESPACE, ($stackPtr - 1));
@@ -259,7 +259,7 @@ class UseDeclarationSniff implements Sniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -88,7 +88,7 @@ final class PropertyDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -116,6 +116,6 @@ final class PropertyDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -46,7 +46,7 @@ final class EndFileNewlineUnitTest extends AbstractSniffTestCase
             return [1 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -54,7 +54,7 @@ final class MethodDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -83,6 +83,6 @@ final class MethodDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -79,7 +79,7 @@ final class UseDeclarationUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -115,7 +115,7 @@ class ArrayDeclarationSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'Short array syntax used', 'yes');
             $arrayStart = $stackPtr;
             $arrayEnd   = $tokens[$stackPtr]['bracket_closer'];
-        }//end if
+        }
 
         // Check for empty arrays.
         $content = $phpcsFile->findNext(T_WHITESPACE, ($arrayStart + 1), ($arrayEnd + 1), true);
@@ -190,7 +190,7 @@ class ArrayDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end for
+        }
 
         // Now check each of the double arrows (if any).
         $nextArrow = $arrayStart;
@@ -218,7 +218,7 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($nextArrow - 1), ' ');
                     }
                 }
-            }//end if
+            }
 
             if ($tokens[($nextArrow + 1)]['code'] !== T_WHITESPACE) {
                 $content = $tokens[($nextArrow + 1)]['content'];
@@ -243,8 +243,8 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($nextArrow + 1), ' ');
                     }
                 }
-            }//end if
-        }//end while
+            }
+        }
 
         if ($valueCount > 0) {
             $nestedParenthesis = false;
@@ -300,7 +300,7 @@ class ArrayDeclarationSniff implements Sniff
                             $phpcsFile->fixer->replaceToken(($comma + 1), ' ');
                         }
                     }
-                }//end if
+                }
 
                 if ($tokens[($comma - 1)]['code'] === T_WHITESPACE) {
                     $content     = $tokens[($comma - 2)]['content'];
@@ -316,8 +316,8 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($comma - 1), '');
                     }
                 }
-            }//end foreach
-        }//end if
+            }
+        }
     }
 
 
@@ -369,7 +369,7 @@ class ArrayDeclarationSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($arrayEnd - 1), str_repeat(' ', $expected));
                 }
             }
-        }//end if
+        }
 
         $keyUsed    = false;
         $singleUsed = false;
@@ -422,7 +422,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             if ($tokens[$nextToken]['code'] !== T_DOUBLE_ARROW && $tokens[$nextToken]['code'] !== T_COMMA) {
                 continue;
@@ -488,7 +488,7 @@ class ArrayDeclarationSniff implements Sniff
                                 $phpcsFile->addError($error, $nextToken, 'SpaceBeforeComma', $data);
                             }
                         }
-                    }//end if
+                    }
 
                     $valueContent = $phpcsFile->findNext(
                         Tokens::EMPTY_TOKENS,
@@ -508,11 +508,11 @@ class ArrayDeclarationSniff implements Sniff
                         // Don't decide if an array is key => value indexed or not when PHP 7.4+ array unpacking is used.
                         $singleUsed = true;
                     }
-                }//end if
+                }
 
                 $lastToken = $nextToken;
                 continue;
-            }//end if
+            }
 
             if ($tokens[$nextToken]['code'] === T_DOUBLE_ARROW) {
                 if ($singleUsed === true) {
@@ -557,8 +557,8 @@ class ArrayDeclarationSniff implements Sniff
                 $currentEntry['value'] = $nextContent;
                 $indices[] = $currentEntry;
                 $lastToken = $nextToken;
-            }//end if
-        }//end for
+            }
+        }
 
         // Check for multi-line arrays that should be single-line.
         $singleValue = false;
@@ -616,8 +616,8 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         /*
             This section checks for arrays that don't specify keys.
@@ -725,9 +725,9 @@ class ArrayDeclarationSniff implements Sniff
                             }
                         }
                     }
-                }//end if
-            }//end foreach
-        }//end if
+                }
+            }
+        }
 
         /*
             Below the actual indentation of the array is checked.
@@ -818,7 +818,7 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($indexPointer - 1), str_repeat(' ', $expected));
                     }
                 }
-            }//end if
+            }
 
             $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
             if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
@@ -846,7 +846,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 continue;
-            }//end if
+            }
 
             $valueStart = ($arrowStart + 3);
             if ($tokens[$valuePointer]['column'] !== $valueStart) {
@@ -885,7 +885,7 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($valuePointer - 1), str_repeat(' ', $expected));
                     }
                 }
-            }//end if
+            }
 
             // Check each line ends in a comma.
             $valueStart = $valuePointer;
@@ -930,7 +930,7 @@ class ArrayDeclarationSniff implements Sniff
 
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
+            }
 
             // Check that there is no space before the comma.
             if ($nextComma !== false && $tokens[($nextComma - 1)]['code'] === T_WHITESPACE) {
@@ -951,6 +951,6 @@ class ArrayDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end foreach
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -80,8 +80,8 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
     }
 
 
@@ -162,7 +162,7 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
                     }
                 }
             }
-        }//end if
+        }
 
         if ($difference !== -1 && $difference !== 1) {
             for ($nextSignificant = $nextContent; $nextSignificant < $phpcsFile->numTokens; $nextSignificant++) {
@@ -214,6 +214,6 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -113,9 +113,9 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
 
                     // Fix potential whitespace issues in the next loop.
                     return;
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         if ($tokens[($stackPtr - 1)]['code'] === T_WHITESPACE) {
             $found = $tokens[($stackPtr - 1)]['length'];

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -118,7 +118,7 @@ class BlockCommentSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         $commentLines  = [$stackPtr];
         $nextComment   = $stackPtr;
@@ -147,7 +147,7 @@ class BlockCommentSniff implements Sniff
             ) {
                 break;
             }
-        }//end while
+        }
 
         $commentText = str_replace($phpcsFile->eolChar, '', $commentString);
         $commentText = trim($commentText, "/* \t");
@@ -210,7 +210,7 @@ class BlockCommentSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         $starColumn = $tokens[$stackPtr]['column'];
         $hasStars   = false;
@@ -260,13 +260,13 @@ class BlockCommentSniff implements Sniff
 
                     $phpcsFile->fixer->replaceToken($commentLines[1], $padding . $commentText);
                 }
-            }//end if
+            }
 
             if (preg_match('/^\p{Ll}/u', $commentText) === 1) {
                 $error = 'Block comments must start with a capital letter';
                 $phpcsFile->addError($error, $commentLines[1], 'NoCapital');
             }
-        }//end if
+        }
 
         // Check that each line of the comment is indented past the star.
         foreach ($commentLines as $line) {
@@ -320,8 +320,8 @@ class BlockCommentSniff implements Sniff
 
                     $phpcsFile->fixer->replaceToken($line, $padding . $commentText);
                 }
-            }//end if
-        }//end foreach
+            }
+        }
 
         // Finally, test the last line is correct.
         $lastIndex   = (count($commentLines) - 1);
@@ -364,8 +364,8 @@ class BlockCommentSniff implements Sniff
 
                     $phpcsFile->fixer->replaceToken($commentLines[$lastIndex], $padding . $commentText);
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         // Check that the lines before and after this comment are blank.
         $contentBefore = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -80,7 +80,7 @@ class ClosingDeclarationCommentSniff implements Sniff
             $comment = '//end trait';
         } else {
             $comment = '//end enum';
-        }//end if
+        }
 
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             // Parse error or live coding.
@@ -114,7 +114,7 @@ class ClosingDeclarationCommentSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         if (rtrim($tokens[($closingBracket + 1)]['content']) !== $comment) {
             $fix = $phpcsFile->addFixableError('Expected %s', $closingBracket, 'Incorrect', $data);

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -111,7 +111,7 @@ class DocCommentAlignmentSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($i - 1), $padding);
                     }
                 }
-            }//end if
+            }
 
             if ($tokens[$i]['code'] !== T_DOC_COMMENT_STAR) {
                 continue;
@@ -138,6 +138,6 @@ class DocCommentAlignmentSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($i + 1), ' ');
                 }
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -183,8 +183,8 @@ class FileCommentSniff implements Sniff
                         $phpcsFile->fixer->replaceToken($string, $expected);
                     }
                 }
-            }//end if
-        }//end foreach
+            }
+        }
 
         // Check if the tags are in the correct position.
         $pos = 0;
@@ -209,7 +209,7 @@ class FileCommentSniff implements Sniff
             }
 
             $pos++;
-        }//end foreach
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -142,7 +142,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                                 $phpcsFile->addError($error, $return, 'InvalidReturnVoid');
                             }
                         }
-                    }//end if
+                    }
                 } elseif ($returnType !== 'mixed'
                     && $returnType !== 'never'
                     && in_array('void', $typeNames, true) === false
@@ -177,9 +177,9 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                                 $phpcsFile->addError($error, $returnToken, 'InvalidReturnNotVoid');
                             }
                         }
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
         } else {
             if ($isSpecialMethod === true) {
                 return;
@@ -187,7 +187,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
             $error = 'Missing @return tag in function comment';
             $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
-        }//end if
+        }
     }
 
 
@@ -261,8 +261,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $error = '@throws tag comment must end with a full stop';
                     $phpcsFile->addError($error, ($tag + 2), 'ThrowsNoFullStop');
                 }
-            }//end if
-        }//end foreach
+            }
+        }
     }
 
 
@@ -366,15 +366,15 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                         $error = 'Missing parameter comment';
                         $phpcsFile->addError($error, $tag, 'MissingParamComment');
                         $commentLines[] = ['comment' => ''];
-                    }//end if
+                    }
                 } else {
                     $error = 'Missing parameter name';
                     $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }//end if
+                }
             } else {
                 $error = 'Missing parameter type';
                 $phpcsFile->addError($error, $tag, 'MissingParamType');
-            }//end if
+            }
 
             $params[] = [
                 'tag'          => $tag,
@@ -385,7 +385,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 'type_space'   => $typeSpace,
                 'var_space'    => $varSpace,
             ];
-        }//end foreach
+        }
 
         $realParams  = $phpcsFile->getMethodParameters($stackPtr);
         $foundParams = [];
@@ -492,7 +492,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                             $param['var'],
                         ];
                         $phpcsFile->addError($error, $stackPtr, 'IncorrectTypeHint', $data);
-                    }//end if
+                    }
                 } elseif ($suggestedTypeHint === '' && isset($realParams[$pos]) === true) {
                     $typeHint = $realParams[$pos]['type_hint'];
                     if ($typeHint !== '') {
@@ -503,8 +503,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                         ];
                         $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHint', $data);
                     }
-                }//end if
-            }//end foreach
+                }
+            }
 
             $suggestedType = implode('|', $suggestedTypeNames);
             if ($param['type'] !== $suggestedType) {
@@ -545,8 +545,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     }
 
                     $phpcsFile->fixer->endChangeset();
-                }//end if
-            }//end if
+                }
+            }
 
             if ($param['var'] === '') {
                 continue;
@@ -598,12 +598,12 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $error .= 'actual variable name %s';
 
                     $phpcsFile->addError($error, $param['tag'], $code, $data);
-                }//end if
+                }
             } elseif (substr($param['var'], -4) !== ',...') {
                 // We must have an extra parameter comment.
                 $error = 'Superfluous parameter comment';
                 $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
-            }//end if
+            }
 
             if ($param['comment'] === '') {
                 continue;
@@ -623,7 +623,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $error = 'Parameter comment must end with a full stop';
                 $phpcsFile->addError($error, $param['tag'], 'ParamCommentFullStop');
             }
-        }//end foreach
+        }
 
         $realNames = [];
         foreach ($realParams as $realParam) {
@@ -693,8 +693,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
-        }//end if
+            }
+        }
     }
 
 
@@ -751,8 +751,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
-        }//end if
+            }
+        }
     }
 
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -158,7 +158,7 @@ class FunctionCommentThrowTagSniff implements Sniff
                 }
             } else {
                 ++$unknownCount;
-            }//end if
+            }
         } while ($currPos < $stackPtrEnd && $currPos !== false);
 
         if ($foundThrows === false) {

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -110,7 +110,7 @@ class InlineCommentSniff implements Sniff
                 $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
                 $phpcsFile->addError($error, $stackPtr, 'DocBlock');
             }
-        }//end if
+        }
 
         if ($tokens[$stackPtr]['content'][0] === '#') {
             $error = 'Perl-style comments are not allowed; use "// Comment" instead';
@@ -159,7 +159,7 @@ class InlineCommentSniff implements Sniff
 
             $commentTokens[] = $nextComment;
             $lastComment     = $nextComment;
-        }//end while
+        }
 
         $commentText = '';
         foreach ($commentTokens as $lastCommentToken) {
@@ -209,7 +209,7 @@ class InlineCommentSniff implements Sniff
                     $comment,
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
-            }//end if
+            }
 
             if ($fix === true) {
                 $newComment = '// ' . ltrim($tokens[$lastCommentToken]['content'], "/\t ");
@@ -217,7 +217,7 @@ class InlineCommentSniff implements Sniff
             }
 
             $commentText .= trim(substr($tokens[$lastCommentToken]['content'], 2));
-        }//end foreach
+        }
 
         if ($commentText === '') {
             $error = 'Blank comments are not allowed';
@@ -305,7 +305,7 @@ class InlineCommentSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
 
         return ($lastCommentToken + 1);
     }

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -124,9 +124,9 @@ class LongConditionClosingCommentSniff implements Sniff
                     $endBrace = $tokens[$stackPtr];
                 } else {
                     break;
-                }//end if
+                }
             } while (isset($tokens[$nextToken]['scope_closer']) === true);
-        }//end if
+        }
 
         if ($startCondition['code'] === T_TRY) {
             // TRY statements need to check until the end of all CATCH statements.

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -113,8 +113,8 @@ class VariableCommentSniff extends AbstractVariableSniff
                 $data  = [$tokens[$tag]['content']];
                 $code  = ucwords(ltrim($tokens[$tag]['content'], '@')) . 'TagNotAllowed';
                 $phpcsFile->addWarning($error, $tag, $code, $data);
-            }//end if
-        }//end foreach
+            }
+        }
 
         // The @var tag is the only one we require.
         if ($foundVar === null) {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -115,7 +115,7 @@ class ControlSignatureSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), str_repeat(' ', $expected));
                 }
             }
-        }//end if
+        }
 
         // Single space after closing parenthesis.
         if (isset($tokens[$stackPtr]['parenthesis_closer']) === true
@@ -182,10 +182,10 @@ class ControlSignatureSniff implements Sniff
                         }
 
                         $phpcsFile->fixer->endChangeset();
-                    }//end if
-                }//end if
-            }//end if
-        }//end if
+                    }
+                }
+            }
+        }
 
         // Single newline after opening brace.
         if (isset($tokens[$stackPtr]['scope_opener']) === true) {
@@ -211,7 +211,7 @@ class ControlSignatureSniff implements Sniff
                 // We found the first bit of a code, or a comment on the
                 // following line.
                 break;
-            }//end for
+            }
 
             if ($tokens[$next]['line'] === $tokens[$opener]['line']) {
                 $error = 'Newline required after opening brace';
@@ -230,7 +230,7 @@ class ControlSignatureSniff implements Sniff
                     $phpcsFile->fixer->addContent($opener, $phpcsFile->eolChar);
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
+            }
         } elseif ($tokens[$stackPtr]['code'] === T_WHILE) {
             // Zero spaces after parenthesis closer, but only if followed by a semicolon.
             $closer       = $tokens[$stackPtr]['parenthesis_closer'];
@@ -254,7 +254,7 @@ class ControlSignatureSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         // Only want to check multi-keyword structures from here on.
         if ($tokens[$stackPtr]['code'] === T_WHILE) {
@@ -288,7 +288,7 @@ class ControlSignatureSniff implements Sniff
             }
         } else {
             return;
-        }//end if
+        }
 
         // Single space after closing brace.
         $found = 1;

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -97,7 +97,7 @@ class ForEachLoopDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         if ($this->requiredSpacesBeforeClose === 0 && $tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
             $error = 'Space found before closing bracket of FOREACH loop';
@@ -127,7 +127,7 @@ class ForEachLoopDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         $asToken = $phpcsFile->findNext(T_AS, $openingBracket);
         if ($asToken === false) {
@@ -188,7 +188,7 @@ class ForEachLoopDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         if ($tokens[($asToken - 1)]['code'] !== T_WHITESPACE) {
             $error = 'Expected 1 space before "as"; 0 found';

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -127,8 +127,8 @@ class ForLoopDeclarationSniff implements Sniff
                         $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         $prevNonWhiteSpace  = $phpcsFile->findPrevious(T_WHITESPACE, ($closingBracket - 1), $openingBracket, true);
         $beforeClosefixable = true;
@@ -199,8 +199,8 @@ class ForLoopDeclarationSniff implements Sniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         /*
          * Check whitespace around each of the semicolon tokens.
@@ -294,8 +294,8 @@ class ForLoopDeclarationSniff implements Sniff
                             $phpcsFile->fixer->endChangeset();
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
         } while ($semicolonCount < 2);
     }
 }

--- a/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
@@ -131,7 +131,7 @@ class InlineIfDeclarationSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         $contentAfter = $phpcsFile->findNext(T_WHITESPACE, ($inlineElse + 1), null, true);
         $spaceAfter   = (($tokens[$contentAfter]['column']) - ($tokens[$inlineElse]['column'] + 1));

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -201,14 +201,14 @@ class SwitchDeclarationSniff implements Sniff
 
                                 $phpcsFile->fixer->endChangeset();
                             }
-                        }//end if
+                        }
                     } else {
                         // Ensure the BREAK statement is not followed by a blank line.
                         if ($nextLine !== ($tokens[$semicolon]['line'] + 1)) {
                             $error = 'Blank lines are not allowed after the DEFAULT case\'s breaking statement';
                             $phpcsFile->addError($error, $nextBreak, 'SpacingAfterDefaultBreak');
                         }
-                    }//end if
+                    }
 
                     $caseLine = $tokens[$nextCase]['line'];
                     $nextLine = $tokens[$nextBreak]['line'];
@@ -223,7 +223,7 @@ class SwitchDeclarationSniff implements Sniff
                         $error = 'Blank lines are not allowed after ' . strtoupper($type) . ' statements';
                         $phpcsFile->addError($error, $nextCase, 'SpacingAfter' . $type);
                     }
-                }//end if
+                }
 
                 if ($tokens[$nextBreak]['code'] === T_BREAK) {
                     if ($type === 'Case') {
@@ -264,13 +264,13 @@ class SwitchDeclarationSniff implements Sniff
                             $error = 'Comment required for empty DEFAULT case';
                             $phpcsFile->addError($error, $nextCase, 'EmptyDefault');
                         }
-                    }//end if
-                }//end if
+                    }
+                }
             } elseif ($type === 'Default') {
                 $error = 'DEFAULT case must have a breaking statement';
                 $phpcsFile->addError($error, $nextCase, 'DefaultNoBreak');
-            }//end if
-        }//end while
+            }
+        }
 
         if ($foundDefault === false) {
             $error = 'All SWITCH statements must contain a DEFAULT case';

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -76,7 +76,7 @@ class OperatorBracketSniff implements Sniff
                     }
                 }
             }
-        }//end if
+        }
 
         $previousToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true, null, true);
         if ($previousToken !== false) {
@@ -183,7 +183,7 @@ class OperatorBracketSniff implements Sniff
                     if ($next !== $endBracket) {
                         break;
                     }
-                }//end if
+                }
 
                 if (in_array($prevCode, Tokens::SCOPE_OPENERS, true) === true) {
                     // This operation is inside a control structure like FOREACH
@@ -204,8 +204,8 @@ class OperatorBracketSniff implements Sniff
 
                 $lastBracket = $bracket;
                 break;
-            }//end foreach
-        }//end if
+            }
+        }
 
         if ($lastBracket === false) {
             // It is not in a bracketed statement at all.
@@ -233,7 +233,7 @@ class OperatorBracketSniff implements Sniff
             }
 
             return;
-        }//end if
+        }
 
         $lastAssignment = $phpcsFile->findPrevious(Tokens::ASSIGNMENT_TOKENS, $stackPtr, null, false, null, true);
         if ($lastAssignment !== false && $lastAssignment > $lastBracket) {
@@ -300,7 +300,7 @@ class OperatorBracketSniff implements Sniff
             }
 
             break;
-        }//end for
+        }
 
         $before = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($before + 1), null, true);
 
@@ -342,7 +342,7 @@ class OperatorBracketSniff implements Sniff
             }
 
             break;
-        }//end for
+        }
 
         $after = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($after - 1), null, true);
 

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -134,8 +134,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                 // No params, so we don't check normal spacing rules.
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         foreach ($params as $paramNumber => $param) {
             if ($param['pass_by_reference'] === true) {
@@ -161,8 +161,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if ($param['variable_length'] === true) {
                 $variadicToken = $param['variadic_token'];
@@ -187,8 +187,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($param['default_equal_token']) === true) {
                 $equalToken = $param['default_equal_token'];
@@ -225,7 +225,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                             $phpcsFile->fixer->endChangeset();
                         }
                     }
-                }//end if
+                }
 
                 $spacesAfter = 0;
                 if ($tokens[$equalToken]['line'] !== $tokens[$param['default_token']]['line']) {
@@ -259,8 +259,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                             $phpcsFile->fixer->endChangeset();
                         }
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if ($param['type_hint_token'] !== false) {
                 $typeHintToken = $param['type_hint_end_token'];
@@ -295,8 +295,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($param['visibility_token']) === true && $param['visibility_token'] !== false) {
                 $visibilityToken      = $param['visibility_token'];
@@ -329,8 +329,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($param['set_visibility_token']) === true && $param['set_visibility_token'] !== false) {
                 $visibilityToken      = $param['set_visibility_token'];
@@ -363,8 +363,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($param['readonly_token']) === true) {
                 $readonlyToken      = $param['readonly_token'];
@@ -394,8 +394,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             $commaToken = false;
             if ($paramNumber > 0 && $params[($paramNumber - 1)]['comma_token'] !== false) {
@@ -448,8 +448,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                         }
 
                         $phpcsFile->fixer->endChangeset();
-                    }//end if
-                }//end if
+                    }
+                }
 
                 // Don't check spacing after the comma if it is the last content on the line.
                 $checkComma = true;
@@ -506,10 +506,10 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                         if ($fix === true) {
                             $phpcsFile->fixer->replaceToken(($commaToken + 1), ' ');
                         }
-                    }//end if
-                }//end if
-            }//end if
-        }//end foreach
+                    }
+                }
+            }
+        }
 
         // Only check spacing around parenthesis for single line definitions.
         if ($multiLine === true) {

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -74,7 +74,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
             if ($next !== false && $tokens[$next]['line'] !== $tokens[$end]['line']) {
                 return true;
             }
-        }//end foreach
+        }
 
         return false;
     }
@@ -123,7 +123,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-        }//end if
+        }
     }
 
 
@@ -205,8 +205,8 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
                         $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         // Each line between the brackets should contain a single parameter.
         for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
@@ -238,6 +238,6 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
                     $phpcsFile->fixer->addNewline($i);
                 }
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -62,9 +62,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff
                         $data  = [$originalVarName];
                         $phpcsFile->addError($error, $var, 'MemberNotCamelCaps', $data);
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         $objOperator = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if ($tokens[$objOperator]['code'] === T_DOUBLE_COLON) {

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -107,8 +107,8 @@ class ComparisonOperatorUsageSniff implements Sniff
                         ) {
                             break;
                         }
-                    }//end if
-                }//end for
+                    }
+                }
 
                 $start = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             } else {
@@ -117,7 +117,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                 }
 
                 $start = $tokens[$end]['parenthesis_opener'];
-            }//end if
+            }
         } elseif ($tokens[$stackPtr]['code'] === T_FOR) {
             if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
                 return;
@@ -138,7 +138,7 @@ class ComparisonOperatorUsageSniff implements Sniff
 
             $start = $tokens[$stackPtr]['parenthesis_opener'];
             $end   = $tokens[$stackPtr]['parenthesis_closer'];
-        }//end if
+        }
 
         $requiredOps   = 0;
         $foundOps      = 0;
@@ -198,7 +198,7 @@ class ComparisonOperatorUsageSniff implements Sniff
             if (isset(Tokens::EMPTY_TOKENS[$type]) === false) {
                 $lastNonEmpty = $i;
             }
-        }//end for
+        }
 
         $requiredOps++;
 

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -220,6 +220,6 @@ class IncrementDecrementUsageSniff implements Sniff
 
             $error .= " operators should be used where possible; found \"$found\" but expected \"$expected\"";
             $phpcsFile->addError($error, $stackPtr, 'Found');
-        }//end if
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -127,7 +127,7 @@ class CommentedOutCodeSniff implements Sniff
                 if (substr($tokenContent, 0, 1) === '*') {
                     $tokenContent = substr($tokenContent, 1);
                 }
-            }//end if
+            }
 
             $content     .= $tokenContent . $phpcsFile->eolChar;
             $lastLineSeen = $tokens[$i]['line'];
@@ -138,7 +138,7 @@ class CommentedOutCodeSniff implements Sniff
                 // Closer of a block comment found.
                 break;
             }
-        }//end for
+        }
 
         // Ignore typical warning suppression annotations from other tools.
         if (preg_match('`^\s*@[A-Za-z()\._-]+\s*$`', $content) === 1) {

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -114,7 +114,7 @@ class DisallowMultipleAssignmentsSniff implements Sniff
                 // We found our variable.
                 break;
             }
-        }//end for
+        }
 
         if ($varToken <= 0) {
             // Didn't find a variable.

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
@@ -92,7 +92,7 @@ class DisallowSizeFunctionsInLoopsSniff implements Sniff
                 $error = 'The use of %s inside a loop condition is not allowed; assign the return value to a variable and use the variable in the loop condition instead';
                 $data  = [$functionName];
                 $phpcsFile->addError($error, $i, 'Found', $data);
-            }//end if
-        }//end for
+            }
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -94,7 +94,7 @@ class EmbeddedPhpSniff implements Sniff
                 $this->reportEmptyTagSet($phpcsFile, $stackPtr, $closingTag);
                 return;
             }
-        }//end if
+        }
 
         if ($tokens[$firstContent]['line'] === $tokens[$stackPtr]['line']) {
             $error = 'Opening PHP tag must be on a line by itself';
@@ -142,7 +142,7 @@ class EmbeddedPhpSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
+                }
 
                 $indent        = $this->calculateLineIndent($phpcsFile, $stackPtr);
                 $contentColumn = ($tokens[$firstContent]['column'] - 1);
@@ -162,8 +162,8 @@ class EmbeddedPhpSniff implements Sniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         $lastContentBeforeBlock = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if ($tokens[$lastContentBeforeBlock]['line'] === $tokens[$stackPtr]['line']
@@ -188,7 +188,7 @@ class EmbeddedPhpSniff implements Sniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
+            }
         } else {
             // Find the first token on the first non-empty line we find.
             for ($first = ($lastContentBeforeBlock - 1); $first > 0; $first--) {
@@ -214,7 +214,7 @@ class EmbeddedPhpSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($stackPtr - 1), str_repeat(' ', $expected));
                 }
             }
-        }//end if
+        }
 
         if ($closingTag === false) {
             return;
@@ -248,7 +248,7 @@ class EmbeddedPhpSniff implements Sniff
                 $phpcsFile->fixer->addContentBefore($closingTag, str_repeat(' ', $closerIndent));
                 $phpcsFile->fixer->addNewlineBefore($closingTag);
                 $phpcsFile->fixer->endChangeset();
-            }//end if
+            }
         } elseif ($firstContentAfterBlock !== false
             && $tokens[$firstContentAfterBlock]['line'] === $tokens[$closingTag]['line']
         ) {
@@ -281,8 +281,8 @@ class EmbeddedPhpSniff implements Sniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
-        }//end if
+            }
+        }
 
         $next = $phpcsFile->findNext($this->register(), ($closingTag + 1));
         if ($next === false) {
@@ -317,7 +317,7 @@ class EmbeddedPhpSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
     }
 
 
@@ -395,8 +395,8 @@ class EmbeddedPhpSniff implements Sniff
                     $data  = [$statementCount];
                     $phpcsFile->addError($error, $stackPtr, 'MultipleStatements', $data);
                 }
-            }//end if
-        }//end if
+            }
+        }
 
         $trailingSpace = 0;
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -118,7 +118,7 @@ class LowercasePHPFunctionsSniff implements Sniff
 
             // No open parenthesis; not a "use function" statement nor a function call.
             return;
-        }//end if
+        }
 
         if ($tokens[$prev]['code'] === T_FUNCTION) {
             // Function declaration, not a function call.

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -91,7 +91,7 @@ class NonExecutableCodeSniff implements Sniff
             if ($tokens[$prev]['code'] === T_FN_ARROW) {
                 return;
             }
-        }//end if
+        }
 
         // This token may be part of an inline condition.
         // If we find a closing parenthesis that belongs to a condition,
@@ -160,12 +160,12 @@ class NonExecutableCodeSniff implements Sniff
                             $lastLine = $line;
                         }
                     }
-                }//end if
+                }
 
                 // That's all we have to check for these types of statements.
                 return;
-            }//end if
-        }//end if
+            }
+        }
 
         $ourConditions = array_keys($tokens[$stackPtr]['conditions']);
 
@@ -202,7 +202,7 @@ class NonExecutableCodeSniff implements Sniff
                         break;
                     }
                 }
-            }//end for
+            }
 
             if ($nextOpener === null) {
                 $end = $closer;
@@ -217,7 +217,7 @@ class NonExecutableCodeSniff implements Sniff
 
             // Throw an error for all lines until the end of the file.
             $end = ($phpcsFile->numTokens - 1);
-        }//end if
+        }
 
         // Find the semicolon or closing PHP tag that ends this statement,
         // skipping nested statements like FOR loops and closures.
@@ -243,7 +243,7 @@ class NonExecutableCodeSniff implements Sniff
             if ($tokens[$start]['code'] === T_SEMICOLON || $tokens[$start]['code'] === T_CLOSE_TAG) {
                 break;
             }
-        }//end for
+        }
 
         if (isset($tokens[$start]) === false) {
             return;
@@ -294,6 +294,6 @@ class NonExecutableCodeSniff implements Sniff
                 $phpcsFile->addWarning($warning, $i, 'Unreachable', $data);
                 $lastLine = $line;
             }
-        }//end for
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -155,6 +155,6 @@ class ConcatenationSpacingSniff implements Sniff
                     $phpcsFile->fixer->addContent($stackPtr, $padding);
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -114,7 +114,7 @@ class DoubleQuoteUsageSniff implements Sniff
             }
 
             return $skipTo;
-        }//end if
+        }
 
         foreach (self::ESCAPE_CHARS as $testChar) {
             if (strpos($workingString, $testChar) !== false) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -98,7 +98,7 @@ class ControlStructureSpacingSniff implements Sniff
             } else {
                 $phpcsFile->recordMetric($stackPtr, 'Spaces before control structure close parenthesis', 0);
             }
-        }//end if
+        }
 
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             return;
@@ -163,7 +163,7 @@ class ControlStructureSpacingSniff implements Sniff
             }
         } else {
             $phpcsFile->recordMetric($stackPtr, 'Blank lines at start of control structure', 0);
-        }//end if
+        }
 
         if ($firstContent !== $scopeCloser) {
             $lastContent = $phpcsFile->findPrevious(
@@ -220,8 +220,8 @@ class ControlStructureSpacingSniff implements Sniff
                 }
             } else {
                 $phpcsFile->recordMetric($stackPtr, 'Blank lines at end of control structure', 0);
-            }//end if
-        }//end if
+            }
+        }
 
         if ($tokens[$stackPtr]['code'] === T_MATCH) {
             // Move the scope closer to the semicolon/comma.
@@ -258,7 +258,7 @@ class ControlStructureSpacingSniff implements Sniff
             ) {
                 $trailingContent = $nextCode;
             }
-        }//end if
+        }
 
         if ($tokens[$trailingContent]['code'] === T_ELSE) {
             if ($tokens[$stackPtr]['code'] === T_IF) {
@@ -340,6 +340,6 @@ class ControlStructureSpacingSniff implements Sniff
                     $phpcsFile->fixer->addNewline($scopeCloser);
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
@@ -94,8 +94,8 @@ class FunctionClosingBraceSpaceSniff implements Sniff
                     }
 
                     $phpcsFile->fixer->endChangeset();
-                }//end if
-            }//end if
+                }
+            }
         } else {
             if ($found !== 1) {
                 if ($found < 0) {
@@ -124,7 +124,7 @@ class FunctionClosingBraceSpaceSniff implements Sniff
                         }
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -240,8 +240,8 @@ class FunctionSpacingSniff implements Sniff
                 }
 
                 $phpcsFile->fixer->endChangeset();
-            }//end if
-        }//end if
+            }
+        }
 
         /*
             Check the number of blank lines
@@ -312,8 +312,8 @@ class FunctionSpacingSniff implements Sniff
                 if ($currentLine === $prevLine) {
                     break;
                 }
-            }//end for
-        }//end if
+            }
+        }
 
         $requiredSpacing = $this->spacing;
         $errorCode       = 'Before';
@@ -365,8 +365,8 @@ class FunctionSpacingSniff implements Sniff
                     }
 
                     $phpcsFile->fixer->endChangeset();
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -144,7 +144,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             }
 
             $i = $nextNonWhitespace;
-        }//end for
+        }
 
         // There needs to be n blank lines before the var, not counting comments.
         if ($start === $startOfStatement) {
@@ -222,7 +222,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             }
 
             $phpcsFile->fixer->endChangeset();
-        }//end if
+        }
 
         if ($endOfStatement !== false) {
             return $endOfStatement;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -169,7 +169,7 @@ class OperatorSpacingSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
                     }
                 }
-            }//end if
+            }
 
             $hasNext = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
             if ($hasNext === false) {
@@ -204,10 +204,10 @@ class OperatorSpacingSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
                     }
                 }
-            }//end if
+            }
 
             return;
-        }//end if
+        }
 
         $operator = $tokens[$stackPtr]['content'];
 
@@ -265,9 +265,9 @@ class OperatorSpacingSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
                         $phpcsFile->fixer->endChangeset();
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         $hasNext = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($hasNext === false) {
@@ -323,8 +323,8 @@ class OperatorSpacingSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
     }
 
 
@@ -387,7 +387,7 @@ class OperatorSpacingSniff implements Sniff
             if (isset($this->nonOperandTokens[$tokens[$prev]['code']]) === true) {
                 return false;
             }
-        }//end if
+        }
 
         return true;
     }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -105,6 +105,6 @@ class ScopeClosingBraceSniff implements Sniff
                     $phpcsFile->fixer->substrToken(($lineStart - 1), 0, $diff);
                 }
             }
-        }//end if
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -87,7 +87,7 @@ class ScopeKeywordSpacingSniff implements Sniff
                     return;
                 }
             }
-        }//end if
+        }
 
         if ($tokens[$prevToken]['code'] === T_AS) {
             // Trait visibility change, e.g., "use HelloWorld { sayHello as private; }".
@@ -162,7 +162,7 @@ class ScopeKeywordSpacingSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
                     $phpcsFile->fixer->endChangeset();
                 }
-            }//end if
-        }//end if
+            }
+        }
     }
 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -204,7 +204,7 @@ class SuperfluousWhitespaceSniff implements Sniff
                         $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }//end if
-        }//end if
+            }
+        }
     }
 }

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -239,7 +239,7 @@ final class ArrayDeclarationUnitTest extends AbstractSniffTestCase
             return [8 => 1];
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -122,7 +122,7 @@ final class ClassFileNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -50,7 +50,7 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -78,6 +78,6 @@ final class ClassCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -61,7 +61,7 @@ final class ClosingDeclarationCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -58,7 +58,7 @@ final class FileCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -182,7 +182,7 @@ final class FunctionCommentUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -88,7 +88,7 @@ final class ControlSignatureUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -69,7 +69,7 @@ final class ForLoopDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -81,7 +81,7 @@ final class OperatorBracketUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -105,7 +105,7 @@ final class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffTest
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -41,7 +41,7 @@ final class FunctionDeclarationUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -52,6 +52,6 @@ final class GlobalFunctionUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -49,7 +49,7 @@ final class ValidFunctionNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -80,7 +80,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -218,7 +218,7 @@ final class EmbeddedPhpUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -41,7 +41,7 @@ final class HeredocUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -117,6 +117,6 @@ final class NonExecutableCodeUnitTest extends AbstractSniffTestCase
             ];
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -53,7 +53,7 @@ final class MemberVarScopeUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -43,7 +43,7 @@ final class MethodScopeUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -127,7 +127,7 @@ final class FunctionSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -97,7 +97,7 @@ final class MemberVarSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -114,7 +114,7 @@ final class OperatorSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -81,7 +81,7 @@ final class ScopeKeywordSpacingUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -71,7 +71,7 @@ final class SuperfluousWhitespaceUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -67,7 +67,7 @@ class ClosingTagSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'PHP closing tag at EOF', 'yes');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PHP closing tag at EOF', 'no');
-        }//end if
+        }
 
         // Ignore the rest of the file.
         return $phpcsFile->numTokens;

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -68,9 +68,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff
                         $data    = [$originalVarName];
                         $phpcsFile->addWarning($warning, $stackPtr, 'ContainsNumbers', $data);
                     }
-                }//end if
-            }//end if
-        }//end if
+                }
+            }
+        }
 
         // There is no way for us to know if the var is public or private,
         // so we have to ignore a leading underscore if there is one and just
@@ -187,7 +187,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff
                     $data    = [$varName];
                     $phpcsFile->addWarning($warning, $stackPtr, 'StringVarContainsNumbers', $data);
                 }
-            }//end foreach
-        }//end if
+            }
+        }
     }
 }

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -75,7 +75,7 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 
 
@@ -113,6 +113,6 @@ final class ValidVariableNameUnitTest extends AbstractSniffTestCase
 
         default:
             return [];
-        }//end switch
+        }
     }
 }

--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -155,7 +155,7 @@ class Comment
 
                 $stackPtr++;
             }
-        }//end foreach
+        }
 
         $tokens[$stackPtr] = $closeTag;
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -224,7 +224,7 @@ class Comment
                     $start   += strlen($space['content']);
                 }
             }
-        }//end if
+        }
 
         // Process the rest of the line.
         $eol = strpos($comment, $eolChar, $start);

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -586,7 +586,7 @@ class PHP extends Tokenizer
 
                 $statusMessage .= ": $type => $content";
                 StatusWriter::write($statusMessage, 1, 0);
-            }//end if
+            }
 
             if ($newStackPtr > 0
                 && isset(Tokens::EMPTY_TOKENS[$finalTokens[($newStackPtr - 1)]['code']]) === false
@@ -623,7 +623,7 @@ class PHP extends Tokenizer
                         $tokens[($stackPtr + 1)][1] = substr($tokens[($stackPtr + 1)][1], 1);
                     }
                 }
-            }//end if
+            }
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 StatusWriter::writeNewline();
@@ -692,7 +692,7 @@ class PHP extends Tokenizer
                             break;
                         }
                     }
-                }//end if
+                }
 
                 // Types in typed constants should not be touched, but the constant name should be.
                 if ((isset(static::T_STRING_CONTEXTS[$finalTokens[$lastNotEmptyToken]['code']]) === true
@@ -716,7 +716,7 @@ class PHP extends Tokenizer
                         $preserveKeyword        = false;
                         $insideConstDeclaration = false;
                     }
-                }//end if
+                }
 
                 if ($finalTokens[$lastNotEmptyToken]['content'] === '&') {
                     $preserveKeyword = true;
@@ -749,7 +749,7 @@ class PHP extends Tokenizer
                     $newStackPtr++;
                     continue;
                 }
-            }//end if
+            }
 
             /*
                 Mark the start of a constant declaration to allow for handling keyword to T_STRING
@@ -802,7 +802,7 @@ class PHP extends Tokenizer
 
                     break;
                 }
-            }//end if
+            }
 
             /*
                 Prior to PHP 7.4, PHP didn't support stand-alone PHP open tags at the end of a file
@@ -842,7 +842,7 @@ class PHP extends Tokenizer
 
                 $newStackPtr++;
                 continue;
-            }//end if
+            }
 
             /*
                 Split whitespace off from long PHP open tag tokens and potentially join the whitespace
@@ -891,11 +891,11 @@ class PHP extends Tokenizer
                         }
 
                         $newStackPtr++;
-                    }//end if
-                }//end if
+                    }
+                }
 
                 continue;
-            }//end if
+            }
 
             /*
                 Parse doc blocks into something that can be easily iterated over.
@@ -949,8 +949,8 @@ class PHP extends Tokenizer
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         StatusWriter::write("* stripped first newline after comment and added it to comment token $stackPtr", 2);
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 For Explicit Octal Notation prior to PHP 8.1 we need to combine the
@@ -991,7 +991,7 @@ class PHP extends Tokenizer
 
                 $stackPtr++;
                 continue;
-            }//end if
+            }
 
             /*
                 PHP 8.1 introduced two dedicated tokens for the & character.
@@ -1058,7 +1058,7 @@ class PHP extends Tokenizer
                         // We found the other end of the double quoted string.
                         break;
                     }
-                }//end for
+                }
 
                 $stackPtr = $i;
 
@@ -1086,7 +1086,7 @@ class PHP extends Tokenizer
 
                 // Continue, as we're done with this token.
                 continue;
-            }//end if
+            }
 
             /*
                 Detect binary casting and assign the casts their own token.
@@ -1202,7 +1202,7 @@ class PHP extends Tokenizer
 
                     $finalTokens[$newStackPtr] = $newToken;
                     $newStackPtr++;
-                }//end for
+                }
 
                 // Add the end heredoc token to the final array.
                 $finalTokens[$newStackPtr] = self::standardiseToken($tokens[$stackPtr]);
@@ -1216,7 +1216,7 @@ class PHP extends Tokenizer
 
                 // Continue, as we're done with this token.
                 continue;
-            }//end if
+            }
 
             /*
                 Enum keyword for PHP < 8.1
@@ -1255,7 +1255,7 @@ class PHP extends Tokenizer
                     $newStackPtr++;
                     continue;
                 }
-            }//end if
+            }
 
             /*
                 Convert enum "case" to T_ENUM_CASE
@@ -1295,7 +1295,7 @@ class PHP extends Tokenizer
                         $isEnumCase = true;
                         break;
                     }
-                }//end for
+                }
 
                 if ($isEnumCase === true) {
                     // Modify $tokens directly so we can use it as optimisation for other enum "case".
@@ -1314,7 +1314,7 @@ class PHP extends Tokenizer
                     $newStackPtr++;
                     continue;
                 }
-            }//end if
+            }
 
             /*
                 Asymmetric visibility for PHP < 8.4
@@ -1357,7 +1357,7 @@ class PHP extends Tokenizer
                 $stackPtr += 3;
 
                 continue;
-            }//end if
+            }
 
             /*
              * There is a select group of keywords - true, false, null, exit and die -,
@@ -1394,7 +1394,7 @@ class PHP extends Tokenizer
 
                     continue;
                 }
-            }//end if
+            }
 
             /*
                 Before PHP 8.0, namespaced names were not tokenized as a single token.
@@ -1449,7 +1449,7 @@ class PHP extends Tokenizer
                     ++$i;
                     $newToken['content'] .= $tokens[$i][1];
                     break;
-                }//end switch
+                }
 
                 while (isset($tokens[($i + 1)], $tokens[($i + 2)]) === true
                     && is_array($tokens[($i + 1)]) === true && $tokens[($i + 1)][0] === T_NS_SEPARATOR
@@ -1497,8 +1497,8 @@ class PHP extends Tokenizer
                     }
 
                     continue;
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 PHP 8.0 Attributes
@@ -1544,7 +1544,7 @@ class PHP extends Tokenizer
                 }
 
                 continue;
-            }//end if
+            }
 
             /*
                 Tokenize the parameter labels for PHP 8.0 named parameters as a special T_PARAM_NAME
@@ -1600,8 +1600,8 @@ class PHP extends Tokenizer
 
                         continue;
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 "readonly" keyword for PHP < 8.1
@@ -1687,8 +1687,8 @@ class PHP extends Tokenizer
                         }
 
                         break;
-                    }//end for
-                }//end if
+                    }
+                }
 
                 if ($isReadonlyKeyword === true) {
                     $finalTokens[$newStackPtr] = [
@@ -1718,10 +1718,10 @@ class PHP extends Tokenizer
                     if (PHP_CODESNIFFER_VERBOSITY > 1 && $type !== T_STRING) {
                         StatusWriter::write("* token $stackPtr changed from $type to T_STRING", 2);
                     }
-                }//end if
+                }
 
                 continue;
-            }//end if
+            }
 
             /*
                 Deal with "yield from" in various PHP versions.
@@ -1846,7 +1846,7 @@ class PHP extends Tokenizer
 
                 unset($yieldFromSubtokens);
                 continue;
-            }//end if
+            }
 
             /*
                 Between PHP 7.0 and 7.3, the ??= operator was tokenized as
@@ -1944,10 +1944,10 @@ class PHP extends Tokenizer
                         }
 
                         continue;
-                    }//end if
+                    }
 
                     break;
-                }//end for
+                }
 
                 if ($newType === T_LNUMBER
                     && ((stripos($newContent, '0x') === 0 && hexdec(str_replace('_', '', $newContent)) > PHP_INT_MAX)
@@ -1971,7 +1971,7 @@ class PHP extends Tokenizer
                 $newStackPtr++;
                 $stackPtr = ($i - 1);
                 continue;
-            }//end if
+            }
 
             /*
                 Backfill the T_MATCH token for PHP versions < 8.0 and
@@ -2004,7 +2004,7 @@ class PHP extends Tokenizer
 
                     $isMatch = true;
                     break;
-                }//end for
+                }
 
                 if ($isMatch === true && $token[0] === T_STRING) {
                     $newToken            = [];
@@ -2033,8 +2033,8 @@ class PHP extends Tokenizer
                     $finalTokens[$newStackPtr] = $newToken;
                     $newStackPtr++;
                     continue;
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 Retokenize the T_DEFAULT in match control structures as T_MATCH_DEFAULT
@@ -2085,8 +2085,8 @@ class PHP extends Tokenizer
                     $finalTokens[$newStackPtr] = $newToken;
                     $newStackPtr++;
                     continue;
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 Convert ? to T_NULLABLE OR T_INLINE_THEN
@@ -2173,7 +2173,7 @@ class PHP extends Tokenizer
                     }
 
                     break;
-                }//end for
+                }
 
                 /*
                  * This can still be a nullable type or a ternary.
@@ -2245,12 +2245,12 @@ class PHP extends Tokenizer
                     if (@isset(Tokens::EMPTY_TOKENS[$tokenType]) === false) {
                         $lastSeenNonEmpty = $tokenType;
                     }
-                }//end for
+                }
 
                 $finalTokens[$newStackPtr] = $newToken;
                 $newStackPtr++;
                 continue;
-            }//end if
+            }
 
             /*
                 Tokens after a double colon may look like scope openers,
@@ -2373,10 +2373,10 @@ class PHP extends Tokenizer
                             }
 
                             break;
-                        }//end for
-                    }//end if
-                }//end if
-            }//end if
+                        }
+                    }
+                }
+            }
 
             /*
                 PHP doesn't assign a token to goto labels, so we have to.
@@ -2451,9 +2451,9 @@ class PHP extends Tokenizer
 
                         $newStackPtr++;
                         continue;
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
 
             /*
                 If this token has newlines in its content, split each line up
@@ -2551,7 +2551,7 @@ class PHP extends Tokenizer
 
                             break;
                         }
-                    }//end if
+                    }
 
                     if ($preserveTstring === true) {
                         $finalTokens[$newStackPtr] = [
@@ -2563,7 +2563,7 @@ class PHP extends Tokenizer
                         $newStackPtr++;
                         continue;
                     }
-                }//end if
+                }
 
                 $newToken = null;
                 if ($tokenIsArray === false) {
@@ -2656,8 +2656,8 @@ class PHP extends Tokenizer
                                     StatusWriter::write('* token is return type, not T_INLINE_ELSE', 2);
                                 }
                             }
-                        }//end if
-                    }//end if
+                        }
+                    }
 
                     // Check to see if this is a CASE or DEFAULT opener.
                     if ($isInlineIf === true) {
@@ -2682,8 +2682,8 @@ class PHP extends Tokenizer
                             ) {
                                 break;
                             }
-                        }//end for
-                    }//end if
+                        }
+                    }
 
                     if ($isInlineIf === true) {
                         array_pop($insideInlineIf);
@@ -2694,7 +2694,7 @@ class PHP extends Tokenizer
                             StatusWriter::write('* token changed from T_COLON to T_INLINE_ELSE', 2);
                         }
                     }
-                }//end if
+                }
 
                 // This is a special condition for T_ARRAY tokens used for anything else
                 // but array declarations, like type hinting function arguments as
@@ -2747,8 +2747,8 @@ class PHP extends Tokenizer
 
                 $finalTokens[$newStackPtr] = $newToken;
                 $newStackPtr++;
-            }//end if
-        }//end for
+            }
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** END PHP TOKENIZING ***', 1);
@@ -2824,7 +2824,7 @@ class PHP extends Tokenizer
                             }
                         }
                     }
-                }//end if
+                }
 
                 continue;
             } elseif ($this->tokens[$i]['code'] === T_CLASS && isset($this->tokens[$i]['scope_opener']) === true) {
@@ -2878,7 +2878,7 @@ class PHP extends Tokenizer
                             StatusWriter::write("* cleaned $x ($type) *", 2);
                         }
                     }
-                }//end if
+                }
 
                 continue;
             } elseif ($this->tokens[$i]['code'] === T_FN && isset($this->tokens[($i + 1)]) === true) {
@@ -3027,7 +3027,7 @@ class PHP extends Tokenizer
                                 $inTernary = false;
                                 continue;
                             }
-                        }//end for
+                        }
 
                         if ($scopeCloser !== $numTokens) {
                             if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -3067,9 +3067,9 @@ class PHP extends Tokenizer
                                 $line = $this->tokens[$arrow]['line'];
                                 StatusWriter::write("* token $arrow on line $line changed from T_DOUBLE_ARROW to T_FN_ARROW", 2);
                             }
-                        }//end if
-                    }//end if
-                }//end if
+                        }
+                    }
+                }
 
                 // If after all that, the extra tokens are not set, this is not a (valid) arrow function.
                 if (isset($this->tokens[$i]['scope_closer']) === false) {
@@ -3147,7 +3147,7 @@ class PHP extends Tokenizer
 
                         break;
                     }
-                }//end for
+                }
 
                 if ($isShortArray === true) {
                     $this->tokens[$i]['code'] = T_OPEN_SHORT_ARRAY;
@@ -3232,8 +3232,8 @@ class PHP extends Tokenizer
                                 StatusWriter::write("* token $x changed from T_DOUBLE_ARROW to T_MATCH_ARROW", 2);
                             }
                         }
-                    }//end for
-                }//end if
+                    }
+                }
 
                 continue;
             } elseif ($this->tokens[$i]['code'] === T_BITWISE_OR
@@ -3321,7 +3321,7 @@ class PHP extends Tokenizer
                     }
 
                     break;
-                }//end for
+                }
 
                 if (($typeTokenCountAfter === 0
                     && ($this->tokens[$i]['code'] !== T_CLOSE_PARENTHESIS
@@ -3392,7 +3392,7 @@ class PHP extends Tokenizer
                                 break;
                             }
                         }
-                    }//end if
+                    }
 
                     if (isset($allowed[$this->tokens[$x]['code']]) === true) {
                         ++$typeTokenCountBefore;
@@ -3462,7 +3462,7 @@ class PHP extends Tokenizer
                         }
 
                         break;
-                    }//end if
+                    }
 
                     if ($suspectedType === 'constant' && $this->tokens[$x]['code'] === T_CONST) {
                         $confirmed = true;
@@ -3482,7 +3482,7 @@ class PHP extends Tokenizer
                     }
 
                     break;
-                }//end for
+                }
 
                 // Remember the last token we examined as part of the (non-)"type declaration".
                 $lastSeenTypeToken = $x;
@@ -3525,11 +3525,11 @@ class PHP extends Tokenizer
                                     $confirmed = true;
                                 }
                             }
-                        }//end if
-                    }//end if
+                        }
+                    }
 
                     unset($parens, $last);
-                }//end if
+                }
 
                 if ($confirmed === false || ($parenthesesCount % 2) !== 0) {
                     // Not a (valid) union, intersection or DNF type after all, move on.
@@ -3569,8 +3569,8 @@ class PHP extends Tokenizer
                             $line = $this->tokens[$x]['line'];
                             StatusWriter::write("* token $x on line $line changed from T_CLOSE_PARENTHESIS to T_TYPE_CLOSE_PARENTHESIS", 1);
                         }
-                    }//end if
-                }//end foreach
+                    }
+                }
 
                 if (isset($maybeNullable) === true) {
                     $this->tokens[$maybeNullable]['code'] = T_NULLABLE;
@@ -3606,7 +3606,7 @@ class PHP extends Tokenizer
                     $this->tokens[$i]['code'] = T_STRING;
                     $this->tokens[$i]['type'] = 'T_STRING';
                 }
-            }//end if
+            }
 
             if (($this->tokens[$i]['code'] !== T_CASE
                 && $this->tokens[$i]['code'] !== T_DEFAULT)
@@ -3708,7 +3708,7 @@ class PHP extends Tokenizer
                         }
                     }
                 }
-            }//end if
+            }
 
             unset($this->tokens[$x]['bracket_opener']);
             unset($this->tokens[$x]['bracket_closer']);
@@ -3745,10 +3745,10 @@ class PHP extends Tokenizer
                         }
 
                         break;
-                    }//end if
-                }//end foreach
-            }//end for
-        }//end for
+                    }
+                }
+            }
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** END ADDITIONAL PHP PROCESSING ***', 1);
@@ -3826,7 +3826,7 @@ class PHP extends Tokenizer
             ];
 
             self::$resolveTokenCache[$token[0]] = $newToken;
-        }//end if
+        }
 
         $newToken['content'] = $token[1];
         return $newToken;
@@ -3930,7 +3930,7 @@ class PHP extends Tokenizer
         default:
             $newToken['type'] = 'T_NONE';
             break;
-        }//end switch
+        }
 
         $newToken['code']    = constant($newToken['type']);
         $newToken['content'] = $token;
@@ -4069,7 +4069,7 @@ class PHP extends Tokenizer
                 if (empty($map) === false) {
                     $this->tokens[$i]['nested_attributes'] = $map;
                 }
-            }//end if
-        }//end for
+            }
+        }
     }
 }

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -243,7 +243,7 @@ abstract class Tokenizer
                 $this->replaceTabsInToken($this->tokens[$i]);
                 $length      = $this->tokens[$i]['length'];
                 $currColumn += $length;
-            }//end if
+            }
 
             $this->tokens[$i]['length'] = $length;
 
@@ -312,7 +312,7 @@ abstract class Tokenizer
 
                             $lineHasOtherContent = true;
                             break;
-                        }//end for
+                        }
 
                         $changedLines = false;
                         for ($next = $i; $next < $this->numTokens; $next++) {
@@ -348,8 +348,8 @@ abstract class Tokenizer
 
                             $lineHasOtherContent = true;
                             break;
-                        }//end for
-                    }//end if
+                        }
+                    }
 
                     if (substr($commentTextLower, 0, 9) === 'phpcs:set') {
                         // Ignore standards for complete lines that change sniff settings.
@@ -430,7 +430,7 @@ abstract class Tokenizer
                             }
 
                             $this->tokens[$i]['sniffCodes'] = $enabledSniffs;
-                        }//end if
+                        }
 
                         $this->tokens[$i]['code'] = T_PHPCS_ENABLE;
                         $this->tokens[$i]['type'] = 'T_PHPCS_ENABLE';
@@ -465,14 +465,14 @@ abstract class Tokenizer
                             // so respect the ignore rules it set.
                             $this->ignoredLines[$this->tokens[$i]['line']] = $lineIgnoring;
                         }
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
 
             if ($ignoring !== null && isset($this->ignoredLines[$this->tokens[$i]['line']]) === false) {
                 $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
             }
-        }//end for
+        }
 
         // If annotations are being ignored, we clear out all the ignore rules
         // but leave the annotations tokenized as normal.
@@ -562,8 +562,8 @@ abstract class Tokenizer
                 $currColumn += $pad;
                 $length     += $pad;
                 $newContent .= $prefix . str_repeat($padding, ($pad - 1));
-            }//end foreach
-        }//end if
+            }
+        }
 
         $token['orig_content'] = $token['content'];
         $token['content']      = $newContent;
@@ -646,7 +646,7 @@ abstract class Tokenizer
                     $this->tokens[$i]['parenthesis_opener']      = $opener;
                     $this->tokens[$i]['parenthesis_closer']      = $i;
                     $this->tokens[$opener]['parenthesis_closer'] = $i;
-                }//end if
+                }
             } elseif ($this->tokens[$i]['code'] === T_ATTRIBUTE) {
                 $openers[] = $i;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -677,8 +677,8 @@ abstract class Tokenizer
                     } elseif (PHP_CODESNIFFER_VERBOSITY > 1) {
                         StatusWriter::write("=> Found unowned attribute closer at $i for $opener", (count($openers) + 1));
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             /*
                 Bracket mapping.
@@ -731,8 +731,8 @@ abstract class Tokenizer
                 break;
             default:
                 continue 2;
-            }//end switch
-        }//end for
+            }
+        }
 
         // Cleanup for any openers that we didn't find closers for.
         // This typically means there was a syntax error breaking things.
@@ -778,8 +778,8 @@ abstract class Tokenizer
                 if (empty($map) === false) {
                     $this->tokens[$i]['nested_parenthesis'] = $map;
                 }
-            }//end if
-        }//end for
+            }
+        }
     }
 
 
@@ -813,8 +813,8 @@ abstract class Tokenizer
                 }
 
                 $i = $this->recurseScopeMap($i);
-            }//end if
-        }//end for
+            }
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** END SCOPE MAP ***', 1);
@@ -873,7 +873,7 @@ abstract class Tokenizer
 
                 $statusMessage .= "]: $type => $content";
                 StatusWriter::write($statusMessage, $depth);
-            }//end if
+            }
 
             // Very special case for IF statements in PHP that can be defined without
             // scope tokens. E.g., if (1) 1; 1 ? (1 ? 1 : 1) : 1;
@@ -984,7 +984,7 @@ abstract class Tokenizer
                         // The closer was not processed, so we need to
                         // complete that token as well.
                         $todo[] = $scopeCloser;
-                    }//end if
+                    }
 
                     if ($validCloser === true) {
                         foreach ($todo as $token) {
@@ -1014,9 +1014,9 @@ abstract class Tokenizer
                         }
                     } else {
                         continue;
-                    }//end if
-                }//end if
-            }//end if
+                    }
+                }
+            }
 
             // Is this an opening condition ?
             if (isset($this->scopeOpeners[$tokenType]) === true) {
@@ -1049,7 +1049,7 @@ abstract class Tokenizer
 
                         $i = self::recurseScopeMap($i, ($depth + 1), $ignore);
                         continue;
-                    }//end if
+                    }
 
                     if ($tokenType === T_CLASS) {
                         // Probably an anonymous class inside another anonymous class,
@@ -1071,7 +1071,7 @@ abstract class Tokenizer
 
                         $i = self::recurseScopeMap($i, ($depth + 1), $ignore);
                         continue;
-                    }//end if
+                    }
 
                     // Found another opening condition but still haven't
                     // found our opener, so we are never going to find one.
@@ -1098,7 +1098,7 @@ abstract class Tokenizer
 
                         return $stackPtr;
                     }
-                }//end if
+                }
 
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     StatusWriter::write('* token is an opening condition *', $depth);
@@ -1168,8 +1168,8 @@ abstract class Tokenizer
                     if (isset($this->scopeOpeners[$tokenType]['end'][T_CLOSE_CURLY_BRACKET]) === true) {
                         $ignore = $oldIgnore;
                     }
-                }//end if
-            }//end if
+                }
+            }
 
             if (isset($this->scopeOpeners[$currType]['start'][$tokenType]) === true
                 && $opener === null
@@ -1214,10 +1214,10 @@ abstract class Tokenizer
                                 }
 
                                 break;
-                            }//end if
-                        }//end for
-                    }//end if
-                }//end if
+                            }
+                        }
+                    }
+                }
 
                 if ($ignore === 0 || $tokenType !== T_OPEN_CURLY_BRACKET) {
                     $openerNested = isset($this->tokens[$i]['nested_parenthesis']);
@@ -1242,7 +1242,7 @@ abstract class Tokenizer
 
                         $opener = $i;
                     }
-                }//end if
+                }
             } elseif ($tokenType === T_SEMICOLON
                 && $opener === null
                 && (isset($this->tokens[$stackPtr]['parenthesis_closer']) === false
@@ -1342,10 +1342,10 @@ abstract class Tokenizer
                         }
 
                         return ($i - 1);
-                    }//end if
-                }//end if
-            }//end if
-        }//end for
+                    }
+                }
+            }
+        }
 
         return $stackPtr;
     }
@@ -1394,7 +1394,7 @@ abstract class Tokenizer
 
                 $statusMessage .= "]: $type => $content";
                 StatusWriter::write($statusMessage, ($level + 1));
-            }//end if
+            }
 
             $this->tokens[$i]['level']      = $level;
             $this->tokens[$i]['conditions'] = $conditions;
@@ -1462,8 +1462,8 @@ abstract class Tokenizer
                                     StatusWriter::write("* cleaned $x:$type *", ($level + 1));
                                     StatusWriter::write("=> level changed from $oldLevel to $newLevel", ($level + 2));
                                     StatusWriter::write("=> conditions changed from $oldConds to $newConds", ($level + 2));
-                                }//end if
-                            }//end for
+                                }
+                            }
 
                             unset($conditions[$badToken]);
                             if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -1477,8 +1477,8 @@ abstract class Tokenizer
                             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                                 StatusWriter::write('* level decreased *', ($level + 2));
                             }
-                        }//end if
-                    }//end if
+                        }
+                    }
 
                     $level++;
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -1554,10 +1554,10 @@ abstract class Tokenizer
                                             StatusWriter::write("* cleaned $x:$type *", ($level + 1));
                                             StatusWriter::write("=> level changed from $oldLevel to $newLevel", ($level + 2));
                                             StatusWriter::write("=> conditions changed from $oldConds to $newConds", ($level + 2));
-                                        }//end if
-                                    }//end for
-                                }//end if
-                            }//end if
+                                        }
+                                    }
+                                }
+                            }
 
                             $level--;
                             if (PHP_CODESNIFFER_VERBOSITY > 1) {
@@ -1566,11 +1566,11 @@ abstract class Tokenizer
 
                             $this->tokens[$i]['level']      = $level;
                             $this->tokens[$i]['conditions'] = $conditions;
-                        }//end if
-                    }//end foreach
-                }//end if
-            }//end if
-        }//end for
+                        }
+                    }
+                }
+            }
+        }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             StatusWriter::write('*** END LEVEL MAP ***', 1);

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -189,7 +189,7 @@ class Cache
             }
 
             StatusWriter::write("=> cacheHash: $cacheHash", 2);
-        }//end if
+        }
 
         if ($config->cacheFile !== null) {
             $cacheFile = $config->cacheFile;
@@ -255,13 +255,13 @@ class Cache
                     $cacheFile = $testFile;
                     break;
                 }
-            }//end foreach
+            }
 
             if ($cacheFile === null) {
                 // Unlikely, but just in case $paths is empty for some reason.
                 $cacheFile = $cacheDir . DIRECTORY_SEPARATOR . "phpcs.$cacheHash.cache";
             }
-        }//end if
+        }
 
         self::$path = $cacheFile;
         if (PHP_CODESNIFFER_VERBOSITY > 1) {

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -308,7 +308,7 @@ class Common
             if (in_array(' ', $exclude, true) === false) {
                 $content = str_replace(' ', "\033[30;1m·\033[0m", $content);
             }
-        }//end if
+        }
 
         return $content;
     }
@@ -405,7 +405,7 @@ class Common
 
                 $lastCharWasCaps = $isCaps;
             }
-        }//end if
+        }
 
         return true;
     }
@@ -482,7 +482,7 @@ class Common
             case 'array()':
             case 'array':
                 return 'array';
-            }//end switch
+            }
 
             if (strpos($lowerVarType, 'array(') !== false) {
                 // Valid array declaration:
@@ -509,15 +509,15 @@ class Common
                     return "array($type1$type2)";
                 } else {
                     return 'array';
-                }//end if
+                }
             } elseif (isset(self::ALLOWED_TYPES[$lowerVarType]) === true) {
                 // A valid type, but not lower cased.
                 return $lowerVarType;
             } else {
                 // Must be a custom type name.
                 return $varType;
-            }//end if
-        }//end if
+            }
+        }
     }
 
 

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -206,7 +206,7 @@ final class Help
             if (empty($filteredOptions[$category]) === true || count($filteredOptions[$category]) === $spacerCount) {
                 unset($filteredOptions[$category]);
             }
-        }//end foreach
+        }
 
         $this->activeOptions = $filteredOptions;
     }

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -116,7 +116,7 @@ class Standards
                     }
                 }
             }
-        }//end foreach
+        }
 
         $installedStandards = [];
 
@@ -140,7 +140,7 @@ class Standards
                 'name'      => $standardName,
                 'namespace' => $namespace,
             ];
-        }//end foreach
+        }
 
         return $installedStandards;
     }
@@ -210,7 +210,7 @@ class Standards
 
             natsort($standardsInDir);
             $installedStandards += $standardsInDir;
-        }//end foreach
+        }
 
         return $installedStandards;
     }
@@ -256,7 +256,7 @@ class Standards
             if (is_file($ruleset) === true) {
                 return true;
             }
-        }//end if
+        }
 
         return false;
     }
@@ -300,7 +300,7 @@ class Standards
                     return $path;
                 }
             }
-        }//end foreach
+        }
 
         return null;
     }

--- a/tests/Core/Config/SniffsExcludeArgsTest.php
+++ b/tests/Core/Config/SniffsExcludeArgsTest.php
@@ -191,7 +191,7 @@ final class SniffsExcludeArgsTest extends TestCase
                 ],
                 'suggestion' => 'sTANDARD.cATEGORY.sNIFF',
             ];
-        }//end foreach
+        }
 
         return $data;
     }
@@ -270,7 +270,7 @@ final class SniffsExcludeArgsTest extends TestCase
                 'value'    => 'Standard.Category.Sniff, standard.category.sniff, STANDARD.CATEGORY.SNIFF',
                 'result'   => ['Standard.Category.Sniff'],
             ];
-        }//end foreach
+        }
 
         return $data;
     }

--- a/tests/Core/Files/File/GetMethodParametersTest.php
+++ b/tests/Core/Files/File/GetMethodParametersTest.php
@@ -3264,7 +3264,7 @@ final class GetMethodParametersTest extends AbstractMethodTestCase
             if (isset($param['readonly_token']) === true) {
                 $expected[$key]['readonly_token'] += $target;
             }
-        }//end foreach
+        }
 
         $this->assertSame($expected, $found);
     }

--- a/tests/Core/Ruleset/PopulateTokenListenersTest.php
+++ b/tests/Core/Ruleset/PopulateTokenListenersTest.php
@@ -285,8 +285,8 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
                     $details['source'],
                     sprintf('Unexpected value for "source" key for sniff class %s for token %s', $className, Tokens::tokenName($token))
                 );
-            }//end foreach
-        }//end foreach
+            }
+        }
     }
 
 
@@ -320,7 +320,7 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
                     sprintf('Unexpected value for "include" key for sniff class %s for token %s', $className, Tokens::tokenName($token))
                 );
             }
-        }//end foreach
+        }
     }
 
 
@@ -354,7 +354,7 @@ final class PopulateTokenListenersTest extends AbstractRulesetTestCase
                     sprintf('Unexpected value for "ignore" key for sniff class %s for token %s', $className, Tokens::tokenName($token))
                 );
             }
-        }//end foreach
+        }
     }
 
 

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -74,7 +74,7 @@ final class RuleInclusionTest extends AbstractRulesetTestCase
 
             $config        = new ConfigDouble(["--standard=$standard"]);
             self::$ruleset = new Ruleset($config);
-        }//end if
+        }
     }
 
 

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -66,7 +66,7 @@ abstract class AbstractTokenizerTestCase extends TestCase
 
             $this->phpcsFile = new LocalFile($pathToTestFile, $ruleset, $config);
             $this->phpcsFile->parse();
-        }//end if
+        }
     }
 
 

--- a/tests/Core/Tokenizers/Comment/CommentTestCase.php
+++ b/tests/Core/Tokenizers/Comment/CommentTestCase.php
@@ -119,6 +119,6 @@ abstract class CommentTestCase extends AbstractTokenizerTestCase
                 $tokens[$i]['content'],
                 'Token content did not match expectations' . $errorMsgSuffix
             );
-        }//end for
+        }
     }
 }

--- a/tests/Core/Tokenizers/PHP/DNFTypesParseError2Test.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesParseError2Test.php
@@ -186,8 +186,8 @@ final class DNFTypesParseError2Test extends AbstractTokenizerTestCase
 
             default:
                 break;
-            }//end switch
-        }//end for
+            }
+        }
     }
 
 

--- a/tests/Core/Tokenizers/PHP/DNFTypesTest.php
+++ b/tests/Core/Tokenizers/PHP/DNFTypesTest.php
@@ -324,7 +324,7 @@ final class DNFTypesTest extends AbstractTokenizerTestCase
                 // For the purposes of this test, presume it was intended as an intersection.
                 ++$intersectionCount;
             }
-        }//end for
+        }
 
         $this->assertGreaterThanOrEqual(1, $intersectionCount, 'Did not find an intersection "&" between the DNF type parentheses');
 

--- a/tests/Core/Tokenizers/PHP/HeredocNowdocTest.php
+++ b/tests/Core/Tokenizers/PHP/HeredocNowdocTest.php
@@ -199,6 +199,6 @@ final class HeredocNowdocTest extends AbstractTokenizerTestCase
                 $tokens[$i]['content'],
                 'Token content did not match expectations' . $errorMsgSuffix
             );
-        }//end for
+        }
     }
 }

--- a/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
@@ -64,7 +64,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
                 $tokens[$colon]['type'],
                 'Token tokenized as ' . $tokens[$colon]['type'] . ', not T_COLON (type)'
             );
-        }//end foreach
+        }
     }
 
 
@@ -969,7 +969,7 @@ final class NamedFunctionCallArgumentsTest extends AbstractTokenizerTestCase
                 $tokensTypes,
                 $keyword,
             ];
-        }//end foreach
+        }
 
         return $data;
     }

--- a/tests/Core/Tokenizers/PHP/PHPOpenTagTest.php
+++ b/tests/Core/Tokenizers/PHP/PHPOpenTagTest.php
@@ -272,7 +272,7 @@ final class PHPOpenTagTest extends AbstractTokenizerTestCase
             );
 
             ++$stackPtr;
-        }//end foreach
+        }
     }
 
 

--- a/tests/Core/Tokenizers/PHP/ResolveSimpleTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/ResolveSimpleTokenTest.php
@@ -407,6 +407,6 @@ final class ResolveSimpleTokenTest extends AbstractTokenizerTestCase
             );
 
             ++$sequenceKey;
-        }//end for
+        }
     }
 }

--- a/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateParenthesisNestingMapDNFTypesTest.php
@@ -220,7 +220,7 @@ final class CreateParenthesisNestingMapDNFTypesTest extends AbstractTokenizerTes
             $this->assertArrayHasKey('nested_parenthesis', $tokens[$i], "Nested parenthesis key not set on token $i ({$tokens[$i]['type']})");
             $this->assertArrayHasKey($openPtr, $tokens[$i]['nested_parenthesis'], 'Nested parenthesis is missing target parentheses set');
             $this->assertSame($closePtr, $tokens[$i]['nested_parenthesis'][$openPtr], 'Nested parenthesis closer not set correctly');
-        }//end for
+        }
     }
 
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -265,7 +265,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                 $tokens[$closer]['scope_closer'],
                 sprintf('T_DEFAULT closer scope closer token incorrect. Marker: %s.', $closerMarker)
             );
-        }//end if
+        }
 
         if (($opener + 1) !== $closer) {
             $end = $closer;
@@ -280,7 +280,7 @@ final class RecurseScopeMapDefaultKeywordConditionsTest extends AbstractTokenize
                     sprintf('T_DEFAULT condition not added for token belonging to the T_DEFAULT structure. Marker: %s.', $testMarker)
                 );
             }
-        }//end if
+        }
     }
 
 

--- a/tests/Core/Util/Help/HelpTest.php
+++ b/tests/Core/Util/Help/HelpTest.php
@@ -126,8 +126,8 @@ final class HelpTest extends TestCase
                         "Option $name: a description should always be accompanied by an argument"
                     );
                 }
-            }//end foreach
-        }//end foreach
+            }
+        }
     }
 
 

--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -232,11 +232,11 @@ TEMPLATE;
                     $diff = trim($phpcsFile->fixer->generateDiff($testFile));
                     $failureMessages[] = "Missing fixed version of $filename to verify the accuracy of fixes, while the sniff is making fixes against the test case file; the diff is\n$diff";
                 }
-            }//end if
+            }
 
             // Restore the config.
             $config->setSettings($oldConfig);
-        }//end foreach
+        }
 
         if (empty($failureMessages) === false) {
             $this->fail(implode(PHP_EOL, $failureMessages));
@@ -301,7 +301,7 @@ TEMPLATE;
                 }
 
                 $allProblems[$line]['found_errors'] = array_merge($foundErrorsTemp, $errorsTemp);
-            }//end foreach
+            }
 
             if (isset($expectedErrors[$line]) === true) {
                 $allProblems[$line]['expected_errors'] = $expectedErrors[$line];
@@ -310,7 +310,7 @@ TEMPLATE;
             }
 
             unset($expectedErrors[$line]);
-        }//end foreach
+        }
 
         foreach ($expectedErrors as $line => $numErrors) {
             if (isset($allProblems[$line]) === false) {
@@ -347,7 +347,7 @@ TEMPLATE;
                 }
 
                 $allProblems[$line]['found_warnings'] = array_merge($foundWarningsTemp, $warningsTemp);
-            }//end foreach
+            }
 
             if (isset($expectedWarnings[$line]) === true) {
                 $allProblems[$line]['expected_warnings'] = $expectedWarnings[$line];
@@ -356,7 +356,7 @@ TEMPLATE;
             }
 
             unset($expectedWarnings[$line]);
-        }//end foreach
+        }
 
         foreach ($expectedWarnings as $line => $numWarnings) {
             if (isset($allProblems[$line]) === false) {
@@ -426,8 +426,8 @@ TEMPLATE;
                 }
 
                 $failureMessages[] = $fullMessage;
-            }//end if
-        }//end foreach
+            }
+        }
 
         return $failureMessages;
     }


### PR DESCRIPTION
# Description

### CS: remove long condition end comments

Includes removing the rule from the PHPCS native ruleset.

## Suggested changelog entry
_N/A_

## Related issues/external references

Part of a series of PRs to address #155
