### PR TITLE
Reports/*blame: properly escape file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vendor/
 /phpstan.neon
 /phpunit.xml
 /tests/EndToEnd/Fixtures/*.fixed
+/tests/Core/Reports/GitBlame/newfile.txt
+/tests/Core/Reports/GitBlame/$*
+/tests/Core/Reports/GitBlame/-*

--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -70,7 +70,7 @@ class Gitblame extends VersionControl
         $cwd = getcwd();
 
         chdir(dirname($filename));
-        $command = 'git blame --date=short "'.basename($filename).'" 2>&1';
+        $command = 'git blame --date=short -- '.escapeshellarg(basename($filename)).' 2>&1';
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -89,7 +89,7 @@ class Hgblame extends VersionControl
             throw new DeepExitException($error, 3);
         }
 
-        $command = 'hg blame -u -d -v "'.$filename.'" 2>&1';
+        $command = 'hg blame -u -d -v '.escapeshellarg($filename).' 2>&1';
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;

--- a/src/Reports/Svnblame.php
+++ b/src/Reports/Svnblame.php
@@ -53,7 +53,7 @@ class Svnblame extends VersionControl
      */
     protected function getBlameContent($filename)
     {
-        $command = 'svn blame "'.$filename.'" 2>&1';
+        $command = 'svn blame '.escapeshellarg($filename).' 2>&1';
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;

--- a/tests/Core/Reports/GitBlame/GitblameEscapesFilenameTest.php
+++ b/tests/Core/Reports/GitBlame/GitblameEscapesFilenameTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests a security fix for the Gitblame report generation.
+ *
+ * @copyright 2026 PHPCSStandards and contributors
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Reports\Gitblame;
+
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Runner;
+use PHP_CodeSniffer\Tests\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Tests a security fix for the Gitblame report generation.
+ *
+ * @coversNothing
+ *
+ * @group Windows
+ */
+final class GitblameEscapesFilenameTest extends TestCase
+{
+
+    /**
+     * Name of the file which, if the filename of the temporary file is escaped correctly, should *not* be created.
+     *
+     * @var string
+     */
+    const DO_NOT_CREATE_FILE = 'newfile.txt';
+
+    /**
+     * List of files to clean up after running the tests in this file.
+     *
+     * @var string[]
+     */
+    private static $temporaryFiles = [];
+
+
+    /**
+     * Skip these tests when in CBF mode.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function maybeSkipTests()
+    {
+        if (PHP_CODESNIFFER_CBF === true) {
+            $this->markTestSkipped('This test needs CS mode to run');
+        }
+
+    }//end maybeSkipTests()
+
+
+    /**
+     * Clean up temporary file(s).
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function deleteTemporaryFiles()
+    {
+        foreach (self::$temporaryFiles as $file) {
+            @unlink($file);
+        }
+
+        @unlink(__DIR__.'/'.self::DO_NOT_CREATE_FILE);
+
+    }//end deleteTemporaryFiles()
+
+
+    /**
+     * Test that arbitrary shell commands injected in a filename do not get executed.
+     *
+     * @return void
+     */
+    public function testFilenameEscaping()
+    {
+        $untrustedFileName = __DIR__.'/$(touch '.self::DO_NOT_CREATE_FILE.').php';
+        $this->createTemporaryFile($untrustedFileName);
+
+        $errorMessage = sprintf('File %s should not exist at the start of the test', self::DO_NOT_CREATE_FILE);
+        $this->verifyFileDoesNotExist(__DIR__.'/'.self::DO_NOT_CREATE_FILE, $errorMessage);
+
+        // While we do not care about the report output for this particular test,
+        // we do need to be sure that the correct report ran.
+        // This regex checks that the output complies with the expected format for a 'Gitblame' reports.
+        $this->expectOutputRegex('`\bUnknown\s+\([0-9\.]+\)\s+\(100\)\s+3\b`');
+
+        $args = [
+            '--standard=PSR12',
+            '--basepath='.__DIR__,
+            '--report=Gitblame',
+            '--report-width=80',
+            $untrustedFileName,
+        ];
+        $this->generateReport($args);
+
+        $errorMessage = sprintf('File %s should not exist at the end of the test', self::DO_NOT_CREATE_FILE);
+        $this->verifyFileDoesNotExist(__DIR__.'/'.self::DO_NOT_CREATE_FILE, $errorMessage);
+
+    }//end testFilenameEscaping()
+
+
+    /**
+     * Test that file names are not interpreted as parameters/CLI flags to the external command 'git'.
+     *
+     * @param string $fileName Name for a temporary file to create to run the test with.
+     *
+     * @dataProvider dataFilenameParameterInjection
+     *
+     * @return void
+     */
+    public function testFilenameParameterInjection($fileName)
+    {
+        $this->createTemporaryFile($fileName);
+
+        // This line of the report is different when 'git' interprets the
+        // filename as a parameter.
+        $this->expectOutputRegex('`\bUnknown\s+\(100\)\s+\(100\)\s+3\b`');
+
+        $args = [
+            '--standard=PSR12',
+            '--basepath='.__DIR__,
+            '--report=Gitblame',
+            '--report-width=80',
+            $fileName,
+        ];
+        $this->generateReport($args);
+
+    }//end testFilenameParameterInjection()
+
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataFilenameParameterInjection()
+    {
+        return [
+            'long-option'  => [__DIR__.'/--invalid-parameter-injection.php'],
+
+            // At time of writing, there is no valid '-V' option to git(1).
+            'short-option' => [__DIR__.'/-V.php'],
+        ];
+
+    }//end dataFilenameParameterInjection()
+
+
+    /**
+     * Create a temporary file with the supplied name.
+     *
+     * The created file MUST contain at least one error when run against the PSR12 ruleset,
+     * as otherwise the report code will not be reached.
+     *
+     * @param string $fileName Name of the file to create.
+     *
+     * @return void
+     */
+    private function createTemporaryFile($fileName)
+    {
+        file_put_contents($fileName, "<?php\n\$x=1 ;\n");
+        $this->assertFileExists($fileName, 'Failed to write temporary test file');
+
+        // Remember that the file was created for clean up later.
+        self::$temporaryFiles[] = $fileName;
+
+    }//end createTemporaryFile()
+
+
+    /**
+     * Helper function to run PHPCS and create the report with the provided CLI arguments.
+     *
+     * @param array<string> $args CLI arguments to pass to the PHPCS run.
+     *
+     * @return void
+     */
+    private function generateReport($args)
+    {
+        $runner          = new Runner();
+        $runner->config  = new ConfigDouble($args);
+        $runner->ruleset = new Ruleset($runner->config);
+
+        $reflMethod = new ReflectionMethod($runner, 'run');
+        (PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
+        $result = $reflMethod->invoke($runner);
+
+        $this->assertGreaterThan(0, $result, 'File scanned did not contain any errors. Report code would not be triggered');
+
+        $runner->reporter->printReports();
+
+    }//end generateReport()
+
+
+    /**
+     * Helper function for PHPUnit cross-version compatible checking whether a file does *not* exist.
+     *
+     * @param string $fileName     Name of the file to check.
+     * @param string $errorMessage Message to display if the file unexpectedly would be found.
+     *
+     * @return void
+     */
+    public function verifyFileDoesNotExist($fileName, $errorMessage)
+    {
+        if (method_exists($this, 'assertFileDoesNotExist') === true) {
+            // PHPUnit 9.1.0+.
+            $this->assertFileDoesNotExist($fileName, $errorMessage);
+        } else {
+            // PHPUnit < 9.1.0.
+            $this->assertFileNotExists($fileName, $errorMessage);
+        }
+
+    }//end verifyFileDoesNotExist()
+
+
+}//end class


### PR DESCRIPTION
# Description

This is a security fix for CVE-2026-67434 / [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq).

Properly escape file names before calling the `* blame` command to prevent maliciously crafted file names from potentially running system commands.

Includes tests covering the fix for the `Gitblame` report.

Notes:
* While the issue could not be reproduced on Windows with the current proof of concept, the tests should still _run_ on Windows to safeguard that the issue continues to not exist for Windows.
* Similar test(s) should be added for the `Hgblame` and `Svnblame` reports, but that will require installing those version management systems in a GitHub Actions environment and possibly initializing a system directory for Mercurial/Svn to be able to recognize the file for use with the `blame` command. This needs further investigation, which is outside the scope of the security fix.


## Suggested changelog entry
- **SECURITY FIX**: Running PHP_CodeSniffer over untrusted files, for example, in a CI pipeline that scans pull requests, or on a developer machine reviewing third-party code, could result in attacker-controlled shell commands being executed when the `Gitblame`, `Hgblame` or `Svnblame` report(s) would process a file whose name contains shell metacharacters. [#1473]
    - Users using the default `Full` report, or any of the other non-*blame reports, are not affected.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

