### PR TITLE
Add test for processing hidden files

### DIFF
--- a/tests/Core/Filters/Filter/ShouldProcessHiddenFileTest.php
+++ b/tests/Core/Filters/Filter/ShouldProcessHiddenFileTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Filters\Filter class.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Filters\Filter;
+
+use PHP_CodeSniffer\Filters\Filter;
+use PHP_CodeSniffer\Tests\Core\Filters\AbstractFilterTestCase;
+use RecursiveArrayIterator;
+
+/**
+ * Tests handling of hidden files.
+ *
+ * @covers \PHP_CodeSniffer\Filters\Filter
+ */
+final class ShouldProcessHiddenFileTest extends AbstractFilterTestCase
+{
+
+
+    /**
+     * Verify that if a hidden is explicitly requested for scan, it is accepted.
+     *
+     * @return void
+     */
+    public function testHiddenFileIsAcceptedWhenExplicitlyRequested()
+    {
+        $hiddenFile = self::getBaseDir() . '/.config.php';
+
+        $fakeDI = new RecursiveArrayIterator([$hiddenFile]);
+        $filter = new Filter($fakeDI, $hiddenFile, self::$config, self::$ruleset);
+
+        $this->assertSame([$hiddenFile], $this->getFilteredResultsAsArray($filter));
+    }
+
+
+    /**
+     * Verify that when (recursively) scanning a directory, hidden files are filtered out.
+     *
+     * @return void
+     */
+    public function testHiddenFileIsRejectedWhenRecursingDirectory()
+    {
+        $baseDir      = self::getBaseDir();
+        $fakeFileList = [
+            $baseDir . '/.config.php',
+            $baseDir . '/autoload.php',
+            $baseDir . '/scripts',
+            $baseDir . '/scripts/.script-config.php',
+        ];
+        $fakeDI       = new RecursiveArrayIterator($fakeFileList);
+        $filter       = new Filter($fakeDI, self::getBaseDir(), self::$config, self::$ruleset);
+
+        $expectedOutput = [
+            $baseDir . '/autoload.php',
+            $baseDir . '/scripts',
+        ];
+
+        $this->assertSame($expectedOutput, $this->getFilteredResultsAsArray($filter));
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
This test is effectively a copy of `ShouldProcessFileWithoutExtensionTest` for hidden files.

See also #1424:

> When debugging behavior on treatment of hidden files, I discovered after some testing the following behavior:
> - on 3.x hidden files are always ignored, even if explicitly added by full path
> - on 4.x hidden files are ignored on recursive traversal, but processed when explicitly added by full path
> 
> As I could not find any change that intended to change this behavior,
> I was wondering if this was entirely intended,
> but it seems to match with the suggested approach in #395.
> For what I have gathered, I think this behavioral change was a potentially unintended side-effect of adding processing of files without extensions in 4.x.
> Given that I think this new behavior has been around since and better matches user expectation,
> I've opted to create two tests, one here (3.x) and one for 4.x (see #1425) to actively verify this behavior.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

n/a

Note: apart from some issues here and the previous repo, I could not find any proper documentation on this behavior.
It may still be noteworthy to (retroactively) mention in the 4.x changes or document in some other way,
so that this behavior is also clear towards consumers when searching for it.

## Related issues/external references

Related to #395


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
- [x] None of the above; just a new behavior test

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
