### PR TITLE
PHP 8.5 | Tokenizer/PHP: polyfill the (void) cast 

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.1.inc
@@ -98,3 +98,7 @@ $var = (boolean)/* comment */ $var2;
 
 $var = (  int )$spacesInsideParenthesis;
 $var = (	int		)$tabsInsideParenthesis;
+
+(void) callMe();
+(void)callMe();
+(void)   callMe();

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.1.inc.fixed
@@ -95,3 +95,7 @@ $var = (boolean)/* comment */ $var2;
 
 $var = (  int ) $spacesInsideParenthesis;
 $var = (	int		) $tabsInsideParenthesis;
+
+(void) callMe();
+(void) callMe();
+(void) callMe();

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -77,6 +77,8 @@ final class SpaceAfterCastUnitTest extends AbstractSniffTestCase
                     97  => 1,
                     99  => 1,
                     100 => 1,
+                    103 => 1,
+                    104 => 1,
                 ];
 
             default:

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc
@@ -63,3 +63,7 @@ $var = array(
 );
 
 (bool) $a ? echo $b : echo $c;
+
+(void) callMe();
+(void)(bool) callMe();
+   (void) callMe(); // Indentation whitespace before should be and will be ignored.

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc.fixed
@@ -63,3 +63,7 @@ $var = array(
 );
 
 (bool) $a ? echo $b : echo $c;
+
+(void) callMe();
+(void) (bool) callMe();
+   (void) callMe(); // Indentation whitespace before should be and will be ignored.

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -61,6 +61,7 @@ final class SpaceBeforeCastUnitTest extends AbstractSniffTestCase
             53 => 1,
             55 => 1,
             56 => 1,
+            68 => 1,
         ];
     }
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.1.inc
@@ -142,3 +142,5 @@ class DNFTypes {
 interface PHP84HookedProperty {
     public String $readable { get; }
 }
+
+(VOID) php85();

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.1.inc.fixed
@@ -142,3 +142,5 @@ class DNFTypes {
 interface PHP84HookedProperty {
     public string $readable { get; }
 }
+
+(void) php85();

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -99,6 +99,7 @@ final class LowerCaseTypeUnitTest extends AbstractSniffTestCase
                     136 => 1,
                     139 => 2,
                     143 => 1,
+                    146 => 1,
                 ];
 
             default:

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -304,6 +304,11 @@ class OperatorBracketSniff implements Sniff
         }
 
         $before = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($before + 1), null, true);
+        if ($tokens[$before]['code'] === T_VOID_CAST) {
+            // Don't throw an error if a (void) cast is the first token in the expression
+            // as adding parentheses would turn that into a parse error.
+            return;
+        }
 
         // A few extra tokens are allowed to be on the right side of the expression.
         $allowed[T_EQUAL] = true;

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.1.inc
@@ -205,3 +205,6 @@ $cntPages = ceil(count($items) / parent::ON_PAGE);
 $nsRelative = namespace\doSomething($items + 10);
 $partiallyQualified = Partially\qualified($items + 10);
 $fullyQualified = \Fully\qualified($items + 10);
+
+// The below should be ignored as adding parentheses will turn this into a parse error.
+(void) CallMeOnce() + (bool) CallMeTwice();

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.1.inc.fixed
@@ -205,3 +205,6 @@ $cntPages = ceil(count($items) / parent::ON_PAGE);
 $nsRelative = namespace\doSomething($items + 10);
 $partiallyQualified = Partially\qualified($items + 10);
 $fullyQualified = \Fully\qualified($items + 10);
+
+// The below should be ignored as adding parentheses will turn this into a parse error.
+(void) CallMeOnce() + (bool) CallMeTwice();

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc
@@ -7,3 +7,5 @@ $var = (	int	) $var2;
 
 $var = (binary) $var2;
 $var = (   binary   ) $var2;
+
+( void) callMe();

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc.fixed
@@ -7,3 +7,5 @@ $var = (int) $var2;
 
 $var = (binary) $var2;
 $var = (binary) $var2;
