### PR TITLE
Composer: clarify that the PHP `libxml` extension is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require": {
         "php": ">=7.2.0",
+        "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*"

--- a/requirements.php
+++ b/requirements.php
@@ -41,6 +41,7 @@ function checkRequirements()
 
     $requiredExtensions = array(
         'tokenizer',
+        'libxml',
         'xmlwriter',
         'SimpleXML',
     );

--- a/scripts/BuildRequirementsCheckMatrix.php
+++ b/scripts/BuildRequirementsCheckMatrix.php
@@ -82,7 +82,7 @@ class BuildRequirementsCheckMatrix
      */
     private function getValidBuilds()
     {
-        $extensions = ['minimal' => 'none, tokenizer, xmlwriter, SimpleXML'];
+        $extensions = ['minimal' => 'none, tokenizer, libxml, xmlwriter, SimpleXML'];
 
         $builds = [];
         foreach ($this->validPhp as $php) {
@@ -145,10 +145,10 @@ class BuildRequirementsCheckMatrix
     private function getMissingExtensionsBuilds()
     {
         $extensions = [
-            'missing tokenizer'     => 'none, xmlwriter, SimpleXML',
-            'missing xmlwriter'     => ':xmlwriter',
-            'missing SimpleXML'     => ':SimpleXML',
-            'missing both XML exts' => 'none, tokenizer',
+            'missing tokenizer'    => 'none, xmlwriter, SimpleXML',
+            'missing xmlwriter'    => ':xmlwriter',
+            'missing SimpleXML'    => ':SimpleXML',
+            'missing all XML exts' => 'none, tokenizer',
         ];
 
         $builds = [];


### PR DESCRIPTION
# Description

The `simplexml` and `xmlwriter` extensions both need the `libxml` extension, so the requirement not being explicit was not problematic, as it was already enforced via the other two requirements.

Still, better to be explicit.

Includes adding the extension to the requirements check and the related tests.


## Suggested changelog entry
Clarified that `libxml` is a required PHP extension

## Related issues/external references

Related to #1392
