### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -49,6 +49,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: "error_reporting=-1, display_errors=On, display_startup_errors=On"
           coverage: none
+        env:
+          fail-fast: true
 
       - name: "Install bashunit"
         shell: bash

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -59,6 +59,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: 'error_reporting=-1, display_errors=On, display_startup_errors=On'
           coverage: none
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/reusable-build-phar.yml
+++ b/.github/workflows/reusable-build-phar.yml
@@ -43,6 +43,8 @@ jobs:
           php-version: ${{ inputs.phpVersion }}
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, display_startup_errors=On
+        env:
+          fail-fast: true
 
       - name: Build the phar files
         run: php scripts/build-phar.php

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,6 +204,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+        env:
+          fail-fast: true
 
       - name: "DEBUG: show libxml loaded version (php)"
         run: php -r 'echo "libxml loaded version = ", LIBXML_LOADED_VERSION, PHP_EOL;'
@@ -322,6 +324,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+        env:
+          fail-fast: true
 
       # This action also handles the caching of the dependencies.
       - name: Set up node

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -151,6 +151,8 @@ jobs:
           php-version: 'latest'
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Create a PHP file
         run: echo '<?php echo "Hello, World!";' > hello.php
@@ -222,6 +224,8 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On
           coverage: none
           tools: phive
+        env:
+          fail-fast: true
 
       - name: Install
         run: >


### PR DESCRIPTION
# Description
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional


## Suggested changelog entry
_N/A_