### PR TITLE
Generic.WhiteSpace.ScopeIndent: Fix multi-line extends/implements indentation

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -1152,6 +1152,12 @@ class ScopeIndentSniff implements Sniff
                     StatusWriter::write("=> indent will be set to $futureIndent at token $opener ($type)", 1);
                 }
 
+                // If it is a closure, jump to the future.
+                if ($tokens[$i]['code'] === T_CLOSURE) {
+                    $i = $opener;
+                    $currentIndent = $futureIndent;
+                }
+
                 continue;
             }
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -831,6 +831,31 @@ class ScopeIndentSniff implements Sniff
                 $exact = false;
             }
 
+            // Special handling for multi-line extends and implements lists.
+            // Only apply to interface/class names that are directly part of extends/implements statements.
+            if ($checkToken !== null
+                && (isset(Tokens::NAME_TOKENS[$tokens[$checkToken]['code']]) === true
+                || $tokens[$checkToken]['code'] === T_EXTENDS
+                || $tokens[$checkToken]['code'] === T_IMPLEMENTS)
+            ) {
+                $scopeToken = $phpcsFile->findPrevious(Tokens::OO_SCOPE_TOKENS, ($checkToken - 1));
+
+                // Verify that the token is part of declaration by checking that the token is before the scope opener.
+                if ($scopeToken !== false
+                    && $tokens[$scopeToken]['line'] !== $tokens[$checkToken]['line']
+                    && isset($tokens[$scopeToken]['scope_opener']) === true
+                    && $tokens[$scopeToken]['scope_opener'] > $checkToken
+                ) {
+                    $checkIndent = (($tokens[$scopeToken]['column'] - 1) + $this->indent);
+
+                    if (isset($adjustments[$scopeToken]) === true) {
+                        $checkIndent += $adjustments[$scopeToken];
+                    }
+
+                    $checkIndent = (int) (ceil($checkIndent / $this->indent) * $this->indent);
+                }
+            }
+
             if ($checkIndent === null) {
                 $checkIndent = $currentIndent;
             }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -846,10 +846,16 @@ class ScopeIndentSniff implements Sniff
                     && isset($tokens[$scopeToken]['scope_opener']) === true
                     && $tokens[$scopeToken]['scope_opener'] > $checkToken
                 ) {
-                    $checkIndent = (($tokens[$scopeToken]['column'] - 1) + $this->indent);
+                    $start = $phpcsFile->findStartOfStatement($scopeToken);
 
-                    if (isset($adjustments[$scopeToken]) === true) {
-                        $checkIndent += $adjustments[$scopeToken];
+                    if ($start === false) {
+                        $start = $scopeToken;
+                    }
+
+                    $checkIndent = (($tokens[$start]['column'] - 1) + $this->indent);
+
+                    if (isset($adjustments[$start]) === true) {
+                        $checkIndent += $adjustments[$start];
                     }
 
                     $checkIndent = (int) (ceil($checkIndent / $this->indent) * $this->indent);
@@ -1112,7 +1118,13 @@ class ScopeIndentSniff implements Sniff
                     }
                 }
 
-                $currentIndent = (($tokens[$first]['column'] - 1) + $this->indent);
+                $currentIndent = ($tokens[$first]['column'] - 1);
+
+                if ($this->debug === true) {
+                    $type = $tokens[$i]['type'];
+                    StatusWriter::write("=> indent set to $currentIndent by token $i ($type)", 1);
+                }
+
                 $openScopes[$tokens[$i]['scope_closer']] = $tokens[$i]['scope_condition'];
                 if ($this->debug === true) {
                     $closerToken    = $tokens[$i]['scope_closer'];
@@ -1130,12 +1142,14 @@ class ScopeIndentSniff implements Sniff
 
                 // Make sure it is divisible by our expected indent.
                 $currentIndent = (int) (floor($currentIndent / $this->indent) * $this->indent);
-                $i = $tokens[$i]['scope_opener'];
-                $setIndents[$i] = $currentIndent;
+
+                $opener       = $tokens[$i]['scope_opener'];
+                $futureIndent = ($currentIndent + $this->indent);
+                $setIndents[$opener] = $futureIndent;
 
                 if ($this->debug === true) {
-                    $type = $tokens[$i]['type'];
-                    StatusWriter::write("=> indent set to $currentIndent by token $i ($type)", 1);
+                    $type = $tokens[$opener]['type'];
+                    StatusWriter::write("=> indent will be set to $futureIndent at token $opener ($type)", 1);
                 }
 
                 continue;

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
@@ -1,0 +1,70 @@
+<?php
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+
+// Correct multi-line extends/implements.
+class CorrectClass extends BaseClass implements
+    InterfaceOne,
+    Some\Namespace\InterfaceTwo
+{
+    public function test()
+    {
+        return true;
+    }
+}
+
+// Incorrect multi-line extends/implements (should trigger errors).
+class IncorrectClass extends
+    BaseClass implements
+        \Some\Namespace\InterfaceOne,
+        InterfaceTwo
+{
+    public function test()
+    {
+        return true;
+    }
+}
+
+// Interface with multi-line extends.
+interface TestInterface extends
+    BaseInterface,
+    AnotherInterface
+{
+    public function testMethod();
+}
+
+// Edge case: constant/property names should NOT trigger multi-line logic.
+class EdgeCase
+    extends BaseClass
+        implements InterfaceOne
+{
+    public const extends = 'value';
+    public const implements = 'value';
+    private $extends = null;
+    private $implements = null;
+    public function test() {
+        $this->extends = 'test';
+        $this->implements = 'test';
+        return true;
+    }
+}
+
+// Edge case: property access should NOT trigger multi-line logic.
+function test_function() {
+    $obj = new stdClass();
+    $obj->extends = 'value';
+    $obj->implements = 'value';
+    echo $obj->extends;
+    echo $obj->implements;
+}
+
+// Conditional class with inconsistent indentation.
+if (class_exists('ConditionalClass') === false) {
+class ConditionalClass implements
+            InterfaceOne,
+    InterfaceTwo,
+            InterfaceThree {
+        public function test() {
+            return true;
+        }
+    }
+}

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
@@ -67,4 +67,15 @@ class ConditionalClass implements
             return true;
         }
     }
