### PR TITLE
Generic/LineLength: use different warning and errors for namespaced names

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -178,7 +178,7 @@ class LineLengthSniff implements Sniff
             && $lineLength > $this->absoluteLineLimit
         ) {
             $code = 'MaxExceeded';
-            if ($this->isLineNamespacedName($tokens, $tokens[$stackPtr]['line']) === true) {
+            if ($this->isNamespacedNameExceedingLength($tokens, $stackPtr, $this->absoluteLineLimit) === true) {
                 $code = 'NamespacedNameMaxExceeded';
             }
 
@@ -191,7 +191,7 @@ class LineLengthSniff implements Sniff
             $phpcsFile->addError($error, $stackPtr, $code, $data);
         } elseif ($lineLength > $this->lineLimit) {
             $code = 'TooLong';
-            if ($this->isLineNamespacedName($tokens, $tokens[$stackPtr]['line']) === true) {
+            if ($this->isNamespacedNameExceedingLength($tokens, $stackPtr, $this->lineLimit) === true) {
                 $code = 'NamespacedNameTooLong';
             }
 
@@ -209,21 +209,30 @@ class LineLengthSniff implements Sniff
     /**
      * Checks if a line is a namespaced name
      *
-     * @param array $tokens The token stack.
-     * @param int   $line   The line to check validate
+     * @param array $tokens    The token stack.
+     * @param int   $stackPtr  The last token on the line.
+     * @param int   $lineLimit The line limit.
      *
      * @return bool
      */
-    private function isLineNamespacedName(array $tokens, int $line): bool
+    private function isNamespacedNameExceedingLength(array $tokens, int $stackPtr, int $lineLimit): bool
     {
-        $filteredTokens = array_filter(
-            $tokens,
-            function ($token) use ($line) {
-                return $token['line'] === $line
-                    && in_array($token['code'], [T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED, T_NAME_RELATIVE], true);
-            }
-        );
+        $line = $tokens[$stackPtr]['line'];
 
-        return $filteredTokens !== [];
+        for ($i = $stackPtr; $tokens[$i]['line'] === $line; $i--) {
+            $length = ($tokens[$i]['column'] + $tokens[$i]['length'] - 1);
+
+            // Check the line limit of the namespaced name is equal or over the line length. This check accounts for the
+            // fact that namespaced names are or closed by ; or opened by ( or {.
+            if ($length >= $lineLimit
+                && ($tokens[$i]['code'] === T_NAME_QUALIFIED
+                || $tokens[$i]['code'] === T_NAME_FULLY_QUALIFIED
+                || $tokens[$i]['code'] === T_NAME_RELATIVE)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -177,21 +177,53 @@ class LineLengthSniff implements Sniff
         if ($this->absoluteLineLimit > 0
             && $lineLength > $this->absoluteLineLimit
         ) {
+            $code = 'MaxExceeded';
+            if ($this->isLineNamespacedName($tokens, $tokens[$stackPtr]['line']) === true) {
+                $code = 'NamespacedNameMaxExceeded';
+            }
+
             $data = [
                 $this->absoluteLineLimit,
                 $lineLength,
             ];
 
             $error = 'Line exceeds maximum limit of %s characters; contains %s characters';
-            $phpcsFile->addError($error, $stackPtr, 'MaxExceeded', $data);
+            $phpcsFile->addError($error, $stackPtr, $code, $data);
         } elseif ($lineLength > $this->lineLimit) {
+            $code = 'TooLong';
+            if ($this->isLineNamespacedName($tokens, $tokens[$stackPtr]['line']) === true) {
+                $code = 'NamespacedNameTooLong';
+            }
+
             $data = [
                 $this->lineLimit,
                 $lineLength,
             ];
 
             $warning = 'Line exceeds %s characters; contains %s characters';
-            $phpcsFile->addWarning($warning, $stackPtr, 'TooLong', $data);
+            $phpcsFile->addWarning($warning, $stackPtr, $code, $data);
         }
+    }
+
+
+    /**
+     * Checks if a line is a namespaced name
+     *
+     * @param array $tokens The token stack.
+     * @param int   $line   The line to check validate
+     *
+     * @return bool
+     */
+    private function isLineNamespacedName(array $tokens, int $line): bool
+    {
+        $filteredTokens = array_filter(
+            $tokens,
+            function ($token) use ($line) {
+                return $token['line'] === $line
+                    && in_array($token['code'], [T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED, T_NAME_RELATIVE], true);
+            }
+        );
+
+        return $filteredTokens !== [];
     }
 }

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -1,0 +1,37 @@
+<?php
+
+// This is just within the limit
+namespace This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLongLongLongLoong;
+
+// This is just within the absolute limit and should throw a NamespacedNameTooLong warning
+namespace This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLongLongLongLongLongLongLongLongLongLongLongLongLoooooong;
+
+// This is too long and should throw a NamespacedNameMaxExceeded error
+namespace This\Name\Space\IsGoingToBeTooLong\LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLoooong;
+
+// These are just within the limits
+use ThisReallyLong\Looooooooooooooong\UseStatement\ShouldBeNotTooLong\ClassName;
+use function ThisReallyLong\Looong\UseStatement\ShouldBeNotTooLong\functionCall;
+use const ThisReallyLong\Loooooooooong\UseStatement\ShouldBeNotTooLong\CONSTANT;
+
+// These are just a bit too long and should throw a NamespacedNameTooLong warning
+use ThisReallyLong\Long\Looooong\Looooooooooooooong\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\ClassName;
+use function ThisReallyLong\Long\Looooooong\Long\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\functionCall;
+use const ThisReallyLong\Long\Looooong\Loooooooooong\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\CONSTANT;
+
+// These are just a bit too long and should throw a NamespacedNameMaxExceeded error
+use ThisReallyLong\Long\Loooooong\Looooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\ClassName;
+use function ThisReallyLong\Long\Looong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\functionCall;
+use const ThisReallyLong\Long\Loooooooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\CONSTANT;
+
+// These are just within the limits
+echo \This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLooong\functionCall();
+new \This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLongLooong\ClassName();
+
+// These are just a bit too long and should throw a NamespacedNameTooLong warning
+echo \ThisReallyLong\Long\Looooong\Loooooooong\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\functionCall();
+new \ThisReallyLong\Long\Looooong\Loooooooooooong\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\ClassName();
+
+// These are just a bit too long and should throw a NamespacedNameMaxExceeded error
+echo \ThisReallyLong\Long\Long\Looong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\functionCall();
+new \ThisReallyLong\Long\Long\Looooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\ClassName();

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -33,5 +33,13 @@ echo \ThisReallyLong\Long\Looooong\Loooooooong\UseStatement\ThatShouldThrowAWarn
 new \ThisReallyLong\Long\Looooong\Loooooooooooong\UseStatement\ThatShouldThrowAWarning\BecauseItsNotTooLong\ClassName();
 
 // These are just a bit too long and should throw a NamespacedNameMaxExceeded error
-echo \ThisReallyLong\Long\Long\Looong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\functionCall();
-new \ThisReallyLong\Long\Long\Looooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\ClassName();
+echo \ThisReallyLong\Long\Long\Looooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\functionCall();
+new \ThisReallyLong\Long\Long\Looooooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\ClassName();
+
+// These are a bit too long but can be shortened and should throw a TooLong warning
+echo \This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLooong\functionCall('foo', 'bar', 'baz');
+new \This\Name\Space\IsGoingToBeJustWithinLimits\LongLongLongLooong\ClassName('foo', 'bar', 'baz');
+
+// These are just a bit too long but can be shortened and should throw a MaxExceeded error
+echo \ThisReallyLong\Long\Long\Looong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\functionCall('foo', 'bar', 'baz');
+new \ThisReallyLong\Long\Long\Looooooong\UseStatement\ThatShouldNotBeAllowed\AndThrowErrorsBecauseItsTooLong\ClassName('foo', 'bar', 'baz');

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -68,6 +68,8 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
                     25 => 1,
                     36 => 1,
                     37 => 1,
+                    44 => 1,
+                    45 => 1,
                 ];
 
             default:
@@ -120,6 +122,8 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
                     20 => 1,
                     32 => 1,
                     33 => 1,
+                    40 => 1,
+                    41 => 1,
                 ];
 
             default:

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -60,6 +60,15 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
             case 'LineLengthUnitTest.2.inc':
             case 'LineLengthUnitTest.3.inc':
                 return [7 => 1];
+            case 'LineLengthUnitTest.5.inc':
+                return [
+                    10 => 1,
+                    23 => 1,
+                    24 => 1,
+                    25 => 1,
+                    36 => 1,
+                    37 => 1,
+                ];
 
             default:
                 return [];
@@ -102,6 +111,15 @@ final class LineLengthUnitTest extends AbstractSniffTestCase
                 return [
                     10 => 1,
                     14 => 1,
+                ];
+            case 'LineLengthUnitTest.5.inc':
+                return [
+                    7  => 1,
+                    18 => 1,
+                    19 => 1,
+                    20 => 1,
+                    32 => 1,
+                    33 => 1,
                 ];
 
             default:


### PR DESCRIPTION
This implementation returns a different warning or error when the line is too long because of namespaced names. By using a different warning or error they can be excluded by using the following excludes.

```
<rule ref="Generic.Files.LineLength">
    <exclude name="Generic.Files.LineLength.NamespacedNameTooLong"/>
    <exclude name="Generic.Files.LineLength.NamespacedNameMaxExceeded"/>
</rule>
```

I flagged this a breaking change for the following reason:
When user excludes only the warning for line length. Their build would now break because a new warning is introduced.

## Suggested changelog entry
Use NamespacedNameTooLong warning & NamespacedNameMaxExceeded error when a namespaced name LineLength is too long or exceeded max length.

## Related issues/external references

Fixes #1365


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.