+
+(void) callMe();

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -32,11 +32,12 @@ final class CastSpacingUnitTest extends AbstractSniffTestCase
     public function getErrorList()
     {
         return [
-            3 => 1,
-            4 => 1,
-            5 => 1,
-            6 => 1,
-            9 => 1,
+            3  => 1,
+            4  => 1,
+            5  => 1,
+            6  => 1,
+            9  => 1,
+            11 => 1,
         ];
     }
 

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -143,6 +143,11 @@ if (defined('T_PRIVATE_SET') === false) {
     define('T_PRIVATE_SET', 'PHPCS_T_PRIVATE_SET');
 }
 
+// Some PHP 8.5 tokens, replicated for lower versions.
+if (defined('T_VOID_CAST') === false) {
+    define('T_VOID_CAST', 'PHPCS_T_VOID_CAST');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');
@@ -266,6 +271,7 @@ final class Tokens
         T_OBJECT_CAST => T_OBJECT_CAST,
         T_UNSET_CAST  => T_UNSET_CAST,
         T_BINARY_CAST => T_BINARY_CAST,
+        T_VOID_CAST   => T_VOID_CAST,
     ];
 
     /**

--- a/tests/Core/Tokenizers/PHP/TypecastsTest.inc
+++ b/tests/Core/Tokenizers/PHP/TypecastsTest.inc
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Safeguard that all type casts past and present are tokenized correctly.
+ *
+ * This is also intended as an early warning system for when type cast tokens would be removed
+ * for type casts which are no longer supported by PHP itself.
+ *
+ * Pertinent type cast changes in PHP:
+ * - (unset) cast was introduced in PHP 5.0.
+ * - (binary) cast was introduced in PHP 5.2.1.
+ * - (unset) cast was deprecated in PHP 7.2 and removed in PHP 8.0.
+ * - (real) cast was deprecated in PHP 7.4 and removed in PHP 8.0.
+ * - (void) cast was introduced in PHP 8.5.
+ * - (integer), (boolean), (double) and (binary) casts are deprecated since PHP 8.5 and will be removed in PHP 9.0.
+ */
+
+/* testNotATypeCast1 */
+$a = (NOT_A_TYPECAST);
+
+/* testBool */
+$a = (bool) $b;
+
+/* testSpacyUppercaseBool */
+$a = ( BOOL) $b;
+
+/* testBoolean */
+$a = (boolean) $b;
+
+/* testSpacyUppercaseBoolean */
+$a = ( BOOLEAN ) $b;
+
+/* testInt */
+$a = (int) $b;
+
+/* testSpacyUppercaseInt */
+$a = ( INT ) $b;
+
+/* testInteger */
+$a = (integer) $b;
+
+/* testSpacyUppercaseInteger */
+$a = (   INTEGER ) $b;
+
+/* testFloat */
+$a = (float) $b;
+
+/* testSpacyUppercaseFloat */
+$a = ( FLOAT ) $b;
+
+/* testReal */
+$a = (real) $b;
+
+/* testSpacyUppercaseReal */
+$a = ( REAL ) $b;
+
+/* testDouble */
+$a = (double) $b;
+
+/* testSpacyUppercaseDouble */
+$a = ( DOUBLE   ) $b;
+
+/* testString */
+$a = (string) $b;
+
+/* testSpacyUppercaseString */
+$a = (STRING ) $b;
+
+/* testBinary */
+$a = (binary) $b;
+
+/* testSpacyUppercaseBinary */
+$a = ( BINARY ) $b;
+
+/* testArray */
+$a = (array) $b;
+
+/* testSpacyUppercaseArray */
+$a = (   ARRAY   ) $b;
+
+/* testObject */
+$a = (object) $b;
+
+/* testSpacyUppercaseObject */
+$a = ( OBJECT ) $b;
+
+/* testUnset */
+$a = (unset) $b;
+
+/* testSpacyUppercaseUnset */
+$a = ( UNSET ) $b;
+
+/* testVoid */
+(void) $b;
+
+// This is a parse error, but the cast should still be tokenized correctly.
+/* testVoidNested */
+((void) $b);
+
+/* testSpacyVoid */
+(   void   ) $b;
+
+/* testTabbyVoid */
+(	void	) $b; // Tab whitespace.
+
+/* testUppercaseVoid */
+(VOID) $b;
+
+
+/*
+ * New lines and comments are not allowed in a type cast.
+ */
+
+/* testNotATypeCast2 */
+(
+void
+) $b;
+
+/* testNotATypeCast3 */
+(
+
+    void
+
+) $b;
+
+/* testNotATypeCast4 */
+( /*comment*/ void /*comment */ ) $b;
+
+// Parse error. This must be the last test in the file!
+/* testNotATypeCast5 */
+(void

--- a/tests/Core/Tokenizers/PHP/TypecastsTest.php
+++ b/tests/Core/Tokenizers/PHP/TypecastsTest.php
@@ -1,0 +1,410 @@
+<?php
+/**
+ * Tests the tokenization of typecast tokens.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Tests the tokenization of typecast tokens.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class TypecastsTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that something between parentheses which may _look_ like a type cast, but isn't, tokenizes correctly.
+     *
+     * @param string                       $testMarker     The comment which prefaces the target tokens in the test file.
+     * @param array<array<string, string>> $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataNotATypeCast
+     *
+     * @return void
+     */
+    public function testNotATypeCast($testMarker, $expectedTokens)
+    {
+        $tokens = $this->phpcsFile->getTokens();
+        $target = $this->getTargetToken($testMarker, [T_OPEN_PARENTHESIS]);
+
+        foreach ($expectedTokens as $nr => $tokenInfo) {
+            $this->assertSame(
+                constant($tokenInfo['type']),
+                $tokens[$target]['code'],
+                'Token tokenized as ' . Tokens::tokenName($tokens[$target]['code']) . ', not ' . $tokenInfo['type'] . ' (code)'
+            );
+            $this->assertSame(
+                $tokenInfo['type'],
+                $tokens[$target]['type'],
+                'Token tokenized as ' . $tokens[$target]['type'] . ', not ' . $tokenInfo['type'] . ' (type)'
+            );
+            $this->assertSame(
+                $tokenInfo['content'],
+                $tokens[$target]['content'],
+                'Content of token ' . ($nr + 1) . ' (' . $tokens[$target]['type'] . ') does not match expectations'
+            );
+
+            ++$target;
+        }
+    }
+
+
+    /**
+     * Data provider.
+     *
+     * @see testNotATypeCast()
+     *
+     * @return array<string, array<string, string|array<array<string, string>>>>
+     */
+    public static function dataNotATypeCast()
+    {
+        return [
+            'constant within parentheses'                            => [
+                'testMarker'     => '/* testNotATypeCast1 */',
+                'expectedTokens' => [
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'NOT_A_TYPECAST',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_PARENTHESIS',
+                        'content' => ')',
+                    ],
+                ],
+            ],
+            'Invalid type cast void - new lines are not allowed [1]' => [
+                'testMarker'     => '/* testNotATypeCast2 */',
+                'expectedTokens' => [
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'void',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_PARENTHESIS',
+                        'content' => ')',
+                    ],
+                ],
+            ],
+            'Invalid type cast void - new lines are not allowed [2]' => [
+                'testMarker'     => '/* testNotATypeCast3 */',
+                'expectedTokens' => [
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'void',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_PARENTHESIS',
+                        'content' => ')',
+                    ],
+                ],
+            ],
+            'Invalid type cast void - comments are not allowed'      => [
+                'testMarker'     => '/* testNotATypeCast4 */',
+                'expectedTokens' => [
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/*comment*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'void',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/*comment */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_PARENTHESIS',
+                        'content' => ')',
+                    ],
+                ],
+            ],
+            'Live coding/parse error'                                => [
+                'testMarker'     => '/* testNotATypeCast5 */',
+                'expectedTokens' => [
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'void',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => "\n",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+
+    /**
+     * Test that valid type casts are tokenized as such.
+     *
+     * @param string $testMarker      The comment which prefaces the target token in the test file.
+     * @param string $expectedType    Expected token type.
+     * @param string $expectedContent Expected token content.
+     *
+     * @dataProvider dataTypeCast
+     *
+     * @return void
+     */
+    public function testTypeCast($testMarker, $expectedType, $expectedContent)
+    {
+        $tokens       = $this->phpcsFile->getTokens();
+        $expectedCode = constant($expectedType);
+        $target       = $this->getTargetToken($testMarker, $expectedCode);
+        $tokenArray   = $tokens[$target];
+
+        $this->assertSame($expectedCode, $tokenArray['code'], "Token tokenized as {$tokenArray['type']}, not $expectedType (code)");
+        $this->assertSame($expectedType, $tokenArray['type'], "Token tokenized as {$tokenArray['type']}, not $expectedType (type)");
+
+        if (isset($tokenArray['orig_content']) === true) {
+            $this->assertSame($expectedContent, $tokenArray['orig_content'], 'Token (orig) content does not match expectation');
+        } else {
+            $this->assertSame($expectedContent, $tokenArray['content'], 'Token content does not match expectation');
+        }
+
+        // Make sure there are no stray tokens.
+        // This assertion requires all type casts tested via this test to be followed whitespace + a variable.
+        $this->assertSame(T_WHITESPACE, $tokens[($target + 1)]['code'], 'Stray tokens detected');
+        $this->assertSame(T_VARIABLE, $tokens[($target + 2)]['code'], 'Stray tokens detected');
+    }
+
+
+    /**
+     * Data provider.
+     *
+     * @see testTypeCast()
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataTypeCast()
+    {
+        return [
+            '(bool)'                => [
+                'testMarker'      => '/* testBool */',
+                'expectedType'    => 'T_BOOL_CAST',
+                'expectedContent' => '(bool)',
+            ],
+            '( BOOL )'              => [
+                'testMarker'      => '/* testSpacyUppercaseBool */',
+                'expectedType'    => 'T_BOOL_CAST',
+                'expectedContent' => '( BOOL)',
+            ],
+            '(boolean)'             => [
+                'testMarker'      => '/* testBoolean */',
+                'expectedType'    => 'T_BOOL_CAST',
+                'expectedContent' => '(boolean)',
+            ],
+            '( BOOLEAN )'           => [
+                'testMarker'      => '/* testSpacyUppercaseBoolean */',
+                'expectedType'    => 'T_BOOL_CAST',
+                'expectedContent' => '( BOOLEAN )',
+            ],
+            '(int)'                 => [
+                'testMarker'      => '/* testInt */',
+                'expectedType'    => 'T_INT_CAST',
+                'expectedContent' => '(int)',
+            ],
+            '( INT )'               => [
+                'testMarker'      => '/* testSpacyUppercaseInt */',
+                'expectedType'    => 'T_INT_CAST',
+                'expectedContent' => '( INT )',
+            ],
+            '(integer)'             => [
+                'testMarker'      => '/* testInteger */',
+                'expectedType'    => 'T_INT_CAST',
+                'expectedContent' => '(integer)',
+            ],
+            '(   INTEGER )'         => [
+                'testMarker'      => '/* testSpacyUppercaseInteger */',
+                'expectedType'    => 'T_INT_CAST',
+                'expectedContent' => '(   INTEGER )',
+            ],
+            '(float)'               => [
+                'testMarker'      => '/* testFloat */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '(float)',
+            ],
+            '( FLOAT )'             => [
+                'testMarker'      => '/* testSpacyUppercaseFloat */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '( FLOAT )',
+            ],
+            '(real)'                => [
+                'testMarker'      => '/* testReal */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '(real)',
+            ],
+            '( REAL )'              => [
+                'testMarker'      => '/* testSpacyUppercaseReal */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '( REAL )',
+            ],
+            '(double)'              => [
+                'testMarker'      => '/* testDouble */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '(double)',
+            ],
+            '( DOUBLE   )'          => [
+                'testMarker'      => '/* testSpacyUppercaseDouble */',
+                'expectedType'    => 'T_DOUBLE_CAST',
+                'expectedContent' => '( DOUBLE   )',
+            ],
+            '(string)'              => [
+                'testMarker'      => '/* testString */',
+                'expectedType'    => 'T_STRING_CAST',
+                'expectedContent' => '(string)',
+            ],
+            '( STRING )'            => [
+                'testMarker'      => '/* testSpacyUppercaseString */',
+                'expectedType'    => 'T_STRING_CAST',
+                'expectedContent' => '(STRING )',
+            ],
+            '(binary)'              => [
+                'testMarker'      => '/* testBinary */',
+                'expectedType'    => 'T_BINARY_CAST',
+                'expectedContent' => '(binary)',
+            ],
+            '( BINARY )'            => [
+                'testMarker'      => '/* testSpacyUppercaseBinary */',
+                'expectedType'    => 'T_BINARY_CAST',
+                'expectedContent' => '( BINARY )',
+            ],
+            '(array)'               => [
+                'testMarker'      => '/* testArray */',
+                'expectedType'    => 'T_ARRAY_CAST',
+                'expectedContent' => '(array)',
+            ],
+            '(   ARRAY   )'         => [
+                'testMarker'      => '/* testSpacyUppercaseArray */',
+                'expectedType'    => 'T_ARRAY_CAST',
+                'expectedContent' => '(   ARRAY   )',
+            ],
+            '(object)'              => [
+                'testMarker'      => '/* testObject */',
+                'expectedType'    => 'T_OBJECT_CAST',
+                'expectedContent' => '(object)',
+            ],
+            '( OBJECT )'            => [
+                'testMarker'      => '/* testSpacyUppercaseObject */',
+                'expectedType'    => 'T_OBJECT_CAST',
+                'expectedContent' => '( OBJECT )',
+            ],
+            '(unset)'               => [
+                'testMarker'      => '/* testUnset */',
+                'expectedType'    => 'T_UNSET_CAST',
+                'expectedContent' => '(unset)',
+            ],
+            '( UNSET )'             => [
+                'testMarker'      => '/* testSpacyUppercaseUnset */',
+                'expectedType'    => 'T_UNSET_CAST',
+                'expectedContent' => '( UNSET )',
+            ],
+
+            // PHP 8.5: new (void) cast.
+            '(void)'                => [
+                'testMarker'      => '/* testVoid */',
+                'expectedType'    => 'T_VOID_CAST',
+                'expectedContent' => '(void)',
+            ],
+            'Nested (void)'         => [
+                'testMarker'      => '/* testVoidNested */',
+                'expectedType'    => 'T_VOID_CAST',
+                'expectedContent' => '(void)',
+            ],
+            '(   void   ) (spaces)' => [
+                'testMarker'      => '/* testSpacyVoid */',
+                'expectedType'    => 'T_VOID_CAST',
+                'expectedContent' => '(   void   )',
+            ],
+            '(\tvoid\t) (tabs)'     => [
+                'testMarker'      => '/* testTabbyVoid */',
+                'expectedType'    => 'T_VOID_CAST',
+                'expectedContent' => "(\tvoid\t)",
+            ],
+            '(VOID)'                => [
+                'testMarker'      => '/* testUppercaseVoid */',
+                'expectedType'    => 'T_VOID_CAST',
+                'expectedContent' => '(VOID)',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
# Description

### PHP 8.5 | Tokenizer/PHP: polyfill the (void) cast 

As part of the RFC for the `#[NoDiscard]` attribute, a new typecast `(void)` has been introduced.

This commit polyfills this new token for PHP < 8.5.

Includes tests covering the complete set of type casts, even though the PHPCS Tokenizer only handles the `(void)` cast.
Reason being, that PHP has deprecated and removed some casts, like `(unset)`, and their token constants may be removed from PHP Core at some point in the future. These tests should serve as a warning system for that eventuality.

Ref: https://wiki.php.net/rfc/marking_return_value_as_important#void_cast_to_suppress_the_warning

### Various sniffs: add tests with PHP 8.5 (void) cast

## Suggested changelog entry
Added
- Tokenizer support for the new PHP 8.5 `(void)` cast.
    - The `T_VOID_CAST` token has been added to the `Tokens::CAST_TOKENS` array.

## Related issues/external references

Related to #1306

