### PR TITLE
Tokenizer/PHP: fix tokens missing/file content being removed by attribute retokenization

### DIFF
--- a/tests/Core/Tokenizers/PHP/AttributesParseError1Test.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError1Test.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+/* testInvalidAttribute */
+#[ThisIsNotAnAttribute
+function invalid_attribute_test() {}

--- a/tests/Core/Tokenizers/PHP/AttributesParseError1Test.php
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError1Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests the support of PHP 8 attributes
+ *
+ * @author    Alessandro Chitolina <alekitto@gmail.com>
+ * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+final class AttributesParseError1Test extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that invalid attribute (or comment starting with #[ and without ]) are parsed correctly.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testInvalidAttribute()
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
+
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+        $this->assertNull($tokens[$attribute]['attribute_closer']);
+
+    }//end testInvalidAttribute()
+
+
+}//end class

--- a/tests/Core/Tokenizers/PHP/AttributesParseError2Test.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError2Test.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+/* testLiveCoding */
+#[AttributeName(10)
+function hasUnfinishedAttribute() {}

--- a/tests/Core/Tokenizers/PHP/AttributesParseError2Test.php
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError2Test.php
@@ -2,10 +2,7 @@
 /**
  * Tests the support of PHP 8 attributes
  *
- * @author    Alessandro Chitolina <alekitto@gmail.com>
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2023 PHPCSStandards and contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
@@ -13,7 +10,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
 
 use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
 
-final class AttributesParseError1Test extends AbstractTokenizerTestCase
+final class AttributesParseError2Test extends AbstractTokenizerTestCase
 {
 
 
@@ -31,7 +28,7 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
+        $attribute = $this->getTargetToken('/* testLiveCoding */', T_ATTRIBUTE);
 
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
         $this->assertNull($tokens[$attribute]['attribute_closer']);
@@ -39,9 +36,13 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
         $expectedTokenCodes = [
             'T_ATTRIBUTE',
             'T_STRING',
+            'T_OPEN_PARENTHESIS',
+            'T_LNUMBER',
+            'T_CLOSE_PARENTHESIS',
             'T_WHITESPACE',
             'T_FUNCTION',
         ];
