### PR TITLE
Generic/MultipleStatementAlignment: fix wrapped chained assignment

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -223,6 +223,12 @@ class MultipleStatementAlignmentSniff implements Sniff
                     continue;
                 }
 
+                if ($tokens[$lastCode]['line'] !== $tokens[$assign]['line']) {
+                    // Skip multiple assignments within one statement, where the next assignment operator
+                    // is on the next line. We only align the first assignment.
+                    continue;
+                }
+
                 // Make sure it is not assigned inside a condition (eg. IF, FOR).
                 if (isset($tokens[$assign]['nested_parenthesis']) === true) {
                     // If the parenthesis is on the same line as the assignment,
@@ -247,11 +253,6 @@ class MultipleStatementAlignmentSniff implements Sniff
                 null,
                 true
             );
-
-            if ($assign !== $stackPtr && $tokens[$var]['line'] !== $tokens[$assign]['line']) {
-                // A wrapped operator has no operand on its own line to align to.
-                continue;
-            }
 
             // Make sure we wouldn't break our max padding length if we
             // aligned with this statement, or they wouldn't break the max

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -248,6 +248,11 @@ class MultipleStatementAlignmentSniff implements Sniff
                 true
             );
 
+            if ($assign !== $stackPtr && $tokens[$var]['line'] !== $tokens[$assign]['line']) {
+                // A wrapped operator has no operand on its own line to align to.
+                continue;
+            }
+
             // Make sure we wouldn't break our max padding length if we
             // aligned with this statement, or they wouldn't break the max
             // padding length if they aligned with us.

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -503,6 +503,7 @@ function makeSureThatAssignmentWithinClosureAreStillHandled() {
     };
 }
 
+// Issue #1435: ignore multiple assignments in a single statement, even when multi-line.
 $wrappedChain = $foo
     = $bar;
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -502,3 +502,13 @@ function makeSureThatAssignmentWithinClosureAreStillHandled() {
         return $variables;
     };
 }
+
+$wrappedChain = $foo
+    = $bar;
+
+$shortName = $foo
+    = $bar;
+$muchLongerVariableName = $baz;
+
+$commentBeforeOperator = $foo
+/* comment */ = $bar;

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -502,3 +502,13 @@ function makeSureThatAssignmentWithinClosureAreStillHandled() {
         return $variables;
     };
 }
+
+$wrappedChain = $foo
+    = $bar;
+
+$shortName              = $foo
+    = $bar;
+$muchLongerVariableName = $baz;
+
+$commentBeforeOperator = $foo
+/* comment */ = $bar;

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -503,6 +503,7 @@ function makeSureThatAssignmentWithinClosureAreStillHandled() {
     };
 }
 
+// Issue #1435: ignore multiple assignments in a single statement, even when multi-line.
 $wrappedChain = $foo
     = $bar;
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -122,6 +122,7 @@ final class MultipleStatementAlignmentUnitTest extends AbstractSniffTestCase
             487 => 1,
             499 => 1,
             500 => 1,
+            509 => 1,
         ];
     }
 }

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -122,7 +122,7 @@ final class MultipleStatementAlignmentUnitTest extends AbstractSniffTestCase
             487 => 1,
             499 => 1,
             500 => 1,
-            509 => 1,
+            510 => 1,
         ];
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description

Fixed `Generic.Formatting.MultipleStatementAlignment` fixer failure to fix a standard violation if a chained assignment is wrapped.

Change summary:

1. Instead of aligning a wrapped assignment operator against its operand, align it against the start of its own line when it follows another assignment. This stops the fixer from looping.
2. Measure its padding from the indentation before the operator, not the whitespace after the operand.


## Suggested changelog entry

Fixed `Generic.Formatting.MultipleStatementAlignment` fixer failure to fix a standard violation if a chained assignment is wrapped.


## Related issues/external references

Fixes #1435


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
