### PR TITLE
Files/FileList: restore and fix tests

### DIFF
--- a/tests/Core/Files/FileList/AbstractFileListTestCase.php
+++ b/tests/Core/Files/FileList/AbstractFileListTestCase.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Abstract testcase class for testing FileList methods.
+ *
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Files\FileList;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base functionality and utilities for testing FileList methods.
+ */
+abstract class AbstractFileListTestCase extends TestCase
+{
+
+    /**
+     * The Config object.
+     *
+     * @var \PHP_CodeSniffer\Config
+     */
+    protected static $config;
+
+    /**
+     * The Ruleset object.
+     *
+     * @var \PHP_CodeSniffer\Ruleset
+     */
+    protected static $ruleset;
+
+
+    /**
+     * Initialize the config and ruleset objects only once.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function initializeConfigAndRuleset()
+    {
+        // Wrapped in an `isset()` as the properties may have been set already (via a call to this method from a dataprovider).
+        if (isset(self::$ruleset) === false) {
+            self::$config         = new ConfigDouble();
+            self::$config->filter = __DIR__.'/FilterDouble.php';
+            self::$ruleset        = new Ruleset(self::$config);
+        }
+
+    }//end initializeConfigAndRuleset()
+
+
+}//end class

--- a/tests/Core/Files/FileList/AddFileTest.php
+++ b/tests/Core/Files/FileList/AddFileTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\FileList::addFile method.
+ *
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Files\FileList;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Files\FileList;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Files\FileList::addFile method.
+ *
+ * @covers \PHP_CodeSniffer\Files\FileList::addFile
+ */
+final class AddFileTest extends AbstractFileListTestCase
+{
+
+    /**
+     * The FileList object.
+     *
+     * @var \PHP_CodeSniffer\Files\FileList
+     */
+    private $fileList;
+
+
+    /**
+     * Initialize the FileList object.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function initializeFileList()
+    {
+        self::$config->files = [];
+        $this->fileList      = new FileList(self::$config, self::$ruleset);
+
+    }//end initializeFileList()
+
+
+    /**
+     * Test adding a file to the list.
+     *
+     * @param string      $fileName   The name of the file to add.
+     * @param object|null $fileObject An optional file object to add instead of creating a new one.
+     *
+     * @dataProvider dataAddFile
+     *
+     * @return void
+     */
+    public function testAddFile($fileName, $fileObject=null)
+    {
+        $this->assertCount(0, $this->fileList);
+
+        $this->fileList->addFile($fileName, $fileObject);
+
+        $fileListArray = iterator_to_array($this->fileList);
+
+        $this->assertCount(1, $this->fileList, 'File count mismatch');
+        $this->assertArrayHasKey($fileName, $fileListArray, 'File not found in list');
+
+        if (isset($fileObject) === true) {
+            $this->assertSame($fileObject, $fileListArray[$fileName], 'File object mismatch');
+        } else {
+            $this->assertInstanceOf(
+                'PHP_CodeSniffer\Files\File',
+                $fileListArray[$fileName],
+                'File object not found in list'
+            );
+        }
+
+    }//end testAddFile()
+
+
+    /**
+     * Data provider for testAddFile.
+     *
+     * @return array<string, array<string, string|object>>
+     */
+    public static function dataAddFile()
+    {
+        self::initializeConfigAndRuleset();
+
+        return [
+            'Regular file'                  => [
+                'fileName' => 'test1.php',
+            ],
+            'STDIN'                         => [
+                'fileName' => 'STDIN',
+            ],
+            'Regular file with file object' => [
+                'fileName'   => 'test1.php',
+                'fileObject' => new File('test1.php', self::$ruleset, self::$config),
+            ],
+        ];
+
+    }//end dataAddFile()
+
+
+    /**
+     * Test that it is not possible to add the same file twice.
+     *
+     * @return void
+     */
+    public function testAddFileShouldNotAddTheSameFileTwice()
+    {
+        $file1         = 'test1.php';
+        $file2         = 'test2.php';
+        $expectedFiles = [
+            $file1,
+            $file2,
+        ];
+
+        // Add $file1 once.
+        $this->fileList->addFile($file1);
+        $this->assertCount(1, $this->fileList);
+        $this->assertSame([$file1], array_keys(iterator_to_array($this->fileList)));
+
+        // Try to add $file1 again. Should be ignored.
+        $this->fileList->addFile($file1);
+        $this->assertCount(1, $this->fileList);
+        $this->assertSame([$file1], array_keys(iterator_to_array($this->fileList)));
+
+        // Add $file2. Should be added.
+        $this->fileList->addFile($file2);
+        $this->assertCount(2, $this->fileList);
+        $this->assertSame($expectedFiles, array_keys(iterator_to_array($this->fileList)));
+
+    }//end testAddFileShouldNotAddTheSameFileTwice()
+
+
+}//end class

--- a/tests/Core/Files/FileList/AddFileTest.php
+++ b/tests/Core/Files/FileList/AddFileTest.php
@@ -47,15 +47,21 @@ final class AddFileTest extends AbstractFileListTestCase
     /**
      * Test adding a file to the list.
      *
-     * @param string      $fileName   The name of the file to add.
-     * @param object|null $fileObject An optional file object to add instead of creating a new one.
+     * @param string $fileName       The name of the file to add.
+     * @param bool   $passFileObject Whether to pass a File object to addFile() or not.
      *
      * @dataProvider dataAddFile
      *
      * @return void
      */
-    public function testAddFile($fileName, $fileObject=null)
+    public function testAddFile($fileName, $passFileObject=false)
     {
+        $fileObject = null;
+
+        if ($passFileObject === true) {
+            $fileObject = new File($fileName, self::$ruleset, self::$config);
+        }
+
         $this->assertCount(0, $this->fileList);
 
         $this->fileList->addFile($fileName, $fileObject);
@@ -65,7 +71,7 @@ final class AddFileTest extends AbstractFileListTestCase
         $this->assertCount(1, $this->fileList, 'File count mismatch');
         $this->assertArrayHasKey($fileName, $fileListArray, 'File not found in list');
 
-        if (isset($fileObject) === true) {
+        if ($fileObject instanceof File) {
             $this->assertSame($fileObject, $fileListArray[$fileName], 'File object mismatch');
         } else {
             $this->assertInstanceOf(
@@ -81,12 +87,10 @@ final class AddFileTest extends AbstractFileListTestCase
     /**
      * Data provider for testAddFile.
      *
-     * @return array<string, array<string, string|object>>
+     * @return array<string, array<string, string|bool>>
      */
     public static function dataAddFile()
     {
-        self::initializeConfigAndRuleset();
-
         return [
             'Regular file'                  => [
                 'fileName' => 'test1.php',
@@ -95,8 +99,8 @@ final class AddFileTest extends AbstractFileListTestCase
                 'fileName' => 'STDIN',
             ],
             'Regular file with file object' => [
-                'fileName'   => 'test1.php',
-                'fileObject' => new File('test1.php', self::$ruleset, self::$config),
+                'fileName'       => 'test1.php',
+                'passFileObject' => true,
             ],
         ];
 

--- a/tests/Core/Files/FileList/ConstructTest.php
+++ b/tests/Core/Files/FileList/ConstructTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\FileList::__construct method.
+ *
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Files\FileList;
+
+use PHP_CodeSniffer\Files\FileList;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Files\FileList::__construct method.
+ *
+ * @covers \PHP_CodeSniffer\Files\FileList::__construct
+ */
+final class ConstructTest extends AbstractFileListTestCase
+{
+
+
+    /**
+     * Test the __construct() method.
+     *
+     * @param array<string> $files         List of file paths in the Config class.
+     * @param array<string> $expectedFiles List of expected file paths in the FileList.
+     *
+     * @dataProvider dataConstruct
+     *
+     * @return void
+     */
+    public function testConstruct($files, $expectedFiles)
+    {
+        self::$config->files = $files;
+
+        $fileList = new FileList(self::$config, self::$ruleset);
+
+        $this->assertSame(self::$config, $fileList->config, 'Config object mismatch');
+        $this->assertSame(self::$ruleset, $fileList->ruleset, 'Ruleset object mismatch');
+
+        $this->assertCount(count($expectedFiles), $fileList, 'File count mismatch');
+
+        $i = 0;
+
+        // Sort the values to make the tests stable as different OSes will read directories
+        // in a different order and the order is not relevant for these tests. Just the values.
+        $fileListArray = iterator_to_array($fileList);
+        ksort($fileListArray);
+
+        foreach ($fileListArray as $filePath => $fileObject) {
+            $this->assertSame(
+                $expectedFiles[$i],
+                $filePath,
+                sprintf('File path mismatch: expected "%s", got "%s"', $expectedFiles[$i], $filePath)
+            );
+            $this->assertInstanceOf(
+                'PHP_CodeSniffer\Files\File',
+                $fileObject,
+                sprintf('File object for "%s" is not an instance of PHP_CodeSniffer\Files\File', $filePath)
+            );
+            $i++;
+        }
+
+    }//end testConstruct()
+
+
+    /**
+     * Data provider for testConstruct.
+     *
+     * @return array<string, array<string, array<string>>>
+     */
+    public static function dataConstruct()
+    {
+        $fixturesDir = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+
+        return [
+            'No files'                                     => [
+                'files'         => [],
+                'expectedFiles' => [],
+            ],
+            'Two files'                                    => [
+                'files'         => [
+                    'file1.php',
+                    'file2.php',
+                ],
+                'expectedFiles' => [
+                    'file1.php',
+                    'file2.php',
+                ],
+            ],
+            'A directory'                                  => [
+                'files'         => [$fixturesDir],
+                'expectedFiles' => [
+                    $fixturesDir.'file1.php',
+                    $fixturesDir.'file2.php',
+                ],
+            ],
+            'Same file twice'                              => [
+                'files'         => [
+                    'file1.php',
+                    'file1.php',
+                ],
+                'expectedFiles' => [
+                    'file1.php',
+                ],
+            ],
+            'File and then directory containing that file' => [
+                'files'         => [
+                    $fixturesDir.'file1.php',
+                    $fixturesDir,
+                ],
+                'expectedFiles' => [
+                    $fixturesDir.'file1.php',
+                    $fixturesDir.'file2.php',
+                ],
+            ],
+        ];
+
+    }//end dataConstruct()
+
+
+}//end class

--- a/tests/Core/Files/FileList/FilterDouble.php
+++ b/tests/Core/Files/FileList/FilterDouble.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Double of the filter class that will accept every file. Used in the FileList tests.
+ *
+ * @copyright 2025 PHPCSStandards Contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Files\FileList;
+
+use PHP_CodeSniffer\Filters\Filter;
+use ReturnTypeWillChange;
+
+final class FilterDouble extends Filter
+{
+
+
+    /**
+     * Accepts every file.
+     *
+     * @return true
+     */
+    #[ReturnTypeWillChange]
+    public function accept()
+    {
+        return true;
+
+    }//end accept()
+
+
+}//end class

--- a/tests/Core/Files/FileList/Fixtures/file1.php
+++ b/tests/Core/Files/FileList/Fixtures/file1.php
@@ -1,0 +1,3 @@
+<?php
+
+// Empty file for testing purposes.

--- a/tests/Core/Files/FileList/Fixtures/file2.php
+++ b/tests/Core/Files/FileList/Fixtures/file2.php
@@ -1,0 +1,3 @@
+<?php
+
+// Empty file for testing purposes.


### PR DESCRIPTION
# Description

This PR restores the FileList tests that were removed in #1213 and fixes the issue that was breaking the ability to run sniff tests for external standards using the PHPCS native test framework.

This problem was happening because `self::initializeConfigAndRuleset()` was called in a data provider method in `AddFileTest.php`. This means that the `Config` instance created inside `initializeConfigAndRuleset()` using `ConfigDouble` was created before `AllSniffs::suite()` had a chance to get the installed standards from the `CodeSniffer.conf` configuration file. When `AllSniffs::suite()` runs, `ConfigDouble` already overrode the `configData` and `configDataFile` properties, and 
`CodeSniffer.conf` is never read, and the tests for external standards were not included.

To fix this problem, I opted to change the test to create an instance of the `File` class (which requires an instance of the `Config` class) in the test itself instead of doing that in the data provider.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
