### PR TITLE
E2E tests: use new bashunit assertion

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -391,7 +391,7 @@ To run the tests specific to the use of `PHP_CODESNIFFER_CBF === true`:
 
 ### Writing End-to-End Tests
 
-Bash-based end-to-end tests can be written using the [Bashunit](https://bashunit.typeddevs.com/) test tooling.
+Bash-based end-to-end tests can be written using the [Bashunit](https://bashunit.typeddevs.com/) test tooling using version 0.26.0 or higher.
 
 To install bashunit, follow the [installation guide](https://bashunit.typeddevs.com/installation).
 

--- a/tests/EndToEnd/outofmemory_test.sh
+++ b/tests/EndToEnd/outofmemory_test.sh
@@ -6,9 +6,8 @@ function tear_down() {
 
 function test_phpcs_out_of_memory_error_handling() {
   OUTPUT="$(bin/phpcs -d memory_limit=4M --standard=tests/EndToEnd/Fixtures/endtoend.xml.dist tests/EndToEnd/Fixtures/)"
-  # Exit code can't currently be tested as it looks like it may be 255 or 139 depending on the PHP version.
-  # Related feature request upstream: https://github.com/TypedDevs/bashunit/issues/505
-  # assert_exit_code 255
+  # Exit code may be 255 or 139 depending on the PHP version, but the exact code is not our concern, just that it's non-zero.
+  assert_unsuccessful_code
 
   assert_contains "The PHP_CodeSniffer \"phpcs\" command ran out of memory." "$OUTPUT"
   assert_contains "Either raise the \"memory_limit\" of PHP in the php.ini file or raise the memory limit at runtime" "$OUTPUT"
@@ -17,9 +16,8 @@ function test_phpcs_out_of_memory_error_handling() {
 
 function test_phpcbf_out_of_memory_error_handling() {
   OUTPUT="$(bin/phpcbf -d memory_limit=4M --standard=tests/EndToEnd/Fixtures/endtoend.xml.dist tests/EndToEnd/Fixtures/ --suffix=.fixed)"
-  # Exit code can't currently be tested as it looks like it may be 255 or 139 depending on the PHP version.
-  # Related feature request upstream: https://github.com/TypedDevs/bashunit/issues/505
-  # assert_exit_code 255
+  # Exit code may be 255 or 139 depending on the PHP version, but the exact code is not our concern, just that it's non-zero.
+  assert_unsuccessful_code
 
   assert_contains "The PHP_CodeSniffer \"phpcbf\" command ran out of memory." "$OUTPUT"
   assert_contains "Either raise the \"memory_limit\" of PHP in the php.ini file or raise the memory limit at runtime" "$OUTPUT"


### PR DESCRIPTION

# Description
PR #1296 added a new test which _should_ also verify that the command had a non-zero exit code, but couldn't do so at the time as this wasn't (yet) supported by Bashunit.

As of Bashunit 0.26.0, a new `assert_unsuccessful_code` is available which fixes that.

This commit starts using that assertion.

Refs:
* https://github.com/TypedDevs/bashunit/releases/tag/0.26.0
* TypedDevs/bashunit#505
* TypedDevs/bashunit#506

## Suggested changelog entry
_N/A_