### PR TITLE
Tokenizer/PHP: fix error when a const name is the last non-empty token in a file

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2580,7 +2580,7 @@ class PHP extends Tokenizer
                             break;
                         }
 
-                        if ($tokens[$i] === '=') {
+                        if (isset($tokens[$i]) === true && $tokens[$i] === '=') {
                             $preserveTstring        = true;
                             $insideConstDeclaration = false;
                         }

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2580,7 +2580,7 @@ class PHP extends Tokenizer
                             break;
                         }
 
-                        if (isset($tokens[$i]) === true && $tokens[$i] === '=') {
+                        if ($i < $numTokens && $tokens[$i] === '=') {
                             $preserveTstring        = true;
                             $insideConstDeclaration = false;
                         }

--- a/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.inc
+++ b/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// This should be the only test in the file.
+// Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1451
+
+/* testConstNameAsLastToken */
+const A

--- a/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.inc
+++ b/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.inc
@@ -1,7 +1,8 @@
 <?php
 
-// This should be the only test in the file.
+// Testing that the tokenizer doesn't cause an "Undefined array key" warning.
+// Intentional parse error. This should be the only test in the file.
 // Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1451
 
-/* testConstNameAsLastToken */
+/* testLiveCoding */
 const A

--- a/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Tests that a const declaration name which is the last non-empty token in a file is tokenized without an error.
+ *
+ * @copyright 2025 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+/**
+ * Tests that a const declaration name which is the last non-empty token in a file is tokenized without an error.
+ *
+ * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+ */
+final class ConstNameAsLastTokenTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Test that the name of a const declaration which is the last non-empty token in a file is tokenized as T_STRING.
+     *
+     * @return void
+     */
+    public function testConstNameAsLastToken()
+    {
+        $tokens     = $this->phpcsFile->getTokens();
+        $target     = $this->getTargetToken('/* testConstNameAsLastToken */', [T_STRING]);
+        $tokenArray = $tokens[$target];
+
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_STRING (type)');
+    }
+}

--- a/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.php
+++ b/tests/Core/Tokenizers/PHP/ConstNameAsLastTokenTest.php
@@ -2,7 +2,7 @@
 /**
  * Tests that a const declaration name which is the last non-empty token in a file is tokenized without an error.
  *
- * @copyright 2025 PHPCSStandards and contributors
+ * @copyright 2026 PHPCSStandards and contributors
  * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
@@ -20,14 +20,14 @@ final class ConstNameAsLastTokenTest extends AbstractTokenizerTestCase
 
 
     /**
-     * Test that the name of a const declaration which is the last non-empty token in a file is tokenized as T_STRING.
+     * Test that an unfinished constant declaration during live coding doesn't cause an "Undefined array key" error.
      *
      * @return void
      */
-    public function testConstNameAsLastToken()
+    public function testLiveCoding()
     {
         $tokens     = $this->phpcsFile->getTokens();
-        $target     = $this->getTargetToken('/* testConstNameAsLastToken */', [T_STRING]);
+        $target     = $this->getTargetToken('/* testLiveCoding */', [T_STRING]);
         $tokenArray = $tokens[$target];
 
         $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_STRING (code)');


### PR DESCRIPTION
# Description

Tokenizing a file where the name of a `const` declaration is the last non-empty token, such as `const A` with nothing after it, aborts with `An error occurred during processing; checking has been aborted. The error message was: Undefined array key ... in src/Tokenizers/PHP.php`.

The loop that walks forward from the constant name to the next non-empty token ends with `$i` equal to `$numTokens` when there is no such token, and the `$tokens[$i] === '='` check that follows then reads an index that does not exist. This adds an `isset()` guard so the check only runs when that token is present.

## Suggested changelog entry

Fixed a tokenizer error ("Undefined array key") which could occur when the name of a `const` declaration was the last non-empty token in a file.

## Related issues/external references

Fixes #1451

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
