### PR TITLE
Handle parse error in File::getMethodProperties()

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1781,6 +1781,8 @@ class File
                 T_TYPE_CLOSE_PARENTHESIS => T_TYPE_CLOSE_PARENTHESIS,
             ];
 
+            $hasColon = false;
+
             for ($i = $this->tokens[$stackPtr]['parenthesis_closer']; $i < $this->numTokens; $i++) {
                 if (($scopeOpener === null && $this->tokens[$i]['code'] === T_SEMICOLON)
                     || ($scopeOpener !== null && $i === $scopeOpener)
@@ -1800,11 +1802,17 @@ class File
                     continue;
                 }
 
-                if ($this->tokens[$i]['code'] === T_NULLABLE) {
-                    $nullableReturnType = true;
+                if ($this->tokens[$i]['code'] === T_COLON) {
+                    $hasColon = true;
+                    continue;
                 }
 
-                if (isset($valid[$this->tokens[$i]['code']]) === true) {
+                if ($this->tokens[$i]['code'] === T_NULLABLE) {
+                    $nullableReturnType = true;
+                    continue;
+                }
+
+                if ($hasColon === true && isset($valid[$this->tokens[$i]['code']]) === true) {
                     if ($returnTypeToken === false) {
                         $returnTypeToken = $i;
                     }

--- a/tests/Core/Files/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/Files/File/GetMethodPropertiesTest.inc
@@ -221,6 +221,10 @@ $closure = function () use /*comment*/ ($a): Type {};
 /* testClosureWithUseMultiParamWithReturnType */
 $closure = function () use ($a, &$b, $c, $d, $e, $f, $g): ?array {};
 
+/* testMissingColonParseError */
+// Intentional parse error.
+$closure = function () null { return null; };
+
 /* testArrowFunctionLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 $fn = fn

--- a/tests/Core/Files/File/GetMethodPropertiesTest.php
+++ b/tests/Core/Files/File/GetMethodPropertiesTest.php
@@ -1451,6 +1451,31 @@ final class GetMethodPropertiesTest extends AbstractMethodTestCase
 
 
     /**
+     * Test handling of a parse error where the colon is missing from the return type declaration.
+     *
+     * @return void
+     */
+    public function testMissingColonParseError()
+    {
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+
+    /**
      * Test handling of closure declarations with a use variable import with a return type declaration.
      *
      * @return void


### PR DESCRIPTION
# Description

While investigating the cause of a PHP Fatal error while processing some input in the `PSR12.Functions.ReturnTypeDeclaration` sniff, I noticed that the `File::getMethodProperties()` method did not return sensible values in for some parse errors. The input file in question was
`src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.2.inc`, which contains an intentional parse error. The `File::getMethodProperties()` method claimed that the return type of the `test` function was `<< HEAD`, which is nonsense.

The change in this commit safeguards from such parse errors and resolves the issue that was being encountered downstream in the sniff.

## Suggested changelog entry

Handle parse error in File::getMethodProperties()

## Related issues/external references

Relates to #152

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
