### PR TITLE
Generic/InlineControlStructure: remove unreachable if condition

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -115,10 +115,6 @@ class InlineControlStructureSniff implements Sniff
         }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($start + 1), null, true);
-        if ($nextNonEmpty === false) {
-            // Live coding or parse error.
-            return;
-        }
 
         if ($tokens[$nextNonEmpty]['code'] === T_OPEN_CURLY_BRACKET
             || $tokens[$nextNonEmpty]['code'] === T_COLON


### PR DESCRIPTION
# Description

This PR is a follow-up to #1144 and removes an unreachable if condition.

Commit 29d0be3ecbbf9975614d5da009f463a7eee804ed changed the `InlineControlStructure` sniff to make it bail early for all control structures without a body (before the sniff did that only for `while` and `for`).

Before commit 29d0be3ecbbf9975614d5da009f463a7eee804ed, `$nextNonEmpty` could be `false` as there were some scenarios where there would be no non-empty tokens after the `$stackPtr` or after the parenthesis_closer. This is the case for the else without a body in InlineControlStructureUnitTest.2.inc and the if without a body in InlineControlStructureUnitTest.5.inc.

After commit 29d0be3ecbbf9975614d5da009f463a7eee804ed, `$nextNonEmpty` cannot be `false` anymore, as cases where there are no non-empty tokens are handled before this variable is set. This happens either in line 83 when `$nextTokenIndex` is set or line 98 when `$nextTokenIndex` is not set (a control structure that is not `T_ELSE` or `T_DO` and is missing the parenthesis closer).

## Suggested changelog entry

_N/A_

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.