### PR TITLE
PSR2/ClassDeclarationSniff: use placeholders in error messages

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -215,8 +215,12 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
             $keyword = $phpcsFile->findNext(constant('T_' . strtoupper($keywordType)), ($compareToken + 1), $openingBrace);
             if ($keyword !== false) {
                 if ($tokens[$keyword]['line'] !== $tokens[$compareToken]['line']) {
-                    $error = 'The ' . $keywordType . ' keyword must be on the same line as the %s ' . $compareType;
-                    $data  = [$stackPtrType];
+                    $error = 'The %2$s keyword must be on the same line as the %1$s %3$s';
+                    $data  = [
+                        $stackPtrType,
+                        $keywordType,
+                        $compareType,
+                    ];
                     $fix   = $phpcsFile->addFixableError($error, $keyword, ucfirst($keywordType) . 'Line', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->beginChangeset();
@@ -252,8 +256,11 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                     // in the list.
                     $gap = $tokens[($keyword - 1)]['length'];
                     if ($gap !== 1) {
-                        $error = 'Expected 1 space before ' . $keywordType . ' keyword; %s found';
-                        $data  = [$gap];
+                        $error = 'Expected 1 space before %2$s keyword; %1$s found';
+                        $data  = [
+                            $gap,
+                            $keywordType,
+                        ];
                         $fix   = $phpcsFile->addFixableError($error, $keyword, 'SpaceBefore' . ucfirst($keywordType), $data);
                         if ($fix === true) {
                             $phpcsFile->fixer->replaceToken(($keyword - 1), ' ');


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Replace string concatenation with placeholders to follow the best practice.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

Changed:
- PSR2.Classes.ClassDeclaration: improvements to error messages
  - `ExtendsLine` and `ImplementsLine` error messages now expose 3 data values (previously 1).
  - `SpaceBeforeExtends` and `SpaceBeforeImplements` error messages now expose 2 data values (previously 1).

## Related issues/external references

Related to #1240


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

Changes are already covered by `PSR2/Tests/Classes/ClassDeclarationUnitTest.inc`
<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
