### PR TITLE
Reports/Ctrf: add CTRF reporter

### DIFF
--- a/CHANGELOG-4.x.md
+++ b/CHANGELOG-4.x.md
@@ -2,6 +2,16 @@
 
 The file documents changes to the PHP_CodeSniffer project for the 4.x series of releases.
 
+## [Unreleased]
+
+### Added
+- New `ctrf` report which emits results in the [Common Test Report Format](https://ctrf.io/) (CTRF), an open JSON standard for test results.
+    - Each violation becomes one CTRF test entry. ERROR violations have status `failed`; WARNING violations have status `other`.
+    - Files with no violations emit one `passed` test, so the report contains the full set of files that were processed.
+    - Native PHPCS metadata (sniff source, severity, fixability) is preserved via CTRF's `rawStatus`, `tags`, and `extra` fields.
+    - Output validates against the CTRF schema (e.g. `npx --package=ctrf-cli@0.0.5 -- ctrf-cli validate <file>`).
+    - Use `--report=ctrf` for stdout output, or `--report-ctrf=/path/to/file.json` to write to a file.
+
 ## [4.0.1] - 2025-11-10
 
 This release includes all improvements and bugfixes from PHP_CodeSniffer [3.13.5].

--- a/CHANGELOG-4.x.md
+++ b/CHANGELOG-4.x.md
@@ -2,7 +2,7 @@
 
 The file documents changes to the PHP_CodeSniffer project for the 4.x series of releases.
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 - New `ctrf` report which emits results in the [Common Test Report Format](https://ctrf.io/) (CTRF), an open JSON standard for test results.

--- a/src/Reports/Ctrf.php
+++ b/src/Reports/Ctrf.php
@@ -184,6 +184,12 @@ class Ctrf implements Report
         $stop     = $now;
         $duration = ($stop - $start);
 
+        // `failed` and `other` come from the authoritative parameters PHPCS
+        // passes us. `passed` is not provided as a parameter (PHPCS doesn't
+        // separately track clean files), so we count it from the cached
+        // partials, where each clean file emitted exactly one entry with
+        // `"status":"passed"`. The asymmetry is intentional: prefer the
+        // authoritative source where one exists.
         $passed = substr_count($cachedData, '"status":"passed"');
         $failed = $totalErrors;
         $other  = $totalWarnings;

--- a/src/Reports/Ctrf.php
+++ b/src/Reports/Ctrf.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * CTRF (Common Test Report Format) report for PHP_CodeSniffer.
+ *
+ * Emits results in the open standard CTRF JSON format (https://ctrf.io/),
+ * mapping each sniff violation to a CTRF test entry. ERROR violations are
+ * reported with status "failed", WARNING violations with status "other",
+ * and clean files emit a single "passed" test so the report contains the
+ * full set of files that were processed.
+ *
+ * Implementation note: PHPCS supports parallel scanning by forking child
+ * processes which each call generateFileReport() and append the captured
+ * output to a shared temp file. The parent process later reads the merged
+ * file and calls generate() once. This means we cannot share PHP state
+ * across the boundary, so:
+ *   - generateFileReport() emits each test as a self-contained JSON object
+ *     terminated by a comma. The order-independent stream concatenates
+ *     correctly regardless of which child wrote which file.
+ *   - generate() derives the run-level start time and the passed count by
+ *     scanning the merged cached data (mirroring the regex-on-cached-data
+ *     pattern used by the JUnit reporter). This is safe because json_encode
+ *     escapes inner quotes, so the only `"status":"passed"` and `"start":N`
+ *     occurrences in the cached stream are top-level keys we emitted.
+ *
+ * @author    Lucas Bustamante <lucasfbustamante@gmail.com>
+ * @copyright 2006-2023 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2023 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Reports;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+
+class Ctrf implements Report
+{
+
+    /**
+     * The CTRF specification version targeted by this reporter.
+     *
+     * @var string
+     */
+    private const SPEC_VERSION = '1.0.0';
+
+    /**
+     * Flags passed to every json_encode() call.
+     *
+     * `JSON_INVALID_UTF8_SUBSTITUTE` substitutes the Unicode replacement
+     * character (U+FFFD) for invalid UTF-8 byte sequences. Without it,
+     * a single bad byte in a violation message or filename would cause
+     * json_encode() to return false and silently drop the entire test
+     * entry, leaving the summary counts disagreeing with the tests array.
+     *
+     * @var int
+     */
+    private const JSON_FLAGS = JSON_INVALID_UTF8_SUBSTITUTE;
+
+
+    /**
+     * Generate a partial report for a single processed file.
+     *
+     * Each violation produces one CTRF test entry. A file with no violations
+     * emits a single "passed" test entry so consumers can see clean files in
+     * the report. Each emitted test is a complete JSON object terminated with
+     * a trailing comma, which is later joined and de-trailed in {@see generate()}.
+     *
+     * @param array<string, string|int|array> $report      Prepared report data.
+     *                                                     See the {@see Report} interface for a detailed specification.
+     * @param \PHP_CodeSniffer\Files\File     $phpcsFile   The file being reported on.
+     * @param bool                            $showSources Show sources?
+     * @param int                             $width       Maximum allowed line width.
+     *
+     * @return bool
+     */
+    public function generateFileReport(array $report, File $phpcsFile, bool $showSources = false, int $width = 80)
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        if (count($report['messages']) === 0) {
+            $test = [
+                'name'     => $report['filename'],
+                'status'   => 'passed',
+                'duration' => 0,
+                'start'    => $now,
+                'stop'     => $now,
+                'filePath' => $report['filename'],
+                'suite'    => [$report['filename']],
+                'type'     => 'lint',
+            ];
+            echo json_encode($test, self::JSON_FLAGS) . ',';
+            return true;
+        }
+
+        $encoding = $phpcsFile->config->encoding;
+        foreach ($report['messages'] as $line => $lineErrors) {
+            foreach ($lineErrors as $column => $colErrors) {
+                foreach ($colErrors as $error) {
+                    $message = $error['message'];
+                    if ($encoding !== 'utf-8') {
+                        $message = iconv($encoding, 'utf-8', $message);
+                    }
+
+                    if ($error['type'] === 'ERROR') {
+                        $status = 'failed';
+                    } else {
+                        $status = 'other';
+                    }
+
+                    $tags = [$error['type']];
+                    if ($error['fixable'] === true) {
+                        $tags[] = 'fixable';
+                    }
+
+                    $test = [
+                        'name'      => $error['source'] . ' at ' . $report['filename'] . " ($line:$column)",
+                        'status'    => $status,
+                        'duration'  => 0,
+                        'start'     => $now,
+                        'stop'      => $now,
+                        'message'   => $message,
+                        'filePath'  => $report['filename'],
+                        'line'      => $line,
+                        'suite'     => [$report['filename']],
+                        'rawStatus' => $error['type'],
+                        'type'      => 'lint',
+                        'tags'      => $tags,
+                        'extra'     => [
+                            'column'   => $column,
+                            'severity' => $error['severity'],
+                            'fixable'  => $error['fixable'],
+                            'source'   => $error['source'],
+                        ],
+                    ];
+                    echo json_encode($test, self::JSON_FLAGS) . ',';
+                }
+            }
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Generates a CTRF JSON report.
+     *
+     * @param string $cachedData    Any partial report data that was returned from
+     *                              generateFileReport during the run.
+     * @param int    $totalFiles    Total number of files processed during the run.
+     * @param int    $totalErrors   Total number of errors found during the run.
+     * @param int    $totalWarnings Total number of warnings found during the run.
+     * @param int    $totalFixable  Total number of problems that can be fixed.
+     * @param bool   $showSources   Show sources?
+     * @param int    $width         Maximum allowed line width.
+     * @param bool   $interactive   Are we running in interactive mode?
+     * @param bool   $toScreen      Is the report being printed to screen?
+     *
+     * @return void
+     */
+    public function generate(
+        string $cachedData,
+        int $totalFiles,
+        int $totalErrors,
+        int $totalWarnings,
+        int $totalFixable,
+        bool $showSources = false,
+        int $width = 80,
+        bool $interactive = false,
+        bool $toScreen = true
+    ) {
+        $now = (int) (microtime(true) * 1000);
+
+        // Run start = earliest per-test start in the cached partials; run stop
+        // = the moment we are generating the envelope. If no tests were emitted
+        // (e.g. no files processed), both fall back to "now".
+        $start = $now;
+        if ($cachedData !== '') {
+            $matches = [];
+            if (preg_match_all('/"start":(\d+)/', $cachedData, $matches) > 0) {
+                $start = min(array_map('intval', $matches[1]));
+            }
+        }
+
+        $stop     = $now;
+        $duration = ($stop - $start);
+
+        $passed = substr_count($cachedData, '"status":"passed"');
+        $failed = $totalErrors;
+        $other  = $totalWarnings;
+        $tests  = ($passed + $failed + $other);
+
+        $tool = [
+            'name'    => 'PHP_CodeSniffer',
+            'version' => Config::VERSION,
+        ];
+
+        $summary = [
+            'tests'    => $tests,
+            'passed'   => $passed,
+            'failed'   => $failed,
+            'skipped'  => 0,
+            'pending'  => 0,
+            'other'    => $other,
+            'suites'   => $totalFiles,
+            'start'    => $start,
+            'stop'     => $stop,
+            'duration' => $duration,
+            'extra'    => ['fixable' => $totalFixable],
+        ];
+
+        // Build the envelope as a regular PHP array and json_encode it whole.
+        // The `tests` array contains the cached per-file output, which is already
+        // a comma-separated stream of JSON objects. We splice it in via a
+        // unique placeholder so we don't have to re-decode and re-encode each
+        // test entry just to wrap the envelope around them.
+        $placeholder = '__ctrf_tests_' . bin2hex(random_bytes(8)) . '__';
+        $envelope    = [
+            'reportFormat' => 'CTRF',
+            'specVersion'  => self::SPEC_VERSION,
+            'reportId'     => $this->generateUuidV4(),
+            'timestamp'    => gmdate('Y-m-d\TH:i:s\Z'),
+            'generatedBy'  => 'PHP_CodeSniffer ' . Config::VERSION,
+            'results'      => [
+                'tool'    => $tool,
+                'summary' => $summary,
+                'tests'   => $placeholder,
+            ],
+        ];
+
+        $json = json_encode($envelope, self::JSON_FLAGS);
+        $json = str_replace('"' . $placeholder . '"', '[' . rtrim($cachedData, ',') . ']', $json);
+        echo $json . PHP_EOL;
+    }
+
+
+    /**
+     * Generate a random RFC 4122 v4 UUID.
+     *
+     * @return string
+     */
+    private function generateUuidV4()
+    {
+        $data    = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0F) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3F) | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+}

--- a/tests/Core/Reports/CtrfTest.php
+++ b/tests/Core/Reports/CtrfTest.php
@@ -78,18 +78,40 @@ final class CtrfTest extends TestCase
 
         $this->assertSame('CTRF', $report['reportFormat']);
         $this->assertSame('1.0.0', $report['specVersion']);
-        $this->assertMatchesRegularExpression(
+        $this->assertRegex(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
             $report['reportId'],
             'reportId should be a v4 UUID.'
         );
-        $this->assertMatchesRegularExpression(
+        $this->assertRegex(
             '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
             $report['timestamp']
         );
         $this->assertStringStartsWith('PHP_CodeSniffer ', $report['generatedBy']);
         $this->assertSame('PHP_CodeSniffer', $report['results']['tool']['name']);
         $this->assertSame(Config::VERSION, $report['results']['tool']['version']);
+    }
+
+
+    /**
+     * Cross-version regex assertion: assertMatchesRegularExpression() was added
+     * in PHPUnit 9.1.0 and assertRegExp() was removed in PHPUnit 10. PHPCS
+     * supports both, so dispatch by feature detection.
+     *
+     * @param string $regex   The regular expression pattern.
+     * @param string $value   The string to match against.
+     * @param string $message Optional failure message.
+     *
+     * @return void
+     */
+    private function assertRegex($regex, $value, $message = '')
+    {
+        if (method_exists($this, 'assertMatchesRegularExpression') === true) {
+            $this->assertMatchesRegularExpression($regex, $value, $message);
+        } else {
+            // PHPUnit < 9.1.0.
+            $this->assertRegExp($regex, $value, $message);
+        }
     }
 
 
@@ -289,6 +311,48 @@ final class CtrfTest extends TestCase
         $this->assertSame('WARNING', $test['rawStatus']);
         $this->assertSame(['WARNING'], $test['tags']);
         $this->assertFalse($test['extra']['fixable']);
+    }
+
+
+    /**
+     * Messages from a non-UTF-8 source file must be transcoded so the JSON output is UTF-8.
+     *
+     * @return void
+     */
+    public function testNonUtf8EncodingIsTranscoded()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('iso-8859-1');
+        // The byte 0xE9 is "é" in ISO-8859-1 but invalid as a standalone byte in UTF-8.
+        $latinMessage = "Found char \xE9 (e-acute)";
+        $report       = [
+            'filename' => '/tmp/iso.php',
+            'errors'   => 1,
+            'warnings' => 0,
+            'fixable'  => 0,
+            'messages' => [
+                1 => [
+                    1 => [
+                        [
+                            'message'  => $latinMessage,
+                            'source'   => 'X.Y.Z',
+                            'severity' => 5,
+                            'fixable'  => false,
+                            'type'     => 'ERROR',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $this->assertCount(1, $decoded);
+        // After transcoding, the message must contain the proper UTF-8 sequence for é.
+        $this->assertStringContainsString("\xC3\xA9", $decoded[0]['message']);
     }
 
 

--- a/tests/Core/Reports/CtrfTest.php
+++ b/tests/Core/Reports/CtrfTest.php
@@ -1,0 +1,448 @@
+<?php
+/**
+ * Tests for the CTRF (Common Test Report Format) reporter.
+ *
+ * @copyright 2026 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Reports;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Reports\Ctrf;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the CTRF reporter's envelope, summary aggregation, and per-violation mapping.
+ *
+ * @covers \PHP_CodeSniffer\Reports\Ctrf
+ */
+final class CtrfTest extends TestCase
+{
+
+
+    /**
+     * Decode the captured output, asserting it parses as JSON.
+     *
+     * @param string $output The captured stdout to decode.
+     *
+     * @return array<string, mixed>
+     */
+    private function decode($output)
+    {
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded, 'Reporter output should be valid JSON. Raw output: ' . $output);
+        return $decoded;
+    }
+
+
+    /**
+     * Build a File stub whose `config->encoding` is the given value.
+     *
+     * The reporter only ever reads `$phpcsFile->config->encoding`, so this
+     * minimal stub is sufficient. The constructor is disabled because File's
+     * real constructor requires a Ruleset, which we don't need for reporter
+     * tests.
+     *
+     * @param string $encoding The encoding to expose via `$file->config->encoding`.
+     *
+     * @return \PHP_CodeSniffer\Files\File
+     */
+    private function fileWithEncoding($encoding)
+    {
+        $config           = new ConfigDouble();
+        $config->encoding = $encoding;
+
+        $file         = $this->getMockBuilder(File::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $file->config = $config;
+
+        return $file;
+    }
+
+
+    /**
+     * The envelope must contain the required CTRF top-level fields with valid values.
+     *
+     * @return void
+     */
+    public function testEnvelopeShape()
+    {
+        $reporter = new Ctrf();
+        ob_start();
+        $reporter->generate('', 0, 0, 0, 0);
+        $report = $this->decode(ob_get_clean());
+
+        $this->assertSame('CTRF', $report['reportFormat']);
+        $this->assertSame('1.0.0', $report['specVersion']);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $report['reportId'],
+            'reportId should be a v4 UUID.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
+            $report['timestamp']
+        );
+        $this->assertStringStartsWith('PHP_CodeSniffer ', $report['generatedBy']);
+        $this->assertSame('PHP_CodeSniffer', $report['results']['tool']['name']);
+        $this->assertSame(Config::VERSION, $report['results']['tool']['version']);
+    }
+
+
+    /**
+     * With no inputs the summary should still be valid: all counts 0, tests array empty.
+     *
+     * @return void
+     */
+    public function testEmptySummary()
+    {
+        $reporter = new Ctrf();
+        ob_start();
+        $reporter->generate('', 0, 0, 0, 0);
+        $report = $this->decode(ob_get_clean());
+
+        $summary = $report['results']['summary'];
+        $this->assertSame(0, $summary['tests']);
+        $this->assertSame(0, $summary['passed']);
+        $this->assertSame(0, $summary['failed']);
+        $this->assertSame(0, $summary['skipped']);
+        $this->assertSame(0, $summary['pending']);
+        $this->assertSame(0, $summary['other']);
+        $this->assertSame(0, $summary['suites']);
+        $this->assertSame(0, $summary['extra']['fixable']);
+        $this->assertSame([], $report['results']['tests']);
+    }
+
+
+    /**
+     * Errors must map to summary.failed; warnings must map to summary.other.
+     *
+     * @return void
+     */
+    public function testSummaryAggregatesErrorsAndWarnings()
+    {
+        $reporter = new Ctrf();
+        ob_start();
+        // Cached data simulates 2 passed, 3 failed, 1 other test entries.
+        $cached = '{"status":"passed"},{"status":"passed"},{"status":"failed"},{"status":"failed"},{"status":"failed"},{"status":"other"},';
+        $reporter->generate($cached, 5, 3, 1, 2);
+        $report = $this->decode(ob_get_clean());
+
+        $summary = $report['results']['summary'];
+        $this->assertSame(2, $summary['passed']);
+        $this->assertSame(3, $summary['failed']);
+        $this->assertSame(1, $summary['other']);
+        $this->assertSame(6, $summary['tests']);
+        $this->assertSame(5, $summary['suites']);
+        $this->assertSame(2, $summary['extra']['fixable']);
+    }
+
+
+    /**
+     * A run-level start should be derived from the earliest per-test start in the cached data.
+     *
+     * @return void
+     */
+    public function testTimingDerivedFromCachedTests()
+    {
+        $reporter = new Ctrf();
+        ob_start();
+        $cached = '{"start":1700000000000,"stop":1700000000010},{"start":1699999999000,"stop":1700000000020},';
+        $reporter->generate($cached, 1, 0, 0, 0);
+        $report = $this->decode(ob_get_clean());
+
+        $summary = $report['results']['summary'];
+        $this->assertSame(1699999999000, $summary['start']);
+        $this->assertGreaterThanOrEqual($summary['start'], $summary['stop']);
+        $this->assertSame(($summary['stop'] - $summary['start']), $summary['duration']);
+    }
+
+
+    /**
+     * A clean file (no violations) emits one passed CTRF test entry.
+     *
+     * @return void
+     */
+    public function testCleanFileEmitsPassedTest()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+        $report   = [
+            'filename' => '/tmp/clean.php',
+            'errors'   => 0,
+            'warnings' => 0,
+            'fixable'  => 0,
+            'messages' => [],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        // Output is a comma-terminated JSON object — wrap as array to decode.
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $this->assertIsArray($decoded);
+        $this->assertCount(1, $decoded);
+
+        $test = $decoded[0];
+        $this->assertSame('/tmp/clean.php', $test['name']);
+        $this->assertSame('passed', $test['status']);
+        $this->assertSame('/tmp/clean.php', $test['filePath']);
+        $this->assertSame(['/tmp/clean.php'], $test['suite']);
+        $this->assertSame('lint', $test['type']);
+    }
+
+
+    /**
+     * An ERROR violation maps to a failed CTRF test, preserving PHPCS metadata.
+     *
+     * @return void
+     */
+    public function testErrorViolationMapsToFailed()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+        $report   = [
+            'filename' => '/tmp/dirty.php',
+            'errors'   => 1,
+            'warnings' => 0,
+            'fixable'  => 1,
+            'messages' => [
+                3 => [
+                    10 => [
+                        [
+                            'message'  => 'Expected at least 1 space before "=="',
+                            'source'   => 'PSR12.Operators.OperatorSpacing.NoSpaceBefore',
+                            'severity' => 5,
+                            'fixable'  => true,
+                            'type'     => 'ERROR',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $this->assertCount(1, $decoded);
+
+        $test = $decoded[0];
+        $this->assertSame('failed', $test['status']);
+        $this->assertSame('ERROR', $test['rawStatus']);
+        $this->assertSame('PSR12.Operators.OperatorSpacing.NoSpaceBefore at /tmp/dirty.php (3:10)', $test['name']);
+        $this->assertSame('/tmp/dirty.php', $test['filePath']);
+        $this->assertSame(3, $test['line']);
+        $this->assertSame(['/tmp/dirty.php'], $test['suite']);
+        $this->assertContains('ERROR', $test['tags']);
+        $this->assertContains('fixable', $test['tags']);
+        $this->assertSame(10, $test['extra']['column']);
+        $this->assertSame(5, $test['extra']['severity']);
+        $this->assertTrue($test['extra']['fixable']);
+        $this->assertSame('PSR12.Operators.OperatorSpacing.NoSpaceBefore', $test['extra']['source']);
+    }
+
+
+    /**
+     * A WARNING violation maps to status "other", and non-fixable warnings have no "fixable" tag.
+     *
+     * @return void
+     */
+    public function testWarningViolationMapsToOther()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+        $report   = [
+            'filename' => '/tmp/file.php',
+            'errors'   => 0,
+            'warnings' => 1,
+            'fixable'  => 0,
+            'messages' => [
+                7 => [
+                    1 => [
+                        [
+                            'message'  => 'Comment refers to a TODO task',
+                            'source'   => 'Generic.Commenting.Todo.TaskFound',
+                            'severity' => 5,
+                            'fixable'  => false,
+                            'type'     => 'WARNING',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $test    = $decoded[0];
+
+        $this->assertSame('other', $test['status']);
+        $this->assertSame('WARNING', $test['rawStatus']);
+        $this->assertSame(['WARNING'], $test['tags']);
+        $this->assertFalse($test['extra']['fixable']);
+    }
+
+
+    /**
+     * Invalid UTF-8 bytes in messages must not silently drop the test entry.
+     *
+     * Without `JSON_INVALID_UTF8_SUBSTITUTE`, json_encode() returns false for
+     * any string containing invalid UTF-8, and `echo false . ','` would emit
+     * just a stray comma. The summary count would then disagree with the
+     * actual tests array. This regression test guards against that.
+     *
+     * @return void
+     */
+    public function testInvalidUtf8DoesNotDropTest()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+        $report   = [
+            'filename' => '/tmp/x.php',
+            'errors'   => 1,
+            'warnings' => 0,
+            'fixable'  => 0,
+            'messages' => [
+                1 => [
+                    1 => [
+                        [
+                            'message'  => "bad \xC3\x28 utf8 here",
+                            'source'   => 'X.Y.Z',
+                            'severity' => 5,
+                            'fixable'  => false,
+                            'type'     => 'ERROR',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $this->assertIsArray($decoded);
+        $this->assertCount(1, $decoded, 'Test entry must not be dropped due to invalid UTF-8.');
+        $this->assertSame('failed', $decoded[0]['status']);
+        $this->assertStringContainsString("\u{FFFD}", $decoded[0]['message']);
+    }
+
+
+    /**
+     * Multiple violations on the same file each become their own test entry.
+     *
+     * @return void
+     */
+    public function testMultipleViolationsEmitMultipleTests()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+        $report   = [
+            'filename' => '/tmp/multi.php',
+            'errors'   => 1,
+            'warnings' => 1,
+            'fixable'  => 0,
+            'messages' => [
+                1 => [
+                    1 => [
+                        [
+                            'message'  => 'first',
+                            'source'   => 'Cat.A.B',
+                            'severity' => 5,
+                            'fixable'  => false,
+                            'type'     => 'ERROR',
+                        ],
+                    ],
+                ],
+                5 => [
+                    3 => [
+                        [
+                            'message'  => 'second',
+                            'source'   => 'Cat.C.D',
+                            'severity' => 5,
+                            'fixable'  => false,
+                            'type'     => 'WARNING',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        ob_start();
+        $reporter->generateFileReport($report, $file);
+        $output = ob_get_clean();
+
+        $decoded = json_decode('[' . rtrim($output, ',') . ']', true);
+        $this->assertCount(2, $decoded);
+        $this->assertSame('failed', $decoded[0]['status']);
+        $this->assertSame('other', $decoded[1]['status']);
+    }
+
+
+    /**
+     * A full end-to-end pass — file report fed back into generate() — produces
+     * a single well-formed CTRF document.
+     *
+     * @return void
+     */
+    public function testFullRoundTrip()
+    {
+        $reporter = new Ctrf();
+        $file     = $this->fileWithEncoding('utf-8');
+
+        ob_start();
+        $reporter->generateFileReport(
+            [
+                'filename' => '/tmp/clean.php',
+                'errors'   => 0,
+                'warnings' => 0,
+                'fixable'  => 0,
+                'messages' => [],
+            ],
+            $file
+        );
+        $reporter->generateFileReport(
+            [
+                'filename' => '/tmp/dirty.php',
+                'errors'   => 1,
+                'warnings' => 0,
+                'fixable'  => 0,
+                'messages' => [
+                    1 => [
+                        1 => [
+                            [
+                                'message'  => 'oops',
+                                'source'   => 'Cat.X.Y',
+                                'severity' => 5,
+                                'fixable'  => false,
+                                'type'     => 'ERROR',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $file
+        );
+        $cached = ob_get_clean();
+
+        ob_start();
+        $reporter->generate($cached, 2, 1, 0, 0);
+        $report = $this->decode(ob_get_clean());
+
+        $this->assertSame(2, $report['results']['summary']['tests']);
+        $this->assertSame(1, $report['results']['summary']['passed']);
+        $this->assertSame(1, $report['results']['summary']['failed']);
+        $this->assertSame(2, $report['results']['summary']['suites']);
+        $this->assertCount(2, $report['results']['tests']);
+    }
+}

--- a/tests/EndToEndBash/ctrf_test.sh
+++ b/tests/EndToEndBash/ctrf_test.sh
@@ -6,6 +6,7 @@ FIX_DIR="tests/EndToEndBash/Fixtures"
 # Validate that stdin is well-formed CTRF. Asserts via exit code so callers can
 # follow up with `assert_successful_code`.
 function _validate_ctrf_from_stdin() {
+  # shellcheck disable=SC2016 # PHP code is intentionally inside single quotes.
   php -r '
     $json = stream_get_contents(STDIN);
     $d    = json_decode($json, true);
@@ -48,27 +49,34 @@ function _validate_ctrf_from_stdin() {
 
 
 function test_phpcs_ctrf_report_runs_sequentially() {
-  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc; } 2>&1 )"
+  # PHPCS prints a "Time: Xms; Memory: YMB" line to stderr after the report; suppress it
+  # so the captured stdout is pure JSON.
+  OUTPUT="$(bin/phpcs --no-colors --no-cache --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" "$FIX_DIR/ClassOneWithoutStyleError.inc" 2>/dev/null)"
   echo "$OUTPUT" | _validate_ctrf_from_stdin
   assert_successful_code
 }
 
 
 function test_phpcs_ctrf_report_runs_in_parallel() {
-  OUTPUT="$( { bin/phpcs --no-cache --parallel=2 --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
+  OUTPUT="$(bin/phpcs --no-colors --no-cache --parallel=2 --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" "$FIX_DIR/ClassOneWithoutStyleError.inc" "$FIX_DIR/ClassWithTwoStyleErrors.inc" 2>/dev/null)"
   echo "$OUTPUT" | _validate_ctrf_from_stdin
   assert_successful_code
 }
 
 
 function test_phpcs_ctrf_parallel_matches_sequential() {
-  # Same input, same set of test entries (regardless of order).
-  SEQ="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
-  PAR="$( { bin/phpcs --no-cache --parallel=2 --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
+  # Same input must produce the same set of test entries regardless of order.
+  SEQ="$(bin/phpcs --no-colors --no-cache --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" "$FIX_DIR/ClassOneWithoutStyleError.inc" "$FIX_DIR/ClassWithTwoStyleErrors.inc" 2>/dev/null)"
+  PAR="$(bin/phpcs --no-colors --no-cache --parallel=2 --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" "$FIX_DIR/ClassOneWithoutStyleError.inc" "$FIX_DIR/ClassWithTwoStyleErrors.inc" 2>/dev/null)"
 
+  # shellcheck disable=SC2016 # PHP code is intentionally inside single quotes.
   RESULT="$(php -r '
-    $seq = json_decode($argv[1], true)["results"]["tests"];
-    $par = json_decode($argv[2], true)["results"]["tests"];
+    $seq = json_decode($argv[1], true)["results"]["tests"] ?? null;
+    $par = json_decode($argv[2], true)["results"]["tests"] ?? null;
+    if (!is_array($seq) || !is_array($par)) {
+      echo "INVALID";
+      exit(0);
+    }
     $proj = function ($t) { return ($t["status"] ?? "") . "|" . ($t["name"] ?? ""); };
     $seqKeys = array_map($proj, $seq);
     $parKeys = array_map($proj, $par);
@@ -82,22 +90,24 @@ function test_phpcs_ctrf_parallel_matches_sequential() {
 
 function test_phpcs_ctrf_report_to_file() {
   OUT_FILE="$(mktemp /tmp/phpcs-ctrf-XXXXXX.json)"
-  bin/phpcs --no-cache --report-ctrf="$OUT_FILE" --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc > /dev/null 2>&1
-  cat "$OUT_FILE" | _validate_ctrf_from_stdin
-  RC=$?
+  bin/phpcs --no-colors --no-cache --report-ctrf="$OUT_FILE" --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" > /dev/null 2>&1
+  CONTENTS="$(cat "$OUT_FILE")"
   rm -f "$OUT_FILE"
-  return $RC
+
+  echo "$CONTENTS" | _validate_ctrf_from_stdin
+  assert_successful_code
+  assert_contains '"reportFormat":"CTRF"' "$CONTENTS"
 }
 
 
 function test_phpcs_ctrf_clean_file_emits_passed_test() {
-  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassOneWithoutStyleError.inc; } 2>&1 )"
+  OUTPUT="$(bin/phpcs --no-colors --no-cache --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassOneWithoutStyleError.inc" 2>/dev/null)"
   assert_contains '"status":"passed"' "$OUTPUT"
 }
 
 
 function test_phpcs_ctrf_error_emits_failed_test() {
-  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc; } 2>&1 )"
+  OUTPUT="$(bin/phpcs --no-colors --no-cache --report=ctrf --standard="$ENDTOEND_STD" "$FIX_DIR/ClassWithStyleError.inc" 2>/dev/null)"
   assert_contains '"status":"failed"' "$OUTPUT"
   assert_contains '"rawStatus":"ERROR"' "$OUTPUT"
 }

--- a/tests/EndToEndBash/ctrf_test.sh
+++ b/tests/EndToEndBash/ctrf_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+ENDTOEND_STD="tests/EndToEndBash/Fixtures/endtoend.xml.dist"
+FIX_DIR="tests/EndToEndBash/Fixtures"
+
+# Validate that stdin is well-formed CTRF. Asserts via exit code so callers can
+# follow up with `assert_successful_code`.
+function _validate_ctrf_from_stdin() {
+  php -r '
+    $json = stream_get_contents(STDIN);
+    $d    = json_decode($json, true);
+    if ($d === null) {
+      fwrite(STDERR, "Output is not valid JSON\n");
+      exit(1);
+    }
+    if (($d["reportFormat"] ?? null) !== "CTRF") {
+      fwrite(STDERR, "reportFormat must be \"CTRF\"\n");
+      exit(1);
+    }
+    if (!preg_match("/^\d+\.\d+\.\d+$/", $d["specVersion"] ?? "")) {
+      fwrite(STDERR, "specVersion missing or malformed\n");
+      exit(1);
+    }
+    $summary = $d["results"]["summary"] ?? null;
+    if ($summary === null) {
+      fwrite(STDERR, "Missing results.summary\n");
+      exit(1);
+    }
+    foreach (["tests", "passed", "failed", "skipped", "pending", "other", "start", "stop"] as $k) {
+      if (!array_key_exists($k, $summary)) {
+        fwrite(STDERR, "Missing summary.$k\n");
+        exit(1);
+      }
+    }
+    if (!is_array($d["results"]["tests"] ?? null)) {
+      fwrite(STDERR, "results.tests is not an array\n");
+      exit(1);
+    }
+    // Cross-check: summary.tests must equal the actual tests array length.
+    $actual = count($d["results"]["tests"]);
+    if ($summary["tests"] !== $actual) {
+      fwrite(STDERR, "summary.tests ($summary[tests]) != actual count ($actual)\n");
+      exit(1);
+    }
+    exit(0);
+  '
+}
+
+
+function test_phpcs_ctrf_report_runs_sequentially() {
+  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc; } 2>&1 )"
+  echo "$OUTPUT" | _validate_ctrf_from_stdin
+  assert_successful_code
+}
+
+
+function test_phpcs_ctrf_report_runs_in_parallel() {
+  OUTPUT="$( { bin/phpcs --no-cache --parallel=2 --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
+  echo "$OUTPUT" | _validate_ctrf_from_stdin
+  assert_successful_code
+}
+
+
+function test_phpcs_ctrf_parallel_matches_sequential() {
+  # Same input, same set of test entries (regardless of order).
+  SEQ="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
+  PAR="$( { bin/phpcs --no-cache --parallel=2 --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc $FIX_DIR/ClassOneWithoutStyleError.inc $FIX_DIR/ClassWithTwoStyleErrors.inc; } 2>&1 )"
+
+  RESULT="$(php -r '
+    $seq = json_decode($argv[1], true)["results"]["tests"];
+    $par = json_decode($argv[2], true)["results"]["tests"];
+    $proj = function ($t) { return ($t["status"] ?? "") . "|" . ($t["name"] ?? ""); };
+    $seqKeys = array_map($proj, $seq);
+    $parKeys = array_map($proj, $par);
+    sort($seqKeys);
+    sort($parKeys);
+    echo $seqKeys === $parKeys ? "MATCH" : "MISMATCH";
+  ' "$SEQ" "$PAR")"
+  assert_equals "MATCH" "$RESULT"
+}
+
+
+function test_phpcs_ctrf_report_to_file() {
+  OUT_FILE="$(mktemp /tmp/phpcs-ctrf-XXXXXX.json)"
+  bin/phpcs --no-cache --report-ctrf="$OUT_FILE" --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc > /dev/null 2>&1
+  cat "$OUT_FILE" | _validate_ctrf_from_stdin
+  RC=$?
+  rm -f "$OUT_FILE"
+  return $RC
+}
+
+
+function test_phpcs_ctrf_clean_file_emits_passed_test() {
+  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassOneWithoutStyleError.inc; } 2>&1 )"
+  assert_contains '"status":"passed"' "$OUTPUT"
+}
+
+
+function test_phpcs_ctrf_error_emits_failed_test() {
+  OUTPUT="$( { bin/phpcs --no-cache --report=ctrf --standard=$ENDTOEND_STD $FIX_DIR/ClassWithStyleError.inc; } 2>&1 )"
+  assert_contains '"status":"failed"' "$OUTPUT"
+  assert_contains '"rawStatus":"ERROR"' "$OUTPUT"
+}


### PR DESCRIPTION
# Description

Adds a new `ctrf` report which emits results in the [Common Test Report Format](https://ctrf.io/) (CTRF), an open JSON standard for test results. The format is consumed by a growing ecosystem of CI/CD integrations (GitHub Actions summaries, dashboards, etc.), letting PHPCS lint runs feed into the same reporting pipelines as test runs.

JUnit already serves a similar purpose, but JUnit XML is older, has looser semantics, and isn't as well-supported by modern CI surfaces. CTRF is a tighter JSON schema that's validatable end-to-end.

## Minimal example

Given this fixture (`example.php`):

```php
<?php

namespace Vendor\App;

class Greeter
{
    public function hello($name) {
        return "hi $name";
    }
}
```

Running `bin/phpcs --no-colors --basepath=. --standard=PSR12 --report=ctrf example.php` produces (verbatim):

```json
{
    "reportFormat": "CTRF",
    "specVersion": "1.0.0",
    "reportId": "c236c666-f286-457f-82da-b5074eaec7ec",
    "timestamp": "2026-04-28T13:26:26Z",
    "generatedBy": "PHP_CodeSniffer 4.0.2",
    "results": {
        "tool": {
            "name": "PHP_CodeSniffer",
            "version": "4.0.2"
        },
        "summary": {
            "tests": 1,
            "passed": 0,
            "failed": 1,
            "skipped": 0,
            "pending": 0,
            "other": 0,
            "suites": 1,
            "start": 1777382786761,
            "stop": 1777382786761,
            "duration": 0,
            "extra": {
                "fixable": 1
            }
        },
        "tests": [
            {
                "name": "Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine at example.php (7:34)",
                "status": "failed",
                "duration": 0,
                "start": 1777382786761,
                "stop": 1777382786761,
                "message": "Opening brace should be on a new line",
                "filePath": "example.php",
                "line": 7,
                "suite": [
                    "example.php"
                ],
                "rawStatus": "ERROR",
                "type": "lint",
                "tags": [
                    "ERROR",
                    "fixable"
                ],
                "extra": {
                    "column": 34,
                    "severity": 5,
                    "fixable": true,
                    "source": "Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"
                }
            }
        ]
    }
}
```

## How violations map to CTRF

Each sniff violation produces one CTRF test entry (mirroring the JUnit reporter's per-violation pattern):

- **ERROR** → `status: "failed"`
- **WARNING** → `status: "other"` (CTRF's catch-all for non-pass/non-fail outcomes; the ERROR/WARNING distinction is preserved in `rawStatus`, `tags`, and `extra.severity`)
- **Clean file** → one `status: "passed"` test entry, so the report contains the full set of files that were processed

PHPCS-native metadata (sniff source, severity, fixability, column) is preserved via CTRF's `rawStatus`, `tags`, and `extra` extension fields. The output passes `npx --package=ctrf-cli@0.0.5 -- ctrf-cli validate <file>`.

Use `--report=ctrf` for stdout, or `--report-ctrf=/path/to/file.json` to write to a file. Composes with other reporters (`--report=ctrf,summary`).

## Manual testing

Beyond the unit and end-to-end tests added in this PR, I validated the reporter against a real-world codebase: WooCommerce's `plugins/woocommerce/src/Internal/` directory (443 PHP files, ~10MB of source) using the PSR12 standard. The same scan was run with `--report=json` and `--report=ctrf`, and in both serial and parallel (`--parallel=8`) modes.

| Metric                     | Serial   | Parallel (8 workers) |
| -------------------------- | -------- | -------------------- |
| Time                       | 13.2s    | 2.8s (~4.7× speedup) |
| Memory peak                | 581 MB   | 431 MB               |
| Output size                | 106 MB   | 106 MB               |
| Tests emitted              | 136,749  | 136,749              |
| Schema valid (`ctrf-cli validate` + `validate-strict`) | ✓ | ✓ |

Equivalence checks performed:

1. **Schema** — both outputs pass `ctrf-cli validate` AND `ctrf-cli validate-strict` (the strict variant enforces `additionalProperties: false`, so no extra fields anywhere). Verified on both serial and parallel outputs.
2. **Self-consistency** — `summary.tests` equals the actual `tests` array length in both runs (136,749).
3. **Serial ↔ parallel equivalence** — identical sets of test entries (matched on `(status, name, line, rawStatus, source)`); identical per-file violation counts. The fork-merge pattern preserves every entry without drops or duplicates.
4. **Cross-reporter consistency vs. the JSON reporter on the same scan**:
   - JSON: 134,138 errors + 2,611 warnings = 136,749 violations
   - CTRF: 134,138 `failed` + 2,611 `other` = 136,749 tests ✓
   - Per-file violation counts match for **443/443** files
   - Fixable count matches (131,224 in both)

Edge cases also verified:
- Filenames with backslashes, quotes, or newlines (handled via `json_encode`).
- Invalid UTF-8 bytes in messages — explicitly guarded via `JSON_INVALID_UTF8_SUBSTITUTE` to prevent silent test drops; covered by `testInvalidUtf8DoesNotDropTest`.
- Composite report mode (`--report=ctrf,summary`).
- File output mode (`--report-ctrf=/path`).

## Suggested changelog entry

> Added: New `ctrf` report which emits results in the [Common Test Report Format](https://ctrf.io/), an open JSON standard for test results. Each violation becomes one CTRF test entry (errors as `failed`, warnings as `other`). Use `--report=ctrf` for stdout output, or `--report-ctrf=/path/to/file.json` to write to a file.

## Related issues/external references

CTRF spec: https://ctrf.io/

## Types of changes

- [x] New feature _(non-breaking change which adds functionality)_

## PR checklist

- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes (10 unit tests + 6 end-to-end bash tests, including parallel-mode equivalence).
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff. _(N/A — this is a reporter, not a sniff.)_
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki. _(Happy to open one if maintainers want — wanted to check direction first.)_
