### PR TITLE
Runner: add test for "out of memory" shutdown handler

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -957,12 +957,12 @@ class Runner
         // Allocate all needed memory beforehand as much as possible.
         $errorMsg    = PHP_EOL.'The PHP_CodeSniffer "%1$s" command ran out of memory.'.PHP_EOL;
         $errorMsg   .= 'Either raise the "memory_limit" of PHP in the php.ini file or raise the memory limit at runtime'.PHP_EOL;
-        $errorMsg   .= 'using `%1$s -d memory_limit=512M` (replace 512M with the desired memory limit).'.PHP_EOL;
+        $errorMsg   .= 'using "%1$s -d memory_limit=512M" (replace 512M with the desired memory limit).'.PHP_EOL;
         $errorMsg    = sprintf($errorMsg, $command);
         $memoryError = 'Allowed memory size of';
         $errorArray  = [
             'type'    => 42,
-            'message' => 'Some random dummy string to take up memory and take up some more memory and some more',
+            'message' => 'Some random dummy string to take up memory and take up some more memory and some more and more and more and more',
             'file'    => 'Another random string, which would be a filename this time. Should be relatively long to allow for deeply nested files',
             'line'    => 31427,
         ];

--- a/tests/EndToEnd/outofmemory_test.sh
+++ b/tests/EndToEnd/outofmemory_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+function tear_down() {
+  rm -f tests/EndToEnd/Fixtures/*.fixed
+}
+
+function test_phpcs_out_of_memory_error_handling() {
+  OUTPUT="$(bin/phpcs -d memory_limit=4M --standard=tests/EndToEnd/Fixtures/endtoend.xml.dist tests/EndToEnd/Fixtures/)"
+  # Exit code can't currently be tested as it looks like it may be 255 or 139 depending on the PHP version.
+  # Related feature request upstream: https://github.com/TypedDevs/bashunit/issues/505
+  # assert_exit_code 255
+
+  assert_contains "The PHP_CodeSniffer \"phpcs\" command ran out of memory." "$OUTPUT"
+  assert_contains "Either raise the \"memory_limit\" of PHP in the php.ini file or raise the memory limit at runtime" "$OUTPUT"
+  assert_contains "using \"phpcs -d memory_limit=512M\" (replace 512M with the desired memory limit)." "$OUTPUT"
+}
+
+function test_phpcbf_out_of_memory_error_handling() {
+  OUTPUT="$(bin/phpcbf -d memory_limit=4M --standard=tests/EndToEnd/Fixtures/endtoend.xml.dist tests/EndToEnd/Fixtures/ --suffix=.fixed)"
+  # Exit code can't currently be tested as it looks like it may be 255 or 139 depending on the PHP version.
+  # Related feature request upstream: https://github.com/TypedDevs/bashunit/issues/505
+  # assert_exit_code 255
+
+  assert_contains "The PHP_CodeSniffer \"phpcbf\" command ran out of memory." "$OUTPUT"
+  assert_contains "Either raise the \"memory_limit\" of PHP in the php.ini file or raise the memory limit at runtime" "$OUTPUT"
+  assert_contains "using \"phpcbf -d memory_limit=512M\" (replace 512M with the desired memory limit)." "$OUTPUT"
+}


### PR DESCRIPTION
# Description

👉🏻 Note: this PR is pulled to the 3.x branch as runtime compatibility with new PHP versions is one of the few types of fixes still allowed to go into the 3.x branch. So if these tests would fail, the mitigation for that would need to go into the 3.x branch as a PHP runtime-compatibility fix.

---

PR squizlabs/PHP_CodeSniffer#3630 introduced a shutdown handler specifically to provide a more user-friendly error message when users run into "out of memory" errors. One of the challenges of doing this is making sure that enough memory is allocated for our own error message beforehand to make sure that the error message can still be created and displayed properly, even though PHP has already run out of memory.

As of PHP 8.5, a new `fatal_error_backtraces` ini setting has been added and enabled by default, which adds a backtrace to fatal errors, which could have an impact on this memory allocation.

> If the sub-vote to default to “1” passes, messages for fatal errors will now contain backtraces and may not match the format existing code is expecting.

As this _may_ (or may not) impact the shutdown function in PHPCS, I'm adding some end-to-end tests to safeguard this functionality.

Also reserving a little extra memory for the base message to be safer anyway.

Ref: https://wiki.php.net/rfc/error_backtraces_v2#backward_incompatible_changes


## Suggested changelog entry
_N/A_ (test only change - unless the tests would fail)
