### PR TITLE
Config: `--parallel=auto` detects the number of CPU cores

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -653,6 +653,10 @@ class Config
 
         $parallel = self::getConfigData('parallel');
         if ($parallel !== null) {
+            if ($parallel === 'auto') {
+                $parallel = self::detectNumberOfProcessors();
+            }
+
             $this->parallel = max((int) $parallel, 1);
         }
     }
@@ -1185,7 +1189,12 @@ class Config
                         break;
                     }
 
-                    $this->parallel = max((int) substr($arg, 9), 1);
+                    $value = substr($arg, 9);
+                    if ($value === 'auto') {
+                        $value = self::detectNumberOfProcessors();
+                    }
+
+                    $this->parallel = max((int) $value, 1);
                     $this->overriddenDefaults['parallel'] = true;
                 } elseif (substr($arg, 0, 9) === 'severity=') {
                     $this->errorSeverity   = (int) substr($arg, 9);
@@ -1718,6 +1727,40 @@ class Config
         self::$configDataFile = $configFile;
         self::$configData     = $phpCodeSnifferConfig;
         return self::$configData;
+    }
+
+
+    /**
+     * Detect the number of CPU cores available.
+     *
+     * @return int
+     */
+    private static function detectNumberOfProcessors()
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $count = getenv('NUMBER_OF_PROCESSORS');
+            if (is_string($count) === true && preg_match('`\d+`', $count, $matches) === 1) {
+                return max((int) $matches[0], 1);
+            }
+
+            return 1;
+        }
+
+        if (function_exists('shell_exec') === true) {
+            // Linux, macOS with coreutils, and most modern Unix-like systems.
+            $count = shell_exec('nproc 2>/dev/null');
+            if (is_string($count) === true && preg_match('`\d+`', $count, $matches) === 1) {
+                return max((int) $matches[0], 1);
+            }
+
+            // MacOS / BSD fallback.
+            $count = shell_exec('sysctl -n hw.ncpu 2>/dev/null');
+            if (is_string($count) === true && preg_match('`\d+`', $count, $matches) === 1) {
+                return max((int) $matches[0], 1);
+            }
+        }
+
+        return 1;
     }
 
 

--- a/src/Util/Help.php
+++ b/src/Util/Help.php
@@ -475,6 +475,7 @@ final class Help
             'parallel'   => [
                 'argument'    => '--parallel=<processes>',
                 'description' => 'The number of files to be checked simultaneously. Defaults to 1 (no parallel processing).' . "\n"
+                    . 'Set to "auto" to use a number of processes equal to the number of detected CPU cores.' . "\n"
                     . 'If enabled, this option only takes effect if the PHP PCNTL (Process Control) extension is available.',
             ],
             'suffix'     => [

--- a/tests/Core/Config/ParallelTest.php
+++ b/tests/Core/Config/ParallelTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Config parallel value.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Config;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Tests\Core\Config\AbstractRealConfigTestCase;
+
+/**
+ * Tests for the \PHP_CodeSniffer\Config parallel value.
+ *
+ * @covers \PHP_CodeSniffer\Config::processLongArgument
+ * @covers \PHP_CodeSniffer\Config::restoreDefaults
+ */
+final class ParallelTest extends AbstractRealConfigTestCase
+{
+
+
+    /**
+     * Test that parallel defaults to 1 when no value is provided.
+     *
+     * @return void
+     */
+    public function testParallelDefault()
+    {
+        $config = new Config(['--standard=PSR1']);
+        $this->assertSame(1, $config->parallel);
+    }
+
+
+    /**
+     * Test that parallel can be set from a CLI argument.
+     *
+     * @return void
+     */
+    public function testParallelCanBeSetFromCLI()
+    {
+        $_SERVER['argv'] = [
+            'phpcs',
+            '--standard=PSR1',
+            '--parallel=8',
+        ];
+
+        $config = new Config();
+        $this->assertSame(8, $config->parallel);
+    }
+
+
+    /**
+     * Test that parallel can be set from a CodeSniffer.conf file.
+     *
+     * @return void
+     */
+    public function testParallelCanBeSetFromConfFile()
+    {
+        $this->setStaticConfigProperty('configData', ['parallel' => '4']);
+
+        $config = new Config(['--standard=PSR1']);
+        $this->assertSame(4, $config->parallel);
+    }
+
+
+    /**
+     * Test that "auto" passed on the CLI resolves to a non-0 positive integer.
+     *
+     * @return void
+     */
+    public function testParallelInputHandlingForAutoFromCLI()
+    {
+        $_SERVER['argv'] = [
+            'phpcs',
+            '--standard=PSR1',
+            '--parallel=auto',
+        ];
+
+        $config = new Config();
+
+        // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
+        $this->assertIsInt($config->parallel);
+        $this->assertGreaterThan(0, $config->parallel);
+    }
+
+
+    /**
+     * Test that "auto" set in the CodeSniffer.conf file resolves to a non-0 positive integer.
+     *
+     * @return void
+     */
+    public function testParallelInputHandlingForAutoFromConfFile()
+    {
+        $this->setStaticConfigProperty('configData', ['parallel' => 'auto']);
+
+        $config = new Config(['--standard=PSR1']);
+
+        // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
+        $this->assertIsInt($config->parallel);
+        $this->assertGreaterThan(0, $config->parallel);
+    }
+}


### PR DESCRIPTION
# Description
- Autodetect CPUs when `--parallel=auto` is used

## Suggested changelog entry
- CLI option `--parallel` now accepts `auto` value which tries to auto-detect host CPUs


## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
   - Will do once approved
