### PR TITLE
Generic/ScopeIndent: fix false positive after inline HTML before an open tag

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -363,6 +363,12 @@ class ScopeIndentSniff implements Sniff
                     } else {
                         $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $parenOpener, true);
 
+                        if ($tokens[$first]['code'] === T_INLINE_HTML
+                            && ltrim($tokens[$first]['content']) === ''
+                        ) {
+                            $first = $phpcsFile->findFirstOnLine([T_WHITESPACE, T_INLINE_HTML], $parenOpener, true);
+                        }
+
                         $checkIndent = ($tokens[$first]['column'] - 1);
                         if (isset($adjustments[$first]) === true) {
                             $checkIndent += $adjustments[$first];

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -1648,6 +1648,38 @@ $result = array_map(
     $data
 );
 
+// Issue #1434: Arrow function method call inside template echo tag
+?>
+<div>
+    <div>
+        <span><?= $title ?></span>
+    </div>
+
+    <?= render(
+        [
+            'data' => map(
+                [],
+                static fn($item) => $item->getValue()
+            ),
+            'options' => [],
+        ]
+    ) ?>
+</div>
+<?php
+
+// Issue #1434: Meaningful inline HTML immediately before a PHP open tag
+?>
+<div><?= render(
+         [
+             'data' => map(
+                 [],
+                 static fn($item) => $item->getValue()
+             ),
+             'options' => [],
+         ]
+     ) ?></div>
+<?php
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -1648,6 +1648,38 @@ $result = array_map(
     $data
 );
 
+// Issue #1434: Arrow function method call inside template echo tag
+?>
+<div>
+    <div>
+        <span><?= $title ?></span>
+    </div>
+
+    <?= render(
+        [
+            'data' => map(
+                [],
+                static fn($item) => $item->getValue()
+            ),
+            'options' => [],
+        ]
+    ) ?>
+</div>
+<?php
+
+// Issue #1434: Meaningful inline HTML immediately before a PHP open tag
+?>
+<div><?= render(
+         [
+             'data' => map(
+                 [],
+                 static fn($item) => $item->getValue()
+             ),
+             'options' => [],
+         ]
+     ) ?></div>
+<?php
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
@@ -1648,6 +1648,38 @@ $result = array_map(
 	$data
 );
 
+// Issue #1434: Arrow function method call inside template echo tag
+?>
+<div>
+	<div>
+		<span><?= $title ?></span>
+	</div>
+
+	<?= render(
+		[
+			'data' => map(
+				[],
+				static fn($item) => $item->getValue()
+			),
+			'options' => [],
+		]
+	) ?>
+</div>
+<?php
+
+// Issue #1434: Meaningful inline HTML immediately before a PHP open tag
+?>
+<div><?= render(
+         [
+             'data' => map(
+                 [],
+                 static fn($item) => $item->getValue()
+             ),
+             'options' => [],
+         ]
+     ) ?></div>
+<?php
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
@@ -1648,6 +1648,38 @@ $result = array_map(
 	$data
 );
 
+// Issue #1434: Arrow function method call inside template echo tag
+?>
+<div>
+	<div>
+		<span><?= $title ?></span>
+	</div>
+
+	<?= render(
+		[
+			'data' => map(
+				[],
+				static fn($item) => $item->getValue()
+			),
+			'options' => [],
+		]
+	) ?>
+</div>
+<?php
+
+// Issue #1434: Meaningful inline HTML immediately before a PHP open tag
+?>
+<div><?= render(
+         [
+             'data' => map(
+                 [],
+                 static fn($item) => $item->getValue()
+             ),
+             'options' => [],
+         ]
+     ) ?></div>
+<?php
+
 /* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -169,10 +169,10 @@ final class ScopeIndentUnitTest extends AbstractSniffTestCase
             1527 => 1,
             1529 => 1,
             1530 => 1,
-            1659 => 1,
-            1660 => 1,
-            1661 => 1,
-            1662 => 1,
+            1691 => 1,
+            1692 => 1,
+            1693 => 1,
+            1694 => 1,
         ];
     }
 


### PR DESCRIPTION
# Description

`Generic.WhiteSpace.ScopeIndent` reported a false positive when a multi-line function call's opening line started with only whitespace before a `<?=`/`<?php` open tag (a common shape in template files), and an earlier, unrelated `<?= ... ?>` block appeared previously in the file.

The cause: PHP_CodeSniffer's tokenizer splits multi-line inline HTML into one `T_INLINE_HTML` token per physical line, so leading indentation before an open tag is its own `T_INLINE_HTML` token, not `T_WHITESPACE`, which only applies inside PHP code. `ScopeIndentSniff`'s closing-parenthesis handling picked up that whitespace-only token as the "first token on the line", then called `File::findStartOfStatement()` to find the real statement start. Since `T_INLINE_HTML` isn't a stop token for that walk, it crossed into a previous, disjoint short-echo block and anchored the indentation check on unrelated code, producing an incorrect expected indent.

The fix skips a whitespace-only inline-HTML token so the sniff lands on the actual PHP open tag on that line, which `findStartOfStatement()` already treats as a statement start, avoiding the backward walk entirely for this case. The check is scoped to whitespace-only content specifically, so lines that start with meaningful inline HTML/markup before the open tag (a separate, already-existing and intentionally lenient behavior elsewhere in this file) are unaffected.

## Suggested changelog entry

Fixed a `Generic.WhiteSpace.ScopeIndent` false positive for multi-line statements that follow whitespace-only inline HTML before a PHP open tag (e.g. in template files).

## Related issues/external references

Fixes #1434

## Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist

- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
