### PR TITLE
CS: some clean up of test fixtures

### DIFF
--- a/tests/Core/Generators/Fixtures/HTMLDouble.php
+++ b/tests/Core/Generators/Fixtures/HTMLDouble.php
@@ -20,7 +20,7 @@ class HTMLDouble extends HTML
      */
     protected function getFormattedFooter()
     {
-        $output ='  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
+        $output = '  <div class="tag-line">Documentation generated on #REDACTED# by <a href="https://github.com/PHPCSStandards/PHP_CodeSniffer">PHP_CodeSniffer #VERSION#</a></div>
  </body>
 </html>';
 

--- a/tests/Core/Generators/Fixtures/MarkdownDouble.php
+++ b/tests/Core/Generators/Fixtures/MarkdownDouble.php
@@ -20,8 +20,8 @@ class MarkdownDouble extends Markdown
      */
     protected function getFormattedFooter()
     {
-        $output     = PHP_EOL.'Documentation generated on *REDACTED*';
-        $output    .= ' by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)'.PHP_EOL;
+        $output  = PHP_EOL.'Documentation generated on *REDACTED*';
+        $output .= ' by [PHP_CodeSniffer *VERSION*](https://github.com/PHPCSStandards/PHP_CodeSniffer)'.PHP_EOL;
 
         return $output;
     }

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithLongReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithLongReplacementSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithLongReplacementSniff implements Sniff,DeprecatedSniff
+class WithLongReplacementSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingLinuxNewlinesSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingLinuxNewlinesSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithReplacementContainingLinuxNewlinesSniff implements Sniff,DeprecatedSniff
+class WithReplacementContainingLinuxNewlinesSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingNewlinesSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementContainingNewlinesSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithReplacementContainingNewlinesSniff implements Sniff,DeprecatedSniff
+class WithReplacementContainingNewlinesSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithReplacementSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithReplacementSniff implements Sniff,DeprecatedSniff
+class WithReplacementSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithoutReplacementSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/Deprecated/WithoutReplacementSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class WithoutReplacementSniff implements Sniff,DeprecatedSniff
+class WithoutReplacementSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyDeprecationVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyDeprecationVersionSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class EmptyDeprecationVersionSniff implements Sniff,DeprecatedSniff
+class EmptyDeprecationVersionSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyRemovalVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/EmptyRemovalVersionSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class EmptyRemovalVersionSniff implements Sniff,DeprecatedSniff
+class EmptyRemovalVersionSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationMessageSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationMessageSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use stdClass;
 
-class InvalidDeprecationMessageSniff implements Sniff,DeprecatedSniff
+class InvalidDeprecationMessageSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidDeprecationVersionSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class InvalidDeprecationVersionSniff implements Sniff,DeprecatedSniff
+class InvalidDeprecationVersionSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidRemovalVersionSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/DeprecatedInvalid/InvalidRemovalVersionSniff.php
@@ -11,7 +11,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\DeprecatedSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class InvalidRemovalVersionSniff implements Sniff,DeprecatedSniff
+class InvalidRemovalVersionSniff implements Sniff, DeprecatedSniff
 {
 
     public function getDeprecationVersion()

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsViaAbstractSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/MissingInterface/ValidImplementsViaAbstractSniff.php
@@ -13,12 +13,12 @@ final class ValidImplementsViaAbstractSniff extends AbstractArraySniff
 {
 
     protected function processSingleLineArray($phpcsFile, $stackPtr, $arrayStart, $arrayEnd, $indices)
-	{
-		// Do something.
+    {
+        // Do something.
     }
 
     protected function processMultiLineArray($phpcsFile, $stackPtr, $arrayStart, $arrayEnd, $indices)
-	{
-		// Do something.
+    {
+        // Do something.
     }
 }

--- a/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForPHPAndCSSAndJSSniff.php
+++ b/tests/Core/Ruleset/Fixtures/TestStandard/Sniffs/SupportedTokenizers/ListensForPHPAndCSSAndJSSniff.php
@@ -23,7 +23,7 @@ class ListensForPHPAndCSSAndJSSniff implements Sniff
     {
         return [
             T_OPEN_TAG,
-            T_OPEN_TAG_WITH_ECHO
+            T_OPEN_TAG_WITH_ECHO,
         ];
     }
 


### PR DESCRIPTION
# Description
Test fixtures do not have to comply with all the CS rules, but it is helpful if their formatting is relative close to the project's rules.

This fixes up some sloppiness which had creeped into the test fixture files.


## Suggested changelog entry
_N/A_
