### PR TITLE
PSR12 ruleset: report property names prefixed with an underscore as an error

### DIFF
--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -144,6 +144,10 @@
     That is, an underscore prefix explicitly has no meaning. -->
     <!-- There MUST be a space between type declaration and property name. -->
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+        <type>error</type>
+        <message>Property name "%s" must not be prefixed with an underscore to indicate visibility</message>
+    </rule>
 
     <!-- Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities (PHP 7.1 or later). -->
     <!-- checked by PSR12.Properties.ConstantVisibility -->


### PR DESCRIPTION
PSR-12 section 4.3 uses MUST NOT for underscore-prefixed property names, the same wording section 4.4 uses for methods. The PSR12 standard already promotes the method message (`PSR2.Methods.MethodDeclaration.Underscore`) to an error, but the property message (`PSR2.Classes.PropertyDeclaration.Underscore`) was still inherited from PSR2 as a warning.

This adds the same ruleset-level override for the property message: type `error` and the message text updated to "must not", mirroring the existing method override.

PSR2 itself is unchanged and still reports both cases as warnings.

Verified against a small fixture with an underscore-prefixed property and method: PSR12 now reports both as errors with the "must not" wording, PSR2 output is unchanged. `composer cs` and `composer test` both pass.

Fixes #1426