### PR TITLE
EndToEnd tests: fix `tear_down()`

### DIFF
--- a/tests/EndToEnd/phpcbf_test.sh
+++ b/tests/EndToEnd/phpcbf_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function tear_down() {
-  rm -r tests/EndToEnd/Fixtures/*.fixed
+  rm -rf tests/EndToEnd/Fixtures/*.fixed
 }
 
 function test_phpcbf_is_working() {


### PR DESCRIPTION
# Description
BashUnit 0.25.0 improves the error reporting from the test fixture methods, which exposes a flaw in the `phpcbf_test.sh::tear_down()` method.

Should be fixed now.

Ref:
* https://github.com/TypedDevs/bashunit/releases/tag/0.25.0
* TypedDevs/bashunit#489
* TypedDevs/bashunit#491

## Suggested changelog entry
_N/A_ (test only change)