### PR TITLE
Tokenizer/PHP: fix tokenizer error for a line comment before a ternary colon

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2670,6 +2670,11 @@ class PHP extends Tokenizer
                     // Make sure this isn't a named parameter label.
                     // Get the previous non-empty token.
                     for ($i = ($stackPtr - 1); $i > 0; $i--) {
+                        if (isset($tokens[$i]) === false) {
+                            // Ignore skipped tokens (related to PHP 8+ slash/hash comment vs new line retokenization).
+                            continue;
+                        }
+
                         if (is_array($tokens[$i]) === false
                             || isset(Tokens::EMPTY_TOKENS[$tokens[$i][0]]) === false
                         ) {
@@ -2687,6 +2692,11 @@ class PHP extends Tokenizer
                     if ($isInlineIf === true) {
                         // Make sure this isn't a return type separator.
                         for ($i = ($stackPtr - 1); $i > 0; $i--) {
+                            if (isset($tokens[$i]) === false) {
+                                // Ignore skipped tokens (related to PHP 8+ slash/hash comment vs new line retokenization).
+                                continue;
+                            }
+
                             if (is_array($tokens[$i]) === false
                                 || ($tokens[$i][0] !== T_DOC_COMMENT
                                 && $tokens[$i][0] !== T_COMMENT
@@ -2714,6 +2724,11 @@ class PHP extends Tokenizer
                             // Note that we need to skip T_STRING tokens here as these
                             // can be function names.
                             for ($i--; $i > 0; $i--) {
+                                if (isset($tokens[$i]) === false) {
+                                    // Ignore skipped tokens (related to PHP 8+ slash/hash comment vs new line retokenization).
+                                    continue;
+                                }
+
                                 if (is_array($tokens[$i]) === false
                                     || ($tokens[$i][0] !== T_DOC_COMMENT
                                     && $tokens[$i][0] !== T_COMMENT

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * The colon in the ternaries below is deliberately placed on a line without any indentation.
+ * On PHP 8+, this makes the tokenizer merge the new line after the `//`/`#` comment into the
+ * comment token and set the original new line token to `null`. The backward-walking loops in
+ * the colon retokenization need to skip over these `null` tokens.
+ * See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1418.
+ */
+
+/* testInlineElseAfterSlashComment */
+echo (5 >= 10)
+? "a"
+//
+: "b";
+
+/* testInlineElseAfterHashComment */
+$var = true
+? "a"
+#
+: "b";

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
@@ -19,3 +19,22 @@ $var = true
 ? "a"
 #
 : "b";
+
+/*
+ * The colon after the closure/arrow function below is a return type separator, not an inline else.
+ * The comment between the `function`/`fn` keyword and the parameter parenthesis creates the same
+ * `null` token, which the backward-walking loop looking for the function keyword must skip over so
+ * the return type colon is not mistaken for an inline else.
+ */
+
+/* testColonReturnTypeAfterSlashComment */
+$fn = (5 >= 10)
+? fn//
+($x): int => $x
+: "b";
+
+/* testColonReturnTypeAfterHashComment */
+$fn = (5 >= 10)
+? function#
+($x): int { return $x; }
+: "b";

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
@@ -41,3 +41,16 @@ $fn = $foo
 ($x): int { return $x; }
 /* testInlineElseAfterReturnTypeAfterHashComment */
 : "b";
+
+/*
+ * For the below test case, the tokenizer tries to distinguish between a colon for a return type
+ * of a function declaration versus the colon in an inline else.
+ * To do so, the tokenizer needs to look at what comes before the open parenthesis and could
+ * hit a comment again with the original new line token having been set to `null`.
+ * This test safeguards against a warning being thrown for that specific situation.
+ */
+
+/* testInlineElseAfterParenthesizedExpressionWithCommentBefore */
+echo true
+? // Comment before parenthesized expression.
+(5 >= 10) : "b";

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.inc
@@ -5,19 +5,20 @@
  * On PHP 8+, this makes the tokenizer merge the new line after the `//`/`#` comment into the
  * comment token and set the original new line token to `null`. The backward-walking loops in
  * the colon retokenization need to skip over these `null` tokens.
+ *
  * See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1418.
  */
 
 /* testInlineElseAfterSlashComment */
 echo (5 >= 10)
 ? "a"
-//
+// Comment.
 : "b";
 
 /* testInlineElseAfterHashComment */
 $var = true
 ? "a"
-#
+# Comment.
 : "b";
 
 /*
@@ -28,13 +29,15 @@ $var = true
  */
 
 /* testColonReturnTypeAfterSlashComment */
-$fn = (5 >= 10)
-? fn//
+$fn = $foo
+? fn // Comment.
 ($x): int => $x
+/* testInlineElseAfterReturnTypeAfterSlashComment */
 : "b";
 
 /* testColonReturnTypeAfterHashComment */
-$fn = (5 >= 10)
-? function#
+$fn = $foo
+? function # Comment.
 ($x): int { return $x; }
+/* testInlineElseAfterReturnTypeAfterHashComment */
 : "b";

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
@@ -50,8 +50,9 @@ final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
     public static function dataInlineElseAfterComment()
     {
         return [
-            'colon after slash comment' => ['/* testInlineElseAfterSlashComment */'],
-            'colon after hash comment'  => ['/* testInlineElseAfterHashComment */'],
+            'colon after slash comment'                                => ['/* testInlineElseAfterSlashComment */'],
+            'colon after hash comment'                                 => ['/* testInlineElseAfterHashComment */'],
+            'colon after parenthesized expression with comment before' => ['/* testInlineElseAfterParenthesizedExpressionWithCommentBefore */'],
         ];
     }
 

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests the retokenization of the ternary colon to T_INLINE_ELSE when preceded by a comment.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+/**
+ * Tests the retokenization of the ternary colon to T_INLINE_ELSE when preceded by a comment.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the colon of a ternary expression is tokenized as T_INLINE_ELSE when it is
+     * preceded by a slash or hash comment which is not followed by indentation.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataInlineElseAfterComment
+     *
+     * @return void
+     */
+    public function testInlineElseAfterComment($testMarker)
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_INLINE_ELSE, T_COLON]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_INLINE_ELSE, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_INLINE_ELSE (code)');
+        $this->assertSame('T_INLINE_ELSE', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_INLINE_ELSE (type)');
+    }
+
+
+    /**
+     * Data provider.
+     *
+     * @see testInlineElseAfterComment()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataInlineElseAfterComment()
+    {
+        return [
+            'colon after slash comment' => ['/* testInlineElseAfterSlashComment */'],
+            'colon after hash comment'  => ['/* testInlineElseAfterHashComment */'],
+        ];
+    }
+}

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
@@ -80,7 +80,7 @@ final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
         $this->assertSame(T_COLON, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (code)');
         $this->assertSame('T_COLON', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (type)');
 
-        // Verify the ternary else colon is retokenized correctly to .
+        // Verify the ternary else colon is retokenized correctly to T_INLINE_ELSE.
         $target     = $this->getTargetToken($markerTernaryElseColon, [T_INLINE_ELSE, T_COLON]);
         $tokenArray = $tokens[$target];
 

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
@@ -54,4 +54,42 @@ final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
             'colon after hash comment'  => ['/* testInlineElseAfterHashComment */'],
         ];
     }
+
+
+    /**
+     * Test that the return type colon of a closure or arrow function is not mistaken for an inline
+     * else when a slash or hash comment sits between the function keyword and the parameter
+     * parenthesis and is not followed by indentation.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataColonReturnTypeAfterComment
+     *
+     * @return void
+     */
+    public function testColonReturnTypeAfterComment($testMarker)
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken($testMarker, [T_INLINE_ELSE, T_COLON]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_COLON, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (code)');
+        $this->assertSame('T_COLON', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (type)');
+    }
+
+
+    /**
+     * Data provider.
+     *
+     * @see testColonReturnTypeAfterComment()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataColonReturnTypeAfterComment()
+    {
+        return [
+            'return type colon after slash comment' => ['/* testColonReturnTypeAfterSlashComment */'],
+            'return type colon after hash comment'  => ['/* testColonReturnTypeAfterHashComment */'],
+        ];
+    }
 }

--- a/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
+++ b/tests/Core/Tokenizers/PHP/CommentBeforeInlineElseTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests the retokenization of the ternary colon to T_INLINE_ELSE when preceded by a comment.
  *
- * @copyright 2025 PHPCSStandards and contributors
+ * @copyright 2026 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
@@ -61,20 +61,30 @@ final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
      * else when a slash or hash comment sits between the function keyword and the parameter
      * parenthesis and is not followed by indentation.
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param string $markerReturnTypeColon  The comment which prefaces the target token for the return type colon.
+     * @param string $markerTernaryElseColon The comment which prefaces the target token for the inline else colon.
      *
      * @dataProvider dataColonReturnTypeAfterComment
      *
      * @return void
      */
-    public function testColonReturnTypeAfterComment($testMarker)
+    public function testColonReturnTypeAfterComment($markerReturnTypeColon, $markerTernaryElseColon)
     {
-        $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken($testMarker, [T_INLINE_ELSE, T_COLON]);
+        $tokens = $this->phpcsFile->getTokens();
+
+        // Verify the return type colon is still T_COLON.
+        $target     = $this->getTargetToken($markerReturnTypeColon, [T_INLINE_ELSE, T_COLON]);
         $tokenArray = $tokens[$target];
 
         $this->assertSame(T_COLON, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (code)');
         $this->assertSame('T_COLON', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_COLON (type)');
+
+        // Verify the ternary else colon is retokenized correctly to .
+        $target     = $this->getTargetToken($markerTernaryElseColon, [T_INLINE_ELSE, T_COLON]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_INLINE_ELSE, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_INLINE_ELSE (code)');
+        $this->assertSame('T_INLINE_ELSE', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_INLINE_ELSE (type)');
     }
 
 
@@ -83,13 +93,19 @@ final class CommentBeforeInlineElseTest extends AbstractTokenizerTestCase
      *
      * @see testColonReturnTypeAfterComment()
      *
-     * @return array<string, array<string>>
+     * @return array<string, array<string, string>>
      */
     public static function dataColonReturnTypeAfterComment()
     {
         return [
-            'return type colon after slash comment' => ['/* testColonReturnTypeAfterSlashComment */'],
-            'return type colon after hash comment'  => ['/* testColonReturnTypeAfterHashComment */'],
+            'return type colon after slash comment' => [
+                'markerReturnTypeColon'  => '/* testColonReturnTypeAfterSlashComment */',
+                'markerTernaryElseColon' => '/* testInlineElseAfterReturnTypeAfterSlashComment */',
+            ],
+            'return type colon after hash comment'  => [
+                'markerReturnTypeColon'  => '/* testColonReturnTypeAfterHashComment */',
+                'markerTernaryElseColon' => '/* testInlineElseAfterReturnTypeAfterHashComment */',
+            ],
         ];
     }
 }


### PR DESCRIPTION
# Description

When a `//` or `#` line comment sits directly before the `:` of a ternary, with the comment on its own line and the `:` on the following line without indentation, tokenizing the file aborts on PHP 8+ with `An error occurred during processing; checking has been aborted. The error message was: Trying to access array offset on null` pointing into `src/Tokenizers/PHP.php`.

The root cause was diagnosed by @rodrigoprimo in the issue. On PHP 8+, `//` and `#` comment tokens no longer include the trailing new line. To account for that, the tokenizer merges the new line back into the comment token and sets the original new line token entry to `null`. The main tokenizer loop skips those `null` entries, and the `?` retokenization has skipped them since #1230, but the three backward-walking loops in the colon retokenization did not. When one of those loops reached a `null` entry, `is_array(null)` returned `false`, so the loop broke with `$i` pointing at the `null` entry, after which the `$tokens[$i][0]` access triggered the error.

This applies the same `null`-skip guard already used in the `?` retokenization to each of the three backward-walking loops, so they step over the blanked out tokens instead of breaking on them.

## Suggested changelog entry

Fixed a tokenizer error ("Trying to access array offset on null") which could occur on PHP 8+ when a `//` or `#` comment preceded the colon of a ternary expression.

## Related issues/external references

Fixes #1418
Related to #1231

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
