### PR TITLE
GH Actions: do not persist credentials

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ steps.base_branch.outputs.BRANCH }}
+          persist-credentials: false
       
       - name: Install PHP
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # 2.35.4


### PR DESCRIPTION
# Description

👉🏻 Mind this PR is for the `gh-pages` branch!

> By default, using `actions/checkout` causes a credential to be persisted in the checked-out repo's `.git/config`, so that subsequent `git` operations can be authenticated.
>
> Subsequent steps may accidentally publicly persist `.git/config`, e.g. by including it in a publicly accessible artifact via `actions/upload-artifact`.
>
> However, even without this, persisting the credential in the `.git/config` is non-ideal unless actually needed.
>
> **Remediation**
>
> Unless needed for `git` operations, `actions/checkout` should be used with `persist-credentials: false`.
>
> If the persisted credential is needed, it should be made explicit with `persist-credentials: true`.

This has now been addressed in all workflows.

Refs:
* https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
* https://docs.zizmor.sh/audits/#artipacked

## Suggested changelog entry
_N/A_