### PR TITLE
Tests/FileList: don't return from a constructor

### DIFF
--- a/tests/FileList.php
+++ b/tests/FileList.php
@@ -72,8 +72,6 @@ class FileList
 
         $this->fileIterator = new RegexIterator($flattened, $filter);
 
-        return $this;
-
     }//end __construct()
 
 


### PR DESCRIPTION
# Description

Ref: https://wiki.php.net/rfc/deprecate-return-value-from-construct

## Suggested changelog entry
_N/A_