### PR TITLE
Squiz/StaticThisUsage: improve handling of anonymous functions

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -86,12 +86,15 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $tokens = $phpcsFile->getTokens();
 
         do {
-            $next = $phpcsFile->findNext([T_VARIABLE, T_ANON_CLASS], ($next + 1), $end);
+            $next = $phpcsFile->findNext([T_VARIABLE, T_CLOSURE, T_ANON_CLASS], ($next + 1), $end);
             if ($next === false) {
                 continue;
             }
 
-            if ($tokens[$next]['code'] === T_ANON_CLASS) {
+            if (($tokens[$next]['code'] === T_ANON_CLASS
+                || $tokens[$next]['code'] === T_CLOSURE)
+                && isset($tokens[$next]['scope_opener']) === true
+            ) {
                 $this->checkThisUsage($phpcsFile, $next, $tokens[$next]['scope_opener']);
                 $next = $tokens[$next]['scope_closer'];
                 continue;

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -23,7 +23,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS, T_TRAIT, T_ENUM, T_ANON_CLASS], [T_FUNCTION]);
+        parent::__construct([T_CLASS, T_TRAIT, T_ENUM, T_ANON_CLASS], [T_FUNCTION, T_CLOSURE], true);
     }
 
 
@@ -42,22 +42,28 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $tokens = $phpcsFile->getTokens();
 
         // Determine if this is a function which needs to be examined.
-        $conditions = $tokens[$stackPtr]['conditions'];
-        end($conditions);
-        $deepestScope = key($conditions);
-        if ($deepestScope !== $currScope) {
-            return;
-        }
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
+            $conditions = $tokens[$stackPtr]['conditions'];
+            end($conditions);
+            $deepestScope = key($conditions);
+            if ($deepestScope !== $currScope) {
+                return;
+            }
 
-        // Ignore abstract functions.
-        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
-            return;
-        }
+            // Ignore abstract functions.
+            if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+                return;
+            }
 
-        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
-        if ($next === false || $tokens[$next]['code'] !== T_STRING) {
-            // Not a function declaration, or incomplete.
-            return;
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
+            if ($next === false || $tokens[$next]['code'] !== T_STRING) {
+                // Not a function declaration, or incomplete.
+                return;
+            }
+
+            $type = 'method';
+        } else {
+            $type = 'closure';
         }
 
         $methodProps = $phpcsFile->getMethodProperties($stackPtr);
@@ -68,7 +74,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $next = $stackPtr;
         $end  = $tokens[$stackPtr]['scope_closer'];
 
-        $this->checkThisUsage($phpcsFile, $next, $end);
+        $this->checkThisUsage($phpcsFile, $next, $end, $type);
     }
 
 
@@ -78,10 +84,11 @@ class StaticThisUsageSniff extends AbstractScopeSniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being scanned.
      * @param int                         $next      The position of the next token to check.
      * @param int                         $end       The position of the last token to check.
+     * @param string                      $type      Type of context being checked. Either 'method' or 'closure'.
      *
      * @return void
      */
-    private function checkThisUsage(File $phpcsFile, int $next, int $end)
+    private function checkThisUsage(File $phpcsFile, int $next, int $end, string $type)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -95,7 +102,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
                 || $tokens[$next]['code'] === T_CLOSURE)
                 && isset($tokens[$next]['scope_opener']) === true
             ) {
-                $this->checkThisUsage($phpcsFile, $next, $tokens[$next]['scope_opener']);
+                $this->checkThisUsage($phpcsFile, $next, $tokens[$next]['scope_opener'], $type);
                 $next = $tokens[$next]['scope_closer'];
                 continue;
             }
@@ -104,8 +111,10 @@ class StaticThisUsageSniff extends AbstractScopeSniff
                 continue;
             }
 
-            $error = 'Usage of "$this" in static methods will cause runtime errors';
-            $phpcsFile->addError($error, $next, 'Found');
+            $error = 'Usage of "$this" in a static %s will cause runtime errors';
+            $data  = [$type];
+
+            $phpcsFile->addError($error, $next, 'Found', $data);
         } while ($next !== false);
     }
 
@@ -122,5 +131,18 @@ class StaticThisUsageSniff extends AbstractScopeSniff
      */
     protected function processTokenOutsideScope(File $phpcsFile, int $stackPtr)
     {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] !== T_CLOSURE) {
+            // We're only interested in closures when looking outside of OO.
+            return;
+        }
+
+        $methodProps = $phpcsFile->getMethodProperties($stackPtr);
+        if ($methodProps['is_static'] === false) {
+            return;
+        }
+
+        $this->checkThisUsage($phpcsFile, $stackPtr, $tokens[$stackPtr]['scope_closer'], 'closure');
     }
 }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -125,3 +125,22 @@ enum MyEnum {
         $this->doSomething();
     }
 }
