### PR TITLE
Assorted minor fixes

### DIFF
--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -115,7 +115,7 @@ class Junit implements Report
         $tests   = 0;
         $matches = [];
         preg_match_all('/tests="([0-9]+)"/', $cachedData, $matches);
-        if (isset($matches[1]) === true) {
+        if (empty($matches[1]) === false) {
             foreach ($matches[1] as $match) {
                 $tests += $match;
             }

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -110,9 +110,7 @@ class DisallowYodaConditionsSniff implements Sniff
                 if ($prev === false) {
                     return;
                 }
-            } else if ($tokens[$beforeOpeningParenthesisIndex]['code'] === T_ARRAY
-                && $this->isArrayStatic($phpcsFile, $beforeOpeningParenthesisIndex) === false
-            ) {
+            } else if ($this->isArrayStatic($phpcsFile, $beforeOpeningParenthesisIndex) === false) {
                 return;
             }//end if
         }//end if

--- a/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -62,7 +62,7 @@ class MultiLineAssignmentSniff implements Sniff
         }
 
         // Make sure it is the first thing on the line, otherwise we ignore it.
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), false, true);
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if ($prev === false) {
             // Bad assignment.
             return;

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -66,8 +66,6 @@ class FunctionDeclarationSniff implements Sniff
 
         if (isset($tokens[$stackPtr]['parenthesis_opener']) === false
             || isset($tokens[$stackPtr]['parenthesis_closer']) === false
-            || $tokens[$stackPtr]['parenthesis_opener'] === null
-            || $tokens[$stackPtr]['parenthesis_closer'] === null
         ) {
             return;
         }

--- a/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -47,8 +47,6 @@ class ReturnTypeDeclarationSniff implements Sniff
 
         if (isset($tokens[$stackPtr]['parenthesis_opener']) === false
             || isset($tokens[$stackPtr]['parenthesis_closer']) === false
-            || $tokens[$stackPtr]['parenthesis_opener'] === null
-            || $tokens[$stackPtr]['parenthesis_closer'] === null
         ) {
             return;
         }

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -68,9 +68,8 @@ class VariableCommentSniff extends AbstractVariableSniff
             break;
         }
 
-        if ($commentEnd === false
-            || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-            && $tokens[$commentEnd]['code'] !== T_COMMENT)
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
             $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
             return;

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -70,8 +70,6 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
         if (isset($tokens[$stackPtr]['parenthesis_opener']) === false
             || isset($tokens[$stackPtr]['parenthesis_closer']) === false
-            || $tokens[$stackPtr]['parenthesis_opener'] === null
-            || $tokens[$stackPtr]['parenthesis_closer'] === null
         ) {
             return;
         }


### PR DESCRIPTION
# Description

### Reports/JUnit: improve condition

### Generic/DisallowYodaConditions: remove redundant condition 

The condition in the `if` already takes everything that's not an array, so if we reach the `elseif` we can be sure it's a `T_ARRAY` token.

### PEAR/FunctionDeclaration: remove redundant conditions 

The `isset()`'s in the same condition block already take care of this.

### PSR12/ReturnTypeDeclaration: remove redundant conditions 

The `isset()`'s in the same condition block already take care of this.

### Squiz/VariableComment: remove redundant conditions 

`$commentEnd` is retrieved by walking backwards (since the sniffs allows for attributes), so will never be `false`

### Squiz/FunctionDeclarationArgumentSpacing: remove redundant conditions 

The `isset()`'s in the same condition block already take care of this.

### PEAR/MultiLineAssignment: fix incorrect parameter passed to `findPrevious()`

## Suggested changelog entry
_N/A_ These fixes should have no functional impact.