+
+    // Edge case: anonymous class with extends/implements.
+$anonymous = new class() extends
+BaseClass implements
+InterfaceOne,
+InterfaceTwo
+{
+public function test() {
+return true;
+}
+};
 }

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
@@ -79,3 +79,15 @@ return true;
 }
 };
 }
+
+// Edge case: anonymous function.
+register_shutdown_function(
+    static function () use (
+        $errorMsg,
+        $errorArray
+    ) {
+        if (empty($errorMsg) === false) {
+            fwrite(STDERR, $errorMsg);
+        }
+    }
+);

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
@@ -79,3 +79,15 @@ if (class_exists('ConditionalClass') === false) {
         }
     };
 }
+
+// Edge case: anonymous function.
+register_shutdown_function(
+    static function () use (
+        $errorMsg,
+        $errorArray
+    ) {
+        if (empty($errorMsg) === false) {
+            fwrite(STDERR, $errorMsg);
+        }
+    }
+);

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
@@ -67,4 +67,15 @@ if (class_exists('ConditionalClass') === false) {
             return true;
         }
     }
+
+    // Edge case: anonymous class with extends/implements.
+    $anonymous = new class() extends
+        BaseClass implements
+        InterfaceOne,
+        InterfaceTwo
+    {
+        public function test() {
+            return true;
+        }
+    };
 }

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc.fixed
@@ -1,0 +1,70 @@
+<?php
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+
+// Correct multi-line extends/implements.
+class CorrectClass extends BaseClass implements
+    InterfaceOne,
+    Some\Namespace\InterfaceTwo
+{
+    public function test()
+    {
+        return true;
+    }
+}
+
+// Incorrect multi-line extends/implements (should trigger errors).
+class IncorrectClass extends
+    BaseClass implements
+    \Some\Namespace\InterfaceOne,
+    InterfaceTwo
+{
+    public function test()
+    {
+        return true;
+    }
+}
+
+// Interface with multi-line extends.
+interface TestInterface extends
+    BaseInterface,
+    AnotherInterface
+{
+    public function testMethod();
+}
+
+// Edge case: constant/property names should NOT trigger multi-line logic.
+class EdgeCase
+    extends BaseClass
+    implements InterfaceOne
+{
+    public const extends = 'value';
+    public const implements = 'value';
+    private $extends = null;
+    private $implements = null;
+    public function test() {
+        $this->extends = 'test';
+        $this->implements = 'test';
+        return true;
+    }
+}
+
+// Edge case: property access should NOT trigger multi-line logic.
+function test_function() {
+    $obj = new stdClass();
+    $obj->extends = 'value';
+    $obj->implements = 'value';
+    echo $obj->extends;
+    echo $obj->implements;
+}
+
+// Conditional class with inconsistent indentation.
+if (class_exists('ConditionalClass') === false) {
+    class ConditionalClass implements
+        InterfaceOne,
+        InterfaceTwo,
+        InterfaceThree {
+        public function test() {
+            return true;
+        }
+    }
+}

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -77,6 +77,15 @@ final class ScopeIndentUnitTest extends AbstractSniffTestCase
                 63 => 1,
                 64 => 1,
                 65 => 1,
+                72 => 1,
+                73 => 1,
+                74 => 1,
+                75 => 1,
+                76 => 1,
+                77 => 1,
+                78 => 1,
+                79 => 1,
+                80 => 1,
             ];
         }
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -68,6 +68,18 @@ final class ScopeIndentUnitTest extends AbstractSniffTestCase
             return [];
         }
 
+        if ($testFile === 'ScopeIndentUnitTest.5.inc') {
+            return [
+                18 => 1,
+                19 => 1,
+                38 => 1,
+                62 => 1,
+                63 => 1,
+                64 => 1,
+                65 => 1,
+            ];
+        }
+
         return [
             7    => 1,
             10   => 1,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
Scope indentation for multi-line declarations was not working. `extends` and `implements` are "children" of the oo scope tokens (for example, class/interface), so when they appear on a separate line, they were not being indented appropriately. Additionally, their "siblings", the name tokens were ignored or sometimes skipped completely.

This PR adds tests for multi-line OO Scope Tokens, adds logic so indentation is correctly checked, and reworks the logic that was causing anonymous class tokens to be skipped.


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Generic.WhiteSpace.ScopeIndent: Fix multi-line extends/implements indentation

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
