### PR TITLE
Release checklist: fix order

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -84,7 +84,6 @@ Please consider [funding the PHP_CodeSniffer project](https://opencollective.com
 - [ ] Merge the changelog PR.
 - [ ] Make sure all CI builds for the release branch are green.
 - [ ] Create a tag for the release & push it.
-- [ ] Merge any open PRs in the documentation repository which relate to the current release.
 - [ ] Make sure all CI builds are green.
 - [ ] Download the PHAR files from the GH Actions test build page.
 - [ ] Sign the PHAR files using:
@@ -121,7 +120,8 @@ Please consider [funding the PHP_CodeSniffer project](https://opencollective.com
     - [ ] Upload the unversioned PHAR files + asc files to the release.
     - [ ] Announce the release in the discussions forum by checking the checkbox at the bottom of the release page.
 - [ ] Make sure all CI builds are green, including the verify-release workflow.
-
+- [ ] Merge any open PRs in the documentation repository which relate to the current release.
+    Important: this MUST be done **after** the release is published as otherwise the auto-generated output samples will not be updated correctly!
 
 ## After Release
 


### PR DESCRIPTION
# Description

Change the release task order.

The wiki documentation PRs should only be merged **after** the release as otherwise the auto-generated output samples won't be updated correctly.
The GH API only allows for getting the tag from a published _release_, not just the latest tag without a release attached to it, so the wiki update automation won't work until the release is published properly.


## Suggested changelog entry
_N/A_