+
         $length = count($expectedTokenCodes);
 
         $map = array_map(

--- a/tests/Core/Tokenizers/PHP/AttributesParseError3Test.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError3Test.inc
@@ -1,0 +1,10 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+class LiveCoding {
+    /* testLiveCoding */
+    #[AttributeName(10), SecondAttribute(
+    public final function hasUnfinishedAttribute() {}
+}

--- a/tests/Core/Tokenizers/PHP/AttributesParseError3Test.php
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError3Test.php
@@ -2,10 +2,7 @@
 /**
  * Tests the support of PHP 8 attributes
  *
- * @author    Alessandro Chitolina <alekitto@gmail.com>
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2023 PHPCSStandards and contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
@@ -13,7 +10,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
 
 use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
 
-final class AttributesParseError1Test extends AbstractTokenizerTestCase
+final class AttributesParseError3Test extends AbstractTokenizerTestCase
 {
 
 
@@ -31,7 +28,7 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
+        $attribute = $this->getTargetToken('/* testLiveCoding */', T_ATTRIBUTE);
 
         $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
         $this->assertNull($tokens[$attribute]['attribute_closer']);
@@ -39,9 +36,22 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
         $expectedTokenCodes = [
             'T_ATTRIBUTE',
             'T_STRING',
+            'T_OPEN_PARENTHESIS',
+            'T_LNUMBER',
+            'T_CLOSE_PARENTHESIS',
+            'T_COMMA',
+            'T_WHITESPACE',
+            'T_STRING',
+            'T_OPEN_PARENTHESIS',
+            'T_WHITESPACE',
+            'T_WHITESPACE',
+            'T_PUBLIC',
+            'T_WHITESPACE',
+            'T_FINAL',
             'T_WHITESPACE',
             'T_FUNCTION',
         ];
+
         $length = count($expectedTokenCodes);
 
         $map = array_map(

--- a/tests/Core/Tokenizers/PHP/AttributesParseError4Test.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError4Test.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+/* testLiveCoding */
+#[ClosedAttribute] #[UnfinishedAttribute
+function hasUnfinishedAttribute() {}

--- a/tests/Core/Tokenizers/PHP/AttributesParseError4Test.php
+++ b/tests/Core/Tokenizers/PHP/AttributesParseError4Test.php
@@ -2,10 +2,7 @@
 /**
  * Tests the support of PHP 8 attributes
  *
- * @author    Alessandro Chitolina <alekitto@gmail.com>
- * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
- * @copyright 2019-2023 Squiz Pty Ltd (ABN 77 084 670 600)
- * @copyright 2023 PHPCSStandards and contributors
+ * @copyright 2025 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
@@ -13,7 +10,7 @@ namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
 
 use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
 
-final class AttributesParseError1Test extends AbstractTokenizerTestCase
+final class AttributesParseError4Test extends AbstractTokenizerTestCase
 {
 
 
@@ -31,18 +28,39 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
     {
         $tokens = $this->phpcsFile->getTokens();
 
-        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
+        $attribute = $this->getTargetToken('/* testLiveCoding */', T_ATTRIBUTE);
 
-        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
-        $this->assertNull($tokens[$attribute]['attribute_closer']);
+        $expectedTokenCodesAttribute1 = [
+            'T_ATTRIBUTE',
+            'T_STRING',
+            'T_ATTRIBUTE_END',
+            'T_WHITESPACE',
+        ];
 
-        $expectedTokenCodes = [
+        $lengthAttribute1 = count($expectedTokenCodesAttribute1);
+
+        $map = array_map(
+            function ($token) use ($attribute, $lengthAttribute1) {
+                if ($token['code'] !== T_WHITESPACE) {
+                    $this->assertArrayHasKey('attribute_closer', $token);
+                    $this->assertSame(($attribute + 2), $token['attribute_closer']);
+                }
+
+                return $token['type'];
+            },
+            array_slice($tokens, $attribute, $lengthAttribute1)
+        );
+
+        $this->assertSame($expectedTokenCodesAttribute1, $map);
+
+        $expectedTokenCodesAttribute2 = [
             'T_ATTRIBUTE',
             'T_STRING',
             'T_WHITESPACE',
             'T_FUNCTION',
         ];
-        $length = count($expectedTokenCodes);
+
+        $lengthAttribute2 = count($expectedTokenCodesAttribute2);
 
         $map = array_map(
             function ($token) {
@@ -55,10 +73,10 @@ final class AttributesParseError1Test extends AbstractTokenizerTestCase
 
                 return $token['type'];
             },
-            array_slice($tokens, $attribute, $length)
+            array_slice($tokens, ($attribute + $lengthAttribute1), $lengthAttribute2)
         );
 
-        $this->assertSame($expectedTokenCodes, $map);
+        $this->assertSame($expectedTokenCodesAttribute2, $map);
 
     }//end testInvalidAttribute()
 

--- a/tests/Core/Tokenizers/PHP/AttributesTest.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.inc
@@ -84,7 +84,3 @@ function attribute_containing_text_looking_like_close_tag() {}
     'reason: <https://some-website/reason?>'
 )]
 function attribute_containing_mulitline_text_looking_like_close_tag() {}
-
-/* testInvalidAttribute */
-#[ThisIsNotAnAttribute
-function invalid_attribute_test() {}

--- a/tests/Core/Tokenizers/PHP/AttributesTest.inc
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.inc
@@ -58,7 +58,7 @@ function attribute_multiline_with_comment_test() {}
 function single_attribute_on_parameter_test(#[ParamAttribute] int $param) {}
 
 /* testMultipleAttributesOnParameter */
-function multiple_attributes_on_parameter_test(#[ParamAttribute, AttributeWithParams(/* another comment */ 'foo')] int $param) {}
+function multiple_attributes_on_parameter_test(#[ParamAttribute, AttributeWithParams(/* another comment */ 'foo')] array $param) {}
 
 /* testFqcnAttribute */
 #[Boo\QualifiedName, \Foo\FullyQualifiedName('foo')]
@@ -73,7 +73,7 @@ function multiline_attributes_on_parameter_test(#[
     AttributeWithParams(
         'foo'
     )
-                                                ] int $param) {}
+                                                ] null $param) {}
 
 /* testAttributeContainingTextLookingLikeCloseTag */
 #[DeprecationReason('reason: <https://some-website/reason?>')]

--- a/tests/Core/Tokenizers/PHP/AttributesTest.php
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
 
 final class AttributesTest extends AbstractTokenizerTestCase
@@ -18,8 +19,9 @@ final class AttributesTest extends AbstractTokenizerTestCase
     /**
      * Test that attributes are parsed correctly.
      *
-     * @param string            $testMarker The comment which prefaces the target token in the test file.
-     * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
+     * @param string            $testMarker         The comment which prefaces the target token in the test file.
+     * @param array<int|string> $tokenCodes         The codes of tokens inside the attributes.
+     * @param int|string        $expectedFirstAfter The expected token code for the first token after the attribute.
      *
      * @dataProvider dataAttribute
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
@@ -28,7 +30,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testAttribute($testMarker, $tokenCodes)
+    public function testAttribute($testMarker, $tokenCodes, $expectedFirstAfter)
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -58,6 +60,9 @@ final class AttributesTest extends AbstractTokenizerTestCase
 
         $this->assertSame($tokenCodes, $map);
 
+        $actualFirstAfter = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+        $this->assertSame($expectedFirstAfter, $tokens[$actualFirstAfter]['code']);
+
     }//end testAttribute()
 
 
@@ -72,14 +77,15 @@ final class AttributesTest extends AbstractTokenizerTestCase
     {
         return [
             'class attribute'                                                                   => [
-                'testMarker' => '/* testAttribute */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttribute */',
+                'tokenCodes'         => [
                     T_STRING,
                 ],
