### PR TITLE
GH Actions/test: fix code coverage flag name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,7 +398,7 @@ jobs:
         with:
           format: clover
           file: build/logs/clover-cbf.xml
-          flag-name: cbf-os-${{ matrix.os }}-ubuntu-latest-php-${{ matrix.php }}-custom-ini-${{ matrix.custom_ini }}
+          flag-name: cbf-os-${{ matrix.os }}-php-${{ matrix.php }}-custom-ini-${{ matrix.custom_ini }}
           parallel: true
 
   coveralls-finish:


### PR DESCRIPTION
# Description

The PHPCBF code coverage check is only run on Ubuntu, not on Windows, but the flag contained both the matrix name as well as a hard-coded "ubuntu-latest".

Fixed now.


## Suggested changelog entry
_N/A_