### PR TITLE
Fix bashunit install URL in E2E workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -391,9 +391,9 @@ To run the tests specific to the use of `PHP_CODESNIFFER_CBF === true`:
 
 ### Writing End-to-End Tests
 
-Bash-based end-to-end tests can be written using the [Bashunit](https://bashunit.typeddevs.com/) test tooling using version 0.26.0 or higher.
+Bash-based end-to-end tests can be written using the [Bashunit](https://bashunit.com/) test tooling using version 0.26.0 or higher.
 
-To install bashunit, follow the [installation guide](https://bashunit.typeddevs.com/installation).
+To install bashunit, follow the [installation guide](https://bashunit.com/installation).
 
 You can then run the bashunit tests on Linux/Mac/WSL, like so:
 ```bash

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: "Install bashunit"
         shell: bash
         run: |
-          curl -s https://bashunit.typeddevs.com/install.sh > install.sh
+          curl -sL https://bashunit.com/install.sh > install.sh
           chmod +x install.sh
           ./install.sh
 


### PR DESCRIPTION
# Description

The E2E test suite is currently failing with the following error ([example](https://github.com/PHPCSStandards/PHP_CodeSniffer/actions/runs/27641392561/job/81742044981)):
```
Run curl -s https://bashunit.typeddevs.com/install.sh > install.sh
  curl -s https://bashunit.typeddevs.com/install.sh > install.sh
  chmod +x install.sh
  ./install.sh
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
./install.sh: line 1: html: No such file or directory
./install.sh: line 2: syntax error near unexpected token `<'
./install.sh: line 2: `<head><title>301 Moved Permanently</title></head>
'
```

This is because the script has been moved to a different location but `curl` doesn't respect that. The solution is:
1. Update the URL
2. Add `-L` to the command to respect future redirects


## Suggested changelog entry

Fixed E2E test suite failure.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
