### PR TITLE
GH Actions: pin re-usable workflows too

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,4 +20,4 @@ concurrency:
 jobs:
   phpstan:
     name: "PHPStan"
-    uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0

--- a/.github/workflows/validate-cron.yml
+++ b/.github/workflows/validate-cron.yml
@@ -17,11 +17,11 @@ jobs:
     # Don't run the cronjob in this workflow on forks.
     if: ${{ github.event.repository.fork == false }}
 
-    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0
 
   remark:
     name: 'QA Markdown'
     # Don't run the cronjob in this workflow on forks.
     if: ${{ github.event.repository.fork == false }}
 
-    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -118,17 +118,17 @@ jobs:
 
   yamllint:
     name: 'Lint Yaml'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0
     with:
       strict: true
 
   markdownlint:
     name: 'Lint Markdown'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0
 
   remark:
     name: 'QA Markdown'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@a06ac9fa50dcd1d98cc581e9a4e331363a69ea09 # v1.1.0
 
   shellcheck:
     name: 'ShellCheck'


### PR DESCRIPTION
# Description
Follow up on #1273, which added commit hash pinning to all externally managed action runners, this commit now also adds this to the re-usable workflows managed in the `PHPCSStandards/.github` repository.


## Suggested changelog entry
_N/A_