### PR TITLE
.gitattributes: export ignore some test fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,19 +5,20 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/
 # https://blog.madewithlove.be/post/gitattributes/
 #
-.github/                export-ignore
-scripts/                export-ignore
-.cspell.json            export-ignore
-.gitattributes          export-ignore
-.gitignore              export-ignore
-.markdownlint-cli2.yaml export-ignore
-.remarkignore           export-ignore
-.remarkrc               export-ignore
-.shellcheckrc           export-ignore
-.yamllint.yml           export-ignore
-phpcs.xml.dist          export-ignore
-phpstan.neon.dist       export-ignore
-phpunit.xml.dist        export-ignore
+.github/                                        export-ignore
+scripts/                                        export-ignore
+tests/Core/Ruleset/Fixtures/DirectoryExpansion/ export-ignore
+.cspell.json                                    export-ignore
+.gitattributes                                  export-ignore
+.gitignore                                      export-ignore
+.markdownlint-cli2.yaml                         export-ignore
+.remarkignore                                   export-ignore
+.remarkrc                                       export-ignore
+.shellcheckrc                                   export-ignore
+.yamllint.yml                                   export-ignore
+phpcs.xml.dist                                  export-ignore
+phpstan.neon.dist                               export-ignore
+phpunit.xml.dist                                export-ignore
 
 #
 # Declare files that should always have CRLF line endings on checkout.


### PR DESCRIPTION
# Description
Some of the test fixtures introduced for testing the `Ruleset` class cause issues with PHPUnit on some versions, in particular the test fixtures involving standards in hidden directories.

While the decision was taken long ago to not `export-ignore` the tests until PHPCS 4.0, I'm now taking the executive decision to selective `export-ignore` the problematic test fixtures only on the 3.x branch already to unblock projects which were seeing these errors (like the Composer Installer plugin).


## Suggested changelog entry
_N/A_
