### PR TITLE
CS: normalize code style rules [9]

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -182,4 +182,17 @@
         <!-- Prevent conflict with function spacing sniff. -->
         <exclude-pattern>/requirements\.php</exclude-pattern>
     </rule>
+
+    <!-- Use select error codes from the Squiz FunctionComment sniff, which shouldn't conflict with the PEAR sniff. -->
+    <rule ref="Squiz.Commenting.FunctionComment.InvalidReturnVoid"/>
+    <rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn"/>
+    <rule ref="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid"/>
+    <rule ref="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/>
+    <rule ref="Squiz.Commenting.FunctionComment.ThrowsNoFullStop"/>
+    <rule ref="Squiz.Commenting.FunctionComment.InvalidReturnVoid"/>
+    <rule ref="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
+    <rule ref="Squiz.Commenting.FunctionComment.InvalidTypeHint"/>
+    <rule ref="Squiz.Commenting.FunctionComment.ParamNameUnexpectedAmpersandPrefix"/>
+    <rule ref="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
+
 </ruleset>


### PR DESCRIPTION
# Description

### PHPCS: remove redundant exclusion 

The test bootstrap file no longer creates aliases for the old PHPUnit class names, so this exclusion is no longer needed.

### PHPCS: add some extra function comment rules

... as suggested in #155 by @fredden.

## Suggested changelog entry
_N/A_

## Related issues/external references

Last PR in the series of PRs to address #155.

Closes #155
