### PR TITLE
Generic/ScopeIndent: don't flag comments between stacked case statements

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -832,6 +832,40 @@ class ScopeIndentSniff implements Sniff
                 $exact = false;
             }
 
+            // A comment between two CASE or DEFAULT statements that share a scope
+            // closer (fall-through cases) belongs with the following statement, so
+            // it is allowed to use that statement's indent instead of the body
+            // indent of the preceding case.
+            if ($checkToken !== null
+                && $exact === false
+                && $tokens[$checkToken]['code'] === T_COMMENT
+                && empty($tokens[$checkToken]['conditions']) === false
+            ) {
+                $lastCondition = $tokens[$checkToken]['conditions'];
+                end($lastCondition);
+                $lastCondition = key($lastCondition);
+                if (($tokens[$lastCondition]['code'] === T_CASE
+                    || $tokens[$lastCondition]['code'] === T_DEFAULT)
+                    && isset($tokens[$lastCondition]['scope_closer']) === true
+                ) {
+                    $nextStatement = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($checkToken + 1), null, true);
+                    if ($nextStatement !== false
+                        && ($tokens[$nextStatement]['code'] === T_CASE
+                        || $tokens[$nextStatement]['code'] === T_DEFAULT)
+                        && isset($tokens[$nextStatement]['scope_closer']) === true
+                        && $tokens[$nextStatement]['scope_closer'] === $tokens[$lastCondition]['scope_closer']
+                    ) {
+                        $checkIndent = ($currentIndent - $this->indent);
+
+                        if ($this->debug === true) {
+                            $line = $tokens[$checkToken]['line'];
+                            StatusWriter::write("Comment between fall-through case statements found on line $line");
+                            StatusWriter::write("=> checking indent of $checkIndent; main indent remains at $currentIndent", 1);
+                        }
+                    }
+                }
+            }
+
             if ($checkIndent === null) {
                 $checkIndent = $currentIndent;
             }

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -1648,6 +1648,17 @@ $result = array_map(
     $data
 );
 
+// Issue #1460: Comments between stacked case/default statements should not be flagged.
+switch ($foo) {
+    case 1:
+    // Comment.
+    case 2:
+    // Comment.
+    default:
+        echo 'Test';
+        break;
+}
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -1648,6 +1648,17 @@ $result = array_map(
     $data
 );
 
+// Issue #1460: Comments between stacked case/default statements should not be flagged.
+switch ($foo) {
+    case 1:
+    // Comment.
+    case 2:
+    // Comment.
+    default:
+        echo 'Test';
+        break;
+}
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
@@ -1648,6 +1648,17 @@ $result = array_map(
 	$data
 );
 
+// Issue #1460: Comments between stacked case/default statements should not be flagged.
+switch ($foo) {
+	case 1:
+	// Comment.
+	case 2:
+	// Comment.
+	default:
+		echo 'Test';
+		break;
+}
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
@@ -1648,6 +1648,17 @@ $result = array_map(
 	$data
 );
 
+// Issue #1460: Comments between stacked case/default statements should not be flagged.
+switch ($foo) {
+	case 1:
+	// Comment.
+	case 2:
+	// Comment.
+	default:
+		echo 'Test';
+		break;
+}
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -169,10 +169,10 @@ final class ScopeIndentUnitTest extends AbstractSniffTestCase
             1527 => 1,
             1529 => 1,
             1530 => 1,
-            1659 => 1,
-            1660 => 1,
-            1661 => 1,
-            1662 => 1,
+            1670 => 1,
+            1671 => 1,
+            1672 => 1,
+            1673 => 1,
         ];
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
`Generic.WhiteSpace.ScopeIndent` flagged the indentation of a comment placed between two stacked `case`/`default` labels that share a body. It expected the comment to line up with the case body instead of with the labels.

The sniff already drops the indent it checks once it reaches a fall-through `case`/`default` label, but a comment sitting right before such a label was still checked against the previous case's body indent. It now checks against the label indent, so a comment aligned with the labels no longer errors, and a comment at the body indent still passes too.

## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->
Fixed:
- `Generic.WhiteSpace.ScopeIndent`: a comment between stacked `case`/`default` statements is no longer flagged as incorrectly indented.

## Related issues/external references

Fixes #1460

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
