### PR TITLE
Tokenizer/PHP: fix ? tokenization in property hook parameters

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2276,7 +2276,7 @@ class PHP extends Tokenizer
                         && isset(Tokens::EMPTY_TOKENS[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
-                        if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
+                        if ($tokenType === ':' || $tokenType === ',' || $tokenType === '(' || $tokenType === T_ATTRIBUTE_END) {
                             $newToken['code'] = T_NULLABLE;
                             $newToken['type'] = 'T_NULLABLE';
 

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.inc
@@ -16,6 +16,18 @@ abstract class Nullable
 
     /* testNullableAbstractOnly */
     abstract ?string $prop5 { get; }
+
+    public int $prop6 {
+        /* testPropertyHookParamTypeNullableInt */
+        set(?int $value) {
+            $this->prop6 = $value ?? 0;
+        }
+    }
+
+    public string $prop7 {
+        /* testShortPropertyHookParamTypeNullableString */
+        set(?string $value) => $value ?? '';
+    }
 }
 
 $closure = function (

--- a/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
+++ b/tests/Core/Tokenizers/PHP/NullableVsInlineThenTest.php
@@ -55,6 +55,9 @@ final class NullableVsInlineThenTest extends AbstractTokenizerTestCase
             'property declaration, final, no visibility'                    => ['/* testNullableFinalOnly */'],
             'property declaration, abstract, no visibility'                 => ['/* testNullableAbstractOnly */'],
 
+            'property hook param type, nullable int'                        => ['/* testPropertyHookParamTypeNullableInt */'],
+            'short property hook param type, nullable string'               => ['/* testShortPropertyHookParamTypeNullableString */'],
+
             'closure param type, nullable int'                              => ['/* testClosureParamTypeNullableInt */'],
             'closure param type, nullable callable'                         => ['/* testClosureParamTypeNullableCallable */'],
             'closure param type, nullable string with comment, issue #1216' => ['/* testClosureParamTypeNullableStringWithAttributeAndSlashComment */'],


### PR DESCRIPTION
# Description

The `?` of a nullable type on a property hook parameter, like `set(?int $value)`, was tokenized as `T_INLINE_THEN` instead of `T_NULLABLE`, so `Squiz.WhiteSpace.OperatorSpacing` treated it as a ternary and `phpcbf` "fixed" the accessor to `set( ? int $value)`.

When the backward walk in the `?` disambiguation reaches the parameter list opener, it currently keeps walking and hits the `{` of the hook block, which is in the list of tokens that mean "ternary". A `?` directly preceded by `(` is always the start of a nullable type though, never a ternary, since a ternary needs an expression before its `?`. This adds `(` to the tokens that make the previous non-empty token check conclude `T_NULLABLE`, which also stops the walk before it can reach the hook block.

Regular methods and closures were never affected: their backward walk finds `function`/`fn` first.

## Suggested changelog entry

* Fixed a bug where the `?` of a nullable type on a property hook parameter would be tokenized as `T_INLINE_THEN` instead of `T_NULLABLE`, which made `Squiz.WhiteSpace.OperatorSpacing` report false positives and `phpcbf` break the code.

## Related issues/external references

Fixes #1494

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.
- [ ] I have opened a sister-PR in the [documentation repository](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation) to update the Wiki.
