### PR TITLE
Various updates for branch rename from `master` to `3.x`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To find bugs which need triage, look for issues and PRs with the
     and suggest closing the issue.
 
 Additionally, for older issues:
-* Check whether an issue still exists or has been fixed in `master` since the issue was initially reported.
+* Check whether an issue still exists or has been fixed since the issue was initially reported.
 * If it has been fixed, document (in a comment) which commit/PR was responsible for fixing the issue
     and suggest closing the ticket.
 
@@ -245,7 +245,7 @@ When in doubt how to proceed with a ticket, feel free to leave a comment with sp
 
 1. Fork/clone the repository.
 2. Run `composer install`.
-3. Create a new branch off the `master` branch to hold your patch.
+3. Create a new branch off the `4.x` branch to hold your patch.
     If there is an open issue associated with your patch, including the issue number in the branch name is good practice.
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -55,7 +55,7 @@ A clear and concise description of what you expected to happen.
 |-----------------------------|---------------------------------------------------------------------------- |
 | Operating System            | (e.g., Windows 10, MacOS 10.15)                                                           |
 | PHP version                      | (e.g., 7.2, 8.1)                                                                                          |
-| PHP_CodeSniffer version | (e.g., 3.7.2, master)                                                                                  |
+| PHP_CodeSniffer version | (e.g., 3.13.4, 4.x)                                                                                  |
 | Standard                          | (e.g., PSR2, PSR12, Squiz, custom)                                                          |
 | Install type                       | (e.g. Composer (global/local), PHAR, git clone, other (please expand)) |
 
@@ -68,4 +68,4 @@ Add any other context about the problem here.
 - [ ] I have searched the issue list and am not opening a duplicate issue.
 - [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md) and this is not a [support question](https://github.com/PHPCSStandards/PHP_CodeSniffer/discussions).
 - [ ] I confirm that this bug is a bug in PHP_CodeSniffer and not in one of the external standards.
-- [ ] I have verified the issue still exists in the `master` branch of PHP_CodeSniffer.
+- [ ] I have verified the issue still exists in the `4.x` branch of PHP_CodeSniffer.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    target-branch: "3.x"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,11 @@
 <!-- Provide a general summary of your changes in the title above. -->
 
 <!--
-Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
+Please target the branch for the current major when submitting your pull request.
+
+For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
+after the new major was released.
+If your patch falls into this category, target the oldest major still accepting patches.
 -->
 
 # Description

--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -77,7 +77,7 @@ Please consider [funding the PHP_CodeSniffer project](https://opencollective.com
 
 - [ ] Merge the changelog PR.
     For now, cherrypick the changelog to the 4.0 branch.
-- [ ] Make sure all CI builds for `master` are green.
+- [ ] Make sure all CI builds for the release branch are green.
 - [ ] Create a tag for the release & push it.
 - [ ] Make sure all CI builds are green.
 - [ ] Download the PHAR files from the GH Actions test build page.

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -1,12 +1,12 @@
 name: Build PHARs
 
 on:
-  # Run on pushes to master and on pull requests which touch files used when building the PHARs.
+  # Run on pushes to the main branches and on pull requests which touch files used when building the PHARs.
   # Prevent the build from running when there are only irrelevant changes.
   push:
     branches:
-      - master
-      - 4.0
+      - 3.x
+      - 4.x
     paths:
       - '.github/workflows/build-phar.yml'
       - '.github/workflows/reusable-build-phar.yml'

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,12 +1,12 @@
 name: E2E Tests
 
 on:
-  # Run on pushes to `master`/`4.0` and on all pull requests.
+  # Run on pushes to the main branches and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
     branches:
-      - master
-      - 4.0
+      - 3.x
+      - 4.x
     tags:
       - '**'
     paths-ignore:

--- a/.github/workflows/happy-new-year.yml
+++ b/.github/workflows/happy-new-year.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set branches to use
         id: branches
         run: |
-          echo "BASE=master" >> "$GITHUB_OUTPUT"
+          echo "BASE=3.x" >> "$GITHUB_OUTPUT"
           echo "PR_BRANCH=feature/squiz-filecomment-update-copyright-year" >> "$GITHUB_OUTPUT"
 
       # Using "Tomorrow" to prevent accidentally getting last year if the server is not using UTC.

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -4,8 +4,8 @@ on:
   # Check for new conflicts due to merges.
   push:
     branches:
-      - master
-      - 4.0
+      - 3.x
+      - 4.x
   # Check conflicts in new PRs and for resolved conflicts due to an open PR being updated.
   pull_request_target:
     types:

--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -3,7 +3,7 @@ name: Label new PRs
 on:
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   # The `pull_request_target` event is used for "normal" PRs to label them when they are opened.
-  # This will use the `labeler.yml` file in the default (master) branch of the repo.
+  # This will use the `labeler.yml` file in the default branch of the repo.
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -1,11 +1,11 @@
 name: Quicktest
 
 on:
-  # Run on pushes to all branches except for `master`/`4.0`.
+  # Run on pushes to all branches except the main branches.
   push:
     branches-ignore:
-      - master
-      - 4.0
+      - 3.x
+      - 4.x
     paths-ignore:
       - '**.md'
   # Allow manually triggering the workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Test
 
 on:
-  # Run on pushes to `master`/`4.0` and on all pull requests.
+  # Run on pushes to the main branches and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
     branches:
-      - master
-      - 4.0
+      - 3.x
+      - 4.x
     tags:
       - '**'
     paths-ignore:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <div aria-hidden="true">
 
 [![Latest Stable Version](https://img.shields.io/github/v/release/PHPCSStandards/PHP_CodeSniffer?label=Stable)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases)
-[![Validate](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml/badge.svg?branch=master)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml)
-[![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=master)][GHA-test]
-[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHP_CodeSniffer/badge.svg?branch=master)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=master)
+[![Validate](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml/badge.svg?branch=3.x)](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/validate.yml)
+[![Test](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/workflows/test.yml/badge.svg?branch=3.x)][GHA-test]
+[![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHP_CodeSniffer/badge.svg?branch=3.x)](https://coveralls.io/github/PHPCSStandards/PHP_CodeSniffer?branch=3.x)
 [![License](https://img.shields.io/github/license/PHPCSStandards/PHP_CodeSniffer)](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt)
 
 ![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/squizlabs/php_codesniffer/php.svg)

--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,6 @@
     "config": {
         "lock": false
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
-        }
-    },
     "scripts": {
         "cs": [
             "@php ./bin/phpcs"


### PR DESCRIPTION
# Description

* Ensure Dependabot still pulls GH Actions related changes to the `3.x` branch, as CI for `3.x` needs to keep working for another year.
* Ensure the "happy new year" PR goes to the `3.x` branch, as CI for `3.x` needs to keep working for another year.
* Update branch references for when to run workflows on `push`.
* Remove Composer branch alias which should no longer be necessary.
* Update README badges branch references.
* Update branch references and related instruction in issue/PR templates/CONTRIBUTING/release checklist.


## Suggested changelog entry
* The `master` branch has been renamed to `3.x` and the default branch has changed to the `4.x` branch.
     - If you contribute to PHP_CodeSniffer, you will need to update your local git clone.
     - If you develop against PHP_CodeSniffer and run your tests against dev branches of PHPCS, you will need to update your workflows.

## Related issues/external references

Related to #3