### PR TITLE
PEAR/FunctionDeclarationSniff: use placeholders in error messages

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -399,8 +399,8 @@ class FunctionDeclarationSniff implements Sniff
         if ($tokens[$closeBracket]['line'] !== $tokens[$tokens[$closeBracket]['parenthesis_opener']]['line']
             && $tokens[$prev]['line'] === $tokens[$closeBracket]['line']
         ) {
-            $error = 'The closing parenthesis of a multi-line ' . $type . ' declaration must be on a new line';
-            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'CloseBracketLine');
+            $error = 'The closing parenthesis of a multi-line %s declaration must be on a new line';
+            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'CloseBracketLine', [$type]);
             if ($fix === true) {
                 $phpcsFile->fixer->addNewlineBefore($closeBracket);
             }
@@ -455,8 +455,8 @@ class FunctionDeclarationSniff implements Sniff
                 if ($tokens[$i]['code'] === T_WHITESPACE
                     && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
                 ) {
-                    $error = 'Blank lines are not allowed in a multi-line ' . $type . ' declaration';
-                    $fix   = $phpcsFile->addFixableError($error, $i, 'EmptyLine');
+                    $error = 'Blank lines are not allowed in a multi-line %s declaration';
+                    $fix   = $phpcsFile->addFixableError($error, $i, 'EmptyLine', [$type]);
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
@@ -495,10 +495,11 @@ class FunctionDeclarationSniff implements Sniff
                 }
 
                 if ($expectedIndent !== $foundIndent) {
-                    $error = 'Multi-line ' . $type . ' declaration not indented correctly; expected %s spaces but found %s';
+                    $error = 'Multi-line %3$s declaration not indented correctly; expected %1$s spaces but found %2$s';
                     $data  = [
                         $expectedIndent,
                         $foundIndent,
+                        $type,
                     ];
 
                     $fix = $phpcsFile->addFixableError($error, $i, 'Indent', $data);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Convert three concatenated error messages in this sniff to use placeholders.

The first two messages previously contained no placeholders and can be converted directly. For the third message, the existing placeholder ordering is preserved to avoid breaking change.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Changed:
- `PEAR.Functions.FunctionDeclaration`: improvements to error messages
  - The `CloseBracketLine` error message now exposes 1 data value (previously 0).
  - The `EmptyLine` error message now exposes 1 data value (previously 0).
  - The `Indent` error message now exposes 3 data values (previously 2).

## Related issues/external references

Related to #1240


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

Eh, maybe a chore rather than bug? :)

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

I verified 3 messages through `FunctionDeclarationUnitTest.1.inc`. And I wasn't able to find any wiki doc about sniff-specific error messages and placeholders. Maybe this's something we could document in the future?
<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->

