### PR TITLE
Generic/InlineControlStructure: fix unchecked findNext() return value

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -65,7 +65,7 @@ class InlineControlStructureSniff implements Sniff
         // Ignore the ELSE in ELSE IF. We'll process the IF part later.
         if ($tokens[$stackPtr]['code'] === T_ELSE) {
             $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
-            if ($tokens[$next]['code'] === T_IF) {
+            if ($next === false || $tokens[$next]['code'] === T_IF) {
                 return;
             }
         }


### PR DESCRIPTION
# Description

On line 67, `findNext()` searches for the first non-empty token after a `T_ELSE` to detect the `else if` pattern. When `else` is the last non-empty token in the file (live coding/parse error), `findNext()` returns `false`. This `false` value was used directly as an array index on line 68 (`$tokens[$next]`), which silently becomes `$tokens[0]`, reading the `T_OPEN_TAG` token instead. The bug was silent because the code would eventually bail out at line 81-83.

This commit adds a `$next === false` check, which also allows the sniff to bail out earlier for an `else` at end of file instead of continuing to do unnecessary work before reaching the existing live coding bail-out further down.

Existing test file InlineControlStructureUnitTest.12.inc already covers this scenario.

## Suggested changelog entry

_N/A_


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
