### PR TITLE
Generator::getTitle(): improve `libxml` cross-version compatibility

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -87,15 +87,13 @@ abstract class Generator
 
         if (empty($title) === true) {
             // Fall back to the sniff name if no title was supplied.
-            $fileName  = $doc->ownerDocument->documentURI;
-            $lastSlash = strrpos($fileName, '/');
-            if (is_int($lastSlash) === true) {
-                // Get the sniff name without "Standard.xml".
-                $title = substr($fileName, ($lastSlash + 1), -12);
+            $fileName = $doc->ownerDocument->documentURI;
 
-                // Split the sniff name to individual words.
-                $title = preg_replace('`[-._]|(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])`', '$1 $2', $title);
-            }
+            // Get the sniff name without "Standard.xml".
+            $title = basename($fileName, 'Standard.xml');
+
+            // Split the sniff name to individual words.
+            $title = preg_replace('`[-._]|(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])`', '$1 $2', $title);
         }
 
         return $title;


### PR DESCRIPTION
# Description

The format of the `DOMDocument::$documentURI` value on PHP 8.6 on Windows has changed due to changes in `libxml` `21500`.

This commit updates the code in the `Generator::getTitle()` method to handle the filename format in a manner which is cross-version compatible with both `libxml` < 21500 and well as >= 21500 and should work on both *nix as well as Windows.

This change should fix the test failure for PHP 8.6 on Windows.

Refs:
* php/php-src#23326
* https://github.com/php/php-src/commit/bc7537dbf01418274a7a1fa8c728fe94835fcccc


## Suggested changelog entry
* Generators: the fallback for missing document titles to use the file name was broken on Windows when PHP was compiled with `libxml` >= `21500` (as it will be in PHP 8.6).
