### PR TITLE
Generic/ESLint: fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,7 @@ jobs:
         run: >
           npm install -g --fund false
           csslint
-          eslint
+          eslint@9.x
           jshint
 
       # Install dependencies and handle caching in one go.
@@ -331,7 +331,7 @@ jobs:
         run: >
           npm install -g --fund false
           csslint
-          eslint
+          eslint@9.x
           jshint
 
       # Install dependencies and handle caching in one go.


### PR DESCRIPTION
# Description
The ESLint project has released a new major, which is breaking test runs for PHPCS 3.x.

As support for JS has been dropped in PHPCS 4.x anyway and the sniff is formally deprecated, investing time in making the tests cross-version compatible is not justifiable.

This commit fixes the ESLint version used in the tests to the last release in the _previous_ major. This should get the tests passing again.

Refs:
* https://eslint.org/blog/2026/02/eslint-v10.0.0-released/

## Suggested changelog entry
_N/A_