### PR TITLE
File docblocks: update `@copyright` tags

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -10,7 +10,8 @@
  * when it only knows the filename, without having to parse the file to find it.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/bin/phpcbf
+++ b/bin/phpcbf
@@ -15,8 +15,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/bin/phpcbf.bat
+++ b/bin/phpcbf.bat
@@ -2,7 +2,8 @@
 REM PHP Code Beautifier and Fixer fixes violations of a defined coding standard.
 REM 
 REM @author    Greg Sherwood <gsherwood@squiz.net>
-REM @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+REM @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+REM @copyright 2023 PHPCSStandards and contributors
 REM @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
 
 set PHPBIN=php

--- a/bin/phpcs
+++ b/bin/phpcs
@@ -15,8 +15,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/bin/phpcs.bat
+++ b/bin/phpcs.bat
@@ -2,7 +2,8 @@
 REM PHP_CodeSniffer detects violations of a defined coding standard.
 REM 
 REM @author    Greg Sherwood <gsherwood@squiz.net>
-REM @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+REM @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+REM @copyright 2023 PHPCSStandards and contributors
 REM @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
 
 set PHPBIN=php

--- a/requirements.php
+++ b/requirements.php
@@ -14,8 +14,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/scripts/BuildRequirementsCheckMatrix.php
+++ b/scripts/BuildRequirementsCheckMatrix.php
@@ -5,7 +5,6 @@
  * This matrix is used in two different GH Actions jobs and would be excruciating
  * (and pretty error-prone) to manually maintain, so better to generate it dynamically.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2024 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -3,13 +3,10 @@
 /**
  * Build a PHPCS phar.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Benjamin Pearson <bpearson@squiz.com.au>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/scripts/get-requirements-check-matrix.php
+++ b/scripts/get-requirements-check-matrix.php
@@ -6,7 +6,6 @@
  * This matrix is used in two different GH Actions jobs and would be excruciating
  * (and pretty error-prone) to manually maintain, so better to generate it dynamically.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2024 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,7 +6,8 @@
  * and provides functions to access data stored in config files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Exceptions/DeepExitException.php
+++ b/src/Exceptions/DeepExitException.php
@@ -10,8 +10,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2025 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Exceptions/GeneratorException.php
+++ b/src/Exceptions/GeneratorException.php
@@ -3,7 +3,6 @@
  * An exception thrown by PHP_CodeSniffer when it encounters an error in the XML document being processed
  * by one of the documentation Generators.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2024 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -3,7 +3,8 @@
  * An exception thrown by PHP_CodeSniffer when it encounters an unrecoverable error.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Exceptions/TokenizerException.php
+++ b/src/Exceptions/TokenizerException.php
@@ -3,7 +3,8 @@
  * An exception thrown by PHP_CodeSniffer when it encounters an unrecoverable tokenizer error.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Files/DummyFile.php
+++ b/src/Files/DummyFile.php
@@ -8,7 +8,8 @@
  * as the first line of the file contents.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -3,7 +3,8 @@
  * Represents a piece of content being checked during the run.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -5,7 +5,8 @@
  * File objects are created as needed rather than all at once.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -3,7 +3,8 @@
  * A local file represents a chunk of text has a file system location.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -5,7 +5,8 @@
  * Supports both allowed files and disallowed files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -3,7 +3,8 @@
  * A base filter class for filtering out files and folders during a run.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -3,7 +3,8 @@
  * A filter to only include files that have been modified or added in a Git repository.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -6,6 +6,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -6,7 +6,8 @@
  * content.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -7,8 +7,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -8,8 +8,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -5,7 +5,7 @@
  * @author    Stefano Kowalke <blueduck@gmx.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2014 Arroba IT
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -6,8 +6,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -3,7 +3,8 @@
  * Manages reporting of errors and warnings.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -8,8 +8,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2025 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -3,7 +3,8 @@
  * Checkstyle report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -3,7 +3,8 @@
  * Full report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Csv.php
+++ b/src/Reports/Csv.php
@@ -3,7 +3,8 @@
  * CSV report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -3,7 +3,8 @@
  * Diff report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Emacs.php
+++ b/src/Reports/Emacs.php
@@ -3,7 +3,8 @@
  * Emacs report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -3,7 +3,8 @@
  * Full report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -4,7 +4,8 @@
  *
  * @author    Ben Selby <benmatselby@gmail.com>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -4,7 +4,8 @@
  *
  * @author    Ben Selby <benmatselby@gmail.com>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -3,7 +3,8 @@
  * Info report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -4,7 +4,8 @@
  *
  * @author    Jeffrey Fisher <jeffslofish@gmail.com>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -4,7 +4,8 @@
  *
  * @author    Oleg Lobach <oleg@lobach.info>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -10,7 +10,8 @@
  * @author    Christian Weiske <christian.weiske@netresearch.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2012-2014 Christian Weiske
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Performance.php
+++ b/src/Reports/Performance.php
@@ -3,7 +3,7 @@
  * Performance report for PHP_CodeSniffer.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -3,7 +3,8 @@
  * An interface that PHP_CodeSniffer reports must implement.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -3,7 +3,8 @@
  * Source report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -3,7 +3,8 @@
  * Summary report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Svnblame.php
+++ b/src/Reports/Svnblame.php
@@ -3,7 +3,8 @@
  * SVN blame report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -4,7 +4,8 @@
  *
  * @author    Ben Selby <benmatselby@gmail.com>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -3,7 +3,8 @@
  * XML report for PHP_CodeSniffer.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -5,7 +5,8 @@
  * A ruleset object directly maps to a ruleset XML file.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -6,7 +6,8 @@
  * call runPHPCS() or runPHPCBF().
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -3,7 +3,8 @@
  * Processes single and multi-line arrays.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -3,7 +3,8 @@
  * Processes pattern strings and checks that the code conforms to the pattern.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -20,7 +20,8 @@
  * </code>
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -9,7 +9,8 @@
  * called.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/DeprecatedSniff.php
+++ b/src/Sniffs/DeprecatedSniff.php
@@ -9,7 +9,7 @@
  * as well, or extend an abstract sniff which does, to be recognized as a valid sniff.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 PHPCSStandards Contributors
+ * @copyright 2024 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Sniffs/Sniff.php
+++ b/src/Sniffs/Sniff.php
@@ -8,7 +8,8 @@
  * PHP_CodeSniffer file in which the token was found.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -3,7 +3,8 @@
  * Ensures that array are indented one tab stop.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
@@ -3,7 +3,8 @@
  * Bans the use of the PHP long array syntax.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/DisallowShortArraySyntaxSniff.php
@@ -3,7 +3,8 @@
  * Bans the use of the PHP short array syntax.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -3,7 +3,8 @@
  * Reports errors if the same class or interface name is used in multiple files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -3,7 +3,8 @@
  * Checks that the opening brace of a class/interface/trait is on the same line as the class declaration.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -8,6 +8,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -7,6 +7,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -18,6 +18,7 @@
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopShouldBeWhileLoopSniff.php
@@ -17,6 +17,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/ForLoopWithTestFunctionCallSniff.php
@@ -21,6 +21,7 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -24,6 +24,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceSniff.php
@@ -23,7 +23,7 @@
  *
  * @author    Tim Duesterhus <duesterhus@woltlab.com>
  * @copyright 2021-2023 WoltLab GmbH.
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
@@ -21,6 +21,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
@@ -17,6 +17,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -11,6 +11,7 @@
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -16,6 +16,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -3,7 +3,8 @@
  * Ensures doc blocks follow basic formatting.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -4,7 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Sam Graham <php-codesniffer@illusori.co.uk>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -3,7 +3,8 @@
  * Warns about TODO comments.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/DisallowYodaConditionsSniff.php
@@ -4,7 +4,8 @@
  *
  * @author    Mponos George <gmponos@gmail.com>
  * @author    Mark Scherer <username@example.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -3,7 +3,8 @@
  * Verifies that inline control statements are not present.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
@@ -5,6 +5,7 @@
  * @author    Piotr Karas <office@mediaself.pl>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2010-2014 mediaSELF Sp. z o.o.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/EndFileNewlineSniff.php
@@ -3,7 +3,8 @@
  * Ensures the file ends with a newline character.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/EndFileNoNewlineSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/EndFileNoNewlineSniff.php
@@ -3,7 +3,8 @@
  * Ensures the file does not end with a newline character.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/ExecutableFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/ExecutableFileSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Matthew Peveler <matt.peveler@gmail.com>
  * @copyright 2019 Matthew Peveler
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
@@ -3,7 +3,8 @@
  * Ensures the whole file is PHP only, with no whitespace or inline HTML.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -3,7 +3,8 @@
  * Checks that end of line characters are correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -7,7 +7,8 @@
  * figures can be changed in a ruleset.xml file.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
@@ -3,7 +3,8 @@
  * Checks that only one object structure is declared per file.
  *
  * @author    Mponos George <gmponos@gmail.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Alexander Obuhovich <aik.bold@gmail.com>
  * @copyright 2010-2014 Alexander Obuhovich
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/DisallowMultipleStatementsSniff.php
@@ -3,7 +3,8 @@
  * Ensures each statement is on a line by itself.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -6,7 +6,8 @@
  * each assignment are aligned. It will display a warning to advise that the signs should be aligned.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
@@ -3,7 +3,8 @@
  * Ensures there is a single space after cast tokens.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -3,7 +3,8 @@
  * Ensures there is a single space after a NOT operator.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
@@ -3,7 +3,8 @@
  * Ensures there is a single space before cast tokens.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks that calls to methods and functions are spaced correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -3,7 +3,8 @@
  * Checks that the opening brace of a function is on the line after the function declaration.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -3,7 +3,8 @@
  * Checks that the opening brace of a function is on the same line as the function declaration.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -9,6 +9,7 @@
  * @author    Johann-Peter Hartmann <hartmann@mayflower.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2007-2014 Mayflower GmbH
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
@@ -5,6 +5,7 @@
  * @author    Johann-Peter Hartmann <hartmann@mayflower.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2007-2014 Mayflower GmbH
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures method and functions are named correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -7,7 +7,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Leif Wickland <lwickland@rightnow.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures that constant names are all uppercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
@@ -3,7 +3,8 @@
  * Bans the use of the backtick execution operator.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/CharacterBeforePHPOpeningTagSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Stefano Kowalke <blueduck@gmx.net>
  * @copyright 2010-2014 Stefano Kowalke
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -4,7 +4,8 @@
  *
  * @author    Sebastian Bergmann <sb@sebastian-bergmann.de>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -5,7 +5,8 @@
  * If alternative PHP open tags are found, this sniff can fix both the open and close tags.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
@@ -3,7 +3,8 @@
  * Ensures the $_REQUEST superglobal is not used
  *
  * @author    Jeantwan Teuma <jeant.m24@gmail.com>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -3,7 +3,8 @@
  * Makes sure that shorthand PHP open tags are not used.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
@@ -3,7 +3,8 @@
  * Discourage the use of the PHP `goto` language construct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -6,7 +6,8 @@
  * with older versions. Can be used to forbid the use of any function.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -3,7 +3,8 @@
  * Checks that all uses of true, false and null are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -3,7 +3,8 @@
  * Checks that all PHP keywords are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -3,7 +3,8 @@
  * Checks that all PHP types are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -10,7 +10,8 @@
  * </code>
  *
  * @author    Andy Brockhurst <abrock@yahoo-inc.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -3,7 +3,8 @@
  * Checks that the strict_types has been declared.
  *
  * @author    Sertan Danis <sdanis@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
@@ -3,7 +3,8 @@
  * Ensures the PHP_SAPI constant is used instead of php_sapi_name().
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -4,7 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Blaine Schmeisser <blainesch@gmail.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/PHP/UpperCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/UpperCaseConstantSniff.php
@@ -3,7 +3,8 @@
  * Checks that all uses of TRUE, FALSE and NULL are uppercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -3,7 +3,8 @@
  * Checks that two strings are not concatenated together; suggests using one string instead.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -3,7 +3,8 @@
  * Tests that the correct Subversion properties are set.
  *
  * @author    Jack Bates <ms419@freezone.co.uk>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -7,6 +7,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -3,7 +3,8 @@
  * Throws errors if spaces are used for indentation other than precision indentation.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -3,7 +3,8 @@
  * Throws errors if tabs are used for indentation.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/GotoTargetSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/GotoTargetSpacingSniff.php
@@ -2,7 +2,6 @@
 /**
  * Ensures there is no space between the label for a goto target and the colon following it.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensures all language constructs contain a single space between themselves and their content.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures are defined and indented correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ArrayIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowLongArraySyntax sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowShortArraySyntaxUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowShortArraySyntax sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DuplicateClassName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OpeningBraceSameLine sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopShouldBeWhileLoopUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/ForLoopWithTestFunctionCallUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/JumbledIncrementerUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/RequireExplicitBooleanOperatorPrecedenceUnitTest.php
@@ -4,7 +4,7 @@
  *
  * @author    Tim Duesterhus <duesterhus@woltlab.com>
  * @copyright 2021-2023 WoltLab GmbH.
- * @copyright 2024 PHPCSStandards and contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnconditionalIfStatementUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UselessOverridingMethodUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Manuel Pichler <mapi@manuel-pichler.de>
  * @copyright 2007-2014 Manuel Pichler. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DocCommentSniff sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -4,7 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Sam Graham <php-codesniffer@illusori.co.uk>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the Todo sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/DisallowYodaConditionsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowYodaConditions sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InlineControlStructure sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ByteOrderMarkUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ByteOrderMark sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EndFileNewline sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EndFileNoNewline sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Matthew Peveler <matt.peveler@gmail.com>
  * @copyright 2019 Matthew Peveler
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InlineHTML sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LineEndings sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LineLength sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LowercasedFilenameUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneClassPerFileUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneInterfacePerFileUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OneObjectStructurePerFile sniff.
  *
  * @author    Mponos George <gmponos@gmail.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Alexander Obuhovich <aik.bold@gmail.com>
  * @copyright 2010-2014 Alexander Obuhovich
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowMultipleStatements sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MultipleStatementAlignment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SpaceAfterCast sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SpaceAfterNot sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SpaceBeforeCast sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionCallArgumentSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OpeningFunctionBraceBsdAllman sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OpeningFunctionBraceKernighanRitchie sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CyclomaticComplexity sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/NestingLevelUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the NestingLevel sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CamelCapsFunctionName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ConstructorName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidConstantName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the BacktickOperator sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ClosingPHPTagUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Andy Grunwald <andygrunwald@gmail.com>
  * @copyright 2010-2014 Andy Grunwald
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowAlternativePHPTags sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperglobalUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowRequestSuperglobal sniff.
  *
  * @author    Jeantwan Teuma <jeant.m24@gmail.com>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowShortOpenTag sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DiscourageGoto sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ForbiddenFunctions sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowerCaseConstant sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowerCaseKeyword sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowerCaseType sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the NoSilencedErrors sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the RequireStrictType sniff.
  *
  * @author    Sertan Danis <sdanis@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SAPIUsage sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -4,7 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Blaine Schmeisser <blainesch@gmail.com>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/UpperCaseConstantUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the UpperCaseConstant sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/src/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the UnnecessaryStringConcat sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ArbitraryParenthesesSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowSpaceIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowTabIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LanguageConstructSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ScopeIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks the declaration of the class is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the doc comments for classes.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the doc comments for files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the doc comments for functions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/InlineCommentSniff.php
@@ -3,7 +3,8 @@
  * Checks that no Perl-style comments are used.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -3,7 +3,8 @@
  * Verifies that control statements conform to their coding standards.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -3,7 +3,8 @@
  * Ensure multi-line IF conditions are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
+++ b/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php
@@ -5,7 +5,8 @@
  * Also checks that brackets do not surround the file being included.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -3,7 +3,8 @@
  * If an assignment goes over two lines, ensure the equal sign is indented.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -3,7 +3,8 @@
  * Ensures function calls are formatted correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensure single and multi-line function declarations are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -3,7 +3,8 @@
  * Ensures function params with default values are at the end of the declaration.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures class and interface names start with a capital letter and use _ separators.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures method and function names are correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -3,7 +3,8 @@
  * Checks the naming of member variables.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -3,7 +3,8 @@
  * Checks that object operators are indented correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -3,7 +3,8 @@
  * Checks that the closing braces of scopes are aligned correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures are structured and indented correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FileComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/InlineCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InlineComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ControlSignature sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MultiLineCondition sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
+++ b/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the IncludingFile sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Formatting/MultiLineAssignmentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MultiLineAssignment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionCallSignature sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidDefaultValue sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidClassName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidFunctionName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidVariableName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ObjectOperatorIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ScopeClosingBrace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ScopeIndent sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks the declaration of the class is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -3,7 +3,8 @@
  * Ensures a file declares new symbols and causes no other side effects, or executes logic with side effects, but not both.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures method names are defined using camel case.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SideEffects sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CamelCapsMethodName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks that the declaration of an anon class is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that classes are instantiated with parentheses.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
@@ -3,7 +3,8 @@
  * Verifies that closing braces are the last content on a line.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/OpeningBraceSpaceSniff.php
@@ -3,7 +3,8 @@
  * Verifies that opening braces are not followed by blank lines.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures have boolean operators in the correct place.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures have the correct spacing.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php
@@ -3,7 +3,8 @@
  * Checks the format of the declare statements.
  *
  * @author    Sertan Danis <sdanis@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -3,7 +3,8 @@
  * Checks the format of the file header.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php
@@ -3,7 +3,8 @@
  * Verifies that import statements are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
@@ -3,7 +3,8 @@
  * Checks that the open tag is defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that nullable typehints are lacking superfluous whitespace, e.g. ?int
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensure return types are defined correctly for functions and closures.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Keywords/ShortFormTypeKeywordsSniff.php
+++ b/src/Standards/PSR12/Sniffs/Keywords/ShortFormTypeKeywordsSniff.php
@@ -3,7 +3,8 @@
  * Verifies that the short form of type keywords is used (e.g., int, bool).
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
+++ b/src/Standards/PSR12/Sniffs/Namespaces/CompoundNamespaceDepthSniff.php
@@ -3,7 +3,8 @@
  * Verifies that compound namespaces are not defined too deep.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
@@ -3,7 +3,8 @@
  * Verifies that operators have valid spacing surrounding them.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
+++ b/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
@@ -3,7 +3,8 @@
  * Verifies that all class constants have their visibility set.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that trait import statements are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the AnonClassDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassInstantiation sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClosingBrace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OpeningBraceSpace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the BooleanOperatorPlacement sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ControlStructureSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/DeclareStatementUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DeclareStatement sniff.
  *
  * @author    Sertan Danis <sdanis@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FileHeader sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ImportStatement sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
+++ b/src/Standards/PSR12/Tests/Files/OpenTagUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OpenTag sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the NullableWhitespace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ReturnTypeDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ShortFormTypeKeywords sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
+++ b/src/Standards/PSR12/Tests/Namespaces/CompoundNamespaceDepthUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CompoundNamespaceDepth sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OperatorSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ConstantVisibility sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the UseDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks the declaration of the class and its inheritance is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that properties are declared correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures have the correct spacing around brackets.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that there are no else if statements (elseif should be used instead).
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures all switch statements are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php
@@ -3,7 +3,8 @@
  * Checks that the file does not end with a closing tag.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -3,7 +3,8 @@
  * Ensures the file ends with a newline character.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -3,7 +3,8 @@
  * Checks that the function call format is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionClosingBraceSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionClosingBraceSniff.php
@@ -3,7 +3,8 @@
  * Checks that the closing brace of a function goes directly after the body.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks that the method declaration is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures namespaces are declared correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures USE blocks are declared correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the PropertyDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ElseIfDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SwitchDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClosingTag sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EndFileNewline sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionCallSignature sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionClosingBraceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionClosingBrace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MethodDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the NamespaceDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the UseDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensure that there are no spaces around square brackets.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures that arrays conform to the array coding standard.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks the declaration of the class and its inheritance is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -3,7 +3,8 @@
  * Tests that the file name and the name of the class contained within the file match.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -3,7 +3,8 @@
  * Ensures all class keywords are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -8,7 +8,8 @@
  * - self:: is used instead of self ::
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures classes are in camel caps, and the first letter is capitalised.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -3,7 +3,8 @@
  * Verifies that block comments are used appropriately.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -11,7 +11,8 @@
  * </ul>
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -3,7 +3,8 @@
  * Checks the //end ... comments on classes, enums, functions, interfaces and traits.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -3,7 +3,8 @@
  * Tests that the stars in a doc comment align correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
@@ -3,7 +3,8 @@
  * Checks for empty catch clause without a comment.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the file doc comment.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the doc comments for functions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -3,7 +3,8 @@
  * Verifies that a @throws tag exists for each exception type a function throws.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -3,7 +3,8 @@
  * Checks that there is adequate spacing between comments.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -3,7 +3,8 @@
  * Ensures long conditions have a comment at the end.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -3,7 +3,8 @@
  * Checks to ensure that there are no comments after statements.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -3,7 +3,8 @@
  * Parses and verifies the variable doc comment.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -3,7 +3,8 @@
  * Verifies that control statements conform to their coding standards.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures the use of else if over elseif.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that there is a space between each condition of foreach loops.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Verifies that there is a space between each condition of for loops.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Tests the spacing of shorthand IF statements.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensures all control structure keywords are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Enforces switch statement formatting.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
@@ -3,7 +3,8 @@
  * Tests that classes and interfaces are not declared in .php files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -3,7 +3,8 @@
  * Tests that all arithmetic operations are bracketed.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks that arguments in function declarations are spaced correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Checks the function declaration is correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
@@ -3,7 +3,8 @@
  * Checks that duplicate arguments are not used in function declarations.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/GlobalFunctionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/GlobalFunctionSniff.php
@@ -3,7 +3,8 @@
  * Tests for functions outside of classes.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
@@ -3,7 +3,8 @@
  * Ensures all function keywords are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -3,7 +3,8 @@
  * Ensure single and multi-line function declarations are defined correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -3,7 +3,8 @@
  * Ensures method names are correct.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -3,7 +3,8 @@
  * Checks the naming of variables and member variables.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -3,7 +3,8 @@
  * Ensures objects are assigned to a variable when instantiated.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -3,7 +3,8 @@
  * A Sniff to enforce the use of IDENTICAL type operators rather than EQUAL operators.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -3,7 +3,8 @@
  * Ensures that the ++ operators are used when possible.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Operators/ValidLogicalOperatorsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ValidLogicalOperatorsSniff.php
@@ -3,7 +3,8 @@
  * Ensures logical operators 'and' and 'or' are not used.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -3,7 +3,8 @@
  * Warn about commented out code.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php
@@ -3,7 +3,8 @@
  * Ensures that boolean operators are only used inside control structure conditions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
@@ -3,7 +3,8 @@
  * Ensures that the value of a comparison is not assigned to a variable.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowInlineIfSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowInlineIfSniff.php
@@ -3,7 +3,8 @@
  * Stops inline IF statements from being used.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -3,7 +3,8 @@
  * Ensures there is only one assignment on a line, and that it is the first thing on the line.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
@@ -3,7 +3,8 @@
  * Bans the use of size-based functions in loop conditions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -3,7 +3,8 @@
  * Discourages the use of debug functions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -3,7 +3,8 @@
  * Checks the indentation of embedded PHP code segments.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/EvalSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EvalSniff.php
@@ -3,7 +3,8 @@
  * The use of eval() is discouraged.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/GlobalKeywordSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/GlobalKeywordSniff.php
@@ -3,7 +3,8 @@
  * Stops the usage of the "global" keyword.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php
@@ -3,7 +3,8 @@
  * Bans the use of heredocs and nowdocs.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
@@ -3,7 +3,8 @@
  * Ensures that functions within functions are never used.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -3,7 +3,8 @@
  * Ensures all calls to inbuilt PHP functions are lowercase.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -3,7 +3,8 @@
  * Warns about code that can never been executed.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -3,7 +3,8 @@
  * Verifies that class members have scope modifiers.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -3,7 +3,8 @@
  * Verifies that class methods have scope modifiers.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -3,7 +3,8 @@
  * Checks for usage of $this in static methods, which will cause runtime errors.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -3,7 +3,8 @@
  * Makes sure there are no spaces around the concatenation operator.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -3,7 +3,8 @@
  * Makes sure that any use of double quotes strings are warranted.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/EchoedStringsSniff.php
@@ -3,7 +3,8 @@
  * Makes sure that any strings that are "echoed" are not enclosed in brackets.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensure cast statements don't contain whitespace.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks that control structures have the correct spacing around brackets.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
@@ -3,7 +3,8 @@
  * Checks that there is one empty line before the closing brace of a function.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
@@ -3,7 +3,8 @@
  * Checks that there is no empty line after the opening brace of a function.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -3,7 +3,8 @@
  * Checks the separation between functions and methods.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
@@ -3,7 +3,8 @@
  * Verifies that operators have valid spacing surrounding them.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -3,7 +3,8 @@
  * Verifies that class members are spaced correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensure there is no whitespace before/after an object operator.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -3,7 +3,8 @@
  * Verifies that operators have valid spacing surrounding them.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -3,7 +3,8 @@
  * Checks that the closing braces of scopes are aligned correctly.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensure there is a single space after scope keywords.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -3,7 +3,8 @@
  * Ensure there is no whitespace before a semicolon.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -7,7 +7,8 @@
  * are two empty lines in functions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ArrayBracketSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ArrayDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassFileName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowercaseClassKeywords sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SelfMemberReference sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidClassName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the BlockComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClassComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClosingDeclarationComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DocCommentAlignment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/EmptyCatchCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EmptyCatchComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FileComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionCommentThrowTag sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InlineComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LongConditionClosingComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the PostStatementComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the VariableComment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ControlSignature sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ElseIfDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ElseIfDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForEachLoopDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ForEachLoopDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ForLoopDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/InlineIfDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InlineIfDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowercaseDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SwitchDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FileExtension sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OperatorBracket sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionDeclarationArgumentSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDuplicateArgumentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionDuplicateArgument sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/GlobalFunctionUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the GlobalFunction sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowercaseFunctionKeywords sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MultiLineFunctionDeclaration sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidFunctionName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidVariableName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ObjectInstantiation sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ComparisonOperatorUsage sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the IncrementDecrementUsage sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/ValidLogicalOperatorsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidLogicalOperators sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CommentedOutCode sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowBooleanStatementUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowBooleanStatement sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowComparisonAssignment sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowObEndFlush sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowMultipleAssignments sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DisallowSizeFunctionsInLoops sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DiscouragedFunctions sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EmbeddedPhp sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EvalUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the Eval sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/GlobalKeywordUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the GlobalKeyword sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/HeredocUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the Heredoc sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/InnerFunctionsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the InnerFunctions sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LowercasePHPFunctions sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the NonExecutableCode sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MemberVarScope sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MethodScope sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the StaticThisUsage sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/ConcatenationSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ConcatenationSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the DoubleQuoteUsage sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/EchoedStringsUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the EchoedStrings sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the CastSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ControlStructureSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionClosingBraceSpaceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionClosingBraceSpace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionOpeningBraceSpaceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionOpeningBraceSpace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the FunctionSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the LogicalOperatorSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the MemberVarSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ObjectOperatorSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the OperatorSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ScopeClosingBrace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ScopeKeywordSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SemicolonSpacing sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the SuperfluousWhitespace sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -3,7 +3,8 @@
  * Checks that the file does not end with a closing tag.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -3,7 +3,8 @@
  * Checks the naming of variables and member variables.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/Zend/Tests/Files/ClosingTagUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ClosingTag sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -3,7 +3,8 @@
  * Unit test class for the ValidVariableName sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Tokenizers/Comment.php
+++ b/src/Tokenizers/Comment.php
@@ -3,7 +3,8 @@
  * Tokenizes doc block comments.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3,7 +3,8 @@
  * Tokenizes PHP code.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -3,7 +3,8 @@
  * The base tokenizer class.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -3,7 +3,8 @@
  * Function for caching between runs.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -3,7 +3,8 @@
  * Basic util functions.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -10,7 +10,7 @@
  * @internal
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -3,7 +3,8 @@
  * Functions for helping process standards.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -11,8 +11,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2025 PHPCSStandards and contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -3,7 +3,8 @@
  * Stores weightings and groupings of tokens.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/ConfigDouble.php
+++ b/tests/ConfigDouble.php
@@ -11,7 +11,7 @@
  * with the exception of select tests for the Config class itself.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/AbstractMethodTestCase.php
+++ b/tests/Core/AbstractMethodTestCase.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2018-2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Autoloader/DetermineLoadedClassTest.php
+++ b/tests/Core/Autoloader/DetermineLoadedClassTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Autoload::determineLoadedClass method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Config/IniSetTest.php
+++ b/tests/Core/Config/IniSetTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for overriding the value of a PHP ini setting using CLI arguments.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -3,7 +3,8 @@
  * Tests for PHP_CodeSniffer error suppression tags.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/FindEndOfStatementTest.php
+++ b/tests/Core/Files/File/FindEndOfStatementTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::findEndOfStatement method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/FindExtendedClassNameTest.php
+++ b/tests/Core/Files/File/FindExtendedClassNameTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::findExtendedClassName method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/Files/File/FindImplementedInterfaceNamesTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/FindStartOfStatementTest.php
+++ b/tests/Core/Files/File/FindStartOfStatementTest.php
@@ -4,8 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2019-2024 PHPCSStandards Contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetClassPropertiesTest.php
+++ b/tests/Core/Files/File/GetClassPropertiesTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File:getClassProperties method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2022-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetConditionTest.php
+++ b/tests/Core/Files/File/GetConditionTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File:getCondition and \PHP_CodeSniffer\Files\File:hasCondition methods.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022-2024 PHPCSStandards Contributors
+ * @copyright 2022 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetDeclarationNameParseError1Test.php
+++ b/tests/Core/Files/File/GetDeclarationNameParseError1Test.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getDeclarationName method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetDeclarationNameParseError2Test.php
+++ b/tests/Core/Files/File/GetDeclarationNameParseError2Test.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getDeclarationName method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetDeclarationNameTest.php
+++ b/tests/Core/Files/File/GetDeclarationNameTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getDeclarationName method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022-2024 PHPCSStandards Contributors
+ * @copyright 2022 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMemberPropertiesTest.php
+++ b/tests/Core/Files/File/GetMemberPropertiesTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodParametersParseError1Test.php
+++ b/tests/Core/Files/File/GetMethodParametersParseError1Test.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019-2024 PHPCSStandards Contributors
+ * @copyright 2019 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodParametersParseError2Test.php
+++ b/tests/Core/Files/File/GetMethodParametersParseError2Test.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019-2024 PHPCSStandards Contributors
+ * @copyright 2019 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodParametersParseError3Test.php
+++ b/tests/Core/Files/File/GetMethodParametersParseError3Test.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodParametersParseError4Test.php
+++ b/tests/Core/Files/File/GetMethodParametersParseError4Test.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodParameters method.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodParametersTest.php
+++ b/tests/Core/Files/File/GetMethodParametersTest.php
@@ -4,8 +4,8 @@
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2019-2024 PHPCSStandards Contributors
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetMethodPropertiesTest.php
+++ b/tests/Core/Files/File/GetMethodPropertiesTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getMethodProperties method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/GetTokensAsStringTest.php
+++ b/tests/Core/Files/File/GetTokensAsStringTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Files\File::getTokensAsString method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022-2024 PHPCSStandards Contributors
+ * @copyright 2022 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/File/IsReferenceTest.php
+++ b/tests/Core/Files/File/IsReferenceTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Files\File::isReference method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/FileList/AbstractFileListTestCase.php
+++ b/tests/Core/Files/FileList/AbstractFileListTestCase.php
@@ -2,7 +2,7 @@
 /**
  * Abstract testcase class for testing FileList methods.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/FileList/AddFileTest.php
+++ b/tests/Core/Files/FileList/AddFileTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\FileList::addFile method.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/FileList/ConstructTest.php
+++ b/tests/Core/Files/FileList/ConstructTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\FileList::__construct method.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Files/FileList/FilterDouble.php
+++ b/tests/Core/Files/FileList/FilterDouble.php
@@ -2,7 +2,7 @@
 /**
  * Double of the filter class that will accept every file. Used in the FileList tests.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Filters/AbstractFilterTestCase.php
+++ b/tests/Core/Filters/AbstractFilterTestCase.php
@@ -3,7 +3,7 @@
  * Abstract Testcase class for testing Filters.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2023 PHPCSStandards Contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -4,7 +4,8 @@
  *
  * @author    Willington Vega <wvega@wvega.com>
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Filters/Filter/ShouldProcessFileWithoutExtensionTest.php
+++ b/tests/Core/Filters/Filter/ShouldProcessFileWithoutExtensionTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the \PHP_CodeSniffer\Filters\Filter class.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Filters/GitModifiedTest.php
+++ b/tests/Core/Filters/GitModifiedTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Filters\GitModified class.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2023 PHPCSStandards Contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Filters/GitStagedTest.php
+++ b/tests/Core/Filters/GitStagedTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Filters\GitStaged class.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2023 PHPCSStandards Contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Fixer/GenerateDiffTest.php
+++ b/tests/Core/Fixer/GenerateDiffTest.php
@@ -3,7 +3,7 @@
  * Tests for diff generation.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/ExplainTest.php
+++ b/tests/Core/Ruleset/ExplainTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/ProcessRulesetIniSetTest.php
+++ b/tests/Core/Ruleset/ProcessRulesetIniSetTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for overriding the value of a PHP ini setting by passing a new value via a ruleset.
  *
- * @copyright 2025 PHPCSStandards Contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.php
+++ b/tests/Core/Ruleset/PropertyTypeHandlingOldArrayFormatTest.php
@@ -2,7 +2,6 @@
 /**
  * Tests for the handling of properties being set via the ruleset.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/tests/Core/Ruleset/RegisterSniffsRemovedTokenizersTest.php
+++ b/tests/Core/Ruleset/RegisterSniffsRemovedTokenizersTest.php
@@ -2,7 +2,6 @@
 /**
  * Test the Ruleset::registerSniffs() method.
  *
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2022 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
+++ b/tests/Core/Ruleset/ShowSniffDeprecationsTest.php
@@ -3,7 +3,7 @@
  * Tests PHPCS native handling of sniff deprecations.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Runner/RunPHPCSExplainTest.php
+++ b/tests/Core/Runner/RunPHPCSExplainTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2023 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Sniffs/AbstractArraySniffTest.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Sniffs\AbstractArraySniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Sniffs/AbstractArraySniffTestable.php
+++ b/tests/Core/Sniffs/AbstractArraySniffTestable.php
@@ -3,7 +3,8 @@
  * A testable implementation of \PHP_CodeSniffer\Sniffs\AbstractArraySniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
+++ b/tests/Core/Tokenizers/AbstractTokenizerTestCase.php
@@ -7,6 +7,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2018-2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/AnonClassParenthesisOwnerTest.php
+++ b/tests/Core/Tokenizers/PHP/AnonClassParenthesisOwnerTest.php
@@ -3,7 +3,8 @@
  * Tests the adding of the "parenthesis" keys to an anonymous class token.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/ArrayKeywordTest.php
@@ -3,7 +3,8 @@
  * Tests that the array keyword is tokenized correctly.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/AttributesTest.php
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.php
@@ -3,7 +3,8 @@
  * Tests the support of PHP 8 attributes
  *
  * @author    Alessandro Chitolina <alekitto@gmail.com>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillEnumTest.php
@@ -3,7 +3,8 @@
  * Tests the support of PHP 8.1 "enum" keyword.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillExplicitOctalNotationTest.php
@@ -3,7 +3,8 @@
  * Tests the tokenization of explicit octal notation to PHP < 8.1.
  *
  * @author    Mark Baker <mark@demon-angel.eu>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillFnTokenTest.php
@@ -3,7 +3,8 @@
  * Tests the backfilling of the T_FN token to PHP < 7.4.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillMatchTokenTest.php
@@ -4,7 +4,8 @@
  * setting of parenthesis/scopes for match control structures across PHP versions.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillNumericSeparatorTest.php
@@ -3,7 +3,8 @@
  * Tests the backfilling of numeric separators to PHP < 7.4.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizers/PHP/BackfillReadonlyTest.php
@@ -3,7 +3,8 @@
  * Tests the support of PHP 8.1 "readonly" keyword.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/BitwiseOrTest.php
+++ b/tests/Core/Tokenizers/PHP/BitwiseOrTest.php
@@ -3,7 +3,8 @@
  * Tests the conversion of bitwise or tokens to type union tokens.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizers/PHP/ContextSensitiveKeywordsTest.php
@@ -3,7 +3,8 @@
  * Tests the conversion of PHP native context sensitive keywords to T_STRING.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizers/PHP/DefaultKeywordTest.php
@@ -4,7 +4,8 @@
  * and makes sure that the tokenization of switch `T_DEFAULT` structures is not aversely affected.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/DoubleArrowTest.php
+++ b/tests/Core/Tokenizers/PHP/DoubleArrowTest.php
@@ -5,7 +5,8 @@
  * is not aversely affected.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizers/PHP/DoubleQuotedStringTest.php
@@ -4,7 +4,8 @@
  * as one double quoted string token.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2022-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/EnumCaseTest.php
+++ b/tests/Core/Tokenizers/PHP/EnumCaseTest.php
@@ -3,7 +3,8 @@
  * Tests converting enum "case" to T_ENUM_CASE.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/FinallyTest.php
+++ b/tests/Core/Tokenizers/PHP/FinallyTest.php
@@ -3,7 +3,8 @@
  * Tests the tokenization of the finally keyword.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/GotoLabelTest.php
+++ b/tests/Core/Tokenizers/PHP/GotoLabelTest.php
@@ -3,7 +3,8 @@
  * Tests the tokenization of goto declarations and statements.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/HeredocStringTest.php
+++ b/tests/Core/Tokenizers/PHP/HeredocStringTest.php
@@ -4,7 +4,8 @@
  * as one heredoc string token.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2022-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizers/PHP/NamedFunctionCallArgumentsTest.php
@@ -3,7 +3,8 @@
  * Tests the backfilling of the parameter labels for PHP 8.0 named parameters in function calls.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/NamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/NamespacedNameSingleTokenTest.php
@@ -13,7 +13,8 @@
  * {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/3041}
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizers/PHP/NullsafeObjectOperatorTest.php
@@ -3,7 +3,8 @@
  * Tests the backfill for the PHP >= 8.0 nullsafe object operator.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/OtherContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizers/PHP/OtherContextSensitiveKeywordsTest.php
@@ -3,7 +3,8 @@
  * Tests the conversion of PHPCS native context sensitive keyword tokens to T_STRING.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/ShortArrayTest.php
+++ b/tests/Core/Tokenizers/PHP/ShortArrayTest.php
@@ -3,7 +3,8 @@
  * Tests the conversion of square bracket tokens to short array tokens.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizers/PHP/StableCommentWhitespaceTest.php
@@ -9,7 +9,8 @@
  * This test file safeguards that.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizers/PHP/StableCommentWhitespaceWinTest.php
@@ -6,7 +6,8 @@
  * Windows line endings.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizers/PHP/TypeIntersectionTest.php
@@ -4,7 +4,8 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/PHP/YieldTest.php
+++ b/tests/Core/Tokenizers/PHP/YieldTest.php
@@ -3,7 +3,8 @@
  * Tests the tokenization of the `yield` and `yield from` keywords.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/CreatePositionMapHeredocNowdocCloserTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreatePositionMapHeredocNowdocCloserTest.php
@@ -3,7 +3,8 @@
  * Tests the tokenization of heredoc/nowdoc closer tokens.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapArrayParenthesesTest.php
@@ -3,7 +3,8 @@
  * Tests that the array keyword is tokenized correctly.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesParseErrorTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesParseErrorTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests the adding of the "parenthesis" keys to closure use tokens.
  *
- * @copyright 2020 PHPCSStandards and contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/CreateTokenMapClosureUseParenthesesTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests the adding of the "parenthesis" keys to closure use tokens.
  *
- * @copyright 2020 PHPCSStandards and contributors
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapCaseKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapCaseKeywordConditionsTest.php
@@ -3,7 +3,8 @@
  * Tests that switch "case" statements get scope indexes, while enum "case" statements do not.
  *
  * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
- * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2021-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapDefaultKeywordConditionsTest.php
@@ -3,7 +3,8 @@
  * Tests that switch "default" statements get scope indexes, while match "default" statements do not.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizers/Tokenizer/RecurseScopeMapWithNamespaceOperatorTest.php
@@ -3,7 +3,8 @@
  * Tests the scope opener/closers are set correctly when the namespace keyword is used as an operator.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2020-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Util/Common/IsCamelCapsTest.php
+++ b/tests/Core/Util/Common/IsCamelCapsTest.php
@@ -3,7 +3,8 @@
  * Tests for the \PHP_CodeSniffer\Util\Common::isCamelCaps method.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Util/Common/StripColorsTest.php
+++ b/tests/Core/Util/Common/StripColorsTest.php
@@ -3,7 +3,7 @@
  * Tests for the \PHP_CodeSniffer\Util\Common::stripColors() method.
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2024 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Core/Util/Common/SuggestTypeTest.php
+++ b/tests/Core/Util/Common/SuggestTypeTest.php
@@ -4,6 +4,7 @@
  *
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/Standards/AbstractSniffTestCase.php
+++ b/tests/Standards/AbstractSniffTestCase.php
@@ -7,7 +7,8 @@
  * warnings and errors that are not expected, are considered test failures.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,8 @@
  * Bootstrap file for PHP_CodeSniffer unit tests.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 


### PR DESCRIPTION
# Description
Update the `@copyright` tags in all file docblocks to:
* Have the correct "end" year for the Squiz copyright.
* Have a secondary `@copyright` tag for the PHPCSStandards organisation and contributors.

This basically standardized the `@copyright` tags going forward, without rewriting history.

Includes removing a few unnecessary `@author` tags from files new to 4.0.

Note: in some case the `@copyright` tag for "PHPCSStandards and contributors" has a year earlier than 2023. In that case, the tests were originally written for PHPCSUtils and have since been ported over to PHPCS itself.


## Suggested changelog entry
_N/A_