### PR TITLE
GH Actions/reusable-build-phar: switch attestation action runner

### DIFF
--- a/.github/workflows/reusable-build-phar.yml
+++ b/.github/workflows/reusable-build-phar.yml
@@ -48,7 +48,7 @@ jobs:
       # Provide provenance for generated binaries.
       - name: Generate artifact attestations
         if: ${{ inputs.createAttestations == true }}
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             ${{ github.workspace }}/phpcs.phar


### PR DESCRIPTION
# Description

As of v4.0.0, the `actions/attest-build-provenance` action runner is just a wrapper around the `actions/attest` action runner, so we may as well switch to the parent action runner.

Refs:
* https://github.com/actions/attest
* https://github.com/actions/attest-build-provenance#usage
* https://github.com/actions/attest-build-provenance/releases/tag/v4.0.0
* https://github.com/actions/attest-build-provenance/releases/tag/v4.1.0

Closes #1384


## Suggested changelog entry
_N/A_