### PR TITLE
Squiz/DisallowMultipleAssignments: remove irrelevant token

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -173,7 +173,6 @@ class DisallowMultipleAssignmentsSniff implements Sniff
                 T_IF     => T_IF,
                 T_ELSEIF => T_ELSEIF,
                 T_SWITCH => T_SWITCH,
-                T_CASE   => T_CASE,
                 T_FOR    => T_FOR,
                 T_MATCH  => T_MATCH,
             ];


### PR DESCRIPTION
# Description
The `foreach()` loop straight after this bit of code checks for parenthesis owners, but `T_CASE` is not a token which can be marked as a parenthesis owner, so will never match.


## Suggested changelog entry
_N/A_ (clean up, should make no functional difference)