### PR TITLE
Runner: distribute files round-robin by size in parallel mode

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -116,8 +116,11 @@ class Runner
 
             // Disable caching if we are processing STDIN as we can't be 100%
             // sure where the file came from or if it will change in the future.
+            // Also disable parallel processing because STDIN is a single file
+            // held in memory and the workers can't see it across the fork.
             if ($this->config->stdin === true) {
-                $this->config->cache = false;
+                $this->config->cache    = false;
+                $this->config->parallel = 1;
             }
 
             $this->run();

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -20,6 +20,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Files\FileList;
+use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Util\Cache;
 use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\ExitCode;
@@ -397,18 +398,37 @@ class Runner
             }
         } else {
             // Batching and forking.
-            $childProcs  = [];
-            $numPerBatch = ceil($numFiles / $this->config->parallel);
+            $childProcs = [];
 
-            for ($batch = 0; $batch < $this->config->parallel; $batch++) {
-                $startAt = ($batch * $numPerBatch);
-                if ($startAt >= $numFiles) {
-                    break;
+            // Distribute files round-robin in size order so each batch
+            // ends up with a similar total workload.
+            $sortedPaths = [];
+            $todo->rewind();
+            while ($todo->valid() === true) {
+                $sortedPaths[] = $todo->key();
+                $todo->next();
+            }
+
+            $sizes = [];
+            foreach ($sortedPaths as $path) {
+                $size = @filesize($path);
+                if ($size === false) {
+                    $size = 0;
                 }
 
-                $endAt = ($startAt + $numPerBatch);
-                if ($endAt > $numFiles) {
-                    $endAt = $numFiles;
+                $sizes[$path] = $size;
+            }
+
+            usort(
+                $sortedPaths,
+                static function ($a, $b) use ($sizes) {
+                    return ($sizes[$b] - $sizes[$a]);
+                }
+            );
+
+            for ($batch = 0; $batch < $this->config->parallel; $batch++) {
+                if ($batch >= $numFiles) {
+                    break;
                 }
 
                 $childOutFilename = tempnam(sys_get_temp_dir(), 'phpcs-child');
@@ -418,12 +438,6 @@ class Runner
                 } elseif ($pid !== 0) {
                     $childProcs[$pid] = $childOutFilename;
                 } else {
-                    // Move forward to the start of the batch.
-                    $todo->rewind();
-                    for ($i = 0; $i < $startAt; $i++) {
-                        $todo->next();
-                    }
-
                     // Reset the reporter to make sure only figures from this
                     // file batch are recorded.
                     $this->reporter->totalFiles           = 0;
@@ -437,12 +451,11 @@ class Runner
                     // Process the files.
                     $pathsProcessed = [];
                     ob_start();
-                    for ($i = $startAt; $i < $endAt; $i++) {
-                        $path = $todo->key();
-                        $file = $todo->current();
+                    for ($i = $batch; $i < $numFiles; $i += $this->config->parallel) {
+                        $path = $sortedPaths[$i];
+                        $file = new LocalFile($path, $this->ruleset, $this->config);
 
                         if ($file->ignored === true) {
-                            $todo->next();
                             continue;
                         }
 
@@ -458,7 +471,6 @@ class Runner
                         $this->processFile($file);
 
                         $pathsProcessed[] = $path;
-                        $todo->next();
                     }
 
                     $debugOutput = ob_get_contents();


### PR DESCRIPTION
## Description
Solves same problem as https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/1419 but with much simplier approach. 

### Measurements:
- before: `3 mins 43 secs`
- after: **`1 min 59 secs`**

(~22 400 PHP files, 24 workers)

## Suggested changelog entry
- `--parallel` mode now better distributes work; gains up to 50% speedup


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
   - Not applicable
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
   - I believe not needed