### PR TITLE
Update for new GPG keys

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -142,6 +142,11 @@ jobs:
           FINGERPRINT: "0xD91D86963AF3A29B6520462297B02DD8E5071466"
         run: gpg --keyserver "hkps://keys.openpgp.org" --recv-keys "$FINGERPRINT"
 
+      - name: Download public key (Aug 2026)
+        env:
+          FINGERPRINT: "0x5CB4F778BF9BC4FB67AE511D96E91A992CF22FF4"
+        run: gpg --keyserver "hkps://keys.openpgp.org" --recv-keys "$FINGERPRINT"
+
       - name: Verify signature of the PHAR file
         run: gpg --verify ${{ steps.source.outputs.FILE }}.asc ${{ steps.source.outputs.FILE }}
 
@@ -230,7 +235,7 @@ jobs:
       - name: Install
         run: >
           phive install ${{ matrix.pharfile }} --copy
-          --trust-gpg-keys 689DAD778FF08760E046228BA978220305CD5C32,D91D86963AF3A29B6520462297B02DD8E5071466
+          --trust-gpg-keys 689DAD778FF08760E046228BA978220305CD5C32,D91D86963AF3A29B6520462297B02DD8E5071466,5CB4F778BF9BC4FB67AE511D96E91A992CF22FF4
 
       - name: "DEBUG: List files"
         run: ls -R

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ php phpcbf.phar -h
 ```
 
 These Phars are signed with the official Release key for PHPCS with the
-fingerprint `D91D 8696 3AF3 A29B 6520 4622 97B0 2DD8 E507 1466`.
+fingerprint `5CB4 F778 BF9B C4FB 67AE 511D 96E9 1A99 2CF2 2FF4`.
 
 As of PHP_CodeSniffer 3.10.3, the provenance of PHAR files associated with a release can be verified via [GitHub Artifact Attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) using the [GitHub CLI tool](https://cli.github.com/) with the following command: `gh attestation verify [phpcs|phpcbf].phar -o PHPCSStandards`.
 
@@ -78,8 +78,8 @@ You will then be able to run PHP_CodeSniffer from the vendor bin directory:
 ### Phive
 If you use Phive, you can install PHP_CodeSniffer as a project tool using the following commands:
 ```bash
-phive install --trust-gpg-keys D91D86963AF3A29B6520462297B02DD8E5071466 phpcs
-phive install --trust-gpg-keys D91D86963AF3A29B6520462297B02DD8E5071466 phpcbf
+phive install --trust-gpg-keys 5CB4F778BF9BC4FB67AE511D96E91A992CF22FF4 phpcs
+phive install --trust-gpg-keys 5CB4F778BF9BC4FB67AE511D96E91A992CF22FF4 phpcbf
 ```
 You will then be able to run PHP_CodeSniffer from the `tools` directory:
 ```bash


### PR DESCRIPTION
# Description

The GPG key used to expire every year - as per the recommendation, so a new key has been generated and uploaded to the openpgp database.
However, as we now _also_ use attestations for the generated PHAR files, the expiry period for the new GPG key has been set to five years.


## Suggested changelog entry
- The GPG signature for the PHAR files has been rotated. The new fingerprint is: 5CB4F778BF9BC4FB67AE511D96E91A992CF22FF4.

## Notes

* This PR should be rebased once new releases using the new key have been created.
* The PR should only be merged after that as otherwise the "Verify release" workflow will fail (as it would try to check older releases against the new key)
* The changelog entry should be included in the changelog for the 3.13.6/4.0.2 releases though.