### PR TITLE
Squiz/SwitchDeclarationSniff: use placeholders in error messages

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -79,10 +79,11 @@ class SwitchDeclarationSniff implements Sniff
 
             if ($tokens[$nextCase]['content'] !== strtolower($tokens[$nextCase]['content'])) {
                 $expected = strtolower($tokens[$nextCase]['content']);
-                $error    = strtoupper($type) . ' keyword must be lowercase; expected "%s" but found "%s"';
+                $error    = '%3$s keyword must be lowercase; expected "%1$s" but found "%2$s"';
                 $data     = [
                     $expected,
                     $tokens[$nextCase]['content'],
+                    strtoupper($type),
                 ];
 
                 $fix = $phpcsFile->addFixableError($error, $nextCase, $type . 'NotLower', $data);
@@ -120,8 +121,12 @@ class SwitchDeclarationSniff implements Sniff
                     }
                 }
             } elseif ($tokens[$nextCase]['column'] !== $caseAlignment) {
-                $error = strtoupper($type) . ' keyword must be indented ' . $this->indent . ' spaces from SWITCH keyword';
-                $fix   = $phpcsFile->addFixableError($error, $nextCase, $type . 'Indent');
+                $error = '%s keyword must be indented %s spaces from SWITCH keyword';
+                $data  = [
+                    strtoupper($type),
+                    $this->indent,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $nextCase, $type . 'Indent', $data);
 
                 if ($fix === true) {
                     $padding = str_repeat(' ', ($caseAlignment - 1));
@@ -155,8 +160,8 @@ class SwitchDeclarationSniff implements Sniff
             }
 
             if ($tokens[($opener - 1)]['type'] === 'T_WHITESPACE') {
-                $error = 'There must be no space before the colon in a ' . strtoupper($type) . ' statement';
-                $fix   = $phpcsFile->addFixableError($error, $nextCase, 'SpaceBeforeColon' . $type);
+                $error = 'There must be no space before the colon in a %s statement';
+                $fix   = $phpcsFile->addFixableError($error, $nextCase, 'SpaceBeforeColon' . $type, [strtoupper($type)]);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($opener - 1), '');
                 }
@@ -188,8 +193,8 @@ class SwitchDeclarationSniff implements Sniff
                             }
                         }
                     } elseif ($tokens[$nextBreak]['column'] !== $caseAlignment) {
-                        $error = 'Case breaking statement must be indented ' . $this->indent . ' spaces from SWITCH keyword';
-                        $fix   = $phpcsFile->addFixableError($error, $nextBreak, 'BreakIndent');
+                        $error = 'Case breaking statement must be indented %s spaces from SWITCH keyword';
+                        $fix   = $phpcsFile->addFixableError($error, $nextBreak, 'BreakIndent', [$this->indent]);
 
                         if ($fix === true) {
                             $padding = str_repeat(' ', ($caseAlignment - 1));
@@ -312,8 +317,8 @@ class SwitchDeclarationSniff implements Sniff
                             }
                         }
                     } elseif (($nextLine - $caseLine) > 1) {
-                        $error = 'Blank lines are not allowed after ' . strtoupper($type) . ' statements';
-                        $phpcsFile->addError($error, $nextCase, 'SpacingAfter' . $type);
+                        $error = 'Blank lines are not allowed after %s statements';
+                        $phpcsFile->addError($error, $nextCase, 'SpacingAfter' . $type, [strtoupper($type)]);
                     }
                 }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Replace string concatenation with placeholders to follow the best practice.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

Changed:
- Squiz.ControlStructures.SwitchDeclaration: improvements to error messages
    - `CaseNotLower` and `DefaultNotLower` error messages now expose 3 data values (previously 2).
    - `CaseIndent` and `DefaultIndent` error messages now expose 2 data values (previously 0).
    - `SpaceBeforeColonCase` and `SpaceBeforeColonDefault` error messages now expose 1 data value (previously 0).
    - `BreakIndent` error message now exposes 1 data value (previously 0).
    - `SpacingAfterCase` and `SpacingAfterDefault` error messages now expose 1 data value (previously 0).
## Related issues/external references

related to #1240


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

Changes are already covered by `Squiz/Tests/ControlStructures/SwitchDeclarationUnitTest.inc`
<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
