### PR TITLE
Sniffs: exclude space from prepareForOutput() in error messages

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -113,7 +113,7 @@ class LanguageConstructSpacingSniff implements Sniff
             }
 
             $error = 'Language constructs must be followed by a single space; expected 1 space between YIELD FROM found "%s"';
-            $data  = [Common::prepareForOutput($found)];
+            $data  = [Common::prepareForOutput($found, [' '])];
 
             if ($hasComment === true) {
                 $phpcsFile->addError($error, $stackPtr, 'IncorrectYieldFromWithComment', $data);
@@ -139,8 +139,16 @@ class LanguageConstructSpacingSniff implements Sniff
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
             $content = $tokens[($stackPtr + 1)]['content'];
             if ($content !== ' ') {
-                $error = 'Language constructs must be followed by a single space; expected 1 space but found "%s"';
-                $data  = [Common::prepareForOutput($content)];
+                if (trim($content, ' ') === '') {
+                    // Only space characters: report the count.
+                    $found = $tokens[($stackPtr + 1)]['length'] . ' spaces';
+                } else {
+                    // Contains tabs or newlines: make them visible.
+                    $found = '"' . Common::prepareForOutput($content, [' ']) . '"';
+                }
+
+                $error = 'Language constructs must be followed by a single space; expected 1 space but found %s';
+                $data  = [$found];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncorrectSingle', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -280,7 +280,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                         $data[] = strlen($gap);
                     } else {
                         // Gap contains more than just spaces: render these for better clarity.
-                        $data[] = '"' . Common::prepareForOutput($gap) . '"';
+                        $data[] = '"' . Common::prepareForOutput($gap, [' ']) . '"';
                     }
 
                     $fix = $phpcsFile->addFixableError($error, $typeHintToken, 'SpacingAfterHint', $data);


### PR DESCRIPTION
# Description

As suggested in [squizlabs/PHP_CodeSniffer#2652 (comment)](https://github.com/squizlabs/PHP_CodeSniffer/issues/2652#issuecomment-4007486179), this PR updates the `Generic.WhiteSpace.LanguageConstructSpacing` and `Squiz.Functions.FunctionDeclarationArgumentSpacing` sniffs to pass `[' ']` as the `$exclude` parameter to `Common::prepareForOutput()`, so that spaces are no longer replaced with UTF-8 middot characters (`·`) in error messages. Tabs and newlines continue to be rendered as `\t` and `\n`.

Additionally, for the `IncorrectSingle` error in `Generic.WhiteSpace.LanguageConstructSpacing`, the spaces-only case now reports a descriptive count like "found 2 spaces" instead of displaying middot characters.

The middot character in the output can break tools that pipe PHPCS output through non-UTF-8 environments.

This is a follow-up to #1379, which addressed the same issue in `Generic.PHP.LowerCaseKeyword`.


## Suggested changelog entry

Changed: `Generic.WhiteSpace.LanguageConstructSpacing` and `Squiz.Functions.FunctionDeclarationArgumentSpacing` no longer embed UTF-8 middot characters for spaces in error messages.


## Related issues/external references

Fixes squizlabs/PHP_CodeSniffer#2652


## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist

- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
