### PR TITLE
CI: fix markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -38,6 +38,8 @@ config:
   MD031: false
   # MD032/blanks-around-lists - Lists should be surrounded by blank lines.
   MD032: false
+  # MD060/table-column-style - Table column style.
+  MD060: false
 
   ##############################
   # Customize a few other rules.


### PR DESCRIPTION
# Description
MarkdownLint v0.39.0 introduced a new rules regarding table formatting.

While the principle of the rule is actually quite nice, it doesn't play nice with the `bug_report.md` template file, and while that file could, of course, be updated, that wouldn't improve the user-friendliness of the form.

So, for now, I'm electing to ignore the new rule (`MD060`).

Refs:
* https://github.com/DavidAnson/markdownlint/blob/v0.39.0/CHANGELOG.md#0390
* https://github.com/DavidAnson/markdownlint/blob/main/doc/md060.md

## Suggested changelog entry
_N/A_
