### PR TITLE
Tokens: add CLASS_MODIFIERS and PROPERTY_MODIFIERS constants

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1909,15 +1909,7 @@ class File
             }
         }
 
-        $valid = [
-            T_STATIC   => T_STATIC,
-            T_VAR      => T_VAR,
-            T_READONLY => T_READONLY,
-            T_FINAL    => T_FINAL,
-            T_ABSTRACT => T_ABSTRACT,
-        ];
-
-        $valid += Tokens::SCOPE_MODIFIERS;
+        $valid  = Tokens::PROPERTY_MODIFIERS;
         $valid += Tokens::EMPTY_TOKENS;
 
         $scope          = 'public';
@@ -2068,12 +2060,11 @@ class File
         }
 
         $valid = [
-            T_FINAL      => T_FINAL,
-            T_ABSTRACT   => T_ABSTRACT,
-            T_READONLY   => T_READONLY,
             T_WHITESPACE => T_WHITESPACE,
             T_COMMENT    => T_COMMENT,
         ];
+
+        $valid += Tokens::CLASS_MODIFIERS;
 
         $isAbstract = false;
         $isFinal    = false;

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -57,13 +57,8 @@ class LowerCaseConstantSniff implements Sniff
     {
         $targets = self::TARGET_TOKENS;
 
-        // Register scope modifiers to filter out property type declarations.
-        $targets  += Tokens::SCOPE_MODIFIERS;
-        $targets[] = T_VAR;
-        $targets[] = T_STATIC;
-        $targets[] = T_READONLY;
-        $targets[] = T_FINAL;
-        $targets[] = T_ABSTRACT;
+        // Register property modifiers to filter out property type declarations.
+        $targets += Tokens::PROPERTY_MODIFIERS;
 
         // Register function keywords to filter out param/return type declarations.
         $targets[] = T_FUNCTION;
@@ -119,13 +114,7 @@ class LowerCaseConstantSniff implements Sniff
          * declarations, in which case, it is correct to skip over them.
          */
 
-        if (isset(Tokens::SCOPE_MODIFIERS[$tokens[$stackPtr]['code']]) === true
-            || $tokens[$stackPtr]['code'] === T_VAR
-            || $tokens[$stackPtr]['code'] === T_STATIC
-            || $tokens[$stackPtr]['code'] === T_READONLY
-            || $tokens[$stackPtr]['code'] === T_FINAL
-            || $tokens[$stackPtr]['code'] === T_ABSTRACT
-        ) {
+        if (isset(Tokens::PROPERTY_MODIFIERS[$tokens[$stackPtr]['code']]) === true) {
             $skipOver = (Tokens::EMPTY_TOKENS + self::PROPERTY_TYPE_TOKENS);
             $skipTo   = $phpcsFile->findNext($skipOver, ($stackPtr + 1), null, true);
             if ($skipTo !== false) {

--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -11,6 +11,7 @@
 namespace PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ClassCommentSniff extends FileCommentSniff
 {
@@ -47,12 +48,8 @@ class ClassCommentSniff extends FileCommentSniff
         $type      = strtolower($tokens[$stackPtr]['content']);
         $errorData = [$type];
 
-        $find = [
-            T_ABSTRACT   => T_ABSTRACT,
-            T_FINAL      => T_FINAL,
-            T_READONLY   => T_READONLY,
-            T_WHITESPACE => T_WHITESPACE,
-        ];
+        $find  = [T_WHITESPACE => T_WHITESPACE];
+        $find += Tokens::CLASS_MODIFIERS;
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
             if (isset($find[$tokens[$commentEnd]['code']]) === true) {

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -181,7 +181,7 @@ class SideEffectsSniff implements Sniff
 
             // Ignore function/class prefixes.
             if (isset(Tokens::METHOD_MODIFIERS[$tokens[$i]['code']]) === true
-                || $tokens[$i]['code'] === T_READONLY
+                || isset(Tokens::CLASS_MODIFIERS[$tokens[$i]['code']]) === true
             ) {
                 continue;
             }

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -187,7 +187,7 @@ class FileHeaderSniff implements Sniff
 
                     if (isset($commentOpeners[$tokens[$docToken]['code']]) === false
                         && isset(Tokens::METHOD_MODIFIERS[$tokens[$docToken]['code']]) === false
-                        && $tokens[$docToken]['code'] !== T_READONLY
+                        && isset(Tokens::CLASS_MODIFIERS[$tokens[$docToken]['code']]) === false
                     ) {
                         // Check for an @var annotation.
                         $annotation = false;

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -18,17 +18,6 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 {
 
     /**
-     * Modifier keywords which can be used in class declarations.
-     *
-     * @var array<int|string, int|string>
-     */
-    private const CLASS_MODIFIERS = [
-        T_ABSTRACT => T_ABSTRACT,
-        T_FINAL    => T_FINAL,
-        T_READONLY => T_READONLY,
-    ];
-
-    /**
      * The number of spaces code should be indented.
      *
      * @var integer
@@ -79,7 +68,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
         $prevNonSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
-        if (isset(self::CLASS_MODIFIERS[$tokens[$prevNonEmpty]['code']]) === true) {
+        if (isset(Tokens::CLASS_MODIFIERS[$tokens[$prevNonEmpty]['code']]) === true) {
             $spaces    = 0;
             $errorCode = 'SpaceBeforeKeyword';
             if ($tokens[$prevNonEmpty]['line'] !== $tokens[$stackPtr]['line']) {

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -57,12 +57,8 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         // Detect multiple properties defined at the same time. Throw an error
         // for this, but also only process the first property in the list so we don't
         // repeat errors.
-        $find   = Tokens::SCOPE_MODIFIERS;
+        $find   = Tokens::PROPERTY_MODIFIERS;
         $find[] = T_VARIABLE;
-        $find[] = T_VAR;
-        $find[] = T_READONLY;
-        $find[] = T_FINAL;
-        $find[] = T_ABSTRACT;
         $find[] = T_SEMICOLON;
         $find[] = T_OPEN_CURLY_BRACKET;
 

--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -63,10 +63,7 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
                 $blankSpace = substr($prevContent, strpos($prevContent, $phpcsFile->eolChar));
                 $spaces     = strlen($blankSpace);
 
-                if ($tokens[($stackPtr - 2)]['code'] !== T_ABSTRACT
-                    && $tokens[($stackPtr - 2)]['code'] !== T_FINAL
-                    && $tokens[($stackPtr - 2)]['code'] !== T_READONLY
-                ) {
+                if (isset(Tokens::CLASS_MODIFIERS[$tokens[($stackPtr - 2)]['code']]) === false) {
                     if ($spaces !== 0) {
                         $type  = strtolower($tokens[$stackPtr]['content']);
                         $error = 'Expected 0 spaces before %s keyword; %s found';

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -26,11 +26,9 @@ class LowercaseClassKeywordsSniff implements Sniff
     public function register()
     {
         $targets   = Tokens::OO_SCOPE_TOKENS;
+        $targets  += Tokens::CLASS_MODIFIERS;
         $targets[] = T_EXTENDS;
         $targets[] = T_IMPLEMENTS;
-        $targets[] = T_ABSTRACT;
-        $targets[] = T_FINAL;
-        $targets[] = T_READONLY;
         $targets[] = T_VAR;
         $targets[] = T_CONST;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -20,6 +20,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ClassCommentSniff implements Sniff
 {
@@ -48,12 +49,9 @@ class ClassCommentSniff implements Sniff
     public function process(File $phpcsFile, int $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $find   = [
-            T_ABSTRACT   => T_ABSTRACT,
-            T_FINAL      => T_FINAL,
-            T_READONLY   => T_READONLY,
-            T_WHITESPACE => T_WHITESPACE,
-        ];
+
+        $find  = [T_WHITESPACE => T_WHITESPACE];
+        $find += Tokens::CLASS_MODIFIERS;
 
         $previousContent = null;
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -64,12 +64,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $endOfPreviousStatement = $phpcsFile->findPrevious($stopPoints, ($stackPtr - 1), null, false, null, true);
 
-        $validPrefixes   = Tokens::SCOPE_MODIFIERS;
-        $validPrefixes[] = T_STATIC;
-        $validPrefixes[] = T_FINAL;
-        $validPrefixes[] = T_VAR;
-        $validPrefixes[] = T_READONLY;
-        $validPrefixes[] = T_ABSTRACT;
+        $validPrefixes = Tokens::PROPERTY_MODIFIERS;
 
         $startOfStatement = $phpcsFile->findNext($validPrefixes, ($endOfPreviousStatement + 1), $stackPtr, false, null, true);
         if ($startOfStatement === false) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Ensure there is a single space after scope keywords.
+ * Ensure there is a single space after all modifier keywords (not just scope modifiers).
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -27,7 +27,8 @@ class ScopeKeywordSpacingSniff implements Sniff
     {
         $register  = Tokens::METHOD_MODIFIERS;
         $register += Tokens::SCOPE_MODIFIERS;
-        $register[T_READONLY] = T_READONLY;
+        $register += Tokens::PROPERTY_MODIFIERS;
+        $register += Tokens::CLASS_MODIFIERS;
         return $register;
     }
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2294,8 +2294,8 @@ class PHP extends Tokenizer
                         || $tokenType === T_FN
                         || isset(Tokens::METHOD_MODIFIERS[$tokenType]) === true
                         || isset(Tokens::SCOPE_MODIFIERS[$tokenType]) === true
-                        || $tokenType === T_VAR
-                        || $tokenType === T_READONLY
+                        || isset(Tokens::PROPERTY_MODIFIERS[$tokenType]) === true
+                        || isset(Tokens::CLASS_MODIFIERS[$tokenType]) === true
                     ) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             StatusWriter::write("* token $stackPtr changed from ? to T_NULLABLE", 2);
@@ -3544,12 +3544,7 @@ class PHP extends Tokenizer
                     }
 
                     if ($suspectedType === 'property or parameter'
-                        && (isset(Tokens::SCOPE_MODIFIERS[$this->tokens[$x]['code']]) === true
-                        || $this->tokens[$x]['code'] === T_VAR
-                        || $this->tokens[$x]['code'] === T_STATIC
-                        || $this->tokens[$x]['code'] === T_READONLY
-                        || $this->tokens[$x]['code'] === T_FINAL
-                        || $this->tokens[$x]['code'] === T_ABSTRACT)
+                        && isset(Tokens::PROPERTY_MODIFIERS[$this->tokens[$x]['code']]) === true
                     ) {
                         // This will also confirm constructor property promotion parameters, but that's fine.
                         $confirmed = true;

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -363,6 +363,30 @@ final class Tokens
     ];
 
     /**
+     * Tokens that can prefix a class name.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const CLASS_MODIFIERS = [
+        T_ABSTRACT => T_ABSTRACT,
+        T_FINAL    => T_FINAL,
+        T_READONLY => T_READONLY,
+    ];
+
+    /**
+     * Tokens that can prefix a property name.
+     *
+     * @var array<int|string, int|string>
+     */
+    public const PROPERTY_MODIFIERS = (self::SCOPE_MODIFIERS + [
+        T_ABSTRACT => T_ABSTRACT,
+        T_FINAL    => T_FINAL,
+        T_READONLY => T_READONLY,
+        T_STATIC   => T_STATIC,
+        T_VAR      => T_VAR,
+    ]);
+
+    /**
      * Tokens that open code blocks.
      *
      * @var array<int|string, int|string>


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Several core sniffs and many custom sniffs rely heavily on the Tokens class to simplify code, particularly as new features (like readonly) are added to PHP. This change adds class and property modifier constants and implements those constants in sniffs that were already hardcoding those collections of values. Semantically, these constants also do a better job of communicating what is being searched for. In one or two cases, I decided to continue including SCOPE_MODIFIERS even though all of the tokens are currently part of the PROPERTY_MODIFIERS constant. I do not know what the future holds, so I do not want to assume that will not change in the future.

There should not be any changes in behavior. PSR2.Classes.PropertyDeclaration was not including T_STATIC and it's unclear to me if that was intentional or not.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Tokens: add CLASS_MODIFIERS and PROPERTY_MODIFIERS constants

## Related issues/external references

May help fix moodlehq/moodle-cs#213


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
