### PR TITLE
GH Actions: set permissions for each workflow/job (gh-pages)

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -9,11 +9,7 @@ on:
   # Allow running this workflow manually from the Actions tab.
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -28,6 +24,10 @@ jobs:
 
     name: "Build the website"
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # to read the contents of the repo
+
     steps:
       # By default use the `gh-pages` branch.
       # For testing changes to the workflow or the scripts, use the PR branch
@@ -83,6 +83,10 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
# Description

👉🏻 Mind this PR is for the `gh-pages` branch!

> Users frequently over-scope their workflow and job permissions, or set broad workflow-level permissions without realizing that all jobs inherit those permissions.
>
> Furthermore, users often don't realize that the _default_ `GITHUB_TOKEN` permissions can be very broad, meaning that workflows that don't configure any permissions at all can _still_ provide excessive credentials to their individual jobs.
>
> **Remediation**
> In general, permissions should be declared as minimally as possible, and as close to their usage site as possible.
>
> In practice, this means that workflows should almost always set `permissions: {}` at the workflow level to disable all permissions by default, and then set specific job-level permissions as needed.


Refs:
* https://docs.zizmor.sh/audits/#excessive-permissions
* https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor

## Suggested changelog entry
_N/A_