+                'expectedFirstAfter' => T_CLASS,
             ],
             'class attribute with param'                                                        => [
-                'testMarker' => '/* testAttributeWithParams */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeWithParams */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_STRING,
@@ -87,10 +93,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_STRING,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_CLASS,
             ],
             'class attribute with named param'                                                  => [
-                'testMarker' => '/* testAttributeWithNamedParam */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeWithNamedParam */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_PARAM_NAME,
@@ -101,16 +108,18 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_STRING,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_CLASS,
             ],
             'function attribute'                                                                => [
-                'testMarker' => '/* testAttributeOnFunction */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeOnFunction */',
+                'tokenCodes'         => [
                     T_STRING,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute with params'                                                    => [
-                'testMarker' => '/* testAttributeOnFunctionWithParams */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeOnFunctionWithParams */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_CONSTANT_ENCAPSED_STRING,
@@ -128,10 +137,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CLOSE_SHORT_ARRAY,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute with arrow function as param'                                   => [
-                'testMarker' => '/* testAttributeWithShortClosureParameter */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeWithShortClosureParameter */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_OPEN_PARENTHESIS,
                     T_STATIC,
@@ -149,10 +159,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_VARIABLE,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute; multiple comma separated classes'                              => [
-                'testMarker' => '/* testAttributeGrouping */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeGrouping */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_COMMA,
                     T_WHITESPACE,
@@ -179,10 +190,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CLOSE_SHORT_ARRAY,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute; multiple comma separated classes, one per line'                => [
-                'testMarker' => '/* testAttributeMultiline */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeMultiline */',
+                'tokenCodes'         => [
                     T_WHITESPACE,
                     T_WHITESPACE,
                     T_STRING,
@@ -214,10 +226,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CLOSE_PARENTHESIS,
                     T_WHITESPACE,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute; multiple comma separated classes, one per line, with comments' => [
-                'testMarker' => '/* testAttributeMultilineWithComment */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testAttributeMultilineWithComment */',
+                'tokenCodes'         => [
                     T_WHITESPACE,
                     T_WHITESPACE,
                     T_STRING,
@@ -252,10 +265,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CLOSE_PARENTHESIS,
                     T_WHITESPACE,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
             'function attribute; using partially qualified and fully qualified class names'     => [
-                'testMarker' => '/* testFqcnAttribute */',
-                'tokenCodes' => [
+                'testMarker'         => '/* testFqcnAttribute */',
+                'tokenCodes'         => [
                     T_STRING,
                     T_NS_SEPARATOR,
                     T_STRING,
@@ -269,6 +283,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CONSTANT_ENCAPSED_STRING,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter' => T_FUNCTION,
             ],
         ];
 
@@ -325,9 +340,11 @@ final class AttributesTest extends AbstractTokenizerTestCase
     /**
      * Test that attributes on function declaration parameters are parsed correctly.
      *
-     * @param string            $testMarker The comment which prefaces the target token in the test file.
-     * @param int               $position   The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
-     * @param array<int|string> $tokenCodes The codes of tokens inside the attributes.
+     * @param string            $testMarker                The comment which prefaces the target token in the test file.
+     * @param int               $position                  The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
+     * @param array<int|string> $tokenCodes                The codes of tokens inside the attributes.
+     * @param int|string        $expectedFirstAfter        The expected token code for the first token after the attribute.
+     * @param string            $expectedFirstAfterContent The expected token code for the first token after the attribute.
      *
      * @dataProvider dataAttributeOnParameters
      *
@@ -337,7 +354,7 @@ final class AttributesTest extends AbstractTokenizerTestCase
      *
      * @return void
      */
-    public function testAttributeOnParameters($testMarker, $position, array $tokenCodes)
+    public function testAttributeOnParameters($testMarker, $position, array $tokenCodes, $expectedFirstAfter, $expectedFirstAfterContent)
     {
         $tokens = $this->phpcsFile->getTokens();
 
@@ -354,8 +371,8 @@ final class AttributesTest extends AbstractTokenizerTestCase
 
         $closer = $tokens[$attribute]['attribute_closer'];
         $this->assertSame(T_WHITESPACE, $tokens[($closer + 1)]['code']);
-        $this->assertSame(T_STRING, $tokens[($closer + 2)]['code']);
-        $this->assertSame('int', $tokens[($closer + 2)]['content']);
+        $this->assertSame($expectedFirstAfter, $tokens[($closer + 2)]['code']);
+        $this->assertSame($expectedFirstAfterContent, $tokens[($closer + 2)]['content']);
 
         $this->assertSame(T_VARIABLE, $tokens[($closer + 4)]['code']);
         $this->assertSame('$param', $tokens[($closer + 4)]['content']);
@@ -386,16 +403,18 @@ final class AttributesTest extends AbstractTokenizerTestCase
     {
         return [
             'parameter attribute; single, inline'                   => [
-                'testMarker' => '/* testSingleAttributeOnParameter */',
-                'position'   => 4,
-                'tokenCodes' => [
+                'testMarker'                => '/* testSingleAttributeOnParameter */',
+                'position'                  => 4,
+                'tokenCodes'                => [
                     T_STRING,
                 ],
+                'expectedFirstAfter'        => T_STRING,
+                'expectedFirstAfterContent' => 'int',
             ],
             'parameter attribute; multiple comma separated, inline' => [
-                'testMarker' => '/* testMultipleAttributesOnParameter */',
-                'position'   => 4,
-                'tokenCodes' => [
+                'testMarker'                => '/* testMultipleAttributesOnParameter */',
+                'position'                  => 4,
+                'tokenCodes'                => [
                     T_STRING,
                     T_COMMA,
                     T_WHITESPACE,
@@ -406,11 +425,13 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_CONSTANT_ENCAPSED_STRING,
                     T_CLOSE_PARENTHESIS,
                 ],
+                'expectedFirstAfter'        => T_STRING,
+                'expectedFirstAfterContent' => 'array',
             ],
             'parameter attribute; single, multiline'                => [
-                'testMarker' => '/* testMultilineAttributesOnParameter */',
-                'position'   => 4,
-                'tokenCodes' => [
+                'testMarker'                => '/* testMultilineAttributesOnParameter */',
+                'position'                  => 4,
+                'tokenCodes'                => [
                     T_WHITESPACE,
                     T_WHITESPACE,
                     T_STRING,
@@ -424,6 +445,8 @@ final class AttributesTest extends AbstractTokenizerTestCase
                     T_WHITESPACE,
                     T_WHITESPACE,
                 ],
+                'expectedFirstAfter'        => T_NULL,
+                'expectedFirstAfterContent' => 'null',
             ],
         ];
 

--- a/tests/Core/Tokenizers/PHP/AttributesTest.php
+++ b/tests/Core/Tokenizers/PHP/AttributesTest.php
@@ -582,27 +582,6 @@ final class AttributesTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that invalid attribute (or comment starting with #[ and without ]) are parsed correctly.
-     *
-     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
-     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
-     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
-     *
-     * @return void
-     */
-    public function testInvalidAttribute()
-    {
-        $tokens = $this->phpcsFile->getTokens();
-
-        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
-
-        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
-        $this->assertNull($tokens[$attribute]['attribute_closer']);
-
-    }//end testInvalidAttribute()
-
-
-    /**
      * Test that nested attributes are parsed correctly.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize


### PR DESCRIPTION
# Description

### Tokenizer/AttributesTest: move parse error test to own file

### Tokenizer/AttributesTest: expand test coverage 

In light of an upcoming change, let's also test the token code/content of the first token _after_ the attribute sequence to safeguard that no token duplication is being introduced via the array_slicing and dicing done in the PHP < 8.0 "comment to attribute" retokenization.

### Tokenizer/PHP: fix tokens missing/file content being removed by attribute retokenization

This commit fixes the issue detailed in ticket #1279, where in case of an unfinished (parse error) attribute, the contents on the same line as the attribute opener would be removed from the token stream when PHPCS is run on PHP < 8.0.

On PHP < 8.0, attributes tokenize as comments and the Tokenizer reparses the contents of the comment to make it a usable token stream.

As things were, if the attribute closer could not be found, the `PHP::parsePhpAttribute()` method would return `null` instead of returning the array of (reparsed) tokens which were on the same line as the attribute opener, which meant the "comment content"/attribute content was effectively removed from the token stream.

The fix includes changing the return type of the (private) `PHP::parsePhpAttribute()` method from `array|null` to `array`, which also allows for simplifying some code handling the return value of this method.

Includes additional tests and improvements to the pre-existing parse error test.

## Suggested changelog entry
Fixed: Tokenizer/PHP: on PHP < 8.0, an unclosed attribute (parse error) could end up removing some tokens from the token stream.
* This could lead to false positives and false negative from sniffs, but could also lead to incorrect fixes being made mangling the file under scan.


## Related issues/external references

Fixes #1279
