### PR TITLE
Squiz/MultiLineFunctionDeclaration: use placeholders in error messages

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -186,8 +186,8 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
         if ($tokens[$openBracket]['line'] !== $tokens[$closeBracket]['line']) {
             $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($openBracket + 1), null, true);
             if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
-                $error = 'The first parameter of a multi-line ' . $type . ' declaration must be on the line after the opening bracket';
-                $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix . 'FirstParamSpacing');
+                $error = 'The first parameter of a multi-line %s declaration must be on the line after the opening bracket';
+                $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix . 'FirstParamSpacing', [$type]);
                 if ($fix === true) {
                     if ($tokens[$next]['line'] === $tokens[$openBracket]['line']) {
                         $phpcsFile->fixer->addNewline($openBracket);
@@ -233,8 +233,8 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
 
             $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             if ($tokens[$next]['line'] === $tokens[$i]['line']) {
-                $error = 'Multi-line ' . $type . ' declarations must define one parameter per line';
-                $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix . 'OneParamPerLine');
+                $error = 'Multi-line %s declarations must define one parameter per line';
+                $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix . 'OneParamPerLine', [$type]);
                 if ($fix === true) {
                     $phpcsFile->fixer->addNewline($i);
                 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the branch for the current major when submitting your pull request.

For older majors, only CI, security and PHP runtime compatibility patches will be accepted for up to a year
after the new major was released.
If your patch falls into this category, target the oldest major still accepting patches.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Replace string concatenation with placeholders to follow the best practice.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->

Changed:
- Squiz.Functions.MultiLineFunctionDeclarationSniff: improvements to error messages
  - `FirstParamSpacing` and `UseFirstParamSpacing` error messages now expose 1 data value (previously 0).
  - `OneParamPerLine` and `UseOneParamPerLine` error messages now expose 1 data value (previously 0).

## Related issues/external references

related to #1240


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.

Changes are already covered by `Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc`
<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
