### PR TITLE
PSR2 WrongOpenercase with colon and bracket is unclear

### DIFF
--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -197,8 +197,12 @@ class SwitchDeclarationSniff implements Sniff
                         }
                     }
                 } else {
-                    // Probably a case/default statement with colon + curly braces.
-                    $phpcsFile->addError($error, $nextCase, 'WrongOpener' . $type);
+                    if ($tokens[$opener]['code'] === T_OPEN_CURLY_BRACKET) {
+                        $error = '%s statements must not use a braced block after the colon';
+                        $phpcsFile->addError($error, $nextCase, 'WrongOpener', [strtoupper($type)]);
+                    } else {
+                        $phpcsFile->addError($error, $nextCase, 'WrongOpener' . $type);
+                    }
                 }
             }
 

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -638,3 +638,12 @@ switch ($foo):
         <div>Some html</div>
         <?php break;
 endswitch;
+
+// Verify that the sniff gracefully handles braced block with trailing comment.
+switch ($foo) {
+    case 'Foo': // Trailing comment.
+    {
+        echo 'foo';
+        break;
+    }
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -641,3 +641,12 @@ switch ($foo):
         <?php
         break;
 endswitch;
+
+// Verify that the sniff gracefully handles braced block with trailing comment.
+switch ($foo) {
+    case 'Foo': // Trailing comment.
+    {
+        echo 'foo';
+        break;
+    }
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -73,6 +73,7 @@ final class SwitchDeclarationUnitTest extends AbstractSniffTestCase
             631 => 1,
             634 => 1,
             637 => 1,
+            644 => 1,
         ];
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

Updated SwitchDeclarationSniff to give a clear error when a case uses a braced block after the colon.

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

The PR introduces a change that correct updates the SwitchDeclarationSniff to give a clear error when a case uses a braced block after the colon.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

Improved PSR2 SwitchDeclaration sniff to detect and report case/default statements using a braced block after the colon with (`CaseWithBlockScope`)

## Related issues/external references

Fixes #1322


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
