### PR TITLE
GH Actions: split "validate" workflow

### DIFF
--- a/.github/workflows/validate-cron.yml
+++ b/.github/workflows/validate-cron.yml
@@ -1,0 +1,27 @@
+name: Validate Cronjob
+
+on:
+  # Run this workflow every Monday at 6:00 (to make sure the broken link check runs regularly).
+  schedule:
+    - cron: '0 6 * * 1'
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownlint:
+    name: 'Lint Markdown'
+    # Don't run the cronjob in this workflow on forks.
+    if: ${{ github.event.repository.fork == false }}
+
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+
+  remark:
+    name: 'QA Markdown'
+    # Don't run the cronjob in this workflow on forks.
+    if: ${{ github.event.repository.fork == false }}
+
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,6 @@ on:
   # Run on all pushes and on all pull requests.
   push:
   pull_request:
-  # Also run this workflow every Monday at 6:00 (to make sure the broken link check runs regularly).
-  schedule:
-    - cron: '0 6 * * 1'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
@@ -20,9 +17,6 @@ jobs:
   phpcs:
     name: Check PHP code style
     runs-on: ubuntu-latest
-
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     steps:
       - name: Checkout code
@@ -46,9 +40,6 @@ jobs:
   checkxml:
     name: Check XML files
     runs-on: ubuntu-latest
-
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     steps:
       - name: Checkout code
@@ -91,9 +82,6 @@ jobs:
     name: 'XML Code style'
     runs-on: ubuntu-latest
 
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
     env:
       XMLLINT_INDENT: '    '
 
@@ -130,25 +118,16 @@ jobs:
 
   yamllint:
     name: 'Lint Yaml'
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
     uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
     with:
       strict: true
 
   markdownlint:
     name: 'Lint Markdown'
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
     uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
 
   remark:
     name: 'QA Markdown'
-    # Don't run the cronjob in this workflow on forks.
-    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
-
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
 
   shellcheck:


### PR DESCRIPTION
# Description
GitHub has the annoying habit of disabling workflows with a cron job after two months if the repo doesn't see any activity.

While this won't happen easily for this repo, it may happen in forks and this creates the following problem:
* If the same workflow is used for both the cron job as well as the push/pull_request CI checks...
* ... and a repo (fork) doesn't have any activity in two months time...
* ... the workflow gets disabled...
* ... which then also means that CI checks will no longer be run on newly pushed branches....
* ... which means that contributors don't get feedback ahead of creating a PR, increasing the likelyhood the PR will fail CI.

Looking at this workflow critically, only the markdown checks should be run via a cron job. All other jobs should only run on push/pull.

With that in mind, this commit splits the workflow into two workflows:
* One workflow will be triggered via `cron` and will only run the markdown related checks.
* One workflow will have all the other triggers (`push`/`pull_request`/`workflow_dispatch`) and will run the full set of validation checks.

This way, if the cron job workflow gets disabled, the workflow which is used for the other triggers will continue to function.


## Suggested changelog entry
_N/A_
