### PR TITLE
Squiz/SwitchDeclaration: bug fix - fixer conflict for single line code

### DIFF
--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -344,3 +344,39 @@ switch ( $a ) {
 
 jumpOut:
 doSomething();
+
+// Bug: the below should not throw "Blank lines are not allowed before/after..." errors (as there are no blank lines).
+// Instead the sniff should flag case/default/break statements not being on their own line.
+switch ($condition) {case 'string': $varStr = 'one line'; break;case 'bool':$varStr = 'one line';return $foo;default: $varStr = 'test'; break;}
+
+switch ($condition) {
+case 'string': /*test comment handling when adding new lines*/$varStr = 'one line';/*test comment handling when adding new lines*/ break;
+default:/*test comment handling when adding new lines*/ $varStr = 'test'; /*test comment handling when adding new lines*/break;
+}
+
+switch ($condition) {
+    case 'too many blank lines':
+
+
+        // This comment should be used for the "blank line after case" determination.
+        $varStr = 'test';
+
+    break;
+
+
+
+    // Comment to use for measuring blank lines between the above break and here.
+    case 'this is fine': // This comment should be ignored and $varStr should be used instead.
+
+
+        $varStr = 'test';
+
+
+    break; // Trailing comment to ignore.
+    // This comment should be used for the "blank line after break" determination.
+    default: // This comment should be ignored and $varStr should be used instead.
+
+        $varStr = 'test';
+    break;
+
+}

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -347,11 +347,11 @@ doSomething();
 
 // Bug: the below should not throw "Blank lines are not allowed before/after..." errors (as there are no blank lines).
 // Instead the sniff should flag case/default/break statements not being on their own line.
-switch ($condition) {case 'string': $varStr = 'one line'; break;case 'bool':$varStr = 'one line';return $foo;default: $varStr = 'test'; break;}
+switch ($condition) {case 'string': $varStr = 'one line'; break; case 'bool':$varStr = 'one line';return $foo;default: $varStr = 'test'; break;}
 
 switch ($condition) {
-case 'string': /*test comment handling when adding new lines*/$varStr = 'one line';/*test comment handling when adding new lines*/ break;
-default:/*test comment handling when adding new lines*/ $varStr = 'test'; /*test comment handling when adding new lines*/break;
+  case 'string': /*test comment handling when adding new lines*/$varStr = 'one line';/*test comment handling when adding new lines*/ break;
+  default:/*test comment handling when adding new lines*/ $varStr = 'test'; /*test comment handling when adding new lines*/break;
 }
 
 switch ($condition) {

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -288,9 +288,8 @@ switch ($something) {
 
 switch ($foo) {
     case '1':
-    return;
+    return; // comment
 
- // comment
     break;
 
 }
@@ -354,3 +353,54 @@ switch ( $a ) {
 
 jumpOut:
 doSomething();
+
+// Bug: the below should not throw "Blank lines are not allowed before/after..." errors (as there are no blank lines).
+// Instead the sniff should flag case/default/break statements not being on their own line.
+switch ($condition) {
+    case 'string':
+        $varStr = 'one line';
+    break;
+
+    case 'bool':
+        $varStr = 'one line';
+    return $foo;
+
+    default:
+        $varStr = 'test';
+    break;}
+
+switch ($condition) {
+    case 'string': /*test comment handling when adding new lines*/
+        $varStr = 'one line';/*test comment handling when adding new lines*/
+    break;
+
+    default:/*test comment handling when adding new lines*/
+        $varStr = 'test'; /*test comment handling when adding new lines*/
+    break;
+}
+
+switch ($condition) {
+    case 'too many blank lines':
+
+
+        // This comment should be used for the "blank line after case" determination.
+        $varStr = 'test';
+
+    break;
+
+    // Comment to use for measuring blank lines between the above break and here.
+    case 'this is fine': // This comment should be ignored and $varStr should be used instead.
+
+
+        $varStr = 'test';
+
+
+    break; // Trailing comment to ignore.
+
+    // This comment should be used for the "blank line after break" determination.
+    default: // This comment should be ignored and $varStr should be used instead.
+
+        $varStr = 'test';
+    break;
+
+}

--- a/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -79,6 +79,15 @@ final class SwitchDeclarationUnitTest extends AbstractSniffTestCase
             330 => 1,
             339 => 2,
             342 => 1,
+            350 => 12,
+            353 => 4,
+            354 => 3,
+            358 => 1,
+            364 => 2,
+            369 => 1,
+            375 => 2,
+            377 => 1,
+            380 => 1,
         ];
     }
 


### PR DESCRIPTION
# Description
While working on something else, I realized that the `Squiz.ControlStructures.SwitchDeclaration` sniff did not take into account that the "code under scan" could potentially be written to have various "parts" of a switch case/default structure on a single line.

This meant that, in that case, the sniff would have a fixer conflict with itself.
It would basically keep adding indentation whitespace for case/default/breaking statements not having the right indentation, but as it never added a new line _before_ the indentation, the indentation would still be incorrect in the next loop.

Fixed now by adding a number of extra checks to the sniff:
* `'ContentBefore' .$type` - which checks if there is anything but indentation whitespace, before a `case` or `default` keyword.
* `'ContentBeforeBreak'` - which checks if there is anything but indentation whitespace, before a `break/return` (etc) keyword.
* `'ContentAfter' .$type` - which checks if there is anything but a trailing comment, after a `case` or `default` statement.

The sniff also contains a couple of checks which verify the number of blank lines above/below certain statements. Those also didn't take into account that the count of the "lines between" may be zero, i.e. the code "after" being on the same line as the starting point for the check.
Those situations should now largely be fixed with the new lines being added via the `Content[Before|After]*` error codes.
For all other cases, the fixer code for the "number of blank lines" checks has been updated to handle trailing comments better, not leave trailing whitespace behind and not get into a fixer conflict with the new checks.

Notes:
* All fixers added/updated have been set up to prevent leaving trailing whitespace behind.
* The "fixed" code for one pre-existing test with a trailing comment has changed. In my opinion, the new "fixed" version is more correct, because:
    1. This sniff is not about disallowing trailing comments, so this sniff should not act as if it has an opinion on that.
    2. When moving (trailing) comments would be allowed, it could also result in tooling annotations being moved, which changes the meaning of the annotation in most cases.
* While working on this, I noticed various other fixes which are needed for this sniff. I've opened a ticket (#1314) as a reminder to address these later.
    While addressing those, the current changes may be made more efficient too.
    
Includes tests.



## Suggested changelog entry
Fixed: Squiz.ControlStructures.SwitchDeclaration: a number of the fixers would get into fixer conflicts with each other if the code under scan contained multiple statements on a line within a `switch`.
    - To fix this, the sniff will now forbid - and auto-fix - multiple statements on one line for `case`/`default` and "case breaking" statements.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
