### PR TITLE
PHP on node.js, no LOCK_EX, added a method to allow cacheFileReport to append to reports when LOCK_EX is missing

### DIFF
--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -383,9 +383,9 @@ class Reporter
                     file_put_contents($this->tmpFiles[$type], '');
                 }
 
-                file_put_contents($this->tmpFiles[$type], $generatedReport, (FILE_APPEND | LOCK_EX));
+                $this->writeReport($this->tmpFiles[$type], $generatedReport);
             } else {
-                file_put_contents($report['output'], $generatedReport, (FILE_APPEND | LOCK_EX));
+                $this->writeReport($report['output'], $generatedReport);
             }
         }
 
@@ -400,6 +400,36 @@ class Reporter
             $this->totalFixableWarnings += $phpcsFile->getFixableWarningCount();
             $this->totalFixedErrors     += $phpcsFile->getFixedErrorCount();
             $this->totalFixedWarnings   += $phpcsFile->getFixedWarningCount();
+        }
+    }
+
+
+    /**
+     * WordPress Studio is running PHP on node.js and the filesystem does not support LOCK_EX
+     * so we have to catch the exception and write the file in a different way.
+     * For most systems this will just roll in and roll out using the usual file_put_contents
+     *
+     * @param string $reportFile The file that has been processed.
+     * @param string $reportData The data to be written to the report file.
+     *
+     * @return void
+     */
+    private function writeReport(string $reportFile, string $reportData)
+    {
+        try {
+            file_put_contents($reportFile, $reportData, (FILE_APPEND | LOCK_EX));
+        } catch (RuntimeException $e) {
+            if (file_exists($reportFile) === true) {
+                $fp = fopen($reportFile, 'a');
+                if ($fp !== false) {
+                    fwrite($fp, $reportData);
+                    fclose($fp);
+                } else {
+                    throw new RuntimeException('ERROR: unable to write report to file "' . $reportFile . '"');
+                }
+            } else {
+                file_put_contents($reportFile, $reportData);
+            }
         }
     }
 


### PR DESCRIPTION
# Description
WordPress Studio is running PHP on node.js and the "filesystem" does not support LOCK_EX so we have to catch the exception and write the file in a different way but only if LOCK_EX is not supported.
I am trying to validate coding standards against WordPress standards in a simple way to validate plug-ins. 
To this end I pulled PHP_CodeSniffer into a plug-in module in WordPress. 
Issue I found was the filesystem does not support LOCK_EX, therefore PHP_CodeSniffer threw an exception.
I added a method to catch this exception and handle appending to the log files generated when the exception occurs. 

### Why
I do not know how widespread PHP on Node, I believe it was only implemented last year but if it becomes more popular this issue could rear it's head again. 

### Target
Enable PHP_CodeSniffer to run in PHP on node.js. My use-case is I want to build a WordPress plugin that properly validates my code and believe PHP_CodeSniffer is part of that solution. The 'WordPress Studio' I have been using runs PHP on node.js. 

### Changes 
Added a function to handle the missing LOCK_EX on node.js and write the running reports. 
The function does the standard file_put_contents but if that throws a RuntimeException it falls back to opening the file for append and closing the file for the next time it needs to append. 
Uses the PHP in built methods to open, write, close in a succinct fashion. 

## Related issues/external references

Fixes #
I searched the issues list, this is not listed. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
