### PR TITLE
Remark: skip flaky URL

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -16,7 +16,8 @@
                 "^https?://github\\.com/[A-Za-z0-9-]+",
                 "^https?://pear\\.php\\.net/bugs/bug\\.php\\?id=[0-9]+",
                 "^https?://x\\.com/PHP_CodeSniffer",
-                "^https?://stackoverflow\\.com/questions/tagged/phpcodesniffer"
+                "^https?://stackoverflow\\.com/questions/tagged/phpcodesniffer",
+                "^https://coveralls\\.io/github/PHPCSStandards/PHP_CodeSniffer"
             ],
             "deadOrAliveOptions": {
                 "maxRetries": 3


### PR DESCRIPTION

# Description

The URL is correct, but Coveralls has started to throw 403s for automatic scans.


## Suggested changelog entry
_N/A_