+
+class NestedScopesShouldBeSkipped
+{
+    public static function examineMe() {
+        $this->shouldBeFlagged();
+
+        function nestedFunction() {
+            $this->nestedFunctionsDoNotHaveAccessToThis();
+        }
+
+        \Closure::bind(
+            function ($this) { // Cannot use $this as a param, so this should still be flagged.
+                $this->x = 1; // This is fine. $this related to the Closure class, not to the NestedScopesShouldBeSkipped class.
+            },
+            new Target(),
+            Target::class,
+        )();
+    }
+}

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -37,7 +37,7 @@ class MyClass
     }
 
     public static function func1() {
-        return function() {
+        return static function() {
             echo $this->name;
         };
     }
@@ -137,10 +137,42 @@ class NestedScopesShouldBeSkipped
 
         \Closure::bind(
             function ($this) { // Cannot use $this as a param, so this should still be flagged.
-                $this->x = 1; // This is fine. $this related to the Closure class, not to the NestedScopesShouldBeSkipped class.
+                $this->x = 1; // This is fine. $this related to the Target class, not to the NestedScopesShouldBeSkipped class.
             },
             new Target(),
             Target::class,
         )();
+
+        $callable = static function ($a, $b) {
+            return $a * $b * $this->multiplier; // This should be flagged. The closure is declared as static.
+        };
+    }
+
+    public function dontExamineMe() {
+        $this->shouldNotBeFlagged();
+
+        \Closure::bind(
+            function () {
+                $this->x = 1; // This is fine. $this related to the Target class, not to the NestedScopesShouldBeSkipped class.
+            },
+            new Target(),
+            Target::class,
+        )();
+
+        $callable = static function ($a, $b) {
+            return $a * $b * $this->multiplier; // This should be flagged. The closure is declared as static.
+        };
     }
 }
+
+function ignoreMe() {
+    $this->notAllowedButNotTheSameIssueAsThisSniffIsLookingFor();
+}
+
+$callable = function ($a, $b) {
+    return $a * $b * $this->multiplier; // This should NOT be flagged. The closure might be bound to an object.
+};
+
+$callable = static function ($a, $b) {
+    return $a * $b * $this->multiplier; // This should be flagged. The closure is declared as static.
+};

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -1,6 +1,6 @@
 <?php
-class MyClass
-{
+abstract class MyClass {
+    abstract public static function ignoreMe($a, $b);
     public static function func1()
     {
         $value = 'hello';

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -37,6 +37,7 @@ final class StaticThisUsageUnitTest extends AbstractSniffTestCase
             9   => 1,
             14  => 1,
             20  => 1,
+            41  => 1,
             61  => 1,
             69  => 1,
             76  => 1,
@@ -47,6 +48,9 @@ final class StaticThisUsageUnitTest extends AbstractSniffTestCase
             132 => 1,
             135 => 1,
             139 => 1,
+            147 => 1,
+            163 => 1,
+            177 => 1,
         ];
     }
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -37,7 +37,6 @@ final class StaticThisUsageUnitTest extends AbstractSniffTestCase
             9   => 1,
             14  => 1,
             20  => 1,
-            41  => 1,
             61  => 1,
             69  => 1,
             76  => 1,
@@ -45,6 +44,9 @@ final class StaticThisUsageUnitTest extends AbstractSniffTestCase
             84  => 1,
             99  => 1,
             125 => 1,
+            132 => 1,
+            135 => 1,
+            139 => 1,
         ];
     }
 


### PR DESCRIPTION
# Description

### Squiz/StaticThisUsage: always skip nested anonymous scope 

As things were, the `Squiz.Scope.StaticThisUsage` sniff already skipped over the body of anonymous classes when found within the body of a static OO method, to prevent false positives related to `$this` when it refers to the anonymous class.
However, the sniff did not skip over the body of an anonymous function (closure).

This is wrong, as anonymous functions can be bound to an object, in which case the closure has access to that object via `$this`.
However, whether the object is actually bound or not, is irrelevant. The closure has its own (closed) scope and doesn't have access to variables from outside the closure, so any usages of `$this` _within_ the closure would not be the "static this usage" this sniff is looking for anyway.

With that in mind, the sniff should skip over the body of closures, same as it skips over the body of anonymous classes.

Having said that, I also believe that the sniff should explicitly examine `static` closures for the use of `$this`, while it currently doesn't (false negative), but that's another matter.

Fixes #1357

Related to previous iterations:
* squizlabs/PHP_CodeSniffer#1747 - solved via 8ad3826
* squizlabs/PHP_CodeSniffer#2725

### Squiz/StaticThisUsage: examine the body of static closures 

As noted in the previous commit, closures can be declared as `static`, in which case they do not have access to `$this`.

That case was so far not considered by this sniff.

This commit changes the sniff to:
1. Also examine `T_CLOSURE` tokens.
2. Examine these when nested inside OO methods, as well as when found completely outside of OO structures.

Note: in a future iteration it should be considered to get rid of the implementation via the `AbstractScopeSniff` as that implementation actually makes the sniff _more complicated_ instead of _less complicated_.

Includes unit tests.

### Squiz/StaticThisUsage: add extra test 

... for code in the sniff previously not covered by tests.


## Suggested changelog entry
* Fixed: Squiz.Scope.StaticThisUsage: false positive for usage of `$this` in non-static closures nested in OO methods.
* Changed: Squiz.Scope.StaticThisUsage: the sniff will now also search for the use of `$this` in `static` closures.

