### PR TITLE
PSR2/SwitchDeclarationSniff: use placeholders in error messages

### DIFF
--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -83,10 +83,11 @@ class SwitchDeclarationSniff implements Sniff
 
             if ($tokens[$nextCase]['content'] !== strtolower($tokens[$nextCase]['content'])) {
                 $expected = strtolower($tokens[$nextCase]['content']);
-                $error    = strtoupper($type) . ' keyword must be lowercase; expected "%s" but found "%s"';
+                $error    = '%3$s keyword must be lowercase; expected "%1$s" but found "%2$s"';
                 $data     = [
                     $expected,
                     $tokens[$nextCase]['content'],
+                    strtoupper($type),
                 ];
 
                 $fix = $phpcsFile->addFixableError($error, $nextCase, $type . 'NotLower', $data);
@@ -114,8 +115,8 @@ class SwitchDeclarationSniff implements Sniff
             $nextCloser = $tokens[$nextCase]['scope_closer'];
             if ($tokens[$opener]['code'] === T_COLON) {
                 if ($tokens[($opener - 1)]['code'] === T_WHITESPACE) {
-                    $error = 'There must be no space before the colon in a ' . strtoupper($type) . ' statement';
-                    $fix   = $phpcsFile->addFixableError($error, $nextCase, 'SpaceBeforeColon' . strtoupper($type));
+                    $error = 'There must be no space before the colon in a %s statement';
+                    $fix   = $phpcsFile->addFixableError($error, $nextCase, 'SpaceBeforeColon' . strtoupper($type), [strtoupper($type)]);
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken(($opener - 1), '');
                     }
@@ -131,8 +132,8 @@ class SwitchDeclarationSniff implements Sniff
                 }
 
                 if ($tokens[$next]['line'] !== ($tokens[$opener]['line'] + 1)) {
-                    $error = 'The ' . strtoupper($type) . ' body must start on the line following the statement';
-                    $fix   = $phpcsFile->addFixableError($error, $nextCase, 'BodyOnNextLine' . strtoupper($type));
+                    $error = 'The %s body must start on the line following the statement';
+                    $fix   = $phpcsFile->addFixableError($error, $nextCase, 'BodyOnNextLine' . strtoupper($type), [strtoupper($type)]);
                     if ($fix === true) {
                         if ($tokens[$next]['line'] === $tokens[$opener]['line']) {
                             $padding = str_repeat(' ', ($caseAlignment + $this->indent - 1));
@@ -185,9 +186,9 @@ class SwitchDeclarationSniff implements Sniff
                     }
                 }
             } else {
-                $error = strtoupper($type) . ' statements must be defined using a colon';
+                $error = '%s statements must be defined using a colon';
                 if ($tokens[$opener]['code'] === T_SEMICOLON || $tokens[$opener]['code'] === T_CLOSE_TAG) {
-                    $fix = $phpcsFile->addFixableError($error, $nextCase, 'WrongOpener' . $type);
+                    $fix = $phpcsFile->addFixableError($error, $nextCase, 'WrongOpener' . $type, [strtoupper($type)]);
                     if ($fix === true) {
                         if ($tokens[$opener]['code'] === T_SEMICOLON) {
                             $phpcsFile->fixer->replaceToken($opener, ':');
@@ -201,7 +202,7 @@ class SwitchDeclarationSniff implements Sniff
                         $error = '%s statements must not use a braced block after the colon';
                         $phpcsFile->addError($error, $nextCase, 'WrongOpener', [strtoupper($type)]);
                     } else {
-                        $phpcsFile->addError($error, $nextCase, 'WrongOpener' . $type);
+                        $phpcsFile->addError($error, $nextCase, 'WrongOpener' . $type, [strtoupper($type)]);
                     }
                 }
             }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Replace string concatenation with placeholders to follow the best practice.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Changed:
* PSR2.ControlStructures.SwitchDeclaration: improvements to error messages
  * `defaultNotLower` and `caseNotLower` error messages now expose 3 data values (previously 2).
  * `SpaceBeforeColonDEFAULT` and `SpaceBeforeColonCASE` error messages now expose 1 data value (previously 0).
  * `BodyOnNextLineDEFAULT` and `BodyOnNextLineCASE` error messages now expose 1 data value (previously 0).
  * `WrongOpenerdefault` and `WrongOpenercase` error messages now expose 1 data value (previously 0).

## Related issues/external references

related to #1240


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

Other than the line mentioned in the comment below, everything else is already covered by `PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc`
<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
