### PR TITLE
Generic/LowerCaseKeyword: remove unnecessary use of prepareForOutput()

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -12,7 +12,6 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\Tokens;
 
 class LowerCaseKeywordSniff implements Sniff
@@ -63,12 +62,10 @@ class LowerCaseKeywordSniff implements Sniff
                 $phpcsFile->recordMetric($stackPtr, 'PHP keyword case', 'mixed');
             }
 
-            $messageKeyword = Common::prepareForOutput($keyword);
-
             $error = 'PHP keywords must be lowercase; expected "%s" but found "%s"';
             $data  = [
-                strtolower($messageKeyword),
-                $messageKeyword,
+                strtolower($keyword),
+                $keyword,
             ];
 
             $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);


### PR DESCRIPTION
# Description

As suggested in https://github.com/squizlabs/PHP_CodeSniffer/issues/2652#issuecomment-1542372339, this PR removes an unnecessary use of `Common::prepareForOutput()` in the `Generic.PHP.LowerCaseKeyword` sniff.

`Common::prepareForOutput()` replaces spaces with a middle dot character to make whitespace visible in error messages. It was added to this sniff in commit 6ef285651 ("Better support for showing spaces and newlines"), probably as a follow-up to the multi-line `yield from` support added in squizlabs/PHP_CodeSniffer#1337 (commits ce600831b and d1a916310) as all three commits are by the same author on the same day.

For most PHP keywords, `Common::prepareForOutput()` has no effect since they don't contain whitespace. The one exception is `yield from` (T_YIELD_FROM), which, in some cases, is tokenized as a single token containing a space. In that case, `Common::prepareForOutput()` would display `yield·from`, but I would argue that showing the keyword as-is is preferable even in this case.

This changes the error output for `Yield From` from:

```
expected "yield·from" but found "Yield·From"
```

To:

```
expected "yield from" but found "Yield From"
```

## Suggested changelog entry

Changed: `Generic.PHP.LowerCaseKeyword` no longer embeds UTF-8 middle dot characters in error messages for the `yield from` keyword.

## Related issues/external references

Related https://github.com/squizlabs/PHP_CodeSniffer/issues/2652#issuecomment-1542372339


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.