### PR TITLE
Skip case-mismatch ruleset tests on macOS

### DIFF
--- a/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
+++ b/tests/Core/Ruleset/ExpandRulesetReferenceTest.php
@@ -113,7 +113,7 @@ final class ExpandRulesetReferenceTest extends AbstractRulesetTestCase
         ];
 
         // Add tests which are only relevant for case-sensitive OSes.
-        if (PHP_OS_FAMILY !== 'Windows') {
+        if (PHP_OS_FAMILY !== 'Windows' && PHP_OS_FAMILY !== 'Darwin') {
             $data['Referencing an existing sniff, but there is a case mismatch (OS-dependent) [1]'] = [
                 'standard'    => 'ExpandRulesetReferenceCaseMismatch1Test.xml',
                 'replacement' => 'psr12.functions.nullabletypedeclaration',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description

PHPUnit test suite fails on macOS:
```
➜ phpunit --no-coverage tests/Core/Ruleset/ExpandRulesetReferenceTest.php
Note: Tests are running in "CS" mode

PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.7
Configuration: /Users/morozov/Projects/PHP_CodeSniffer/phpunit.xml.dist

.........FF                                                                                   11 / 11 (100%)

Time: 00:00.019, Memory: 10.00 MB

There were 2 failures:

1) PHP_CodeSniffer\Tests\Core\Ruleset\ExpandRulesetReferenceTest::testUnresolvableReferenceThrowsException with data set "Referencing an existing sniff, but there is a case mismatch (OS-dependent) [1]" ('ExpandRulesetReferenceCaseMis...st.xml', 'psr12.functions.nullabletyped...ration')
Failed asserting that exception of type "PHP_CodeSniffer\Exceptions\RuntimeException" is thrown.

2) PHP_CodeSniffer\Tests\Core\Ruleset\ExpandRulesetReferenceTest::testUnresolvableReferenceThrowsException with data set "Referencing an existing sniff, but there is a case mismatch (OS-dependent) [2]" ('ExpandRulesetReferenceCaseMis...st.xml', 'PSR12.Functions.ReturntypeDeclaration')
Failed asserting that exception of type "PHP_CodeSniffer\Exceptions\RuntimeException" is thrown.

FAILURES!
Tests: 11, Assertions: 19, Failures: 2, PHPUnit Deprecations: 2.
```

macOS usually uses a case-insensitive filesystem (like Windows) but it's not excluded from the test, hence the failure.


## Suggested changelog entry

Fixed test suite failure on macOS.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
