### PR TITLE
Generators: display a message when no documentation is available

### DIFF
--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -19,6 +19,7 @@ use DOMDocument;
 use DOMElement;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\GeneratorException;
+use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class HTML extends Generator
 {
@@ -133,6 +134,7 @@ class HTML extends Generator
     public function generate()
     {
         if (empty($this->docFiles) === true) {
+            StatusWriter::write('No documentation is available for the requested sniff(s).');
             return;
         }
 

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -14,6 +14,7 @@ namespace PHP_CodeSniffer\Generators;
 use DOMElement;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\GeneratorException;
+use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Markdown extends Generator
 {
@@ -31,6 +32,7 @@ class Markdown extends Generator
     public function generate()
     {
         if (empty($this->docFiles) === true) {
+            StatusWriter::write('No documentation is available for the requested sniff(s).');
             return;
         }
 

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -14,9 +14,30 @@
 namespace PHP_CodeSniffer\Generators;
 
 use DOMElement;
+use PHP_CodeSniffer\Util\Writers\StatusWriter;
 
 class Text extends Generator
 {
+
+
+    /**
+     * Generates the documentation for a standard.
+     *
+     * @return void
+     * @see    processSniff()
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\GeneratorException If there is no <documentation> element
+     *                                                        in the XML document.
+     */
+    public function generate()
+    {
+        if (empty($this->docFiles) === true) {
+            StatusWriter::write('No documentation is available for the requested sniff(s).');
+            return;
+        }
+
+        parent::generate();
+    }
 
 
     /**

--- a/tests/Core/Generators/HTMLTest.php
+++ b/tests/Core/Generators/HTMLTest.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Generators\HTML;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\HTMLDouble;
+use PHP_CodeSniffer\Tests\Core\StatusWriterTestHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class HTMLTest extends TestCase
 {
+    use StatusWriterTestHelper;
 
 
     /**
@@ -81,10 +83,6 @@ final class HTMLTest extends TestCase
     public static function dataDocs()
     {
         return [
-            'Standard without docs'            => [
-                'standard'       => __DIR__ . '/NoDocsTest.xml',
-                'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputEmpty.txt',
-            ],
             'Standard with one doc file'       => [
                 'standard'       => __DIR__ . '/OneDocTest.xml',
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputOneDoc.html',
@@ -94,6 +92,27 @@ final class HTMLTest extends TestCase
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputStructureDocs.html',
             ],
         ];
+    }
+
+
+    /**
+     * Test that a message is shown when no documentation is available for the requested sniffs.
+     *
+     * @return void
+     */
+    public function testShowsMessageWhenNoDocumentationAvailable()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__ . '/NoDocsTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $this->expectNoStdoutOutput();
+
+        $generator = new HTMLDouble($ruleset);
+        $generator->generate();
+
+        $this->assertStderrOutputSameString('No documentation is available for the requested sniff(s).' . PHP_EOL);
     }
 
 

--- a/tests/Core/Generators/MarkdownTest.php
+++ b/tests/Core/Generators/MarkdownTest.php
@@ -13,6 +13,7 @@ use PHP_CodeSniffer\Generators\Markdown;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
 use PHP_CodeSniffer\Tests\Core\Generators\Fixtures\MarkdownDouble;
+use PHP_CodeSniffer\Tests\Core\StatusWriterTestHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class MarkdownTest extends TestCase
 {
+    use StatusWriterTestHelper;
 
 
     /**
@@ -81,10 +83,6 @@ final class MarkdownTest extends TestCase
     public static function dataDocs()
     {
         return [
-            'Standard without docs'            => [
-                'standard'       => __DIR__ . '/NoDocsTest.xml',
-                'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputEmpty.txt',
-            ],
             'Standard with one doc file'       => [
                 'standard'       => __DIR__ . '/OneDocTest.xml',
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputOneDoc.md',
@@ -94,6 +92,27 @@ final class MarkdownTest extends TestCase
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputStructureDocs.md',
             ],
         ];
+    }
+
+
+    /**
+     * Test that a message is shown when no documentation is available for the requested sniffs.
+     *
+     * @return void
+     */
+    public function testShowsMessageWhenNoDocumentationAvailable()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__ . '/NoDocsTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $this->expectNoStdoutOutput();
+
+        $generator = new MarkdownDouble($ruleset);
+        $generator->generate();
+
+        $this->assertStderrOutputSameString('No documentation is available for the requested sniff(s).' . PHP_EOL);
     }
 
 

--- a/tests/Core/Generators/TextTest.php
+++ b/tests/Core/Generators/TextTest.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Tests\Core\Generators;
 use PHP_CodeSniffer\Generators\Text;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHP_CodeSniffer\Tests\Core\StatusWriterTestHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,6 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class TextTest extends TestCase
 {
+    use StatusWriterTestHelper;
 
 
     /**
@@ -59,10 +61,6 @@ final class TextTest extends TestCase
     public static function dataDocs()
     {
         return [
-            'Standard without docs'            => [
-                'standard'       => __DIR__ . '/NoDocsTest.xml',
-                'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputEmpty.txt',
-            ],
             'Standard with one doc file'       => [
                 'standard'       => __DIR__ . '/OneDocTest.xml',
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputOneDoc.txt',
@@ -72,6 +70,27 @@ final class TextTest extends TestCase
                 'pathToExpected' => __DIR__ . '/Expectations/ExpectedOutputStructureDocs.txt',
             ],
         ];
+    }
+
+
+    /**
+     * Test that a message is shown when no documentation is available for the requested sniffs.
+     *
+     * @return void
+     */
+    public function testShowsMessageWhenNoDocumentationAvailable()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__ . '/NoDocsTest.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $this->expectNoStdoutOutput();
+
+        $generator = new Text($ruleset);
+        $generator->generate();
+
+        $this->assertStderrOutputSameString('No documentation is available for the requested sniff(s).' . PHP_EOL);
     }
 
 


### PR DESCRIPTION
# Description

When `--generator` is used but none of the targeted sniffs ship a documentation file, all three generators (`Text`, `HTML` and `Markdown`) currently produce no output at all, which makes it look like the command failed or that the arguments were wrong. Following the discussion with @jrfnl referenced in the issue, this makes the generators print a short message to `STDERR` in that case instead of staying silent.

The message is sent to `STDERR` so it doesn't end up in redirected output such as `phpcs --generator=HTML > docs.html`. I kept it to a single summary line and left the exit code unchanged, but I'm happy to switch to a per-sniff message or a different stream if you'd prefer.

## Suggested changelog entry

Added: the `Text`, `HTML` and `Markdown` documentation generators now print a message to `STDERR` when no documentation is available for the requested sniffs, instead of producing no output at all.

## Related issues/external references

Fixes #1410

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
