### PR TITLE
Tokenizer/PHP: prevent fatal error on unfinished const declaration

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2580,7 +2580,7 @@ class PHP extends Tokenizer
                             break;
                         }
 
-                        if ($tokens[$i] === '=') {
+                        if ($i < $numTokens && $tokens[$i] === '=') {
                             $preserveTstring        = true;
                             $insideConstDeclaration = false;
                         }

--- a/tests/Core/Tokenizers/PHP/TypedConstantParseErrorTest.inc
+++ b/tests/Core/Tokenizers/PHP/TypedConstantParseErrorTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the only test in the file.
+const A

--- a/tests/Core/Tokenizers/PHP/TypedConstantParseErrorTest.php
+++ b/tests/Core/Tokenizers/PHP/TypedConstantParseErrorTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests that an unfinished constant declaration during live coding doesn't cause a fatal error.
+ *
+ * @author    Sai Asish Y <say.apm35@gmail.com>
+ * @copyright 2026 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizers\PHP;
+
+use PHP_CodeSniffer\Tests\Core\Tokenizers\AbstractTokenizerTestCase;
+
+final class TypedConstantParseErrorTest extends AbstractTokenizerTestCase
+{
+
+
+    /**
+     * Verify that an unfinished constant declaration during live coding doesn't cause an "Undefined array key" error.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testUnfinishedConstant()
+    {
+        $tokens = $this->phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken('/* testLiveCoding */', [T_STRING, T_CONST], 'A');
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as ' . $tokenArray['type'] . ', not T_STRING');
+    }
+}


### PR DESCRIPTION
# Description

When the name of a `const` declaration is the last non-empty token in a file (for example `const A` with nothing following it during live coding), PHPCS aborts tokenizing with a fatal `Undefined array key` error.

Inside the const-declaration handling in `PHP::tokenize()`, a loop walks forward from the constant name looking for the next non-empty token to check whether it is an `=`. When the constant name is the last non-empty token, the loop ends with `$i === $numTokens`, so the following `$tokens[$i] === '='` check reads an index that does not exist. This adds an `$i < $numTokens` guard before that access, so the file tokenizes without a fatal error.

## Suggested changelog entry

Fixed a fatal "Undefined array key" error when tokenizing a file where a `const` name is the last non-empty token.

## Related issues/external references

Fixes #1451


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
