### PR TITLE
README: add link to the Requirements wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ PHP_CodeSniffer is a set of two PHP scripts; the main `phpcs` script that tokeni
 
 ## Requirements
 
-PHP_CodeSniffer requires PHP version 7.2.0 or greater, although individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options manual page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) for a list of these requirements.
+PHP_CodeSniffer requires PHP version 7.2.0 or greater. For more information about required and recommended PHP extensions, see the [Requirements wiki page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Requirements).
+
+Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options manual page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) for a list of these requirements.
 
 If you're using PHP_CodeSniffer as part of a team, or you're running it on a [CI](https://en.wikipedia.org/wiki/Continuous_integration) server, you may want to configure your project's settings [using a configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PHP_CodeSniffer is a set of two PHP scripts; the main `phpcs` script that tokeni
 
 ## Requirements
 
-PHP_CodeSniffer requires PHP version 7.2.0 or greater. For more information about required and recommended PHP extensions, see the [Requirements wiki page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Requirements).
+PHP_CodeSniffer requires PHP version 7.2.0 or greater. For more information about required and recommended PHP extensions, see the [Requirements manual page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Requirements).
 
 Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options manual page](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) for a list of these requirements.
 


### PR DESCRIPTION
# Description

As discussed in #1393, this PR adds a link to the [Requirements](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Requirements) wiki page in the README to make information about required and recommended PHP extensions more discoverable.

The existing paragraph was also split into two: one for the core PHP version and extension requirements, and another for individual sniff requirements.

## Suggested changelog entry

N/A

## Related issues/external references

Fixes #1393

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
